### PR TITLE
feat(trip-state-machine): SMs canónicas XState v5 con 54 tests

### DIFF
--- a/packages/trip-state-machine/README.md
+++ b/packages/trip-state-machine/README.md
@@ -1,12 +1,161 @@
 # @booster-ai/trip-state-machine
 
-Placeholder package. Ver ADR relacionado en `docs/adr/` para diseño detallado.
+State machines canónicas (XState v5) para los workflows de **viaje** y **asignación**.
 
-## Status
+Son la **fuente de verdad** de qué transiciones son legales sobre `tripStatusEnum` y `assignmentStatusEnum` (`apps/api/src/db/schema.ts`). Reemplazan el patrón actual de "asumir que el caller manda algo coherente" — sin SM canónica, cualquier service puede romper invariantes (ej. saltar de `borrador` a `entregado`, o resucitar un viaje cancelado).
 
-`SKELETON` — implementación pendiente.
+## Instalación en un workspace dependent
 
-## Scripts
+```jsonc
+// apps/<x>/package.json
+"dependencies": {
+  "@booster-ai/trip-state-machine": "workspace:*"
+}
+```
 
-- `pnpm typecheck` — validación de tipos
-- `pnpm test` — suite de tests (vacía por ahora)
+## API
+
+### Validación de transiciones
+
+```ts
+import {
+  assertTripTransition,
+  canTripTransition,
+  getNextTripStatus,
+  InvalidTransitionError,
+} from '@booster-ai/trip-state-machine';
+
+// Patrón estándar pre-UPDATE en services:
+assertTripTransition(trip.status, { type: 'DELIVERY_CONFIRMED' });
+//   throws InvalidTransitionError si trip.status no acepta DELIVERY_CONFIRMED
+
+// Versión sin throw, para flujos opcionales:
+if (canTripTransition(trip.status, { type: 'CANCEL' })) {
+  await db.update(trips).set({ status: 'cancelado' });
+}
+
+// Computar el próximo status:
+const next = getNextTripStatus('emparejando', { type: 'OFFERS_SENT' });
+//   → 'ofertas_enviadas'
+```
+
+### UI gating (lista de eventos válidos)
+
+```ts
+import { getValidEventsForTripStatus } from '@booster-ai/trip-state-machine';
+
+const allowed = getValidEventsForTripStatus(trip.status);
+//   ['START_MATCHING', 'CANCEL']  // si trip.status === 'borrador'
+
+// En React:
+{allowed.includes('CANCEL') && <CancelButton />}
+```
+
+### Detección de terminales
+
+```ts
+import { isTerminalTripStatus } from '@booster-ai/trip-state-machine';
+
+if (isTerminalTripStatus(trip.status)) {
+  // No se puede crear nuevo chat sobre un trip terminado
+  return forbidden('Trip is closed');
+}
+```
+
+## Estados y eventos
+
+### Trip (`tripStatusEnum`)
+
+```
+                ┌──────────┐
+                │ borrador │
+                └────┬─────┘
+                START_MATCHING
+                     ▼
+           ┌──────────────────┐
+      ┌──→ │ esperando_match  │ ←──── RETRY ──── ┌──────────┐
+      │    └────────┬─────────┘                  │ expirado │
+      │       START_MATCHING                     └─────▲────┘
+      │             ▼                                  │
+      │     ┌──────────────┐                           │
+      └──── │ emparejando  │                           │
+   NO_MATCH └──────┬───────┘                           │
+                OFFERS_SENT                            │
+                   ▼                                   │
+           ┌────────────────────┐                      │
+           │ ofertas_enviadas   │ ── ALL_OFFERS_EXPIRED┘
+           └─────────┬──────────┘
+                OFFER_ACCEPTED
+                     ▼
+               ┌──────────┐
+               │ asignado │
+               └────┬─────┘
+               PICKUP_CONFIRMED
+                    ▼
+              ┌────────────┐
+              │ en_proceso │
+              └─────┬──────┘
+               DELIVERY_CONFIRMED
+                    ▼
+              ┌────────────┐    (terminal)
+              │ entregado  │
+              └────────────┘
+
+  Cancel desde cualquier estado activo:
+      borrador / esperando_match / emparejando / ofertas_enviadas /
+      asignado / en_proceso  ── CANCEL ──→  cancelado (terminal)
+```
+
+### Assignment (`assignmentStatusEnum`)
+
+```
+   ┌──────────┐
+   │ asignado │ ── CANCEL ──→  cancelado (terminal)
+   └────┬─────┘
+    PICKUP_CONFIRMED
+        ▼
+   ┌──────────┐
+   │ recogido │ ── CANCEL ──→  cancelado
+   └────┬─────┘
+    DELIVERY_CONFIRMED
+        ▼
+   ┌────────────┐
+   │ entregado  │  (terminal)
+   └────────────┘
+```
+
+## Plan de migración de services existentes
+
+Hoy hay 6 sites en `apps/api/src/` que hacen `db.update(...).set({ status: 'X' })` directo sin validación:
+
+| Service / Route | Transición |
+|-----------------|------------|
+| `services/matching.ts:99` | `→ emparejando` |
+| `services/matching.ts:216` | `→ ofertas_enviadas` |
+| `services/matching.ts:284` | `→ expirado` |
+| `services/offer-actions.ts:132` | offer `→ reemplazada` (no trip) |
+| `services/offer-actions.ts:145` | trip `→ asignado` |
+| `services/confirmar-entrega-viaje.ts:153` | trip `→ entregado` |
+| `routes/trip-requests-v2.ts:545` | trip `→ cancelado` |
+
+PR follow-up para migrar uno a uno:
+
+```ts
+// Antes:
+await db.update(trips).set({ status: 'entregado' }).where(eq(trips.id, tripId));
+
+// Después:
+const trip = await db.query.trips.findFirst({ where: eq(trips.id, tripId) });
+if (!trip) throw new NotFoundError();
+assertTripTransition(trip.status, { type: 'DELIVERY_CONFIRMED' });
+await db.update(trips).set({ status: 'entregado' }).where(eq(trips.id, tripId));
+```
+
+Cada migración debe ir en commit independiente con su test E2E.
+
+## Referencias
+
+- Drizzle enums: `apps/api/src/db/schema.ts:126-157`
+- ADR-004 — Uber-like model (define el flujo conceptual)
+- HANDOFF.md §5 — bloqueante "trip-state-machine XState canónica"
+- XState v5 docs — https://stately.ai/docs

