### PR TITLE
docs(adr): backfill ADRs 015-019 (KMS, Web Push, SSE, Pub/Sub bus, Workbox)

### DIFF
--- a/docs/adr/015-kms-pkcs1-rsa-4096-sha256-certificates.md
+++ b/docs/adr/015-kms-pkcs1-rsa-4096-sha256-certificates.md
@@ -1,0 +1,107 @@
+# ADR-015 — KMS RSA PKCS#1 v1.5 4096-SHA256 para certificados de huella de carbono
+
+- **Estado**: Accepted
+- **Fecha**: 2026-04-29 (decisión); 2026-05-03 (ADR escrito retroactivo)
+- **Decisores**: Felipe Vicencio (Product Owner)
+- **Supersede**: —
+
+## Contexto
+
+Booster AI emite certificados firmados de huella de carbono cuando un viaje pasa a `entregado`. El certificado es un **PDF firmado digitalmente** con metadata GLEC v3.0 (factor de emisión, distancia, masa transportada, tCO₂eq calculadas, factor de carga). El archivo lo guarda Cloud Storage y queda accesible públicamente para que cualquier auditor externo (stakeholder ESG, comprador con compromiso scope 3, regulador) pueda **validar la firma criptográficamente sin depender de Booster AI**.
+
+Esto exige tres propiedades simultáneas:
+
+1. **No-repudiable**: la firma debe ser verificable contra una public key pública, sin revelar el material privado.
+2. **Auditable a 10 años mínimo**: una vez emitido el certificado, las firmas deben seguir verificables aunque rote la key. Los algoritmos elegidos deben mantenerse como standards reconocidos por NIST/ISO durante esa ventana.
+3. **Interoperabilidad universal**: el auditor externo abre el PDF en Adobe Reader / valida con OpenSSL en CLI / corre verificación con Java JCE en su pipeline ESG / usa node-forge / usa Bouncy Castle. Todos deben poder validar sin parámetros extra.
+
+El espacio de decisión tenía dos ejes:
+
+- **Padding scheme**: PSS (PKCS#1 v2.1) vs PKCS#1 v1.5
+- **Curve / key size**: RSA 4096 vs RSA 2048 vs ECDSA P-256 vs ECDSA P-384 vs Ed25519
+
+## Decisión
+
+Usar **RSA con padding PKCS#1 v1.5, 4096 bits, SHA-256** para firmar los certificados de carbono. La key es una `google_kms_crypto_key` con `purpose = "ASYMMETRIC_SIGN"` y `algorithm = "RSA_SIGN_PKCS1_4096_SHA256"` (`infrastructure/security.tf:68-81`).
+
+Características concretas:
+
+- **Padding PKCS#1 v1.5** (no PSS).
+- **4096 bits** (no 2048).
+- **SHA-256** como hash subyacente.
+- **Determinístico**: misma firma para mismo input — propiedad útil para auditores que reverifican meses después.
+- **Key dedicada**: separada de `document_signing` (que firma actas de entrega y DTEs con SHA-512). Cada propósito su key, audit trail limpio.
+- **IAM least-privilege**: solo el SA `cloud_run_runtime` tiene `roles/cloudkms.signerVerifier` y `roles/cloudkms.publicKeyViewer` sobre esta key específica (`security.tf:87-100`). Sin signing global sobre el keyring.
+- **Public key pública**: el endpoint `GET /certificates/:tracking_code/verify` (Hono, server.ts:251-262) sirve la public key PEM + metadata sin auth. Mismo patrón que `webfinger`/`jwks` para que cualquier auditor externo pueda validar con `openssl dgst -sha256 -verify pubkey.pem -signature sig.bin certificado.pdf`.
+
+## Alternativas consideradas y rechazadas
+
+### A. RSA-PSS 4096 SHA-256 (PKCS#1 v2.1)
+
+Propuesta inicial — modernidad criptográfica.
+
+- **Ventajas**: PSS es probabilistic, ofrece reducción de seguridad demostrable, recomendado por RFC 8017 §8.
+- **Por qué se rechazó**: PSS exige especificar `hashAlgorithm + maskGenAlgorithm + saltLength` en el `AlgorithmIdentifier` del cert X.509 y del `SignerInfo` PKCS#7 que encapsula la firma del PDF. Validadores PAdES viejos (Adobe Reader 11, OpenSSL <1.1.1, Java <8u121, node-forge <1.0) no soportan `id-RSASSA-PSS` y rechazan la firma. Para certificados que viven 10+ años en archivos de auditores, romper la verificación con Reader 11 es inaceptable. PKCS#1 v1.5 es **interoperable universalmente** sin parámetros ASN.1 extras.
+- **Nota**: Hay un drift documental — `packages/certificate-generator/src/firmar-kms.ts:24` dice "RSA-PSS 4096 SHA-256 → 512 bytes" en un comentario, pero el algoritmo real declarado en TF es `RSA_SIGN_PKCS1_4096_SHA256`. El comentario quedó del diseño inicial PSS y no se actualizó al pivote a PKCS#1. Tarea follow-up: alinear el comentario con la realidad TF.
+
+### B. RSA 2048 con cualquier padding
+
+- **Por qué se rechazó**: NIST SP 800-131A clasifica 2048 como "secure until 2030". Los certificados de carbono deben verificar a 10 años (hasta 2036+). El upgrade pre-emptivo a 4096 evita re-firmar certificados históricos cuando 2048 entre en deprecation.
+
+### C. ECDSA P-256 / P-384
+
+- **Por qué se rechazó**: ECDSA es **no-determinístico** por naturaleza (cada firma usa un nonce aleatorio). Si la implementación tiene un bug en el RNG (caso histórico: Sony PS3, varias wallets crypto), la key privada queda extraíble. RSA con PKCS#1 v1.5 es determinístico y elimina esa clase entera de vulnerabilidades. El trade-off (firmas de 512 bytes vs ~71 bytes para P-256) es aceptable: un PDF de 200KB con 512 bytes extras es un overhead irrelevante.
+
+### D. Ed25519
+
+- **Por qué se rechazó**: Ed25519 es excelente criptografía pero la interoperabilidad con Adobe PDF es **limitada**. El estándar PAdES (ETSI EN 319 142) no incluye Ed25519 en su lista de algoritmos obligatorios para validadores. Adobe Reader no valida Ed25519 nativamente. Mismo razonamiento que (A): la interoperabilidad gana sobre la elegancia.
+
+### E. Self-signed cert + key local en archivo
+
+- **Por qué se rechazó**: requiere proteger el material privado en algún lado (KMS, HSM, archivo cifrado). KMS es la opción de menor fricción operativa con audit log nativo (`cloudkms.googleapis.com/cryptokey.use`) y rotación gestionada por Google.
+
+## Consecuencias
+
+### Positivas
+
+- **Verificación universal**: cualquier auditor con OpenSSL CLI puede correr `openssl dgst -sha256 -verify pubkey.pem -signature sig.bin payload.bin` sin parámetros extras. Adobe Reader valida la firma del PDF embebido sin warning de "algoritmo no soportado".
+- **Audit trail nativo**: cada llamada a `asymmetricSign` queda en Cloud Audit Logs con timestamp + caller SA + key version. Reconstruible per-certificado.
+- **Rotation friendly**: KMS soporta rotación de versiones manteniendo las viejas como `state=ENABLED` para verificar firmas pasadas. La función `resolverVersionPrimaria` (`firmar-kms.ts:133`) usa la última `ENABLED` para nuevas firmas; las anteriores siguen disponibles para `getPublicKey` con la versión específica.
+- **Performance aceptable**: KMS asymmetric sign tarda ~50ms por firma RSA 4096. Para emitir certificados al final de un viaje (no path crítico de UX), es invisible.
+- **Determinismo**: dos firmas del mismo bytes-input dan exactamente la misma firma — útil para tests E2E que comparan output, y para auditores que reverifican semanas después.
+
+### Negativas
+
+- **Tamaño de firma**: 512 bytes vs 71 bytes (ECDSA P-256). Trivial en un PDF.
+- **PKCS#1 v1.5 es "viejo"**: no es la moda criptográfica actual. Algunos auditores ESG sofisticados pueden objetar "¿por qué no PSS?". Se responde con este ADR — la decisión es deliberada por interop.
+- **CRC32C del transporte**: KMS retorna CRC32C del digest enviado. La librería valida (`firmar-kms.ts:78-80`) — sin esto, un bit-flip en red produciría un PDF "firmado" pero inválido al verificar. Costo: 1 línea de código defensivo.
+
+### Riesgos abiertos
+
+- **Quantum-resistant**: RSA 4096 cae con Shor's algorithm cuando exista una computadora cuántica con miles de qubits lógicos. Estimaciones actuales: 10-20 años. Si el horizonte de auditoría se extiende (ej. carbon credits con vida 30 años), evaluar migrar a NIST PQC (Dilithium / Falcon) cuando estén estandarizados en KMS. Tarea de revisión: 2030.
+- **PDF/A-3 compliance**: certificados archivables a largo plazo requieren PDF/A. La firma PAdES sobre PDF/A-3 es soportada por la stack actual (`packages/certificate-generator/src/firmar-pades.ts` + `@signpdf/signpdf`). Verificar en E2E al menos una vez que un PDF emitido pasa `verapdf` validation.
+
+## Implementación (estado actual)
+
+| # | Ítem | Archivo | Estado |
+|---|------|---------|--------|
+| 1 | KMS keyring + key | `infrastructure/security.tf:9-81` | ✅ aplicado |
+| 2 | IAM bindings (signerVerifier + publicKeyViewer) sobre la key específica | `infrastructure/security.tf:87-100` | ✅ aplicado |
+| 3 | Env var `CERTIFICATE_SIGNING_KEY_ID` en Cloud Run api | `infrastructure/compute.tf:111` | ✅ aplicado |
+| 4 | Wrapper de KMS sign con CRC32C check + version resolution | `packages/certificate-generator/src/firmar-kms.ts` | ✅ commiteado |
+| 5 | Endpoint público `GET /certificates/:tracking_code/verify` | `apps/api/src/server.ts:251-262` | ✅ commiteado |
+| 6 | Service `emitirCertificadoViaje` (idempotente) | `apps/api/src/services/emitir-certificado-viaje.ts` | ✅ commiteado |
+| 7 | Job de backfill para certificados históricos | `apps/api/src/jobs/backfill-certificados.ts` | ✅ commiteado |
+| 8 | **Drift documental — alinear comentario `firmar-kms.ts:24`** ("RSA-PSS" → "PKCS#1 v1.5") | `packages/certificate-generator/src/firmar-kms.ts` | ⏳ follow-up |
+| 9 | Validar PDF/A-3 + PAdES con `verapdf` en CI | tooling | 📅 backlog |
+
+## Referencias
+
+- `infrastructure/security.tf:49-67` — comentario inline que motiva la decisión
+- `packages/certificate-generator/src/firmar-kms.ts` — implementación
+- `packages/certificate-generator/src/firmar-pades.ts` — capa PAdES sobre la firma KMS
+- `packages/certificate-generator/src/ca-self-signed.ts` — generación del cert X.509 con la public key KMS
+- NIST SP 800-131A — [Transitioning Cryptographic Algorithms and Key Lengths](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-2/final)
+- RFC 8017 — [PKCS #1 v2.2 (RSA Cryptography Specifications)](https://datatracker.ietf.org/doc/html/rfc8017)
+- ETSI EN 319 142 — [PAdES baseline profile](https://www.etsi.org/deliver/etsi_en/319100_319199/319142/)
+- GLEC Framework v3.0 — métodos de cálculo emisiones logísticas

--- a/docs/adr/016-web-push-vapid-w3c-standard.md
+++ b/docs/adr/016-web-push-vapid-w3c-standard.md
@@ -1,0 +1,116 @@
+# ADR-016 — Web Push estándar (W3C/VAPID) sobre FCM SDK para notificaciones push
+
+- **Estado**: Accepted
+- **Fecha**: 2026-04-30 (decisión); 2026-05-03 (ADR escrito retroactivo)
+- **Decisores**: Felipe Vicencio (Product Owner)
+- **Supersede**: —
+
+## Contexto
+
+El producto necesita notificaciones push al usuario cuando llegan eventos asíncronos relevantes con la PWA cerrada o en background:
+
+- Mensaje de chat nuevo en `assignment` activo (P3.c)
+- Oferta nueva al carrier (B.8)
+- Cambio de estado de viaje (futuro)
+
+Booster AI ya tiene Firebase como auth provider (`identitytoolkit.googleapis.com` activo, Firebase Admin SDK en `apps/api`). Lo natural sería usar **Firebase Cloud Messaging (FCM) cliente-side** con el SDK de `firebase/messaging` en el frontend: `getMessaging(app)` + `onMessage(...)` + `getToken({ vapidKey })`. FCM gestiona delivery, retries, token refresh.
+
+La alternativa es la **Web Push API estándar** del W3C: el browser registra una `PushSubscription` con su propio push service (Chrome usa el endpoint FCM `fcm.googleapis.com/wp/...`, Firefox usa Mozilla autopush, Safari usa Apple), el server firma cada push con un JWT VAPID y lo manda al endpoint con un payload encriptado ECDH. Sin SDK de vendor.
+
+## Decisión
+
+Usar **Web Push API estándar W3C** con autenticación VAPID. Implementación:
+
+- **Cliente** (`apps/web/src/lib/web-push.ts` + `apps/web/src/sw.ts`): llama `serviceWorkerRegistration.pushManager.subscribe({ applicationServerKey: VAPID_PUBLIC_KEY })`, persiste la subscription contra `POST /me/push-subscription` del api.
+- **Server** (`apps/api/src/services/web-push.ts`): usa la lib `web-push` (NPM) que firma el JWT VAPID + encripta el payload con ECDH (p256dh + auth secret del browser). `webpush.sendNotification(subscription, payload)`.
+- **Identidad VAPID**: par RSA generado con `npx web-push generate-vapid-keys`, almacenado en Secret Manager (`webpush-vapid-public-key`, `webpush-vapid-private-key`). Subject `mailto:soporte@boosterchile.com`.
+- **Persistencia**: tabla `push_subscriptions` (1 row por user × device) — ver `apps/api/src/db/schema.ts:991-1050`. Endpoint, p256dh, auth secret, last_used_at, estado (`activa`/`inactiva`).
+- **Service Worker** (`apps/web/src/sw.ts:96-160`): handlers `push` (parsea payload, `showNotification`) y `notificationclick` (deep-link al chat con focus de tab existente o `openWindow`).
+
+## Alternativas consideradas y rechazadas
+
+### A. FCM SDK cliente-side (firebase-messaging)
+
+Importar `firebase/messaging`, llamar `getToken({ vapidKey })`, escuchar con `onMessage`. Server manda push via FCM HTTP v1 API.
+
+- **Por qué se rechazó**:
+  - **Vendor lock blando**: el bundle del frontend crece ~50KB con `firebase/messaging`. Si en el futuro se quisiera mover auth fuera de Firebase (ej. Auth0, Clerk), el código de push también requiere migración aunque conceptualmente sean independientes.
+  - **No funciona en Safari < 16**: FCM Web no soporta Safari ARN (Apple Push). Web Push estándar sí (a partir de Safari 16.4 nativamente, vía `pushManager.subscribe`). Para una app que apunta a logística chilena con muchos usuarios iOS Safari, esto es crítico.
+  - **Token vs subscription**: FCM da un token opaco que el cliente debe rotar manualmente cuando expira (`onTokenRefresh`). Web Push da una subscription completa con endpoint + claves de encriptación; el browser maneja la rotación automáticamente vía `pushsubscriptionchange` event en el SW.
+  - **Granularidad de payload**: FCM cliente-side tiene la limitación que `notification` payload se renderiza por el SDK con UI inflexible; para custom rendering hay que mandar `data` payload y manejarlo en `onMessage` (que solo dispara con app abierta) o en el SW. Web Push estándar siempre va al SW, control total.
+
+### B. APNs / Apple Push Notifications directo
+
+Solo iOS, nativo Apple.
+
+- **Por qué se rechazó**: solo cubre Safari/iOS. No cross-platform. Requiere Apple Developer account + cert APNs ($99/año + onboarding). Web Push estándar cubre Safari 16.4+ sin Apple Developer account porque pasa por el endpoint estándar W3C que Apple expone.
+
+### C. Polling agresivo desde el cliente (cada 30s)
+
+Mismo patrón que el listado de ofertas (`/app/ofertas` poll 30s).
+
+- **Por qué se rechazó**: drena batería del mobile, no funciona con app cerrada (que es exactamente el caso de uso del push), genera tráfico continuo al api por usuario sin valor cuando no hay mensajes nuevos. Para chat realtime sí se complementa con SSE (ver ADR-017), pero NO sustituye push para el caso "tab cerrada".
+
+### D. Twilio Notify / Firebase Functions push
+
+Servicios managed sobre los mismos primitives.
+
+- **Por qué se rechazó**: agrega vendor + costo recurrente. La lib `web-push` de NPM es ~50 líneas de uso, sin estado en el server más allá de la tabla `push_subscriptions`. La complejidad de un servicio managed no se justifica para el volumen actual (1 push por mensaje de chat con tab cerrada).
+
+## Consecuencias
+
+### Positivas
+
+- **Cross-browser nativo**: Chrome, Edge, Firefox, Safari 16.4+, Brave, Vivaldi, Samsung Internet. Same código sirve para todos.
+- **Sin vendor lock cliente**: el bundle del frontend no importa Firebase Messaging. El cliente solo usa la Web Push API del browser (`pushManager`, `Notification`, `ServiceWorkerRegistration`).
+- **Audit trail propio**: cada `sendPushToUser` queda en logs estructurados Pino con `userId`, `assignmentId`, `messageId`, `deliveryResult`. Sin depender del dashboard de FCM.
+- **Token rotation transparente**: el browser maneja `pushsubscriptionchange` automáticamente. El cliente re-postea la nueva subscription a `POST /me/push-subscription` y el endpoint upsertea por `endpoint`.
+- **Encriptación E2E del payload**: el payload viaja encriptado con ECDH al endpoint del push service. Ni Google (push service de Chrome) ni Mozilla (autopush) pueden leer el contenido. Solo el browser del destinatario tiene la `auth` secret necesaria.
+- **Costo operativo**: $0 — todos los push services W3C son free para volúmenes razonables.
+
+### Negativas
+
+- **Sin analytics nativos de delivery**: FCM da dashboard con tasas de entrega/abrir. Acá hay que construirlo desde logs (BigQuery sink ya configurado para `cloudaudit.googleapis.com`, queryable). Para el MVP es overkill construir dashboard; los logs estructurados alcanzan.
+- **Manejo manual de errores**: `web-push` no tiene retry automático. La capa `web-push.ts` debe interpretar el status code:
+  - 401/403 → VAPID inválido (regenerar keys + actualizar Secret Manager).
+  - 410 → subscription revocada (marcar `inactiva` — ya implementado en `apps/api/src/services/web-push.ts`).
+  - 413 → payload too large (>4KB encriptado). Acortar `body`.
+  - 5xx → push service down (reintentar en job nocturno — pendiente).
+- **Permission UX**: el browser muestra el prompt nativo "X quiere mostrarte notificaciones". Conversión típica: 30-50%. UI propia (banner amarillo "Activá las notificaciones…") sube la conversión pidiendo intent antes del prompt nativo.
+- **Safari < 16.4**: usuarios de iOS antiguos no reciben push. Mitigación: la lógica de chat tiene fallback WhatsApp (P3.d) — si el push no se puede entregar (subscription inexistente o iOS legacy), se manda WhatsApp template. Cubre el ~5% que queda fuera.
+
+### Riesgos abiertos
+
+- **Job nocturno de retry para 5xx**: hoy un push que falla con 5xx queda perdido. Necesita un Cloud Run Job que escanee logs de los últimos N min y reintente. Backlog explícito.
+- **Chat unread fallback** (P3.d, `content_sid_chat_unread`): el cron envía WhatsApp template cuando un mensaje queda sin leer >X min. Hoy se ejecuta solo si el push falla; si el push parece exitoso pero el user nunca ve la notif (notif silenciada en SO), no se gatilla el fallback. Tracking de "notif clicked" via `notificationclick` handler quedaría como métrica futura para refinar el threshold del cron.
+
+## Implementación (estado actual)
+
+| # | Ítem | Archivo | Estado |
+|---|------|---------|--------|
+| 1 | Secret Manager — VAPID public + private key (placeholders) | `infrastructure/security.tf:172-174` | ✅ aplicado |
+| 2 | Env vars `WEBPUSH_VAPID_*` montados en Cloud Run api | `infrastructure/compute.tf:137-138` | ✅ aplicado |
+| 3 | Schema Zod para env (todas opcionales — graceful degradation) | `apps/api/src/config.ts:172-178` | ✅ commiteado |
+| 4 | `configureWebPush()` idempotente, log warn si VAPID ausente | `apps/api/src/server.ts:86-97` | ✅ commiteado |
+| 5 | Tabla `push_subscriptions` (Drizzle) | `apps/api/src/db/schema.ts:991-1050` | ✅ commiteado |
+| 6 | Endpoint `POST /me/push-subscription` | `apps/api/src/routes/webpush.ts` | ✅ commiteado |
+| 7 | Endpoint `GET /push/vapid-public-key` (retorna la pública para que el cliente subscribe) | `apps/api/src/routes/webpush.ts:137-150` | ✅ commiteado |
+| 8 | `sendPushToUser()` con manejo de 410 (soft-delete) | `apps/api/src/services/web-push.ts` | ✅ commiteado |
+| 9 | `notifyChatMessageViaPush()` invocado post-INSERT mensaje | `apps/api/src/services/web-push.ts:185+` | ✅ commiteado |
+| 10 | Service Worker — `push` + `notificationclick` handlers | `apps/web/src/sw.ts:96-160` | ✅ commiteado |
+| 11 | Cliente `lib/web-push.ts` — subscribe + post a api | `apps/web/src/lib/web-push.ts` | ✅ commiteado |
+| 12 | Banner UI "Activá notificaciones" en `/app/cargas/:id/track` | `apps/web/src/...` | ✅ commiteado |
+| 13 | Cron retry para 5xx en `web-push.ts` | n/a | ⏳ backlog |
+| 14 | Métrica "notif clicked" desde SW | n/a | 📅 futuro |
+
+## Referencias
+
+- `apps/api/src/services/web-push.ts` — implementación servidor
+- `apps/api/src/routes/webpush.ts` — endpoints subscribe + vapid-public-key
+- `apps/api/src/db/schema.ts:983-1050` — tabla `push_subscriptions`
+- `apps/web/src/sw.ts` — service worker handlers
+- W3C — [Push API specification](https://www.w3.org/TR/push-api/)
+- RFC 8292 — [Voluntary Application Server Identification (VAPID) for Web Push](https://datatracker.ietf.org/doc/html/rfc8292)
+- RFC 8291 — [Message Encryption for Web Push](https://datatracker.ietf.org/doc/html/rfc8291)
+- ADR-017 — SSE para chat realtime (complementario, cubre tab abierta)
+- ADR-008 — PWA multirole (contexto del frontend)

--- a/docs/adr/017-sse-chat-realtime.md
+++ b/docs/adr/017-sse-chat-realtime.md
@@ -1,0 +1,121 @@
+# ADR-017 — Server-Sent Events (SSE) para chat realtime
+
+- **Estado**: Accepted
+- **Fecha**: 2026-04-30 (decisión); 2026-05-03 (ADR escrito retroactivo)
+- **Decisores**: Felipe Vicencio (Product Owner)
+- **Supersede**: —
+
+## Contexto
+
+El chat entre `transportista` y `generador de carga` dentro de una asignación activa necesita propagar mensajes nuevos al receptor en menos de 1 segundo cuando ambos están con la PWA abierta. Casos de uso:
+
+- Driver manda "Llegando en 15 min" → shipper lo ve sin refresh.
+- Shipper manda "Cargá por la puerta C" → driver lo ve sin refresh.
+- Sistema inserta un mensaje (cambio de estado del viaje) → ambos lados lo ven.
+
+El chat **NO** es financial trading: tolerancia a 200-1000ms de latencia, tolerancia a perder un mensaje aislado (que se recupera al refetch). El path crítico para "tab cerrada" lo cubre Web Push (ADR-016) — este ADR es solo para el caso "tab abierta".
+
+Espacio de decisión:
+
+- **WebSocket** (RFC 6455) — bidireccional, full-duplex.
+- **SSE** (HTML5 EventSource) — server-to-client unidireccional.
+- **Long polling** — simulación pre-realtime con HTTP estándar.
+- **Fetch streaming con ReadableStream** — moderno pero soporte browser dispar.
+
+## Decisión
+
+Usar **Server-Sent Events (SSE)** para el push server→cliente. Implementación:
+
+- **Endpoint** `GET /assignments/:id/messages/stream` (Hono, `apps/api/src/routes/...`): `Content-Type: text/event-stream`, mantiene la conexión abierta, escribe `data: {json}\n\n` por cada mensaje nuevo.
+- **Cliente** `apps/web/src/hooks/use-chat-stream.ts`: hook React que abre `new EventSource(url)`, escucha `message`, dispara callback `onMessage` que invalida cache de TanStack Query o appendea al cache local. Reconnect manual con exponential backoff (1s → 2s → 4s → … → 30s max) además del reconnect nativo de EventSource — el nativo a veces "se duerme" en errores transitorios.
+- **Auth**: el endpoint requiere Firebase ID token. Como `EventSource` **no soporta headers custom**, el token va como query param `?auth=<token>`. El middleware `firebase-auth.ts:52` tiene un branch especial para SSE que lee del query string. Trade-off documentado abajo.
+- **Backend del push real**: Pub/Sub topic `chat-messages` + subscription efímera por viewer (ver ADR-018). El handler SSE itera el `AsyncIterable` que devuelve la subscription y stream-ea cada mensaje al cliente.
+
+## Alternativas consideradas y rechazadas
+
+### A. WebSocket (RFC 6455)
+
+Bidireccional, full-duplex, con framing eficiente y headers en el handshake.
+
+- **Por qué se rechazó (para chat)**:
+  - **Cloud Run no soporta WebSocket bien**: hasta 2024 era una limitación dura; en 2025 se habilitó pero con tradeoffs (timeout 60min, una conexión cuenta como una request en términos de billing/quota, instances no scale-down mientras hay sockets abiertos). Para una PWA donde típicamente hay 50-200 viewers concurrent en la región Chile, eso es 50-200 instances permanentes — overhead de costo y complejidad operativa.
+  - **Bidireccionalidad innecesaria**: el chat no necesita bidi para realtime. El cliente envía mensajes via `POST /assignments/:id/messages` (HTTP estándar), y el server le notifica con SSE. WebSocket sería sobre-arquitectura.
+  - **HTTP/2 multiplexing**: SSE corre sobre HTTP/2 normal, comparte conexión TCP con el resto de las requests al api. WebSocket abre una conexión TCP dedicada por socket — desperdicio.
+
+### B. Long polling
+
+`GET /assignments/:id/messages?wait=30s` que bloquea hasta que aparezca un mensaje nuevo o expire el timeout.
+
+- **Por qué se rechazó**: cada poll consume una request slot del cliente y del servidor, no permite el server iniciar el push sin un cliente esperando, y el code en cliente para manejar timeouts + reconnects es más feo que SSE. SSE es lo que se inventó para reemplazar long polling.
+
+### C. Fetch streaming con ReadableStream
+
+`fetch(url).then(res => res.body.getReader())` — moderno, soporta `AbortController` y headers custom (resuelve el trade-off de auth de SSE).
+
+- **Por qué se rechazó**:
+  - Soporte browser dispar — Safari iOS tenía bugs hasta 2024 con streaming responses (gzip, buffering del proxy).
+  - No hay reconnect nativo — todo el código de retry hay que escribirlo.
+  - El stack de Hono no tiene helper específico para fetch streaming; SSE sí (`streamSSE` helper).
+- **Reevaluación futura**: cuando Safari iOS estabilice + el stack tenga primitive native, migrar para eliminar el query param `?auth=`.
+
+### D. Firestore real-time listener (`onSnapshot`)
+
+Aprovechar Firestore que ya está configurado (ADR-005) para `tracking` de viajes.
+
+- **Por qué se rechazó**: requiere duplicar los mensajes de chat en Firestore (costo de write extra + sincronización con Postgres canónico) o mover el storage primario de chat a Firestore (rompe consistencia con el resto de domain en Postgres). Pub/Sub + SSE mantiene el storage canónico en Postgres y solo notifica realtime.
+
+### E. Polling cliente cada 5s
+
+Simple y robusto, pero alto costo de battery + tráfico.
+
+- **Por qué se rechazó (para realtime de chat)**: latencia 5s degrada UX percibido. Pero se mantiene como **fallback** cuando SSE no conecta — `useChatStream` con `enabled: false` y `useQuery` con `refetchInterval` de fondo hace el equivalente.
+
+## Consecuencias
+
+### Positivas
+
+- **Latencia <1s**: empíricamente 200-500ms desde `INSERT` en Postgres hasta render en cliente.
+- **Cloud Run friendly**: SSE consume una request HTTP normal, suma 1 a `concurrency` mientras está abierta, no bloquea autoscaling como WebSocket. Una instance Cloud Run con `concurrency=80` aguanta 80 SSE concurrent sin problema.
+- **Reconnect nativo + manual**: EventSource hace reconnect automático en errores transitorios. El backoff manual del hook cubre los casos donde el nativo falla (server explícitamente cierra, error 401 por token expirado, etc.).
+- **Compatible HTTP/1.1 y HTTP/2**: el LB delante del Cloud Run (Global HTTPS LB con NEGs) hace passthrough sin tocar el stream.
+- **Auth con Firebase token**: aunque va como query param (workaround), el resto del stack reusa el mismo middleware.
+- **Stack mínimo**: Hono `streamSSE` helper + EventSource del browser. ~40 líneas en server, ~80 en cliente.
+
+### Negativas
+
+- **Token Firebase en query string**: el token aparece en logs server + posibles caches de proxies entre cliente y server. Mitigación:
+  - Token Firebase TTL = 1h, scope-bounded.
+  - URL HTTPS only (no MITM en transit).
+  - El cliente que abre el SSE es el mismo cliente que tiene el token — no se filtra a terceros.
+  - Logs estructurados Pino redactan `auth=` con serializer (a verificar en `apps/api/src/middleware/firebase-auth.ts`).
+- **No bidirectional**: para enviar mensaje, cliente hace `POST /messages` separado. UX OK porque el cliente no espera respuesta; pero hay un round-trip extra vs WebSocket.
+- **Buffering de proxies**: si algún proxy intermedio buffer-ea el response, los mensajes llegan en batches. Mitigación: header `X-Accel-Buffering: no` en el response del SSE + Hono `streamSSE` helper que mete keepalive frames cada 15s.
+- **Cleanup en desconexión abrupta**: si el cliente cierra la tab sin disconnect (kill -9 al browser), el handler en server detecta el `request aborted` y limpia la subscription Pub/Sub. Si no detecta, el TTL=24h de la subscription la limpia (ver ADR-018).
+
+### Riesgos abiertos
+
+- **Indicador "Reconectando…"**: ya implementado vía `onConnect`/`onDisconnect` del hook. Bug abierto en task #120 (anotado en HANDOFF.md): a veces el indicador se queda colgado en "Reconectando…" cuando el cliente reconectó pero el callback no se disparó. Investigar.
+- **Migración a fetch streaming**: cuando Safari iOS estabilice + el stack tenga helper native, eliminar el query param `?auth=` y usar headers reales. Backlog.
+- **Multi-region**: hoy todo el stack vive en `southamerica-west1`. Si en el futuro se sirve desde múltiples regiones, las subscriptions Pub/Sub son globales pero la UX se beneficiaría de affinity (cliente conecta SSE a la región más cercana). Out of scope.
+
+## Implementación (estado actual)
+
+| # | Ítem | Archivo | Estado |
+|---|------|---------|--------|
+| 1 | Endpoint `GET /assignments/:id/messages/stream` con `streamSSE` helper de Hono | `apps/api/src/routes/...` | ✅ commiteado |
+| 2 | Branch especial en middleware Firebase Auth para leer `?auth=` query param | `apps/api/src/middleware/firebase-auth.ts:52` | ✅ commiteado |
+| 3 | `createEphemeralChatSubscription()` que devuelve AsyncIterable | `apps/api/src/services/chat-pubsub.ts:83-128` | ✅ commiteado |
+| 4 | Hook `useChatStream` con reconnect exponential backoff | `apps/web/src/hooks/use-chat-stream.ts` | ✅ commiteado |
+| 5 | UI indicator "Conectado" / "Reconectando…" en ChatPanel | `apps/web/src/components/...` | ✅ commiteado (con bug task #120) |
+| 6 | Logs Pino redact de `auth=` | `apps/api/src/middleware/firebase-auth.ts` | ⏳ verificar |
+| 7 | Migración a fetch streaming + headers reales | n/a | 📅 backlog |
+
+## Referencias
+
+- `apps/api/src/services/chat-pubsub.ts` — capa Pub/Sub
+- `apps/api/src/middleware/firebase-auth.ts` — auth con branch SSE
+- `apps/web/src/hooks/use-chat-stream.ts` — cliente SSE
+- HTML5 — [Server-Sent Events specification](https://html.spec.whatwg.org/multipage/server-sent-events.html)
+- MDN — [EventSource interface](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)
+- ADR-016 — Web Push VAPID (cubre tab cerrada — complementario)
+- ADR-018 — Pub/Sub `chat-messages` (mecanismo backend de SSE)

--- a/docs/adr/018-pubsub-chat-messages-bus.md
+++ b/docs/adr/018-pubsub-chat-messages-bus.md
@@ -1,0 +1,113 @@
+# ADR-018 — Pub/Sub `chat-messages` con subscriptions efímeras por viewer como bus interno del chat realtime
+
+- **Estado**: Accepted
+- **Fecha**: 2026-04-30 (decisión); 2026-05-03 (ADR escrito retroactivo)
+- **Decisores**: Felipe Vicencio (Product Owner)
+- **Supersede**: —
+
+## Contexto
+
+ADR-017 estableció **SSE** como el mecanismo client-facing de chat realtime. Falta definir **el bus que conecta** el `INSERT` del mensaje en Postgres con cada SSE viewer abierto:
+
+- Múltiples instancias de Cloud Run api (autoscaling) — el INSERT puede ocurrir en `instance #3` y los SSE viewers conectados pueden estar en `instance #7` y `#11`. Necesitamos un bus que cruce instances.
+- Múltiples viewers concurrent del mismo `assignment` (driver mobile + driver desktop + shipper desktop) — todos deben recibir el mensaje.
+- Filtros server-side: cada SSE solo recibe los mensajes de **su** `assignment_id`, no de los otros 200 chats activos en el sistema.
+
+Booster AI ya tiene **Memorystore Redis** (`infrastructure/data.tf:239+`, ADR-005) para conversation store + caching. Redis pub/sub funcionaría. También está habilitada la **Pub/Sub API** (`project.tf:36`) para telemetry events. ¿Cuál usar para el chat?
+
+## Decisión
+
+Usar **Cloud Pub/Sub** con un topic `chat-messages` y **subscriptions efímeras por viewer** (creadas y borradas en runtime). Implementación:
+
+- **Topic**: `infrastructure/messaging.tf:100-109` — `chat-messages`, retención 1h.
+- **Publish**: `apps/api/src/services/chat-pubsub.ts:48-75` (`publishChatMessage`). Fire-and-forget post-INSERT. Si Pub/Sub falla, el mensaje ya está en DB; los viewers se enteran al próximo refetch.
+- **Subscribe**: `apps/api/src/services/chat-pubsub.ts:83-128` (`createEphemeralChatSubscription`). El handler SSE crea una subscription **única por viewer**, con nombre `chat-sse-{assignmentId}-{uuid8}`, **filter server-side** `attributes.assignment_id = "..."`, **TTL 24h** (auto-cleanup si crashea), `ackDeadlineSeconds=10`, `messageRetentionDuration=600s`.
+- **Cleanup**: el handler SSE borra la subscription explícitamente al cerrar (`cleanup()` en el return). Si el handler crashea, el TTL la barre.
+
+## Alternativas consideradas y rechazadas
+
+### A. Redis Pub/Sub
+
+Usar el Memorystore Redis existente con `PUBLISH chat-messages:assignment:{id} {payload}` y `SUBSCRIBE` en cada SSE handler.
+
+- **Por qué se rechazó**:
+  - **Sin filter server-side a nivel topic**: con Redis tendrías que abrir 1 channel por `assignment_id` (`SUBSCRIBE chat-messages:assignment:{id}`) o consumir todo y filtrar en aplicación. Pub/Sub permite `filter` en la subscription que GCP aplica antes de entregar — menos tráfico, menos CPU.
+  - **Persistence cero**: Redis pub/sub es fire-and-forget puro. Si una instance reinicia justo cuando llega un mensaje, se pierde sin posibilidad de redelivery. Pub/Sub mantiene el mensaje hasta que se ACKea (con retención 1h en este topic).
+  - **Sin DLQ**: Redis no tiene dead-letter pattern nativo. Pub/Sub sí (topic `pubsub-dead-letter` configurado en TF).
+  - **Memorystore como SPOF crítico ya**: Redis se usa para sessions + rate limiting + AI conversation store. Cargarle un canal pub/sub adicional aumenta el blast radius si Redis cae.
+  - **Misma cosa, sin ventaja**: Pub/Sub managed con cuota generosa, pricing trivial para nuestro volumen.
+
+### B. Postgres `LISTEN/NOTIFY`
+
+`pg_notify('chat_messages', payload)` desde un trigger post-INSERT, `LISTEN chat_messages` desde cada SSE handler.
+
+- **Por qué se rechazó**:
+  - **Conexiones persistentes a Postgres**: cada SSE viewer requiere mantener una conexión Postgres con `LISTEN` activo. Con 200 viewers concurrent, son 200 conexiones idle del pool — agota el `max_connections` del Cloud SQL tier (200 default).
+  - **Payload limitado a 8000 bytes**: PostgreSQL `pg_notify` tiene límite hardcoded. Para mensajes JSON grandes (con metadata extra) hay que partir.
+  - **Acoplamiento con la BD**: triggers SQL son lógica de negocio escondida. Ya el principio del repo dice "Algoritmos viven en `packages/`, services orquesta DB" — meter un trigger pg_notify viola esa frontera.
+
+### C. Server-Sent Events broadcast directo (in-memory pub/sub)
+
+Cada instance Cloud Run mantiene un mapa `assignmentId → Set<SSEResponse>` y al recibir `INSERT` del mismo proceso, escribe a todos.
+
+- **Por qué se rechazó**: solo funciona si el `INSERT` y todos los SSE viewers viven en la misma instance. Con autoscaling es impredecible. Falla el principio multi-instance del stack.
+
+### D. WebSocket con sticky sessions + in-memory broadcast
+
+WebSocket con session affinity al LB para garantizar que un viewer siempre cae en la misma instance.
+
+- **Por qué se rechazó**: ya descartado WebSocket en ADR-017 por motivos de Cloud Run. Sticky sessions complican el autoscaling y costo.
+
+### E. Subscription compartida (1 sub para todos los viewers de un topic)
+
+Una sola subscription `chat-messages-all-viewers` que recibe todo y la app filtra in-memory.
+
+- **Por qué se rechazó (por ahora)**:
+  - Cada instance Cloud Run tendría que mantener mapa `assignmentId → Set<viewers>` y filtrar en code. Es lo que descartamos en (C).
+  - Pub/Sub paga 1 ACK por mensaje × subscription. Con N viewers en N instances, son N ACKs por mensaje. Con subscription efímera por viewer es 1 ACK por viewer-message — mismo costo.
+- **Reevaluación**: si llegamos a >5000 viewers concurrent, costo de mantener tantas subscriptions efímeras se vuelve significativo (~$0.40/mes/idle subscription). Migrar a 1 subscription compartida + filter in-app.
+
+## Consecuencias
+
+### Positivas
+
+- **Filter server-side por GCP**: el filter `attributes.assignment_id = "..."` se evalúa en el plano de control de Pub/Sub antes de entregar. Cada SSE handler solo procesa los mensajes que le interesan, sin tráfico desperdiciado.
+- **Cross-instance natural**: cualquier `INSERT` desde cualquier instance api alcanza a todos los viewers, sin importar dónde estén corriendo.
+- **Auto-cleanup robusto**: TTL 24h en cada subscription. Si una Cloud Run instance muere mid-handler sin cleanup explícito, GCP la barre.
+- **Audit trail**: cada `publishChatMessage` queda en logs estructurados Pino. Cada subscription create/delete queda en Cloud Audit Logs (`pubsub.googleapis.com/v1.SubscriptionService`).
+- **Naming descubrible**: prefijo `chat-sse-` permite a un operador ver qué subscriptions están vivas con `gcloud pubsub subscriptions list --filter="name:chat-sse-*"` y limpiar a mano si un día se acumulan huérfanas.
+- **DLQ pattern reutilizable**: el topic `pubsub-dead-letter` está disponible si en el futuro se quisiera pasar de fire-and-forget a "garantía de entrega".
+
+### Negativas
+
+- **Latencia de subscription create**: ~500ms al abrir el SSE. Para chat (no live trading) es invisible al user.
+- **Costo creciente con viewers**: ~$0.40/mes por subscription idle. 100 viewers concurrent = $40/mes. 1000 = $400/mes. Sostenible para piloto; reevaluar a partir de 1000 viewers concurrent.
+- **Mensajes perdidos sin viewer**: retención del topic = 1h. Si nadie está suscrito al INSERT (ninguna tab abierta), el mensaje no se entrega via Pub/Sub. **No es bug**: el cliente al refrescar trae el mensaje desde Postgres (canónico). El topic es solo el canal de "push instantáneo a tabs vivos". Para tab cerrada hay Web Push (ADR-016). Para reconectar tras outage el listado regular de mensajes (HTTP) cubre.
+- **Operacional**: si una versión del stack tiene bug que no llama `cleanup()`, las subscriptions efímeras se acumulan. El TTL las limpia en 24h pero hay ventana de costo. Mitigación: alerta de monitoring sobre `pubsub.googleapis.com/subscription/num_undelivered_messages` para `chat-sse-*` agrupado.
+
+### Riesgos abiertos
+
+- **Cuotas de Pub/Sub**: GCP impone límite default 10000 subscriptions per project. Con `chat-sse-*` efímeras, si llegamos a 5000+ viewers concurrent, acercamos el límite. Hoy cuota muy holgada para el volumen.
+- **Migración a subscription compartida**: cuando viewers >5000 o cuando el costo idle supere algún threshold (~$200/mes), migrar al patrón (E). Refactor mantenible en `chat-pubsub.ts`.
+
+## Implementación (estado actual)
+
+| # | Ítem | Archivo | Estado |
+|---|------|---------|--------|
+| 1 | Topic `chat-messages` con retention 1h | `infrastructure/messaging.tf:100-109` | ✅ aplicado |
+| 2 | Env var `CHAT_PUBSUB_TOPIC` en Cloud Run api | `infrastructure/compute.tf:117` | ✅ aplicado |
+| 3 | `publishChatMessage` fire-and-forget post-INSERT | `apps/api/src/services/chat-pubsub.ts:48-75` | ✅ commiteado |
+| 4 | `createEphemeralChatSubscription` con filter + TTL + naming descubrible | `apps/api/src/services/chat-pubsub.ts:83-128` | ✅ commiteado |
+| 5 | DLQ topic disponible (no enchufado al `chat-messages` por ahora — fire-and-forget OK) | `infrastructure/messaging.tf:112-122` | ✅ aplicado |
+| 6 | Alerta sobre `num_undelivered_messages` para `chat-sse-*` | `infrastructure/monitoring.tf` | 📅 backlog |
+| 7 | Migración a 1-subscription-shared + filter in-app | n/a | 📅 al alcanzar 5000 viewers o $200/mes |
+
+## Referencias
+
+- `apps/api/src/services/chat-pubsub.ts` — implementación
+- `infrastructure/messaging.tf:75-122` — topic + DLQ
+- ADR-017 — SSE como mecanismo client-facing
+- ADR-016 — Web Push (cubre tab cerrada)
+- ADR-005 — Telemetry IoT (Pub/Sub fue elegido como bus por defecto del stack)
+- Pub/Sub — [Subscription filter syntax](https://cloud.google.com/pubsub/docs/filtering)
+- Pub/Sub — [Pricing](https://cloud.google.com/pubsub/pricing)

--- a/docs/adr/019-workbox-vite-plugin-pwa-injectmanifest.md
+++ b/docs/adr/019-workbox-vite-plugin-pwa-injectmanifest.md
@@ -1,0 +1,124 @@
+# ADR-019 — Workbox v7 + `vite-plugin-pwa` en modo `injectManifest` para el Service Worker
+
+- **Estado**: Accepted
+- **Fecha**: 2026-04-30 (decisión inicial); 2026-05-01 (pivote a `injectManifest`); 2026-05-03 (ADR escrito retroactivo)
+- **Decisores**: Felipe Vicencio (Product Owner)
+- **Supersede**: —
+
+## Contexto
+
+`apps/web` es la PWA multirol (shipper / carrier / driver / admin / stakeholder) servida desde Cloud Run + Global HTTPS LB en `https://app.boosterchile.com`. Debe ser instalable como PWA (icon en home screen, fullscreen `display: standalone`, splash) y resiliente offline (al menos shell + assets cacheados). A partir de la fase P3.c también necesita un **Service Worker custom** que maneje:
+
+- `push` events (Web Push estándar — ver ADR-016) para mostrar notificaciones nativas con tab cerrada.
+- `notificationclick` para deep-link al chat con focus de tab existente.
+- Eventualmente: background sync, periodic sync para refresh de listas.
+
+Espacio de decisión:
+
+- **Stack base**: vanilla Service Worker / Workbox / `serwist` (fork de Workbox, más moderno).
+- **Build integration con Vite**: `vite-plugin-pwa` / `serwist/vite` / build manual.
+- **Estrategia de SW**:
+  - `generateSW`: el plugin genera el SW completo (precaching auto, runtime caching declarativo).
+  - `injectManifest`: el desarrollador escribe el SW; el plugin solo inyecta el manifest de assets.
+
+## Decisión
+
+Usar **Workbox v7.3.0** + **`vite-plugin-pwa@^0.21.1`** en modo **`injectManifest`** (`apps/web/vite.config.ts:14-50`).
+
+Concreto:
+
+- **SW source**: `apps/web/src/sw.ts` — lo escribe el desarrollador, importa primitives de Workbox según necesite.
+- **Precaching**: el plugin inyecta `__WB_MANIFEST` en build time (lista de hashes de `**/*.{js,css,html,ico,png,svg,woff2}`). El SW llama `precacheAndRoute(self.__WB_MANIFEST)` para cachear.
+- **Runtime caching**: `registerRoute()` con `CacheFirst` + `ExpirationPlugin` para Google Fonts CSS (`fonts.googleapis.com`, 4 entries × 1 año) y WebFonts (`fonts.gstatic.com`, 20 entries × 1 año). Ver `sw.ts:44-71`.
+- **Lifecycle**: `self.skipWaiting()` + `clientsClaim()` explícitos al inicio del SW. `registerType: 'autoUpdate'` en el plugin para que el cliente refresque el SW al detectar cambio.
+- **Push handlers custom**: `addEventListener('push', ...)` y `addEventListener('notificationclick', ...)` agregados al final del SW (ver `sw.ts:96-160`).
+- **Manifest del PWA**: declarado inline en `vite.config.ts:31-49` (name "Booster AI", short_name "Booster", theme `#1FA058`, icons 192/512/maskable).
+
+## Alternativas consideradas y rechazadas
+
+### A. `vite-plugin-pwa` modo `generateSW` (estado inicial)
+
+Configuramos `globPatterns` + `runtimeCaching` declarativo y el plugin genera el SW automáticamente. **Era el modo inicial de Booster AI hasta la fase P3.c**.
+
+- **Por qué se pivoteó a `injectManifest`**:
+  - **Necesitamos handlers custom**: `push` + `notificationclick` para Web Push (ADR-016). En modo `generateSW` no se puede agregar código arbitrario al SW; solo se configuran routes via JSON. Hay un workaround con `additionalManifestEntries` + `importScripts`, pero termina siendo más complejo que escribir el SW directo.
+  - **Control sobre `skipWaiting`/`clientsClaim`**: en `generateSW` se configura por flags; en `injectManifest` se llaman explícitamente — más visible en el code review.
+  - **Migración mínima**: el SW custom mantiene el mismo precaching y runtime caching del modo anterior. Cambia: `skipWaiting` y `clientsClaim` ahora son llamadas explícitas; `runtimeCaching` se hace con `registerRoute()` de `workbox-routing`. El comment en `sw.ts:13-17` documenta la migración.
+
+### B. `serwist` (fork modernizado de Workbox)
+
+Activamente mantenido, mejor TypeScript types, plugin Vite oficial.
+
+- **Por qué se rechazó (por ahora)**:
+  - **Madurez**: serwist tiene <50K downloads/semana vs Workbox ~7M/semana. Comunidad chica, menos respuestas en Stack Overflow / GitHub Issues.
+  - **Riesgo de abandono**: es un fork single-maintainer. Workbox es Google con compromiso de soporte largo.
+  - **Sin ventaja decisiva**: las features que serwist agrega (mejor TS types) son nice-to-have. La fricción del SW custom es la misma.
+- **Reevaluación**: si serwist supera 1M downloads/semana o si Workbox entra en deprecation explícito, migrar.
+
+### C. Vanilla Service Worker (sin Workbox)
+
+Escribir el SW desde cero con `caches.open()` + fetch handlers manuales.
+
+- **Por qué se rechazó**:
+  - El precaching robusto con cache versioning es ~150 líneas de boilerplate. Workbox lo resuelve en 1.
+  - `ExpirationPlugin` tiene casos edge (LRU + TTL) que ya están testeados y funcionando — no vale reimplementar.
+  - La complejidad agregada de Workbox (~30KB minified) es trivial frente al beneficio de tener primitives probados.
+
+### D. Workbox CLI standalone (sin Vite plugin)
+
+Ejecutar `workbox-cli` post-build para generar/inyectar el SW.
+
+- **Por qué se rechazó**: dos pasos en CI (build Vite + workbox CLI). El plugin de Vite hace ambos en un solo `pnpm build`. Menos chance de drift entre el manifest del bundle y el manifest del SW.
+
+### E. Ignorar PWA y servir SPA pelado
+
+No PWA, sin SW, sin install.
+
+- **Por qué se rechazó**: la propuesta de valor del producto incluye uso mobile en zonas de carga (a veces sin red estable). PWA con shell offline + push notification es feature core, no nice-to-have. Está formalizado en ADR-008.
+
+## Consecuencias
+
+### Positivas
+
+- **Push handlers controlables**: el SW source vive en el repo, se code-reviewa como cualquier otro `.ts`. Fácil agregar background sync / periodic sync en el futuro sin desarmar la stack.
+- **Type safety**: `sw.ts` corre con `tsc` y la config TS del workspace. Errores capturables pre-build.
+- **Workbox primitives reusables**: `CacheFirst`, `NetworkFirst`, `StaleWhileRevalidate`, `ExpirationPlugin`, `BroadcastUpdatePlugin`. Coverage probada de casos edge.
+- **AutoUpdate**: cuando se publica una versión nueva, los clientes la reciben transparentemente al próximo navigate (no requiere refresh manual).
+- **Manifest inline en `vite.config.ts`**: una sola fuente de verdad. No hay un `public/manifest.json` separado que pueda quedar drift con el bundle.
+- **Bundle ~30KB extra**: Workbox primitives. Cargado solo en el SW (no en el bundle principal del cliente).
+
+### Negativas
+
+- **`skipWaiting + clientsClaim` agresivos**: la combinación hace que un nuevo SW tome control inmediato de tabs abiertas. Si el usuario está en medio de un flujo (ej. completando un formulario), el SW nuevo podría cachear assets nuevos que no son compatibles con el JS del SPA viejo cargado en memoria. Mitigación: el SPA evita state cross-cache (todo en TanStack Query), y un fallback "actualizá la página" en caso de error inesperado del cliente.
+- **`@ts-expect-error` en `ExpirationPlugin`**: el tsconfig base tiene `exactOptionalPropertyTypes: true`; `workbox-expiration` tipa `cacheDidUpdate` como required. Hay 2 supresiones explícitas en `sw.ts` con comentario justificando. Eventualmente fix upstream o relajar el flag para `apps/web` solo.
+- **Acoplamiento a Workbox**: si en el futuro se decide mover a serwist, hay que cambiar imports y reescribir las llamadas. Mitigación: el SW son ~80 líneas; reescritura factible en 1 sprint.
+- **Debugging del SW**: requiere abrir DevTools → Application → Service Workers, registrar/unregister, simular offline. UX de debugging menos cómodo que el resto del SPA.
+
+### Riesgos abiertos
+
+- **iOS Safari Limitation**: Service Worker en Safari iOS tiene gotchas (storage quota más estricto, eventos en background limitados). Validar en E2E mobile-safari antes de cada release que toca el SW.
+- **Cache poisoning**: si un asset se cachea con un hash y después el deploy cambia el contenido sin cambiar el hash (bug de build), los clientes ven contenido stale hasta el próximo `autoUpdate`. Mitigación: trust en el bundler (Vite) que genera hashes únicos por contenido.
+- **Workbox v8 (futuro)**: cuando salga, evaluar migración. Probable que sea drop-in.
+
+## Implementación (estado actual)
+
+| # | Ítem | Archivo | Estado |
+|---|------|---------|--------|
+| 1 | `vite-plugin-pwa@^0.21.1` configurado modo `injectManifest` | `apps/web/vite.config.ts:14-50` | ✅ commiteado |
+| 2 | Workbox v7.3.0 (core, expiration, precaching, routing, strategies, window) | `apps/web/package.json:52-57` | ✅ commiteado |
+| 3 | SW source `apps/web/src/sw.ts` con precaching + runtime caching + push handlers | `apps/web/src/sw.ts` | ✅ commiteado |
+| 4 | Manifest inline (name, theme_color, icons 192/512/maskable) | `apps/web/vite.config.ts:31-49` | ✅ commiteado |
+| 5 | `registerType: 'autoUpdate'` para refresh transparente | `apps/web/vite.config.ts:26` | ✅ commiteado |
+| 6 | Limpiar `@ts-expect-error` de `ExpirationPlugin` | `apps/web/src/sw.ts:49,64` | 📅 backlog (espera fix upstream o relajar tsconfig de apps/web) |
+| 7 | Smoke E2E iOS Safari (mobile-safari project en Playwright) post-cada release | tooling | 📅 backlog (ver task #122 + ADR-008) |
+
+## Referencias
+
+- `apps/web/vite.config.ts` — config del plugin
+- `apps/web/src/sw.ts` — Service Worker custom
+- `apps/web/package.json` — deps Workbox
+- ADR-008 — PWA multirole (rationale de elegir PWA)
+- ADR-016 — Web Push VAPID (motivó el pivote a `injectManifest`)
+- Workbox — [Documentation v7](https://developer.chrome.com/docs/workbox)
+- vite-plugin-pwa — [GitHub](https://github.com/vite-pwa/vite-plugin-pwa)
+- web.dev — [Service Workers](https://web.dev/learn/pwa/service-workers/)


### PR DESCRIPTION
## Resumen

Documentación retroactiva de **5 decisiones arquitectónicas** ya implementadas en código durante las fases B.3, P3.b, P3.c, P3.e. **Sin cambios funcionales** — solo ADRs.

Cierra `HANDOFF.md` §3 "ADRs candidatos detectados" (deuda doc del traspaso Claude.ai → Claude Code).

## ADRs incluidos

| ADR | Tema | Decisión | Implementación |
|-----|------|----------|----------------|
| **015** | Algoritmo KMS para certificados de carbono | RSA **PKCS#1 v1.5** 4096-SHA256 (no PSS — interop universal) | `infrastructure/security.tf:68-81` + `packages/certificate-generator/src/firmar-kms.ts` |
| **016** | Push notifications | **Web Push estándar W3C/VAPID** (no FCM SDK cliente) — cross-browser nativo + sin vendor lock | `apps/api/src/services/web-push.ts` + `apps/web/src/sw.ts:96-160` |
| **017** | Chat realtime client-facing | **SSE** (no WebSocket — Cloud Run friendly) | `apps/api` `/assignments/:id/messages/stream` + `apps/web/src/hooks/use-chat-stream.ts` |
| **018** | Bus interno del chat realtime | **Pub/Sub `chat-messages`** + subscriptions efímeras por viewer (no Redis pub/sub — filter server-side + DLQ) | `apps/api/src/services/chat-pubsub.ts` + `infrastructure/messaging.tf:100-109` |
| **019** | Stack PWA / Service Worker | **Workbox v7 + `vite-plugin-pwa` modo `injectManifest`** (no `generateSW` — necesitamos push handlers custom) | `apps/web/vite.config.ts:14-50` + `apps/web/src/sw.ts` |

## Hallazgo lateral

**Drift documental detectado** (anotado como follow-up en ADR-015):

- `packages/certificate-generator/src/firmar-kms.ts:24` dice `RSA-PSS 4096 SHA-256` en un comentario del código.
- `infrastructure/security.tf:74` declara el algoritmo como `RSA_SIGN_PKCS1_4096_SHA256` (PKCS#1 v1.5, **no** PSS).

El comentario quedó del diseño inicial PSS y no se actualizó al pivote. PR follow-up para alinear el comentario.

## Test plan

- [ ] Lectura cruzada de los 5 ADRs por el PO.
- [ ] Verificar que los archivos referenciados en cada ADR existen y la sección/línea sigue válida.
- [ ] Sin cambios en código → CI debería pasar todos los checks (excepto los pre-existentes Trivy/SBOM/Playwright comunes a #19/#20/#21).

## Notas

- **Ningún ADR introduce cambios funcionales**. Son retroactivos.
- Los ADRs siguen el formato establecido por ADR-013 + ADR-014 (Contexto / Decisión / Alternativas rechazadas / Consecuencias / Implementación).
- HANDOFF.md §3 se cerrará en `/handoff` sync post-merge.

https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR)_