### PR TITLE
feat(tooling): integrate Playwright MCP server with full capabilities

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "mcp__playwright",
+      "Bash(pnpm playwright:*)",
+      "Bash(pnpm --filter @booster-ai/web test:e2e:*)",
+      "Bash(npx playwright:*)",
+      "Bash(npx @playwright/mcp:*)"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": ["playwright"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -118,5 +118,9 @@ __pycache__/
 * 2.*
 * 3.*
 
-# Claude Code local settings
-.claude/
+# Claude Code local settings (settings.json es shared y se trackea)
+.claude/settings.local.json
+.claude/.credentials.json
+
+# Playwright MCP outputs (sessions, traces, screenshots, video)
+.playwright-mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,17 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@playwright/mcp@latest",
+        "--browser", "chromium",
+        "--headless",
+        "--caps", "vision,pdf,devtools,network,storage,testing",
+        "--viewport-size", "1920x1080",
+        "--save-session",
+        "--output-dir", ".playwright-mcp"
+      ]
+    }
+  }
+}

--- a/skills/playwright-mcp-testing/SKILL.md
+++ b/skills/playwright-mcp-testing/SKILL.md
@@ -1,0 +1,147 @@
+# Skill: Playwright MCP Testing
+
+**Categoría**: core-engineering
+**Relacionado**: `.claude/commands/test.md`, `apps/web/playwright.config.ts`, ADR pendiente sobre adopción Playwright MCP
+
+## Overview
+
+El servidor `@playwright/mcp` (Microsoft, oficial) le da al agente control de un navegador Chromium real desde Claude Code. El servidor expone ~70 tools (`mcp__playwright__browser_*`) que operan sobre **accessibility snapshots** (no screenshots) — determinístico, token-eficiente, sin necesidad de modelos de visión.
+
+Este skill define **cuándo** usar el MCP en vivo, **cuándo** preferir `playwright codegen` o specs escritas a mano, y **cómo** mantener consistencia con la suite E2E del repo (`apps/web/e2e/`).
+
+## When to Use
+
+Usar Playwright MCP cuando:
+
+- **Exploración de UI**: necesito entender un flujo nuevo o ajeno (ej. dashboard de stakeholder) y quiero "ver" la app sin spinear un dev server localmente.
+- **Reproducir un bug reportado**: el ticket dice "el botón X no funciona en Y flujo" y quiero validar antes de escribir el fix.
+- **Generar locators robustos**: con `--caps testing`, `browser_generate_locator` produce locators con la prioridad correcta (role > label > testid).
+- **Auditar accesibilidad ad-hoc**: combinar `browser_snapshot` con `@axe-core/playwright` ya instalado en `apps/web`.
+- **Smoke-test de un deploy preview** apuntando a una URL de staging/preview de Vercel/Cloud Run.
+- **Iterar en un selector que falla**: cuando un spec E2E falla en CI y no es obvio por qué, abrir la página real con MCP y debugger.
+
+**NO usar MCP cuando**:
+
+- Voy a escribir un test E2E nuevo que vivirá en `apps/web/e2e/` → escribir el spec directo o usar `pnpm --filter @booster-ai/web exec playwright codegen <URL>`.
+- Solo necesito correr la suite existente → `pnpm --filter @booster-ai/web test:e2e`.
+- Voy a hacer scraping de un sitio externo (no es nuestro flujo) — no es lo que el MCP existe para hacer en este repo.
+
+## Core Process
+
+### 1. Verificar que el server MCP esté activo
+
+```bash
+# Desde el repo, Claude Code debería detectar .mcp.json automáticamente.
+# Si no, validar:
+ls .mcp.json && cat .mcp.json
+```
+
+Si los tools `mcp__playwright__*` no aparecen en la sesión, reiniciar Claude Code o ejecutar `/mcp` para listar servers conectados.
+
+### 2. Navegar y tomar snapshot
+
+Patrón canónico para empezar cualquier interacción:
+
+1. `mcp__playwright__browser_navigate` con la URL objetivo (localhost o staging).
+2. `mcp__playwright__browser_snapshot` — devuelve árbol de accessibility con refs estables.
+3. Trabajar contra los `ref` del snapshot (NO contra coordenadas, NO contra screenshot).
+
+### 3. Acciones determinísticas
+
+Preferir siempre tools que reciben `ref`:
+
+- `browser_click({ ref })` en lugar de `browser_mouse_click_xy`.
+- `browser_fill_form({ fields: [...] })` en lugar de N `browser_type`.
+- `browser_wait_for({ text | textGone | time })` en lugar de sleeps.
+
+### 4. Verificación con `--caps testing`
+
+- `browser_verify_element_visible({ ref })`
+- `browser_verify_text_visible({ text })`
+- `browser_verify_value({ ref, value })`
+- `browser_generate_locator({ ref })` → produce el locator que pego en el spec.
+
+### 5. Network mocking con `--caps network`
+
+- `browser_route({ url, response })` para stub de APIs.
+- `browser_network_requests()` para inspeccionar lo que disparó la app.
+- `browser_network_state_set({ offline: true })` para simular sin red.
+
+### 6. Storage / sesión con `--caps storage`
+
+- `browser_storage_state()` exporta cookies + localStorage → guardar en `.playwright-mcp/auth.json`.
+- `browser_set_storage_state({ path })` carga estado para skipear login en runs siguientes.
+
+### 7. Convertir hallazgos a spec persistente
+
+**Toda exploración con MCP termina en código tracked**. Si el hallazgo vale la pena:
+
+1. Generar locators con `browser_generate_locator`.
+2. Crear/actualizar `apps/web/e2e/<feature>.spec.ts` siguiendo el patrón ya configurado en `apps/web/playwright.config.ts:5-50` (4 proyectos: chromium, mobile-chrome, webkit, mobile-safari).
+3. Correr `pnpm --filter @booster-ai/web test:e2e` y pegar evidencia en el PR.
+
+## Configuración del MCP server
+
+Definida en `.mcp.json` (raíz del repo, checked-in para todo el equipo). Versión actual: **completa** — todas las capabilities habilitadas.
+
+| Flag | Valor | Razón |
+|------|-------|-------|
+| `--browser` | `chromium` | Match con projects de `playwright.config.ts`. |
+| `--headless` | sí | Default seguro, no requiere display. |
+| `--caps` | `vision,pdf,devtools,network,storage,testing` | Acceso completo a tools opt-in. |
+| `--viewport-size` | `1920x1080` | Desktop full HD; mobile se cubre con specs E2E. |
+| `--save-session` | sí | Persiste sesión en `--output-dir` para debug post-mortem. |
+| `--output-dir` | `.playwright-mcp` | Gitignored. Traces, videos, screenshots aterrizan ahí. |
+
+**Perfil persistente (default)**: el browser data vive en `~/.cache/ms-playwright/mcp-{channel}-{workspace-hash}` (Linux) / `~/Library/Caches/ms-playwright/...` (macOS). El hash se deriva del workspace root → aislamiento automático por proyecto. Cookies y login se preservan entre sesiones.
+
+Para sesiones efímeras (tests aislados): añadir `--isolated` al `args` temporalmente o crear un segundo server entry en `.mcp.json` con sufijo `-isolated`.
+
+## Permisos en Claude Code
+
+`.claude/settings.json` (checked-in) preaprueba:
+
+- `mcp__playwright` — wildcard, todos los tools del server sin prompt.
+- `Bash(pnpm playwright:*)` — corre la suite local.
+- `Bash(pnpm --filter @booster-ai/web test:e2e:*)`
+- `Bash(npx playwright:*)`, `Bash(npx @playwright/mcp:*)`
+
+Si querés permisos adicionales solo para tu máquina, ponelos en `.claude/settings.local.json` (gitignored).
+
+## Anti-patterns
+
+| Tentación | Por qué es un error |
+|-----------|---------------------|
+| Usar `browser_mouse_click_xy` porque "el ref no anduvo" | Indica que el snapshot está desactualizado o el elemento se movió. Re-snapshot antes de claudicar a coordenadas. |
+| Tomar `browser_take_screenshot` para "ver" la página antes de actuar | El snapshot ya da la info estructurada. Screenshot es view-only y consume tokens innecesariamente. |
+| Habilitar `browser_run_code_unsafe` para "ahorrar pasos" | RCE-equivalente en el proceso del MCP server. No tocar salvo necesidad documentada en ADR. |
+| Hardcodear `ref="e123"` en specs | Los refs son efímeros (válidos solo dentro de un snapshot). Convertir a locator real con `browser_generate_locator`. |
+| Saltarse `--allowed-origins` para apuntar a sitios random | El server no es security boundary, pero la allowlist evita exploración accidental fuera de Booster. |
+| Dejar la exploración solo en chat (sin spec) | Hallazgo no reproducible = hallazgo perdido. Toda sesión MCP útil termina en código tracked. |
+
+## Caveats de seguridad
+
+- **El MCP no es un security boundary** (Microsoft lo dice explícito). Tratarlo como código del agente con privilegios de browser local.
+- **`browser_run_code_unsafe`**: ejecuta JS arbitrario en el proceso del server (RCE-equivalent). No usar.
+- **`--allow-unrestricted-file-access`**: NO está activado. Mantener así. El acceso a archivos está confinado al workspace.
+- **`--no-sandbox`**: NO está activado. Solo activar si se corre en un container donde el sandbox de Chromium choca con el sandbox del runtime; documentar en ADR si se hace.
+- **PII en sesiones persistentes**: si se hace login real (no fixture) en el browser persistente, las cookies quedan en `~/.cache/ms-playwright/...`. Limpiar periódicamente o usar `--isolated` para flujos sensibles.
+
+## Exit Criteria
+
+Para considerar una sesión MCP "cerrada con valor":
+
+- [ ] El hallazgo está en código (spec, fix, o issue con repro pasos).
+- [ ] Si se generaron locators, fueron consolidados en el spec correspondiente.
+- [ ] No quedaron archivos sensibles en `.playwright-mcp/` (gitignored, pero igual revisar).
+- [ ] Si se descubrió un bug, hay un test que lo reproduce antes del fix.
+- [ ] Evidence block del PR incluye output de `pnpm --filter @booster-ai/web test:e2e`.
+
+## Referencias
+
+- Repo oficial: https://github.com/microsoft/playwright-mcp
+- Playwright docs: https://playwright.dev/docs/intro
+- Config local: `.mcp.json` (raíz)
+- Permisos: `.claude/settings.json`
+- Suite E2E del repo: `apps/web/playwright.config.ts`, `apps/web/e2e/`
+- Skill relacionada: `skills/using-agent-skills/SKILL.md`