--- a/packages/trip-state-machine/package.json
+++ b/packages/trip-state-machine/package.json
@@ -12,7 +12,9 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
-  "dependencies": {},
+  "dependencies": {
+    "xstate": "^5.31.0"
+  },
   "devDependencies": {
     "typescript": "^5.8.2",
     "vitest": "^4.0.18"

--- a/packages/trip-state-machine/src/assignment.machine.ts
+++ b/packages/trip-state-machine/src/assignment.machine.ts
@@ -1,0 +1,83 @@
+/**
+ * State machine canónica del workflow de una asignación (`asignaciones`).
+ *
+ * Estados matchean `assignmentStatusEnum` en `apps/api/src/db/schema.ts:152-157`.
+ *
+ * Una asignación se crea en estado `asignado` cuando una oferta es
+ * aceptada por el carrier (es decir, en el momento que `trip` transita
+ * `ofertas_enviadas → asignado`). De ahí en adelante:
+ *
+ * ```
+ *   ┌──────────┐
+ *   │ asignado │
+ *   └────┬─────┘
+ *    PICKUP_CONFIRMED
+ *        ▼
+ *   ┌──────────┐
+ *   │ recogido │
+ *   └────┬─────┘
+ *    DELIVERY_CONFIRMED
+ *        ▼
+ *   ┌────────────┐  (terminal)
+ *   │ entregado  │
+ *   └────────────┘
+ *
+ *   asignado / recogido  ── CANCEL ──→  cancelado (terminal)
+ * ```
+ *
+ * Sincronización con el trip (NO implementada en esta SM por separación
+ * de concerns):
+ *   - assignment `asignado` ↔ trip `asignado`
+ *   - assignment `recogido` ↔ trip `en_proceso`
+ *   - assignment `entregado` ↔ trip `entregado`
+ *   - assignment `cancelado` ↔ trip `cancelado`
+ *
+ * El service que confirma una transición debe orquestar AMBAS machines
+ * en una transacción Drizzle. Pendiente: helper `syncTripAndAssignment`
+ * que tome ambos estados y devuelva los próximos estados consistentes.
+ * Por ahora cada service lo hace explícito (fuerza el patrón visible).
+ */
+
+import { createMachine } from 'xstate';
+
+export type AssignmentStatus = 'asignado' | 'recogido' | 'entregado' | 'cancelado';
+
+export type AssignmentEvent =
+  | { type: 'PICKUP_CONFIRMED' }
+  | { type: 'DELIVERY_CONFIRMED' }
+  | { type: 'CANCEL' };
+
+export interface AssignmentContext {
+  assignmentId: string;
+  tripId: string;
+}
+
+export const assignmentMachine = createMachine({
+  id: 'assignment',
+  initial: 'asignado',
+  types: {} as {
+    context: AssignmentContext;
+    events: AssignmentEvent;
+  },
+  context: { assignmentId: '', tripId: '' },
+  states: {
+    asignado: {
+      on: {
+        PICKUP_CONFIRMED: 'recogido',
+        CANCEL: 'cancelado',
+      },
+    },
+    recogido: {
+      on: {
+        DELIVERY_CONFIRMED: 'entregado',
+        CANCEL: 'cancelado',
+      },
+    },
+    entregado: {
+      type: 'final',
+    },
+    cancelado: {
+      type: 'final',
+    },
+  },
+});

--- a/packages/trip-state-machine/src/helpers.ts
+++ b/packages/trip-state-machine/src/helpers.ts
@@ -1,0 +1,174 @@
+/**
+ * Helpers de validación de transiciones — la API que los services del api
+ * deben usar antes de cualquier UPDATE de status.
+ *
+ * Patrón de uso esperado:
+ *
+ * ```ts
+ * // En apps/api/src/services/confirmar-entrega-viaje.ts
+ * import { assertTripTransition } from '@booster-ai/trip-state-machine';
+ *
+ * const trip = await db.query.trips.findFirst({ where: eq(trips.id, tripId) });
+ * if (!trip) throw new NotFoundError();
+ *
+ * // Throws InvalidTransitionError si trip.status no permite DELIVERY_CONFIRMED.
+ * assertTripTransition(trip.status, { type: 'DELIVERY_CONFIRMED' });
+ *
+ * await db.update(trips).set({ status: 'entregado' }).where(eq(trips.id, tripId));
+ * ```
+ *
+ * Esto reemplaza el patrón actual de "asumir que el caller manda algo
+ * coherente". Cierra el bloqueante de HANDOFF.md §5 — sin SM canónica,
+ * cualquier service puede romper invariantes (ej. saltar de `borrador`
+ * a `entregado`, o resucitar un viaje cancelado).
+ *
+ * Implementación: leemos `config.on` de cada state node directamente. Las
+ * machines XState son la **fuente de verdad** de qué transiciones existen;
+ * estos helpers son lookup puro sin runtime de actor. Eso evita acoplarse
+ * a APIs internas de XState (que cambian entre versiones) y mantiene los
+ * helpers triviales de testear.
+ */
+
+import {
+  type AssignmentEvent,
+  type AssignmentStatus,
+  assignmentMachine,
+} from './assignment.machine.js';
+import { type TripEvent, type TripStatus, tripMachine } from './trip.machine.js';
+
+/**
+ * Error que se throwea cuando se intenta una transición ilegal. El service
+ * debe rebotar a HTTP 409 Conflict (semánticamente correcto: el estado
+ * actual del recurso no permite la operación pedida).
+ */
+export class InvalidTransitionError extends Error {
+  constructor(
+    public readonly entity: 'trip' | 'assignment',
+    public readonly fromStatus: string,
+    public readonly event: string,
+  ) {
+    super(`Invalid ${entity} transition: status='${fromStatus}' no acepta evento '${event}'.`);
+    this.name = 'InvalidTransitionError';
+  }
+}
+
+/**
+ * Lee el target de una transición desde la config del state node de XState.
+ * El target en XState v5 puede ser:
+ *   - string                   → target directo
+ *   - { target: string, ... }  → objeto con guards/actions (no usamos guards en estas SMs)
+ *   - Array<...>               → no usamos branching transitions
+ */
+function resolveTransitionTarget(transitionConfig: unknown): string | null {
+  if (typeof transitionConfig === 'string') {
+    return transitionConfig;
+  }
+  if (
+    typeof transitionConfig === 'object' &&
+    transitionConfig !== null &&
+    'target' in transitionConfig &&
+    typeof (transitionConfig as { target: unknown }).target === 'string'
+  ) {
+    return (transitionConfig as { target: string }).target;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Trip helpers
+// ---------------------------------------------------------------------------
+
+/** `true` si la transición es legal — sin throwear. */
+export function canTripTransition(fromStatus: TripStatus, event: TripEvent): boolean {
+  return getNextTripStatus(fromStatus, event) !== null;
+}
+
+/**
+ * Devuelve el `TripStatus` resultante de aplicar el evento, o `null` si
+ * la transición no es legal.
+ */
+export function getNextTripStatus(fromStatus: TripStatus, event: TripEvent): TripStatus | null {
+  const stateNode = tripMachine.states[fromStatus];
+  if (!stateNode) {
+    return null;
+  }
+  const onConfig = stateNode.config.on as Record<string, unknown> | undefined;
+  const transitionConfig = onConfig?.[event.type];
+  return resolveTransitionTarget(transitionConfig) as TripStatus | null;
+}
+
+/**
+ * Lista los eventos que se pueden disparar desde el estado actual.
+ * Útil para que la UI muestre/oculte botones contextualmente.
+ */
+export function getValidEventsForTripStatus(fromStatus: TripStatus): TripEvent['type'][] {
+  const stateNode = tripMachine.states[fromStatus];
+  if (!stateNode) {
+    return [];
+  }
+  const onConfig = stateNode.config.on as Record<string, unknown> | undefined;
+  return Object.keys(onConfig ?? {}) as TripEvent['type'][];
+}
+
+/**
+ * Throws `InvalidTransitionError` si la transición no es legal. Patrón
+ * estándar para invocar antes de un `UPDATE` en Drizzle.
+ */
+export function assertTripTransition(fromStatus: TripStatus, event: TripEvent): void {
+  if (!canTripTransition(fromStatus, event)) {
+    throw new InvalidTransitionError('trip', fromStatus, event.type);
+  }
+}
+
+/** `true` si el estado es terminal (`entregado` o `cancelado`). */
+export function isTerminalTripStatus(status: TripStatus): boolean {
+  return status === 'entregado' || status === 'cancelado';
+}
+
+// ---------------------------------------------------------------------------
+// Assignment helpers
+// ---------------------------------------------------------------------------
+
+export function canAssignmentTransition(
+  fromStatus: AssignmentStatus,
+  event: AssignmentEvent,
+): boolean {
+  return getNextAssignmentStatus(fromStatus, event) !== null;
+}
+
+export function getNextAssignmentStatus(
+  fromStatus: AssignmentStatus,
+  event: AssignmentEvent,
+): AssignmentStatus | null {
+  const stateNode = assignmentMachine.states[fromStatus];
+  if (!stateNode) {
+    return null;
+  }
+  const onConfig = stateNode.config.on as Record<string, unknown> | undefined;
+  const transitionConfig = onConfig?.[event.type];
+  return resolveTransitionTarget(transitionConfig) as AssignmentStatus | null;
+}
+
+export function getValidEventsForAssignmentStatus(
+  fromStatus: AssignmentStatus,
+): AssignmentEvent['type'][] {
+  const stateNode = assignmentMachine.states[fromStatus];
+  if (!stateNode) {
+    return [];
+  }
+  const onConfig = stateNode.config.on as Record<string, unknown> | undefined;
+  return Object.keys(onConfig ?? {}) as AssignmentEvent['type'][];
+}
+
+export function assertAssignmentTransition(
+  fromStatus: AssignmentStatus,
+  event: AssignmentEvent,
+): void {
+  if (!canAssignmentTransition(fromStatus, event)) {
+    throw new InvalidTransitionError('assignment', fromStatus, event.type);
+  }
+}
+
+export function isTerminalAssignmentStatus(status: AssignmentStatus): boolean {
+  return status === 'entregado' || status === 'cancelado';
+}

--- a/packages/trip-state-machine/src/index.ts
+++ b/packages/trip-state-machine/src/index.ts
@@ -1,7 +1,59 @@
 /**
  * @booster-ai/trip-state-machine
  *
- * TODO: implementar según ADRs relacionados.
- * Este archivo es un placeholder para que el monorepo compile.
+ * State machines canónicas (XState v5) para los workflows de viaje y
+ * asignación. Son la fuente de verdad de qué transiciones son legales
+ * sobre `tripStatusEnum` y `assignmentStatusEnum` (`apps/api/src/db/schema.ts`).
+ *
+ * Use-cases:
+ *   1. **Validación pre-UPDATE en services**: antes de hacer
+ *      `db.update(trips).set({ status: nextStatus })`, llamar
+ *      `assertTripTransition(currentStatus, event)`. Si la transición
+ *      no es legal, throws `InvalidTransitionError`.
+ *   2. **Documentación visualizable**: la machine genera el grafo de
+ *      estados navegable en https://stately.ai/viz.
+ *   3. **UI gating**: el frontend puede consultar
+ *      `getValidEventsForTripStatus(currentStatus)` para mostrar/ocultar
+ *      botones contextualmente (ej. "Cancelar" no aparece si ya está
+ *      `entregado`).
+ *
+ * Invariantes que la SM garantiza:
+ *   - No se puede saltar de `ofertas_enviadas` directo a `entregado` sin
+ *     pasar por `asignado` y `en_proceso`.
+ *   - `entregado` y `cancelado` son TERMINALES — ningún evento los saca.
+ *   - `expirado` puede reintentarse via `RETRY` → `esperando_match`.
+ *   - Cancelación posible desde cualquier estado activo, no desde
+ *     terminales.
+ *
+ * Ver ADRs:
+ *   - ADR-004 (Uber-like model) — define el flujo conceptual.
+ *   - HANDOFF.md §5 — bloqueante "trip-state-machine XState canónica".
  */
-export const PACKAGE_NAME = '@booster-ai/trip-state-machine' as const;
+
+export {
+  tripMachine,
+  type TripContext,
+  type TripStatus,
+  type TripEvent,
+} from './trip.machine.js';
+
+export {
+  assignmentMachine,
+  type AssignmentContext,
+  type AssignmentStatus,
+  type AssignmentEvent,
+} from './assignment.machine.js';
+
+export {
+  InvalidTransitionError,
+  canTripTransition,
+  getNextTripStatus,
+  getValidEventsForTripStatus,
+  assertTripTransition,
+  canAssignmentTransition,
+  getNextAssignmentStatus,
+  getValidEventsForAssignmentStatus,
+  assertAssignmentTransition,
+  isTerminalTripStatus,
+  isTerminalAssignmentStatus,
+} from './helpers.js';

--- a/packages/trip-state-machine/src/trip.machine.ts
+++ b/packages/trip-state-machine/src/trip.machine.ts
@@ -1,0 +1,136 @@
+/**
+ * State machine canónica del workflow de un viaje (`trip_request`).
+ *
+ * Estados matchean `tripStatusEnum` en `apps/api/src/db/schema.ts:126-136`.
+ *
+ * Diagrama:
+ *
+ * ```
+ *                ┌──────────┐
+ *                │ borrador │
+ *                └────┬─────┘
+ *                START_MATCHING
+ *                     ▼
+ *           ┌──────────────────┐
+ *      ┌──→ │ esperando_match  │ ←──── RETRY ──── ┌──────────┐
+ *      │    └────────┬─────────┘                  │ expirado │
+ *      │       START_MATCHING                     └─────▲────┘
+ *      │             ▼                                  │
+ *      │     ┌──────────────┐                           │
+ *      └──── │ emparejando  │                           │
+ *   NO_MATCH └──────┬───────┘                           │
+ *                OFFERS_SENT                            │
+ *                   ▼                                   │
+ *           ┌────────────────────┐                      │
+ *           │ ofertas_enviadas   │ ── ALL_OFFERS_EXPIRED┘
+ *           └─────────┬──────────┘
+ *                OFFER_ACCEPTED
+ *                     ▼
+ *               ┌──────────┐
+ *               │ asignado │
+ *               └────┬─────┘
+ *               PICKUP_CONFIRMED
+ *                    ▼
+ *              ┌────────────┐
+ *              │ en_proceso │
+ *              └─────┬──────┘
+ *               DELIVERY_CONFIRMED
+ *                    ▼
+ *              ┌────────────┐    (terminal)
+ *              │ entregado  │
+ *              └────────────┘
+ *
+ *  Cancel from cualquier estado activo:
+ *      borrador / esperando_match / emparejando / ofertas_enviadas /
+ *      asignado / en_proceso  ── CANCEL ──→  cancelado (terminal)
+ * ```
+ */
+
+import { createMachine } from 'xstate';
+
+export type TripStatus =
+  | 'borrador'
+  | 'esperando_match'
+  | 'emparejando'
+  | 'ofertas_enviadas'
+  | 'asignado'
+  | 'en_proceso'
+  | 'entregado'
+  | 'cancelado'
+  | 'expirado';
+
+export type TripEvent =
+  | { type: 'START_MATCHING' }
+  | { type: 'OFFERS_SENT' }
+  | { type: 'NO_MATCH' }
+  | { type: 'OFFER_ACCEPTED' }
+  | { type: 'ALL_OFFERS_EXPIRED' }
+  | { type: 'PICKUP_CONFIRMED' }
+  | { type: 'DELIVERY_CONFIRMED' }
+  | { type: 'CANCEL' }
+  | { type: 'RETRY' };
+
+export interface TripContext {
+  tripId: string;
+}
+
+export const tripMachine = createMachine({
+  id: 'trip',
+  initial: 'borrador',
+  types: {} as {
+    context: TripContext;
+    events: TripEvent;
+  },
+  context: { tripId: '' },
+  states: {
+    borrador: {
+      on: {
+        START_MATCHING: 'esperando_match',
+        CANCEL: 'cancelado',
+      },
+    },
+    esperando_match: {
+      on: {
+        START_MATCHING: 'emparejando',
+        CANCEL: 'cancelado',
+      },
+    },
+    emparejando: {
+      on: {
+        OFFERS_SENT: 'ofertas_enviadas',
+        NO_MATCH: 'esperando_match',
+        CANCEL: 'cancelado',
+      },
+    },
+    ofertas_enviadas: {
+      on: {
+        OFFER_ACCEPTED: 'asignado',
+        ALL_OFFERS_EXPIRED: 'expirado',
+        CANCEL: 'cancelado',
+      },
+    },
+    asignado: {
+      on: {
+        PICKUP_CONFIRMED: 'en_proceso',
+        CANCEL: 'cancelado',
+      },
+    },
+    en_proceso: {
+      on: {
+        DELIVERY_CONFIRMED: 'entregado',
+        CANCEL: 'cancelado',
+      },
+    },
+    entregado: {
+      type: 'final',
+    },
+    cancelado: {
+      type: 'final',
+    },
+    expirado: {
+      on: {
+        RETRY: 'esperando_match',
+      },
+    },
+  },
+});

--- a/packages/trip-state-machine/test/assignment.machine.test.ts
+++ b/packages/trip-state-machine/test/assignment.machine.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type AssignmentEvent,
+  type AssignmentStatus,
+  InvalidTransitionError,
+  assertAssignmentTransition,
+  canAssignmentTransition,
+  getNextAssignmentStatus,
+  getValidEventsForAssignmentStatus,
+  isTerminalAssignmentStatus,
+} from '../src/index.js';
+
+describe('assignmentMachine — happy path', () => {
+  it('asignado → recogido → entregado', () => {
+    let status: AssignmentStatus = 'asignado';
+
+    status = getNextAssignmentStatus(status, { type: 'PICKUP_CONFIRMED' }) ?? status;
+    expect(status).toBe('recogido');
+
+    status = getNextAssignmentStatus(status, { type: 'DELIVERY_CONFIRMED' }) ?? status;
+    expect(status).toBe('entregado');
+
+    expect(isTerminalAssignmentStatus(status)).toBe(true);
+  });
+});
+
+describe('assignmentMachine — cancelación', () => {
+  it('asignado → cancelado', () => {
+    expect(getNextAssignmentStatus('asignado', { type: 'CANCEL' })).toBe('cancelado');
+  });
+
+  it('recogido → cancelado', () => {
+    expect(getNextAssignmentStatus('recogido', { type: 'CANCEL' })).toBe('cancelado');
+  });
+});
+
+describe('assignmentMachine — terminales bloquean todo', () => {
+  const allEvents: AssignmentEvent[] = [
+    { type: 'PICKUP_CONFIRMED' },
+    { type: 'DELIVERY_CONFIRMED' },
+    { type: 'CANCEL' },
+  ];
+
+  for (const event of allEvents) {
+    it(`entregado rechaza ${event.type}`, () => {
+      expect(canAssignmentTransition('entregado', event)).toBe(false);
+    });
+
+    it(`cancelado rechaza ${event.type}`, () => {
+      expect(canAssignmentTransition('cancelado', event)).toBe(false);
+    });
+  }
+});
+
+describe('assignmentMachine — saltos ilegales', () => {
+  it('asignado NO puede saltar directo a entregado', () => {
+    expect(canAssignmentTransition('asignado', { type: 'DELIVERY_CONFIRMED' })).toBe(false);
+  });
+
+  it('recogido NO acepta PICKUP_CONFIRMED (idempotencia rota)', () => {
+    expect(canAssignmentTransition('recogido', { type: 'PICKUP_CONFIRMED' })).toBe(false);
+  });
+});
+
+describe('assertAssignmentTransition', () => {
+  it('throws con info útil', () => {
+    expect(() => assertAssignmentTransition('entregado', { type: 'CANCEL' })).toThrowError(
+      InvalidTransitionError,
+    );
+
+    try {
+      assertAssignmentTransition('asignado', { type: 'DELIVERY_CONFIRMED' });
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidTransitionError);
+      const e = err as InvalidTransitionError;
+      expect(e.entity).toBe('assignment');
+      expect(e.fromStatus).toBe('asignado');
+      expect(e.event).toBe('DELIVERY_CONFIRMED');
+    }
+  });
+});
+
+describe('getValidEventsForAssignmentStatus — UI gating', () => {
+  it('asignado permite PICKUP_CONFIRMED + CANCEL', () => {
+    expect(getValidEventsForAssignmentStatus('asignado').sort()).toEqual(
+      ['CANCEL', 'PICKUP_CONFIRMED'].sort(),
+    );
+  });
+
+  it('recogido permite DELIVERY_CONFIRMED + CANCEL', () => {
+    expect(getValidEventsForAssignmentStatus('recogido').sort()).toEqual(
+      ['CANCEL', 'DELIVERY_CONFIRMED'].sort(),
+    );
+  });
+
+  it('terminales no permiten ningún evento', () => {
+    expect(getValidEventsForAssignmentStatus('entregado')).toEqual([]);
+    expect(getValidEventsForAssignmentStatus('cancelado')).toEqual([]);
+  });
+});

--- a/packages/trip-state-machine/test/trip.machine.test.ts
+++ b/packages/trip-state-machine/test/trip.machine.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import {
+  InvalidTransitionError,
+  type TripEvent,
+  type TripStatus,
+  assertTripTransition,
+  canTripTransition,
+  getNextTripStatus,
+  getValidEventsForTripStatus,
+  isTerminalTripStatus,
+} from '../src/index.js';
+
+describe('tripMachine — happy path completo', () => {
+  it('camino canónico borrador → entregado', () => {
+    let status: TripStatus = 'borrador';
+
+    // borrador → esperando_match
+    status = getNextTripStatus(status, { type: 'START_MATCHING' }) ?? status;
+    expect(status).toBe('esperando_match');
+
+    // esperando_match → emparejando
+    status = getNextTripStatus(status, { type: 'START_MATCHING' }) ?? status;
+    expect(status).toBe('emparejando');
+
+    // emparejando → ofertas_enviadas
+    status = getNextTripStatus(status, { type: 'OFFERS_SENT' }) ?? status;
+    expect(status).toBe('ofertas_enviadas');
+
+    // ofertas_enviadas → asignado
+    status = getNextTripStatus(status, { type: 'OFFER_ACCEPTED' }) ?? status;
+    expect(status).toBe('asignado');
+
+    // asignado → en_proceso
+    status = getNextTripStatus(status, { type: 'PICKUP_CONFIRMED' }) ?? status;
+    expect(status).toBe('en_proceso');
+
+    // en_proceso → entregado
+    status = getNextTripStatus(status, { type: 'DELIVERY_CONFIRMED' }) ?? status;
+    expect(status).toBe('entregado');
+
+    expect(isTerminalTripStatus(status)).toBe(true);
+  });
+});
+
+describe('tripMachine — caminos alternativos', () => {
+  it('emparejando → esperando_match (NO_MATCH retry)', () => {
+    expect(getNextTripStatus('emparejando', { type: 'NO_MATCH' })).toBe('esperando_match');
+  });
+
+  it('ofertas_enviadas → expirado (todas las ofertas vencieron)', () => {
+    expect(getNextTripStatus('ofertas_enviadas', { type: 'ALL_OFFERS_EXPIRED' })).toBe('expirado');
+  });
+
+  it('expirado → esperando_match (RETRY)', () => {
+    expect(getNextTripStatus('expirado', { type: 'RETRY' })).toBe('esperando_match');
+  });
+});
+
+describe('tripMachine — cancelación desde estados activos', () => {
+  const cancellableStates: TripStatus[] = [
+    'borrador',
+    'esperando_match',
+    'emparejando',
+    'ofertas_enviadas',
+    'asignado',
+    'en_proceso',
+  ];
+
+  for (const state of cancellableStates) {
+    it(`${state} → cancelado (CANCEL permitido)`, () => {
+      expect(getNextTripStatus(state, { type: 'CANCEL' })).toBe('cancelado');
+    });
+  }
+
+  it('expirado NO acepta CANCEL (debe retry primero)', () => {
+    expect(canTripTransition('expirado', { type: 'CANCEL' })).toBe(false);
+  });
+});
+
+describe('tripMachine — terminales bloquean transiciones', () => {
+  const allEvents: TripEvent[] = [
+    { type: 'START_MATCHING' },
+    { type: 'OFFERS_SENT' },
+    { type: 'NO_MATCH' },
+    { type: 'OFFER_ACCEPTED' },
+    { type: 'ALL_OFFERS_EXPIRED' },
+    { type: 'PICKUP_CONFIRMED' },
+    { type: 'DELIVERY_CONFIRMED' },
+    { type: 'CANCEL' },
+    { type: 'RETRY' },
+  ];
+
+  for (const event of allEvents) {
+    it(`entregado rechaza ${event.type}`, () => {
+      expect(canTripTransition('entregado', event)).toBe(false);
+    });
+
+    it(`cancelado rechaza ${event.type}`, () => {
+      expect(canTripTransition('cancelado', event)).toBe(false);
+    });
+  }
+
+  it('isTerminalTripStatus identifica entregado y cancelado', () => {
+    expect(isTerminalTripStatus('entregado')).toBe(true);
+    expect(isTerminalTripStatus('cancelado')).toBe(true);
+    expect(isTerminalTripStatus('en_proceso')).toBe(false);
+    expect(isTerminalTripStatus('expirado')).toBe(false);
+  });
+});
+
+describe('tripMachine — saltos ilegales bloqueados', () => {
+  it('borrador NO puede saltar directo a entregado', () => {
+    expect(canTripTransition('borrador', { type: 'DELIVERY_CONFIRMED' })).toBe(false);
+  });
+
+  it('ofertas_enviadas NO puede saltar a entregado sin pasar por asignado/en_proceso', () => {
+    expect(canTripTransition('ofertas_enviadas', { type: 'DELIVERY_CONFIRMED' })).toBe(false);
+  });
+
+  it('asignado NO acepta DELIVERY_CONFIRMED (debe pasar por en_proceso)', () => {
+    expect(canTripTransition('asignado', { type: 'DELIVERY_CONFIRMED' })).toBe(false);
+  });
+
+  it('en_proceso NO acepta OFFER_ACCEPTED (regresión a flujo viejo)', () => {
+    expect(canTripTransition('en_proceso', { type: 'OFFER_ACCEPTED' })).toBe(false);
+  });
+});
+
+describe('assertTripTransition — throws con info útil', () => {
+  it('error message identifica entity, fromStatus y event', () => {
+    expect(() => assertTripTransition('entregado', { type: 'CANCEL' })).toThrowError(
+      InvalidTransitionError,
+    );
+
+    try {
+      assertTripTransition('entregado', { type: 'CANCEL' });
+    } catch (err) {
+      expect(err).toBeInstanceOf(InvalidTransitionError);
+      const e = err as InvalidTransitionError;
+      expect(e.entity).toBe('trip');
+      expect(e.fromStatus).toBe('entregado');
+      expect(e.event).toBe('CANCEL');
+      expect(e.message).toContain("status='entregado'");
+      expect(e.message).toContain("evento 'CANCEL'");
+    }
+  });
+
+  it('no throwea para transición legal', () => {
+    expect(() => assertTripTransition('borrador', { type: 'START_MATCHING' })).not.toThrow();
+  });
+});
+
+describe('getValidEventsForTripStatus — UI gating', () => {
+  it('borrador permite START_MATCHING + CANCEL', () => {
+    expect(getValidEventsForTripStatus('borrador').sort()).toEqual(
+      ['CANCEL', 'START_MATCHING'].sort(),
+    );
+  });
+
+  it('ofertas_enviadas permite OFFER_ACCEPTED + ALL_OFFERS_EXPIRED + CANCEL', () => {
+    expect(getValidEventsForTripStatus('ofertas_enviadas').sort()).toEqual(
+      ['ALL_OFFERS_EXPIRED', 'CANCEL', 'OFFER_ACCEPTED'].sort(),
+    );
+  });
+
+  it('terminales no permiten ningún evento', () => {
+    expect(getValidEventsForTripStatus('entregado')).toEqual([]);
+    expect(getValidEventsForTripStatus('cancelado')).toEqual([]);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -691,6 +691,10 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/trip-state-machine:
+    dependencies:
+      xstate:
+        specifier: ^5.31.0
+        version: 5.31.0
     devDependencies:
       typescript:
         specifier: ^5.8.2
@@ -6736,6 +6740,9 @@ packages:
 
   xstate@5.30.0:
     resolution: {integrity: sha512-mIzIuMjtYVkqXq9dUzYQoag7b/dF1CBS/yhliuPLfR0FwKPC18HiUivb/crcqY2gknhR8gJEhnppLg6ubQ0gGw==}
+
+  xstate@5.31.0:
+    resolution: {integrity: sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -13396,6 +13403,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xstate@5.30.0: {}
+
+  xstate@5.31.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Resumen

Implementa `packages/trip-state-machine` que estaba como skeleton. Cierra el bloqueante explícito de `HANDOFF.md §5` ("trip-state-machine XState canónica"). **No migra** los services existentes — eso queda como follow-up controlado (1 commit por service).

## Qué hace

State machines canónicas XState v5 + helpers de validación + 54 tests:

| Pieza | Archivos | Cobertura |
|-------|----------|-----------|
| **Trip machine** (9 estados, 9 eventos) | `src/trip.machine.ts` | matchea `tripStatusEnum` (`apps/api/src/db/schema.ts:126-136`) |
| **Assignment machine** (4 estados, 3 eventos) | `src/assignment.machine.ts` | matchea `assignmentStatusEnum` (`apps/api/src/db/schema.ts:152-157`) |
| **Helpers públicos** | `src/helpers.ts` | `canTripTransition`, `getNextTripStatus`, `assertTripTransition`, `getValidEventsForTripStatus`, `isTerminalTripStatus` + análogos para assignment + `InvalidTransitionError` |
| **Tests** | `test/trip.machine.test.ts` (45) + `test/assignment.machine.test.ts` (9) | happy path, alternativas (NO_MATCH/RETRY/EXPIRED), cancelación, terminales, saltos ilegales |

## Implementación clave

**No depende de runtime de XState actor**. Lookup directo de `config.on` del state node:

```ts
const stateNode = tripMachine.states[fromStatus];
const transitionConfig = stateNode.config.on?.[event.type];
return resolveTransitionTarget(transitionConfig);
```

Razón: la API runtime de XState v5 cambió firmas (`transition()` requiere `actorScope`, `.changed` removido). Acoplarse a APIs internas hace upgrades costosos. Las machines XState son la **fuente de verdad declarativa**; los helpers son lookup puro testeable en microsegundos.

## Patrón de uso (post-migración)

```ts
// Antes (sin validación):
await db.update(trips).set({ status: 'entregado' }).where(eq(trips.id, tripId));

// Después:
const trip = await db.query.trips.findFirst({ where: eq(trips.id, tripId) });
if (!trip) throw new NotFoundError();
assertTripTransition(trip.status, { type: 'DELIVERY_CONFIRMED' });
//   throws InvalidTransitionError → handler HTTP rebota como 409 Conflict
await db.update(trips).set({ status: 'entregado' }).where(eq(trips.id, tripId));
```

## Plan de migración follow-up

6 sites en `apps/api/src/` hacen UPDATE de status sin validar — uno por commit:

| Service / Route | Transición a validar |
|-----------------|----------------------|
| `services/matching.ts:99` | `→ emparejando` |
| `services/matching.ts:216` | `→ ofertas_enviadas` |
| `services/matching.ts:284` | `→ expirado` |
| `services/offer-actions.ts:145` | trip `→ asignado` |
| `services/confirmar-entrega-viaje.ts:153` | `→ entregado` |
| `routes/trip-requests-v2.ts:545` | `→ cancelado` |

Cada migración debe ir con su test E2E para verificar que el rebound 409 se mapea correctamente.

## Evidencia

```
pnpm --filter @booster-ai/trip-state-machine typecheck  →  pass
pnpm --filter @booster-ai/trip-state-machine test       →  54/54 pass (21ms)
pnpm typecheck workspace                                →  24/25 pass
```

El `1/25` que falla es `@booster-ai/config` con `Cannot find namespace 'NodeJS'` — pre-existente, fix vivo en PR #21 (`fix(config): add @types/node`).

## Test plan

- [x] Typecheck del package
- [x] 54 tests passing
- [x] Workspace typecheck — solo el error pre-existente queda
- [ ] CI verde (espero notificaciones)
- [ ] Validación humana del diagrama de estados — ¿alguna transición que falte vs el flujo real del producto?

## Sin scope creep

- **No migra services** existentes — bajo riesgo de regresiones, queda follow-up.
- **No implementa sync trip↔assignment** — mencionado en docstring como pendiente. Hoy cada service orquesta ambos updates explícitamente.
- **No agrega ADR** — la decisión arquitectónica grande es la SM de viaje, ya cubierta conceptualmente por ADR-004 (Uber-like model). El detalle de la implementación va al README del package.

https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR)_