### PR TITLE
fix(ci): SBOM con cdxgen + Playwright skip-when-empty

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -36,7 +36,21 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Install Playwright browsers
         run: pnpm --filter @booster-ai/web exec playwright install --with-deps chromium webkit
+      - name: Check for E2E specs
+        id: check_specs
+        # Si no hay specs en apps/web/e2e/, skip el step de Run E2E sin
+        # marcar el job como failure. Útil mientras el directorio e2e/
+        # está vacío (workflow se dispara por cualquier cambio en
+        # apps/api/** o apps/web/** aunque no haya tests todavía).
+        run: |
+          if find apps/web/e2e -type f \( -name "*.spec.ts" -o -name "*.spec.tsx" \) 2>/dev/null | grep -q .; then
+            echo "has_specs=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_specs=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No Playwright specs found in apps/web/e2e/ — skipping E2E run."
+          fi
       - name: Run E2E
+        if: steps.check_specs.outputs.has_specs == 'true'
         env:
           BASE_URL: ${{ github.event_name == 'pull_request' && vars.STAGING_URL || vars.PRODUCTION_URL }}
         run: pnpm --filter @booster-ai/web test:e2e

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -144,7 +144,10 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - name: Generate CycloneDX SBOM
-        run: npx @cyclonedx/cyclonedx-npm --output-file sbom.cyclonedx.json
+        # cdxgen soporta nativamente pnpm-lock.yaml + workspaces. La
+        # alternativa @cyclonedx/cyclonedx-npm asume package-lock.json
+        # y falla con exit 254 en repos pnpm.
+        run: npx --yes @cyclonedx/cdxgen@^11 -t pnpm -o sbom.cyclonedx.json --no-install-deps
       - name: Upload SBOM
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Resumen

Resuelve **2 de los 3 failures pre-existentes en CI** que aparecían en TODO PR que tocaba `package.json`/`apps/api/**`/`apps/web/**` (visibles desde PR #21 + #22 + futuros). Sin tocar Trivy (requiere logs autenticados, follow-up separado).

## Cambios

### 1. SBOM (`security.yml`) — `cyclonedx-npm` → `cdxgen`

**Problema**: `npx @cyclonedx/cyclonedx-npm` está pensado para `package-lock.json` (npm). En monorepo pnpm falla con exit 254 al no encontrar el lockfile esperado.

**Fix**: reemplazar por `@cyclonedx/cdxgen@^11` con flag `-t pnpm`. cdxgen es el SBOM generator multi-lockfile de OWASP/CycloneDX, parsea `pnpm-lock.yaml` + `pnpm-workspace.yaml` correctamente.

```diff
- run: npx @cyclonedx/cyclonedx-npm --output-file sbom.cyclonedx.json
+ run: npx --yes @cyclonedx/cdxgen@^11 -t pnpm -o sbom.cyclonedx.json --no-install-deps
```

### 2. Playwright + axe-core (`e2e-staging.yml`) — skip-when-empty

**Problema**: el workflow se dispara en PRs que tocan `apps/api/**` o `apps/web/**` (filtro intencional). Si no hay specs en `apps/web/e2e/`, `pnpm test:e2e` falla con `Error: No tests found` exit 1.

**Fix**: nuevo step `Check for E2E specs` previo. Si no hay archivos `.spec.ts` o `.spec.tsx`, skip el `Run E2E` con `::notice::` (no failure). Cuando se agreguen specs reales (futuro), el workflow vuelve a correr automáticamente sin más cambios.

```yaml
- name: Check for E2E specs
  id: check_specs
  run: |
    if find apps/web/e2e -type f \( -name "*.spec.ts" -o -name "*.spec.tsx" \) 2>/dev/null | grep -q .; then
      echo "has_specs=true" >> "$GITHUB_OUTPUT"
    else
      echo "has_specs=false" >> "$GITHUB_OUTPUT"
      echo "::notice::No Playwright specs found in apps/web/e2e/ — skipping E2E run."
    fi
- name: Run E2E
  if: steps.check_specs.outputs.has_specs == 'true'
  ...
```

## Lo que NO hace este PR

- **Trivy filesystem + config scan**: ortogonal a estos 2. Los logs no son accesibles públicamente (requiere `gcloud logging` o sign-in en GitHub Actions). Hipótesis: Trivy detecta CVEs en deps que `npm audit` no reporta (BD distinta), o misconfigs en Dockerfiles/TF. Follow-up separado.
- **`upload-sarif` step de Trivy** (`sarif_file: .` que parece intentar upload del directorio entero): observación pero sin tocar — fuera del scope acotado.

## Test plan

- [ ] CI de este PR: `Generate SBOM` debería pasar a verde.
- [ ] CI de este PR: `Playwright + axe-core` debería pasar a verde con notice "No Playwright specs found".
- [ ] CI de este PR: el resto de los checks (npm audit, Gitleaks, CodeQL) sin cambios respecto a su estado pre-existente en main.
- [ ] Una vez merged, los próximos PRs (incluido #19, #20, #21, #22 al rebasear) ven verde estos 2 checks también.

## Notas

- `.github/workflows/*.yml` está en `CLAUDE.md` § "NUNCA toco sin permiso explícito". Felipe autorizó explícitamente atacar Frente C en esta sesión.
- Sin cambios en código de apps/packages — solo CI infra.

https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR)_