### PR DESCRIPTION
## Summary

Connect Claude Code to Microsoft's official `@playwright/mcp` server so the agent can drive a real Chromium browser via accessibility snapshots — without screenshots or vision models. Full capabilities enabled and permissions pre-approved per Product Owner request.

- **`.mcp.json`** (project-shared): registers `playwright` MCP server with all caps enabled (`vision,pdf,devtools,network,storage,testing`), Chromium headless, viewport 1920x1080, persistent output dir `.playwright-mcp/`.
- **`.claude/settings.json`** (project-shared): pre-approves `mcp__playwright` wildcard + `pnpm/npx playwright` bash commands so the agent doesn't get prompted on every tool call.
- **`.gitignore`**: narrows the previous broad `.claude/` ignore to only `.claude/settings.local.json` + credentials, and adds `.playwright-mcp/` for runtime outputs (traces, video, sessions).
- **`skills/playwright-mcp-testing/SKILL.md`**: when-to-use, core process, anti-patterns and security caveats following the existing agent-skills format (see `skills/writing-adrs/SKILL.md`).

## Diff scope

This PR contains a **single commit** ahead of `origin/main` touching only 4 files (config + docs). No code, no dependencies, no Dockerfile or Terraform changes:

```
.claude/settings.json                  |  14 ++++
.gitignore                             |   8 +-
.mcp.json                              |  17 ++++
skills/playwright-mcp-testing/SKILL.md | 147 +++++++++++++++++++++++++++++++++
4 files changed, 184 insertions(+), 2 deletions(-)
```

