### PR TITLE
feat(tooling): cloud-sql-proxy bastion con --auto-iam-authn + IAP tunnel persistente (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,19 @@ No "adivino" ni "asumo lo razonable" en decisiones que no son claramente determi
 - **Carrier/Shipper deprecated**. Usar `Transportista`/`GeneradorCarga` en código y SQL. `transportistaIdSchema` reemplaza `carrierIdSchema`; este último queda como alias deprecated mientras schemas legacy se migran.
 - **Stakeholder se mantiene como término** (anglicismo aceptado en español de negocios).
 
+## DB Access Patterns (ADR-013 + ADR-014)
+
+| Caso | Mecanismo | Comando |
+|------|-----------|---------|
+| **Cloud Run services** | VPC connector + `booster_app` password (Secret Manager `database-url`) | automático |
+| **Dev local recurrente** (psql, MCP postgres, DBeaver, drizzle-kit) | LaunchAgent IAP tunnel persistente → bastion proxy `--auto-iam-authn`. Connection string fijo: `postgresql://db-bastion-sa%40booster-ai-494222.iam:dummy@127.0.0.1:5432/booster_ai?sslmode=disable` | `bash scripts/db/connect-local.sh psql` |
+| **DDL / migrations / GRANTs / hotfix admin** | `connect.sh AUTH_MODE=password` ad-hoc → bastion proxy → `booster_app` | `AUTH_MODE=password bash scripts/db/connect.sh -f scripts/sql/X.sql` |
+| **Cloud Run Jobs (one-off ops)** | VPC connector + SA del Cloud Run Job | `gcloud run jobs execute <name>` |
+
+**Setup inicial (una sola vez por laptop)**: ver `scripts/db/README.md` § Quick start dev local. Incluye instalar LaunchAgent (`scripts/db/iap-tunnel.plist.template`), aplicar GRANTs (`scripts/sql/2026-05-03-grant-bastion-sa.sql`), y `claude mcp add postgres --scope user`.
+
+**Audit**: queries via dev local quedan atribuidas a la SA del bastion en `pg_audit`. La trazabilidad per-humano vive en Cloud Audit Logs de IAP (quién abrió el túnel). Trade-off aceptado en ADR-014.
+
 ---
 
 **Estado de adopción**: este contrato entra en vigor desde el primer commit del repo. Cualquier excepción debe documentarse.

--- a/docs/adr/014-cloud-sql-auto-iam-authn-bastion.md
+++ b/docs/adr/014-cloud-sql-auto-iam-authn-bastion.md
@@ -1,0 +1,130 @@
+# ADR-014 — Cloud SQL Auth Proxy en bastion con `--auto-iam-authn` para dev local
+
+- **Estado**: Accepted
+- **Fecha**: 2026-05-03
+- **Decisores**: Felipe Vicencio (Product Owner)
+- **Supersede parcialmente**: [ADR-013](./013-database-access-pattern.md) — sección "Capa 1 — Acceso humano (a implementar)" y comentarios de `infrastructure/modules/iap-bastion/main.tf` que decían "el proxy NO usa --auto-iam-authn".
+
+## Contexto
+
+ADR-013 estableció el patrón de 3 capas para acceso a Cloud SQL. La Capa 1 (operadores humanos) se implementó como:
+
+```
+laptop ──► gcloud start-iap-tunnel ──► bastion ──► cloud-sql-proxy ──► Cloud SQL
+                                                     (sin --auto-iam-authn)
+```
+
+El operador humano pasa su `gcloud auth print-access-token` como `PGPASSWORD` desde la laptop (ver `scripts/db/connect.sh` líneas 115-118). Eso preserva audit per-usuario en `pg_audit` (cada query queda atribuida al email del operador). Funciona para queries ad-hoc.
+
+Pero al integrar **MCP postgres server** de Claude Code para queries asistidas y al automatizar el flujo dev local, este patrón rompe en 2 puntos:
+
+1. **El access token expira a los ~60 min**. El MCP server espera una connection string estable; cuando expira, todas las queries fallan hasta que el operador re-corra `connect.sh`. No hay refresh automático en el path actual.
+2. **El connection string cambia cada sesión** (token regenerado). Imposible persistirlo en `~/.claude.json` o en un LaunchAgent del Mac.
+
+Resultado observado: dev pierde 5-10 min cada hora reabriendo el túnel, y el MCP postgres no puede vivir como servicio user-scope persistente.
+
+## Decisión
+
+Trasladar `--auto-iam-authn` al `cloud-sql-proxy` que corre en el bastion. Cambios:
+
+1. **Bastion systemd unit** (`infrastructure/modules/iap-bastion/main.tf:59`):
+   ```diff
+   - ExecStart=$PROXY_BIN --address=0.0.0.0 --port=5432 --private-ip ${conn_name}
+   + ExecStart=$PROXY_BIN --address=0.0.0.0 --port=5432 --private-ip --auto-iam-authn ${conn_name}
+   ```
+2. **SA del bastion**: añadir `roles/cloudsql.instanceUser` (ya tenía `cloudsql.client`).
+3. **Postgres role**: registrar `db-bastion-sa@booster-ai-494222.iam` como `CLOUD_IAM_SERVICE_ACCOUNT` (`google_sql_user.bastion_sa` en `data.tf`).
+4. **GRANTs SQL post-apply**: `scripts/sql/2026-05-03-grant-bastion-sa.sql` aplica los privilegios al rol nuevo (CONNECT a `booster_ai`, USAGE en `public`, SELECT/INSERT/UPDATE/DELETE en todas las tablas + default privileges para futuras tablas).
+5. **Flow dev local nuevo**: el operador levanta un IAP tunnel **persistente** vía LaunchAgent (`scripts/db/iap-tunnel.plist.template`) que mantiene `127.0.0.1:5432` siempre listening. El proxy del bastion refresca tokens automáticamente (el SA del bastion tiene metadata service local — refresh 100% transparente, sin expiry visible al cliente).
+6. **MCP postgres** y cualquier tooling local (psql, DBeaver, drizzle-kit) conectan a `127.0.0.1:5432` con connection string fijo:
+   ```
+   postgresql://db-bastion-sa%40booster-ai-494222.iam:dummy@127.0.0.1:5432/booster_ai?sslmode=disable
+   ```
+   El `dummy` password se ignora — el proxy del bastion lo reemplaza por el access token del SA. `sslmode=disable` porque IAP TCP cifra el segmento laptop↔bastion y el proxy cifra bastion↔Cloud SQL; la conexión local TCP plana es solo dentro del túnel.
+
+### Diagrama actualizado
+
+```
+┌─────────┐    IAP TCP tunnel    ┌─────────────────┐    cloud-sql-proxy
+│ laptop  │◄────(persistent)────►│  bastion VM     │    --auto-iam-authn
+│  Mac    │   localhost:5432     │  (private IP)   │◄─── (systemd, port 5432)
+│         │                      │                 │       │
+│ ┌─────┐ │                      │  IAM token de   │       │
+│ │psql │─┼──── stable conn ─────┤  db-bastion-sa  │       ▼
+│ │MCP  │ │                      │  (refresh auto) │   Cloud SQL
+│ │drizz│ │                      │                 │   (private IP)
+│ └─────┘ │                      └─────────────────┘
+└─────────┘
+```
+
+## Alternativas consideradas y rechazadas
+
+### A. Habilitar IP pública en Cloud SQL + IAM auth + ephemeral cert (sin authorized networks)
+
+- **Cómo**: `ipv4_enabled = true`, sin lista de IPs (acceso solo via Cloud SQL Auth Proxy con IAM token + cert mTLS).
+- **Por qué se rechazó**: aunque técnicamente seguro, contradice el commitment de "Cloud SQL nunca tiene IP pública" del ADR-013 ("Alternativas rechazadas — A. Public IP + Authorized Networks"). El team prefiere la consistencia conceptual: si en algún momento aparece un misconfig (ej. expose de Postgres por error), una instancia que **nunca** habilitó IP pública es más simple de auditar que una que la tuvo "restringida solo al proxy".
+
+### B. Private Service Connect (PSC) en Cloud SQL + endpoint en VPC
+
+- **Por qué se rechazó**: PSC resuelve acceso desde otra VPC, no desde laptop. Para que la laptop alcance el endpoint PSC interno, igual hace falta Cloud Interconnect/VPN/IAP TCP. Termina siendo el patrón de este ADR + complejidad extra de PSC.
+
+### C. Mantener `--auto-iam-authn` en proxy local de la laptop (sin bastion)
+
+- **Por qué se rechazó**: el `cloud-sql-proxy` v2 desde laptop necesita ruta IP al backend. Cloud SQL es private-only. Sin PSC ni IAP, no hay ruta. El proxy local fallaría con timeout al conectar al backend.
+
+### D. Cloud Workstations
+
+- **Por qué se rechazó (de nuevo)**: USD 50+/mes/usuario, overkill para team de 1-2. Decisión idéntica al ADR-013.
+
+## Consecuencias
+
+### Positivas
+
+- **Connection string estable**: `127.0.0.1:5432` siempre listening (LaunchAgent), MCP postgres + DBeaver + drizzle-kit funcionan sin re-config cada hora.
+- **Token refresh transparente**: el proxy del bastion corre en VM con metadata service — el access token de la SA se refresca automáticamente cada ~50 min sin intervención. Cliente no ve expiry.
+- **Setup user-scope durable**: `claude mcp add postgres --scope user ...` queda persistente en `~/.claude.json` y funciona en cualquier proyecto que necesite la DB.
+- **CI/CD y jobs no afectados**: Capas 2 (Cloud Run services) y 3 (Cloud Run Jobs) del ADR-013 siguen idénticas, con sus propios mecanismos de auth.
+
+### Negativas
+
+- **Pérdida de audit per-humano en `pg_audit`**: todas las queries via bastion quedan atribuidas a `db-bastion-sa@booster-ai-494222.iam`. No es posible distinguir cuál humano corrió cada query desde `pg_audit` solo.
+- **Mitigación**: la atribución per-humano vive en **Cloud Audit Logs de IAP** (`logName="projects/booster-ai-494222/logs/cloudaudit.googleapis.com%2Fdata_access"` con `resource.type="iap_tunnel_dest_group"`). Para reconstruir "quién corrió esta query a las HH:MM:SS", se cruza:
+  ```sql
+  -- pg_audit: query timestamp + statement
+  SELECT ts, statement FROM pg_audit_log WHERE ts BETWEEN '...';
+  -- IAP audit log: humano que tenía túnel activo en ese rango
+  -- (gcloud logging read filter por iap.tunnel + protoPayload.authenticationInfo.principalEmail)
+  ```
+  Runbook detallado: `docs/runbooks/audit-bastion-queries.md` (a crear si se requiere análisis forense real; queda fuera del scope de este ADR).
+- **SPOF**: si el bastion se cae, ningún humano puede conectar (idéntico a ADR-013, no peor).
+- **`scripts/db/connect.sh` AUTH_MODE=iam ya no aplica como estaba**: el script usaba IAM token del operador como password. Con el nuevo flujo, eso fallaría porque el proxy ya pone el token de la SA. Acción: deprecar el modo `iam` del script y dejar `password` como único modo legítimo (para emergencias / GRANTs de admin); el flujo principal pasa a ser `connect-local.sh` o conexión directa al túnel persistente.
+
+### Riesgos abiertos
+
+- **El operador puede ejecutar cualquier query con privilegios de la SA**. Mitigación: los GRANTs (`scripts/sql/2026-05-03-grant-bastion-sa.sql`) limitan a `SELECT/INSERT/UPDATE/DELETE` en `public`. Sin `DROP`, sin `TRUNCATE`, sin `CREATE`. DDL queda restringido a `booster_app` (password mode, uso explícito).
+- **El bastion es bisagra**. Si su systemd se rompe, todo dev pierde acceso. Mitigación: alerta de monitoring sobre el health del proxy + runbook de re-provisión via Terraform.
+
+## Implementación
+
+| # | Cambio | Estado |
+|---|--------|--------|
+| 1 | `infrastructure/modules/iap-bastion/main.tf` — `--auto-iam-authn` en systemd unit | ✅ commiteado |
+| 2 | `infrastructure/iam.tf` — `cloudsql.instanceUser` en `db_bastion_roles` | ✅ commiteado |
+| 3 | `infrastructure/data.tf` — `google_sql_user.bastion_sa` (CLOUD_IAM_SERVICE_ACCOUNT) | ✅ commiteado |
+| 4 | `scripts/sql/2026-05-03-grant-bastion-sa.sql` — GRANTs al rol SA | ✅ commiteado |
+| 5 | `scripts/db/connect-local.sh` — wrapper de IAP tunnel + opcional psql | ✅ commiteado |
+| 6 | `scripts/db/iap-tunnel.plist.template` — LaunchAgent template | ✅ commiteado |
+| 7 | `terraform apply` + restart systemd del bastion | ⏳ Felipe en Mac |
+| 8 | Aplicar `2026-05-03-grant-bastion-sa.sql` con `AUTH_MODE=password` | ⏳ Felipe en Mac |
+| 9 | Cargar LaunchAgent + verificar túnel persistente | ⏳ Felipe en Mac |
+| 10 | `claude mcp add postgres --scope user ...` | ⏳ Felipe en Mac |
+
+## Referencias
+
+- [ADR-013](./013-database-access-pattern.md) — patrón 3 capas (este ADR supersede sección Capa 1)
+- `infrastructure/modules/iap-bastion/main.tf` — implementación del bastion
+- `scripts/db/connect-local.sh` — wrapper para túnel + psql
+- `scripts/db/iap-tunnel.plist.template` — LaunchAgent macOS
+- `scripts/sql/2026-05-03-grant-bastion-sa.sql` — GRANTs post-apply
+- Cloud SQL — [IAM database authentication](https://cloud.google.com/sql/docs/postgres/iam-authentication)
+- Cloud SQL Auth Proxy — [`--auto-iam-authn` flag](https://cloud.google.com/sql/docs/postgres/connect-auth-proxy#authentication-options)

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -192,6 +192,25 @@ resource "google_sql_user" "iam_operators" {
   # Sin password: autenticación via IAM token.
 }
 
+# IAM SERVICE ACCOUNT user en Postgres para el bastion (ADR-014).
+# Cuando cloud-sql-proxy en bastion corre con --auto-iam-authn, autentica
+# como esta SA contra Postgres. Sin este google_sql_user, las conexiones
+# fallan con "FATAL: pg_hba.conf rejects connection".
+#
+# Naming: el `name` debe ser el email del SA SIN el sufijo
+# `.gserviceaccount.com` — convención Cloud SQL para CLOUD_IAM_SERVICE_ACCOUNT.
+# Ver https://cloud.google.com/sql/docs/postgres/add-manage-iam-users#add-service-account
+resource "google_sql_user" "bastion_sa" {
+  name     = trimsuffix(google_service_account.db_bastion.email, ".gserviceaccount.com")
+  type     = "CLOUD_IAM_SERVICE_ACCOUNT"
+  instance = google_sql_database_instance.main.name
+  project  = google_project.booster_ai.project_id
+  # Sin password: autenticación via IAM token (refresh automático del proxy).
+  # Los grants SQL al rol creado se aplican post-apply via:
+  #   bash scripts/db/connect.sh AUTH_MODE=password \
+  #     -f scripts/sql/2026-05-03-grant-bastion-sa.sql
+}
+
 resource "google_project_iam_member" "db_iam_operators_client" {
   for_each = toset(local.db_iam_operators)
   project  = google_project.booster_ai.project_id

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -184,17 +184,20 @@ resource "google_project_iam_member" "compute_default_sa_artifact_reader" {
 }
 
 # =============================================================================
-# IAP BASTION SA — Capa 1 del ADR-013
+# IAP BASTION SA — Capa 1 del ADR-013, evolucionada por ADR-014
 # =============================================================================
-# SA dedicada para el bastion VM. cloud-sql-proxy en el bastion la usa para
-# autenticarse contra la Admin API de Cloud SQL (cloudsql.client) y
-# establecer el túnel TLS hacia la instancia privada. La auth IAM-database
-# del operador al rol Postgres se hace per-laptop con su propio access
-# token — el bastion SA NO conoce esa identidad.
+# SA dedicada para el bastion VM. Tras ADR-014, cloud-sql-proxy corre con
+# --auto-iam-authn y autentica contra Postgres como esta SA (NO como el
+# operador humano). Por eso necesita ambos roles: cloudsql.client (Admin
+# API + tunel TLS) y cloudsql.instanceUser (login IAM al rol Postgres).
+# Tambien hay un google_sql_user tipo CLOUD_IAM_SERVICE_ACCOUNT en data.tf
+# que crea el rol Postgres correspondiente, y un grant SQL en
+# scripts/sql/2026-05-03-grant-bastion-sa.sql que le da los privilegios
+# necesarios sobre booster_ai DB.
 resource "google_service_account" "db_bastion" {
   account_id   = "db-bastion-sa"
   display_name = "Booster AI DB Bastion (IAP)"
-  description  = "Identidad del bastion VM que sirve cloud-sql-proxy a operadores via IAP TCP."
+  description  = "Identidad del bastion VM. Sirve cloud-sql-proxy --auto-iam-authn a operadores via IAP TCP (ADR-014)."
   project      = google_project.booster_ai.project_id
   depends_on   = [google_project_service.apis]
 }
@@ -202,6 +205,7 @@ resource "google_service_account" "db_bastion" {
 locals {
   db_bastion_roles = [
     "roles/cloudsql.client",         # Cloud SQL Admin API + establecer tunel TLS
+    "roles/cloudsql.instanceUser",   # login IAM al rol Postgres (--auto-iam-authn)
     "roles/logging.logWriter",       # journalctl → Cloud Logging
     "roles/monitoring.metricWriter", # métricas de la VM
   ]

--- a/infrastructure/modules/iap-bastion/main.tf
+++ b/infrastructure/modules/iap-bastion/main.tf
@@ -1,4 +1,4 @@
-# IAP Bastion — Capa 1 del ADR-013 (acceso humano a Cloud SQL privada).
+# IAP Bastion — Capa 1 del ADR-013, evolucionada por ADR-014.
 #
 # Patron:
 #   laptop ──► gcloud compute start-iap-tunnel ──► Google IAP frontend
@@ -6,16 +6,25 @@
 #                                                          ▼
 #                                                    bastion VM (private IP)
 #                                                          │
-#                                                          ▼  cloud-sql-proxy
+#                                                          ▼  cloud-sql-proxy --auto-iam-authn
 #                                                          │  (systemd service)
 #                                                          ▼
 #                                                    Cloud SQL private IP
 #
-# El bastion corre cloud-sql-proxy como systemd service. El proxy NO usa
-# --auto-iam-authn — solo termina TLS hacia Cloud SQL. La autenticacion del
-# operador al rol Postgres la hace cada laptop pasando su access token como
-# password (libpq IAM auth manual). Eso preserva audit per-usuario en
-# pg_audit, sin que el proxy unifique sesiones bajo el SA del bastion.
+# El bastion corre cloud-sql-proxy como systemd service con --auto-iam-authn.
+# El proxy obtiene el access token del SA `db-bastion-sa` y lo usa como
+# password al backend Postgres. Por lo tanto:
+#
+#   - Todas las conexiones via tunel se autentican contra Postgres como el
+#     rol IAM `db-bastion-sa@booster-ai-494222.iam` (NO como el email del
+#     operador). pg_audit registra la SA, no al humano.
+#   - La trazabilidad per-humano se preserva en Cloud Audit Logs de IAP
+#     (quien abrio el tunel, cuando, desde que IP). Para queries de auditoria
+#     cruzada ver runbook docs/runbooks/audit-bastion-queries.md.
+#
+# Trade-off aceptado en ADR-014: ergonomia (connection string estable
+# `127.0.0.1:5432` para MCP postgres + tooling local) por granularidad de
+# pg_audit. La trazabilidad humana queda en otro plano (IAP logs).
 
 locals {
   # Startup script: instala cloud-sql-proxy v2 + systemd service.
@@ -56,7 +65,7 @@ locals {
     [Service]
     Type=simple
     User=cloud-sql-proxy
-    ExecStart=$PROXY_BIN --address=0.0.0.0 --port=5432 --private-ip ${var.cloudsql_instance_connection_name}
+    ExecStart=$PROXY_BIN --address=0.0.0.0 --port=5432 --private-ip --auto-iam-authn ${var.cloudsql_instance_connection_name}
     Restart=always
     RestartSec=5
     StandardOutput=journal

--- a/scripts/db/README.md
+++ b/scripts/db/README.md
@@ -2,95 +2,170 @@
 
 Setup definitivo de acceso a la DB de producción para operadores humanos.
 
+Patrones de acceso definidos en:
+- **[ADR-013](../../docs/adr/013-database-access-pattern.md)** — patrón 3 capas (humanos / Cloud Run / jobs).
+- **[ADR-014](../../docs/adr/014-cloud-sql-auto-iam-authn-bastion.md)** — `--auto-iam-authn` en bastion para dev local persistente.
+
 ## Filosofía
 
-- **Cloud Run services** se conectan a Cloud SQL vía VPC privada usando el user
-  `booster_app` con password de Secret Manager (`DATABASE_URL`). Eso no cambia.
-- **Operadores humanos** (devs, db admins) se conectan via Cloud SQL Auth Proxy
-  + IAM authentication. Sin passwords manuales, todo via OAuth tokens del
-  Google account.
+| Caso | Mecanismo | Auth | Atribución audit |
+|------|-----------|------|------------------|
+| **Cloud Run services productivos** | VPC connector → Cloud SQL privada | `booster_app` + password Secret Manager | n/a (service-level) |
+| **Dev local recurrente** (psql, MCP postgres, DBeaver, drizzle-kit) | LaunchAgent IAP tunnel persistente → bastion proxy `--auto-iam-authn` | rol Postgres = SA `db-bastion-sa` | IAP audit logs (humano que abrió túnel) |
+| **DDL / migrations / GRANTs / hotfix admin** | `connect.sh AUTH_MODE=password` → `gcloud start-iap-tunnel` ad-hoc → bastion proxy | `booster_app` + password Secret Manager | password mode — atribución manual |
+| **Cloud Run Jobs (one-off ops)** | VPC connector + SA del Cloud Run | misma SA que services | execution log + git SHA |
 
-## Quick start
+El path **dev local recurrente** es el que cambió con ADR-014: connection string fijo, refresh de token transparente, MCP postgres usable como user-scope.
+
+## Quick start — dev local recurrente (ADR-014)
+
+### Una sola vez
 
 ```bash
-# Una vez por sesión de shell (si no tenés gcloud auth):
+# 1. Auth gcloud
 gcloud auth login dev@boosterchile.com
+gcloud config set project booster-ai-494222
 
-# Conectar a la DB e ir a psql interactivo:
-bash scripts/db/connect.sh
+# 2. Verificar que terraform apply ya aplicó los cambios del ADR-014
+gcloud sql users list --instance=$(gcloud sql instances list --format='value(name)' | head -1) \
+  | grep db-bastion-sa  # debe aparecer como CLOUD_IAM_SERVICE_ACCOUNT
 
-# Ejecutar un archivo SQL:
-bash scripts/db/connect.sh -f scripts/sql/2026-05-02-merge-fvicencio-users.sql
+# 3. Aplicar GRANTs al rol nuevo (booster_app + password mode)
+bash scripts/db/connect.sh AUTH_MODE=password \
+  -f scripts/sql/2026-05-03-grant-bastion-sa.sql
+
+# 4. Instalar LaunchAgent (requiere editar el plist con paths absolutos primero)
+GCLOUD_BIN=$(which gcloud)
+sed "s|__GCLOUD_BIN__|${GCLOUD_BIN}|g; s|__ABSOLUTE_PATH__|$(pwd)|g" \
+  scripts/db/iap-tunnel.plist.template \
+  > ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+
+launchctl load -w ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+
+# 5. Verificar
+bash scripts/db/connect-local.sh status
+# → ✓ tunel activo en 127.0.0.1:5432
+
+# 6. Setup MCP postgres user-scope (Claude Code Desktop / CLI)
+claude mcp remove postgres 2>/dev/null || true
+claude mcp add postgres --scope user -- \
+  npx -y @modelcontextprotocol/server-postgres \
+  "postgresql://db-bastion-sa%40booster-ai-494222.iam:dummy@127.0.0.1:5432/booster_ai?sslmode=disable"
 ```
 
-## Cómo funciona
-
-1. Detecta si `cloud-sql-proxy` y `psql` están instalados, sino los instala
-   con `brew`.
-2. Verifica `gcloud auth` activo.
-3. Detecta si la instancia tiene IAM auth habilitada (`database_flags.cloudsql.iam_authentication`).
-   - **Sí (post `terraform apply` con el nuevo flag):** lanza el proxy con
-     `--auto-iam-authn`, conecta como tu user IAM (`dev@boosterchile.com`)
-     sin password.
-   - **No (legacy):** lee `DATABASE_URL` de Secret Manager, parsea
-     user/password de `booster_app`, conecta con eso.
-4. Lanza el proxy en background al puerto local 5433.
-5. Abre `psql` (o ejecuta el `.sql` que pasaste con `-f`).
-6. Cleanup del proxy al exit (incluye Ctrl+C).
-
-## Configuración
-
-Override con env vars:
+### Uso diario
 
 ```bash
-LOCAL_PORT=5434 bash scripts/db/connect.sh   # otro puerto
-DB_NAME=postgres bash scripts/db/connect.sh  # otra DB
-AUTH_MODE=password bash scripts/db/connect.sh # forzar password mode
+# psql interactivo (rol = SA del bastion, permisos: SELECT/INSERT/UPDATE/DELETE)
+bash scripts/db/connect-local.sh psql
+
+# Una query rápida
+bash scripts/db/connect-local.sh -c "SELECT count(*) FROM mensajes_chat"
+
+# Un script SQL (queries de exploración, no DDL)
+bash scripts/db/connect-local.sh -f scripts/sql/exploration-2026-05-03.sql
+
+# Estado del túnel
+bash scripts/db/connect-local.sh status
 ```
+
+El MCP postgres queda funcionando 24/7 mientras el LaunchAgent esté cargado.
+
+## Quick start — admin / DDL / migrations (`connect.sh` legacy)
+
+Para operaciones que requieren `CREATE/ALTER/DROP/TRUNCATE` o cambiar passwords, usar el script clásico en password mode:
+
+```bash
+# psql como booster_app (acceso completo)
+AUTH_MODE=password bash scripts/db/connect.sh
+
+# Aplicar una migration
+AUTH_MODE=password bash scripts/db/connect.sh -f scripts/sql/2026-05-03-add-column.sql
+```
+
+Este script levanta el túnel ad-hoc, conecta como `booster_app` (password de Secret Manager), y limpia el túnel al exit. **No usa** el LaunchAgent.
+
+## Connection string para tooling externo
+
+DBeaver / DataGrip / `psql` standalone / drizzle-kit / cualquier MCP postgres:
+
+```
+Host:       127.0.0.1
+Port:       5432
+Database:   booster_ai
+Username:   db-bastion-sa@booster-ai-494222.iam
+Password:   dummy   (literalmente — el proxy del bastion lo ignora)
+SSL Mode:   disable
+```
+
+URL completa:
+```
+postgresql://db-bastion-sa%40booster-ai-494222.iam:dummy@127.0.0.1:5432/booster_ai?sslmode=disable
+```
+
+(`%40` es `@` URL-encoded — necesario porque el username contiene `@`)
 
 ## Agregar más operadores
 
-Editar `infrastructure/data.tf`:
+Editar `infrastructure/data.tf` `local.db_iam_operators` con el nuevo email, `terraform apply`. Eso le da acceso a abrir el túnel IAP via su gcloud auth. **Una vez abierto el túnel**, el operador queda atribuido en IAP audit logs y puede consumir el proxy del bastion (que autentica como SA al backend Postgres).
 
 ```hcl
 locals {
   db_iam_operators = [
     "dev@boosterchile.com",
-    "nuevo-operador@boosterchile.com",
+    "nuevo@boosterchile.com",
   ]
 }
 ```
 
-Después `terraform apply`. Eso crea:
-- `google_sql_user` tipo `CLOUD_IAM_USER` para el email
-- Bindings IAM `roles/cloudsql.client` + `roles/cloudsql.instanceUser`
-
-El nuevo operador clona el repo, corre `gcloud auth login`, listo.
-
-## Permisos del IAM user dentro de Postgres
-
-Por default el `CLOUD_IAM_USER` solo tiene `CONNECT` a la DB. Para hacer
-queries necesitás GRANT explícito una vez:
-
-```sql
-GRANT CONNECT ON DATABASE booster_ai TO "dev@boosterchile.com";
-GRANT USAGE ON SCHEMA public TO "dev@boosterchile.com";
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO "dev@boosterchile.com";
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO "dev@boosterchile.com";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "dev@boosterchile.com";
-ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO "dev@boosterchile.com";
-```
-
-Esto se corre **una sola vez** desde un user con permisos de admin (postgres
-o booster_app) tras crear el IAM user.
+El operador nuevo clona el repo, corre `gcloud auth login`, instala el LaunchAgent (5 min de setup), listo.
 
 ## Troubleshooting
 
-- **"could not connect to server: Connection refused"** — el proxy no se
-  levantó. Ver el log que imprime el script y verificar IAM permissions.
-- **"FATAL: Cloud SQL IAM user authentication failed"** — el user IAM no
-  tiene los roles. `terraform apply` para crear los bindings.
-- **"role 'dev@boosterchile.com' is not permitted to log in"** — el user
-  IAM no fue creado. `terraform apply` (resource `google_sql_user.iam_operators`).
-- **El usuario IAM puede conectar pero no SELECT** — falta el GRANT (ver
-  arriba).
+### Connection refused en `127.0.0.1:5432`
+
+```bash
+bash scripts/db/connect-local.sh status
+# → si dice "no hay tunel listening", el LaunchAgent murió
+launchctl list | grep com.booster.db-iap-tunnel  # ver status
+launchctl unload ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+launchctl load -w ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+tail -f /tmp/booster-iap-tunnel.stderr.log  # ver por qué murió
+```
+
+### `FATAL: pg_hba.conf rejects connection`
+
+El rol `db-bastion-sa@booster-ai-494222.iam` no existe en Postgres. Verificar:
+1. `terraform apply` corrió tras el merge del PR del ADR-014.
+2. `gcloud sql users list` muestra el SA como `CLOUD_IAM_SERVICE_ACCOUNT`.
+3. El proxy del bastion fue reiniciado tras el cambio del systemd unit:
+   ```bash
+   gcloud compute ssh db-bastion --zone=southamerica-west1-a --tunnel-through-iap \
+     --command="sudo systemctl restart cloud-sql-proxy && systemctl status cloud-sql-proxy"
+   ```
+
+### `permission denied for table X` desde MCP / psql con SA
+
+GRANTs no aplicados. Correr `scripts/sql/2026-05-03-grant-bastion-sa.sql` con `AUTH_MODE=password`.
+
+### El access token "expira" — queries fallan tras horas
+
+No deberían — el proxy del bastion refresca tokens automáticamente vía metadata service. Si pasa, es bug del proxy o del LaunchAgent. Reiniciar:
+```bash
+launchctl kickstart -k gui/$(id -u)/com.booster.db-iap-tunnel
+gcloud compute ssh db-bastion --tunnel-through-iap --command="sudo systemctl restart cloud-sql-proxy"
+```
+
+### Quiero ver quién corrió una query concreta
+
+`pg_audit` mostrará todo como `db-bastion-sa@...`. Cruzar con IAP audit log:
+
+```bash
+gcloud logging read \
+  'resource.type="iap_tunnel_dest_group" AND timestamp>="2026-05-03T15:00:00Z"' \
+  --project=booster-ai-494222 \
+  --format='table(timestamp,protoPayload.authenticationInfo.principalEmail)' \
+  --limit=20
+```
+
+Cruza con timestamp de la query en `pg_audit` para inferir el humano. Para análisis forense recurrente, escribir un runbook en `docs/runbooks/audit-bastion-queries.md`.

--- a/scripts/db/connect-local.sh
+++ b/scripts/db/connect-local.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Booster AI — IAP tunnel persistente para Cloud SQL (ADR-014)
+# =============================================================================
+# Mantiene un IAP TCP tunnel de la laptop al bastion, exponiendo el proxy
+# del bastion (cloud-sql-proxy --auto-iam-authn) en 127.0.0.1:5432 local.
+#
+# Uso:
+#   bash scripts/db/connect-local.sh                # solo asegura tunel arriba
+#   bash scripts/db/connect-local.sh psql           # tunel + abre psql
+#   bash scripts/db/connect-local.sh -c "SELECT 1"  # tunel + ejecuta query
+#   bash scripts/db/connect-local.sh status         # estado del tunel
+#   bash scripts/db/connect-local.sh stop           # mata tunel temporal
+#
+# Recomendado: cargar el LaunchAgent (scripts/db/iap-tunnel.plist.template)
+# para que el tunel arranque al boot del Mac y reviva si muere. En ese caso
+# este script solo verifica que el LaunchAgent esta vivo.
+#
+# Connection string para tooling local (MCP postgres, DBeaver, drizzle-kit):
+#   postgresql://db-bastion-sa%40booster-ai-494222.iam:dummy@127.0.0.1:5432/booster_ai?sslmode=disable
+#
+# El `dummy` password se ignora — cloud-sql-proxy en bastion lo reemplaza por
+# el access token del SA. sslmode=disable porque IAP TCP cifra el segmento
+# laptop↔bastion y el proxy cifra bastion↔Cloud SQL.
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-booster-ai-494222}"
+ZONE="${ZONE:-southamerica-west1-a}"
+BASTION_NAME="${BASTION_NAME:-db-bastion}"
+LOCAL_PORT="${LOCAL_PORT:-5432}"
+DB_NAME="${DB_NAME:-booster_ai}"
+SA_USER="db-bastion-sa@booster-ai-494222.iam"
+PID_FILE="${TMPDIR:-/tmp}/booster-iap-tunnel.pid"
+LOG_FILE="${TMPDIR:-/tmp}/booster-iap-tunnel.log"
+
+# ------------------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------------------
+tunnel_listening() {
+  (echo > "/dev/tcp/127.0.0.1/${LOCAL_PORT}") 2>/dev/null
+}
+
+tunnel_pid_alive() {
+  [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null
+}
+
+start_tunnel() {
+  if tunnel_listening; then
+    echo "→ tunel ya activo en 127.0.0.1:${LOCAL_PORT} (probablemente LaunchAgent)"
+    return 0
+  fi
+
+  if ! command -v gcloud >/dev/null 2>&1; then
+    echo "✗ gcloud no instalado." >&2
+    exit 1
+  fi
+
+  if [[ -z "$(gcloud config get-value account 2>/dev/null || echo)" ]]; then
+    echo "✗ No hay gcloud auth activa. Corré: gcloud auth login" >&2
+    exit 1
+  fi
+
+  echo "→ levantando IAP tunnel a ${BASTION_NAME} (${ZONE})…"
+  nohup gcloud compute start-iap-tunnel "$BASTION_NAME" 5432 \
+    --local-host-port="127.0.0.1:${LOCAL_PORT}" \
+    --zone="$ZONE" \
+    --project="$PROJECT_ID" \
+    >"$LOG_FILE" 2>&1 &
+  echo $! > "$PID_FILE"
+
+  for _ in $(seq 1 30); do
+    if tunnel_listening; then
+      echo "  tunel listo (pid $(cat "$PID_FILE"))"
+      return 0
+    fi
+    if ! tunnel_pid_alive; then
+      echo "✗ tunel murio. Log:" >&2
+      cat "$LOG_FILE" >&2
+      rm -f "$PID_FILE"
+      exit 1
+    fi
+    sleep 1
+  done
+  echo "✗ tunel no quedo listening tras 30s. Log:" >&2
+  cat "$LOG_FILE" >&2
+  exit 1
+}
+
+stop_tunnel() {
+  if tunnel_pid_alive; then
+    kill "$(cat "$PID_FILE")" 2>/dev/null || true
+    wait "$(cat "$PID_FILE")" 2>/dev/null || true
+    rm -f "$PID_FILE"
+    echo "→ tunel temporal detenido"
+  else
+    echo "→ no hay tunel temporal corriendo (¿LaunchAgent activo?)"
+  fi
+}
+
+status() {
+  if tunnel_listening; then
+    if tunnel_pid_alive; then
+      echo "✓ tunel temporal activo (pid $(cat "$PID_FILE")) en 127.0.0.1:${LOCAL_PORT}"
+    else
+      echo "✓ tunel activo en 127.0.0.1:${LOCAL_PORT} (no manejado por este script — probablemente LaunchAgent)"
+    fi
+  else
+    echo "✗ no hay tunel listening en 127.0.0.1:${LOCAL_PORT}"
+    exit 1
+  fi
+}
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+case "${1:-up}" in
+  up)
+    start_tunnel
+    echo
+    echo "Connection string:"
+    echo "  postgresql://${SA_USER//@/%40}:dummy@127.0.0.1:${LOCAL_PORT}/${DB_NAME}?sslmode=disable"
+    ;;
+  status)
+    status
+    ;;
+  stop)
+    stop_tunnel
+    ;;
+  psql)
+    start_tunnel
+    if ! command -v psql >/dev/null 2>&1; then
+      echo "✗ psql no encontrado. brew install libpq && brew link --force libpq" >&2
+      exit 1
+    fi
+    PGPASSWORD=dummy psql -h 127.0.0.1 -p "$LOCAL_PORT" -U "$SA_USER" -d "$DB_NAME"
+    ;;
+  -c|-f)
+    start_tunnel
+    PGPASSWORD=dummy psql -h 127.0.0.1 -p "$LOCAL_PORT" -U "$SA_USER" -d "$DB_NAME" "$@"
+    ;;
+  -h|--help|help)
+    sed -n '2,30p' "$0"
+    ;;
+  *)
+    echo "uso: $0 [up|status|stop|psql|-c '<query>'|-f <file.sql>|help]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/db/iap-tunnel.plist.template
+++ b/scripts/db/iap-tunnel.plist.template
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Booster AI — LaunchAgent de macOS para mantener el IAP tunnel persistente.
+  ADR-014 — `cloud-sql-proxy --auto-iam-authn` corre en el bastion; este
+  LaunchAgent solo levanta el tunel IAP en la laptop para que 127.0.0.1:5432
+  apunte al proxy del bastion en todo momento.
+
+  Instalacion (una sola vez):
+    1. Reemplazar TODOS los placeholders __ABSOLUTE_PATH__ con el path real
+       del clone (ej. /Users/fvicencio/dev/booster-ai). NO usar ~ — launchd
+       no lo expande.
+    2. Reemplazar __GCLOUD_BIN__ con el resultado de `which gcloud`
+       (tipicamente /opt/homebrew/bin/gcloud o /usr/local/bin/gcloud).
+    3. Copiar a ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+    4. launchctl load -w ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+    5. Verificar:
+         launchctl list | grep com.booster.db-iap-tunnel
+         bash scripts/db/connect-local.sh status
+
+  Reload tras cambio de plist:
+    launchctl unload ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+    launchctl load -w ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+
+  Uninstall:
+    launchctl unload ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+    rm ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist
+
+  Logs:
+    tail -f /tmp/booster-iap-tunnel.stdout.log
+    tail -f /tmp/booster-iap-tunnel.stderr.log
+
+  Por que NO se hace `cloud-sql-proxy local`:
+    Cloud SQL es private-IP only sin PSC. El proxy local no tiene ruta al
+    backend. ADR-014 mueve el proxy al bastion (con --auto-iam-authn) y la
+    laptop solo necesita el tunel IAP. El connection string queda fijo:
+      postgresql://db-bastion-sa%40booster-ai-494222.iam:dummy@127.0.0.1:5432/booster_ai?sslmode=disable
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.booster.db-iap-tunnel</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__GCLOUD_BIN__</string>
+        <string>compute</string>
+        <string>start-iap-tunnel</string>
+        <string>db-bastion</string>
+        <string>5432</string>
+        <string>--local-host-port=127.0.0.1:5432</string>
+        <string>--zone=southamerica-west1-a</string>
+        <string>--project=booster-ai-494222</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>NetworkState</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/booster-iap-tunnel.stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/booster-iap-tunnel.stderr.log</string>
+
+    <key>WorkingDirectory</key>
+    <string>__ABSOLUTE_PATH__</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>CLOUDSDK_PYTHON</key>
+        <string>/usr/bin/python3</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/sql/2026-05-03-grant-bastion-sa.sql
+++ b/scripts/sql/2026-05-03-grant-bastion-sa.sql
@@ -1,0 +1,58 @@
+-- =============================================================================
+-- 2026-05-03 — GRANT al rol IAM SA del bastion (ADR-014)
+-- =============================================================================
+-- Cuando cloud-sql-proxy en el bastion corre con --auto-iam-authn, todas las
+-- conexiones via IAP tunnel se autentican como la SA `db-bastion-sa`. Postgres
+-- crea automaticamente el rol al primer login (porque la SA esta registrada
+-- como CLOUD_IAM_SERVICE_ACCOUNT en data.tf), pero sin grants ese rol no
+-- puede leer/escribir nada.
+--
+-- Este script aplica los privilegios minimos para el flujo dev local:
+--   - CONNECT a la DB
+--   - USAGE en schema public
+--   - SELECT/INSERT/UPDATE/DELETE en tablas existentes
+--   - USAGE+SELECT en sequences (para inserts con SERIAL)
+--   - DEFAULT PRIVILEGES para que tablas/sequences nuevas hereden permisos
+--
+-- DDL (CREATE/DROP/ALTER) queda DELIBERADAMENTE FUERA. Migrations corren con
+-- booster_app (password mode) — el rol SA del bastion es solo para queries
+-- de lectura y escritura puntual. Esto limita el blast radius de un error
+-- humano via psql/MCP.
+--
+-- Como aplicar (una sola vez post terraform apply):
+--   bash scripts/db/connect.sh AUTH_MODE=password \
+--     -f scripts/sql/2026-05-03-grant-bastion-sa.sql
+--
+-- Idempotente: GRANT no falla si los privilegios ya estan asignados.
+
+\set ON_ERROR_STOP on
+
+-- El nombre del rol IAM SERVICE ACCOUNT en Postgres es el email del SA SIN
+-- el sufijo `.gserviceaccount.com` (convencion Cloud SQL). El rol existe
+-- porque `google_sql_user.bastion_sa` esta declarado en data.tf.
+\set bastion_sa '"db-bastion-sa@booster-ai-494222.iam"'
+
+GRANT CONNECT ON DATABASE booster_ai TO :bastion_sa;
+GRANT USAGE ON SCHEMA public TO :bastion_sa;
+
+GRANT SELECT, INSERT, UPDATE, DELETE
+  ON ALL TABLES IN SCHEMA public
+  TO :bastion_sa;
+
+GRANT USAGE, SELECT
+  ON ALL SEQUENCES IN SCHEMA public
+  TO :bastion_sa;
+
+-- Default privileges: aplica automaticamente a tablas/sequences nuevas
+-- creadas por booster_app (el owner de la DB tras migrations).
+ALTER DEFAULT PRIVILEGES FOR ROLE booster_app IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO :bastion_sa;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE booster_app IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO :bastion_sa;
+
+-- Smoke test al final: si llegamos aca sin error, el rol puede leer.
+SELECT current_user AS executing_as,
+       current_database() AS db,
+       (SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public') AS public_tables,
+       'GRANTs aplicados a ' || :'bastion_sa' AS status;


### PR DESCRIPTION
## Resumen

**ADR-014** — Mueve `--auto-iam-authn` al `cloud-sql-proxy` que corre en el bastion. La laptop solo levanta un IAP TCP tunnel persistente vía LaunchAgent. Resultado: connection string fijo (`127.0.0.1:5432`) para MCP postgres + DBeaver + drizzle-kit + psql, refresh de token transparente, sin perder cada hora.

Supersede sección "Capa 1 — Acceso humano" del [ADR-013](../blob/feat/cloud-sql-proxy-iap/docs/adr/013-database-access-pattern.md).

**Trade-off aceptado**: queries en `pg_audit` quedan atribuidas a la SA del bastion (`db-bastion-sa@booster-ai-494222.iam`). La trazabilidad per-humano vive en Cloud Audit Logs de IAP (quién abrió el túnel).

## Cambios

| Archivo | Tipo |
|---------|------|
| `infrastructure/modules/iap-bastion/main.tf` | edit — `--auto-iam-authn` en systemd unit + comments |
| `infrastructure/iam.tf` | edit — `roles/cloudsql.instanceUser` añadido a `db_bastion_roles` |
| `infrastructure/data.tf` | edit — `google_sql_user.bastion_sa` (CLOUD_IAM_SERVICE_ACCOUNT) |
| `docs/adr/014-cloud-sql-auto-iam-authn-bastion.md` | new — decisión + alternativas + plan |
| `scripts/db/connect-local.sh` | new — wrapper IAP tunnel (status/up/stop/psql) |
| `scripts/db/iap-tunnel.plist.template` | new — LaunchAgent macOS template |
| `scripts/sql/2026-05-03-grant-bastion-sa.sql` | new — GRANTs CONNECT/USAGE/CRUD al rol SA |
| `scripts/db/README.md` | rewrite — tabla de patrones + quick start dev/admin + troubleshooting |
| `CLAUDE.md` | edit — sección "DB Access Patterns" |

## Steps que Felipe ejecuta en Mac (post-merge)

> Necesito el output del paso 1 antes de que arranquemos los siguientes — para confirmar que `terraform plan` no trae sorpresas más allá del scope esperado.

### 1. Terraform plan + apply

```bash
cd infrastructure
terraform fmt   # corrijo si dejé algo mal formateado
terraform plan
# Espero ver:
#   ~ google_compute_instance.bastion (in-place: metadata_startup_script)
#   ~ google_project_iam_member.db_bastion_bindings["roles/cloudsql.instanceUser"] (create)
#   + google_sql_user.bastion_sa (create)
terraform apply
```

### 2. Restart systemd del proxy en bastion

(El cambio en `metadata_startup_script` no reinicia la VM ni reescribe el unit — solo se aplicaría en próximo boot. Forzamos restart manual.)

```bash
gcloud compute ssh db-bastion \
  --zone=southamerica-west1-a \
  --tunnel-through-iap \
  --command='sudo bash /var/run/google.startup.script; sudo systemctl restart cloud-sql-proxy; sudo systemctl status cloud-sql-proxy --no-pager'

# Verificar el ExecStart en la unidad nueva:
gcloud compute ssh db-bastion --tunnel-through-iap \
  --command='grep ExecStart /etc/systemd/system/cloud-sql-proxy.service'
# Debe contener: --auto-iam-authn
```

### 3. Aplicar GRANTs SQL al rol SA

(Requiere `connect.sh` en password mode porque es DDL/GRANT que necesita admin.)

```bash
AUTH_MODE=password bash scripts/db/connect.sh \
  -f scripts/sql/2026-05-03-grant-bastion-sa.sql

# Verificar:
AUTH_MODE=password bash scripts/db/connect.sh \
  -c '\du "db-bastion-sa@booster-ai-494222.iam"'
```

### 4. Instalar LaunchAgent

```bash
GCLOUD_BIN=$(which gcloud)
sed "s|__GCLOUD_BIN__|${GCLOUD_BIN}|g; s|__ABSOLUTE_PATH__|$(pwd)|g" \
  scripts/db/iap-tunnel.plist.template \
  > ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist

launchctl load -w ~/Library/LaunchAgents/com.booster.db-iap-tunnel.plist

# Verificar:
bash scripts/db/connect-local.sh status
# Debe imprimir: ✓ tunel activo en 127.0.0.1:5432
```

### 5. Smoke test query como SA

```bash
bash scripts/db/connect-local.sh -c "SELECT current_user, count(*) FROM mensajes_chat"
# Debe devolver:
#   current_user                                  | count
#   db-bastion-sa@booster-ai-494222.iam           | <N>
```

### 6. Configurar MCP postgres user-scope

```bash
claude mcp remove postgres 2>/dev/null || true
claude mcp add postgres --scope user -- \
  npx -y @modelcontextprotocol/server-postgres \
  "postgresql://db-bastion-sa%40booster-ai-494222.iam:dummy@127.0.0.1:5432/booster_ai?sslmode=disable"

claude mcp list  # confirmar postgres connected
```

### 7. Smoke test 1+ hora (sobrevive expiry de token)

Dejar el LaunchAgent corriendo. Volver al rato y correr otra query — debe funcionar sin re-auth.

## Notas para revisión

- **`terraform fmt`** no se corrió en este branch (no hay `terraform` en el sandbox del agente). Felipe corre antes del apply.
- **No toca código de apps** (solo TF + scripts + docs). CI debería pasar Gitleaks; npm audit/Trivy/SBOM seguirán failing por las CVEs pre-existentes ya documentadas en el PR #19.
- **El `connect.sh` legacy queda** como modo `AUTH_MODE=password` para DDL. El modo `iam` del script queda efectivamente deprecated (no se elimina en este PR para no romper memoria muscular; se puede deprecar formal en sprint próximo si conviene).
- **Branch separado del PR #19** (handoff Claude.ai → Claude Code) — sin conflictos, mergeables independientes.

## Test plan

- [ ] `terraform plan` muestra solo los 3 cambios esperados (in-place bastion metadata, +cloudsql.instanceUser binding, +bastion_sa user)
- [ ] `terraform apply` éxito sin warnings
- [ ] Restart systemd del proxy: `ExecStart` contiene `--auto-iam-authn`
- [ ] GRANTs SQL aplicados sin error, `\du` muestra el rol SA con privilegios
- [ ] LaunchAgent cargado, `connect-local.sh status` da OK
- [ ] Smoke query como SA devuelve count
- [ ] MCP postgres connected en `claude mcp list`
- [ ] Query desde Claude Code Desktop funciona
- [ ] Espera 65+ min, query funciona sin re-auth (token refresh transparente)

https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR)_