## Capabilities exposed

~70 `mcp__playwright__browser_*` tools across:

- **Core (always on)**: `browser_navigate`, `browser_click`, `browser_snapshot`, `browser_fill_form`, `browser_evaluate`, `browser_wait_for`, `browser_console_messages`, `browser_network_requests`, `browser_tabs`, `browser_press_key`, `browser_hover`, `browser_drag`, `browser_select_option`, `browser_file_upload`, `browser_handle_dialog`, etc.
- **`testing`** → `browser_generate_locator`, `browser_verify_*`
- **`network`** → `browser_route`, mock responses, offline mode
- **`storage`** → cookies, localStorage, sessionStorage, `storage_state`
- **`devtools`** → `browser_start_tracing`, `browser_start_video`, `browser_highlight`
- **`vision`** → coordinate-based mouse ops (kept enabled, accessibility-first remains the default workflow)
- **`pdf`** → `browser_pdf_save`

## Security posture

Following CLAUDE.md principle #7 (Security by default), these dangerous flags remain **off**:

- `--allow-unrestricted-file-access` → file access stays confined to workspace.
- `--no-sandbox` → Chromium sandbox preserved.
- `browser_run_code_unsafe` → not invoked (RCE-equivalent in the MCP server process).

The skill documents these caveats explicitly so the agent doesn't enable them ad-hoc.

## Pre-existing CI failures (NOT introduced by this PR)

Three security checks fail on this PR. **All are reproducible on `main` and unrelated to the 4 files this PR changes**:

| Check | Cause | Tracked in |
|-------|-------|------------|
| `npm audit (HIGH+)` | `crypto-js<4.2.0` (CRITICAL, GHSA-xwcq-pm8m-c4vf) + `drizzle-orm<0.45.2` (HIGH, GHSA-gpj5-g38j-94v9) in the existing dependency tree. Reproduced locally with `pnpm audit --audit-level=high --prod`. | #17 (crypto-js), #18 (drizzle-orm) |
| `Trivy filesystem + config scan` | Same dependency CVEs surfaced by Trivy at HIGH/CRITICAL threshold. | Resolved transitively when #17 / #18 land |
| `Generate SBOM` | Exit code 254 from `cyclonedx-npm`; logs gated behind GH auth. Predates this PR. | Out of scope — separate investigation |

Decision (per Product Owner): **do not bundle dep upgrades into this PR**. Drizzle 0.44 → 0.45 is architecturally significant (schema/query API surface). Tracked in dedicated issues so each upgrade gets its own validation pass.

## Test plan

- [ ] After merge, restart Claude Code in the repo and run `/mcp` to confirm `playwright` server connects.
- [ ] Smoke test: `mcp__playwright__browser_navigate` → `https://playwright.dev`, then `browser_snapshot` → returns accessibility tree.
- [ ] Verify pre-approved permissions skip the consent prompt for `mcp__playwright__*` tools.
- [ ] Run existing `pnpm --filter @booster-ai/web test:e2e` to confirm Playwright runtime is unaffected by the new MCP layer.
- [ ] Confirm `.playwright-mcp/` outputs are gitignored after a session.

## Follow-ups

- #17 — bump crypto-js to `>=4.2.0`
- #18 — bump drizzle-orm to `>=0.45.2`
- Optional ADR documenting the adoption decision (Playwright MCP as standard agent tooling).
- First spec under `apps/web/e2e/` to exercise the full path (MCP exploration → `browser_generate_locator` → checked-in spec → CI).

https://claude.ai/code/session_01NeDpjCP1BF7ykC9nbJjnPm