### PR TITLE
feat(dte-provider): MVP del adapter SII (interface + Mock + 21 tests)

### DIFF
--- a/packages/dte-provider/README.md
+++ b/packages/dte-provider/README.md
@@ -1,12 +1,205 @@
 # @booster-ai/dte-provider
 
-Placeholder package. Ver ADR relacionado en `docs/adr/` para diseño detallado.
+Abstracción de proveedores de Documentos Tributarios Electrónicos (DTE) para el SII chileno. Implementa el adapter pattern definido en [ADR-007](../../docs/adr/007-chile-document-management.md).
 
-## Status
+Booster **NO emite DTEs propios** — delega a un provider acreditado por SII (Bsale recomendado, alternativas: Paperless, Acepta, SovosChile).
 
-`SKELETON` — implementación pendiente.
+## Estado actual
 
-## Scripts
+- ✅ Interface `DteProvider` definida
+- ✅ Schemas Zod (`GuiaDespachoInput`, `FacturaInput`, `DteResult`, `DteStatus`)
+- ✅ 7 errores tipados (`DteValidationError`, `DteRejectedBySiiError`, `DteCertificateError`, `DteProviderUnavailableError`, `DteFolioConflictError`, `DteNotFoundError`, `DteProviderError` base)
+- ✅ `MockDteProvider` (in-memory) con 21 tests
+- ⏳ `BsaleAdapter` — pendiente, se conecta al provider real
+- ⏳ `PaperlessAdapter` — alternativa pendiente
 
-- `pnpm typecheck` — validación de tipos
-- `pnpm test` — suite de tests (vacía por ahora)
+## Instalación
+
+```jsonc
+// apps/document-service/package.json
+"dependencies": {
+  "@booster-ai/dte-provider": "workspace:*"
+}
+```
+
+## API
+
+### Emit Guía de Despacho (DTE 52)
+
+```ts
+import {
+  MockDteProvider,
+  type DteProvider,
+  type GuiaDespachoInput,
+} from '@booster-ai/dte-provider';
+
+const provider: DteProvider = new MockDteProvider();
+const input: GuiaDespachoInput = {
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  fechaEmision: new Date(),
+  items: [{
+    descripcion: 'Transporte Santiago → Concepción',
+    cantidad: 1,
+    precioUnitarioClp: 850000,
+    unidadMedida: 'VIAJE',
+  }],
+  transporte: {
+    rutChofer: '11111111-1',
+    nombreChofer: 'Juan Pérez',
+    patente: 'AB-CD-12',
+    direccionDestino: 'Av. Principal 123',
+    comunaDestino: 'Concepción',
+  },
+  tipoDespacho: 5, // traslados internos
+};
+
+const result = await provider.emitGuiaDespacho(input);
+console.log(result.folio);     // "1" (mock) o folio SII real
+console.log(result.sha256);    // hash del XML para integrity check
+console.log(result.xmlSigned); // XML firmado para archivo legal 6 años
+```
+
+### Emit Factura Electrónica (DTE 33 / 34)
+
+```ts
+const factura = await provider.emitFactura({
+  tipoDte: 33, // 33 = afecta IVA, 34 = exenta
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  giroEmisor: 'Transporte de Carga',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  giroReceptor: 'Comercio',
+  fechaEmision: new Date(),
+  items: [{
+    descripcion: 'Servicio de transporte',
+    cantidad: 1,
+    precioUnitarioClp: 850000,
+    unidadMedida: 'UN',
+  }],
+  // Vincular a una guía ya emitida (opcional pero recomendado para auditoría):
+  referenciaGuia: {
+    folio: result.folio,
+    fechaEmision: result.fechaEmision,
+  },
+});
+```
+
+### Query Status
+
+```ts
+const status = await provider.queryStatus({
+  folio: '1',
+  rutEmisor: '76123456-7',
+  tipoDte: 52,
+});
+// status.status: 'accepted' | 'pending_sii_validation' | 'rejected' | 'cancelled'
+```
+
+### Manejo de errores
+
+```ts
+import {
+  DteValidationError,
+  DteRejectedBySiiError,
+  DteCertificateError,
+  DteProviderUnavailableError,
+  DteFolioConflictError,
+  DteNotFoundError,
+} from '@booster-ai/dte-provider';
+
+try {
+  await provider.emitGuiaDespacho(input);
+} catch (err) {
+  if (err instanceof DteValidationError) {
+    // 400 Bad Request — input inválido
+    return c.json({ error: 'invalid_input', fields: err.fieldErrors }, 400);
+  }
+  if (err instanceof DteRejectedBySiiError) {
+    // 422 Unprocessable Entity — SII rechazó por contenido
+    return c.json({
+      error: 'sii_rejected',
+      sii_code: err.siiErrorCode,
+      detail: err.siiErrorDetail,
+    }, 422);
+  }
+  if (err instanceof DteCertificateError) {
+    // 422 — certificado del emisor inválido o vencido
+    return c.json({ error: 'certificate_invalid', rut: err.rutEmisor }, 422);
+  }
+  if (err instanceof DteFolioConflictError) {
+    // 409 Conflict — folio ya en uso
+    return c.json({ error: 'folio_conflict', folio: err.folio }, 409);
+  }
+  if (err instanceof DteProviderUnavailableError) {
+    // 503 Service Unavailable — transient, reintentar
+    return c.json({
+      error: 'provider_down',
+      retry_after_seconds: err.retryAfterSeconds,
+    }, 503);
+  }
+  if (err instanceof DteNotFoundError) {
+    // 404 Not Found
+    return c.json({ error: 'dte_not_found' }, 404);
+  }
+  // Fallback 502
+  throw err;
+}
+```
+
+## MockDteProvider
+
+Para tests + desarrollo local. Genera folios autoincrementales por `(rutEmisor, tipoDte)`, persiste en memoria, y soporta inyección de fallos:
+
+```ts
+// Tests del flujo de error
+const provider = new MockDteProvider({
+  failNextEmit: 'rejected_sii', // o 'certificate_error', 'unavailable', 'folio_conflict'
+});
+await expect(provider.emitGuiaDespacho(input)).rejects.toThrowError(
+  DteRejectedBySiiError,
+);
+
+// Simulación de latencia para tests de timeout
+const slow = new MockDteProvider({ artificialLatencyMs: 5000 });
+
+// Folio inicial custom
+const fromN = new MockDteProvider({ startingFolio: 1000 });
+```
+
+`environment` por default es `'certification'` para que ningún test claim "production" output accidentalmente. Si querés simular prod (sin emitir nada real, obvio): `new MockDteProvider({ environment: 'production' })`.
+
+## Plan de migración a Bsale
+
+Para implementar el adapter real:
+
+1. **Crear `packages/dte-provider/src/bsale.ts`** con clase `BsaleAdapter implements DteProvider`.
+2. **Auth**: Bsale usa API token + certificado digital del emisor. Token via env var; cert via Secret Manager (`carrier-{id}-cert-pfx` según ADR-007).
+3. **Mapping**: traducir `GuiaDespachoInput` → request body Bsale (formato propio que Bsale convierte a XML SII).
+4. **Error mapping**: traducir respuestas Bsale → errores tipados de este package:
+   - HTTP 400 → `DteValidationError`
+   - HTTP 422 con código SII → `DteRejectedBySiiError`
+   - HTTP 401/403 sobre cert → `DteCertificateError`
+   - HTTP 5xx → `DteProviderUnavailableError`
+5. **Tests de integración** con sandbox Bsale (no production). Usar idempotency key para reintentos seguros.
+6. **Switch en factory**: `apps/document-service` reemplaza `new MockDteProvider()` por `new BsaleAdapter({ apiKey, environment })`.
+
+Estimación: 2-3 días dev + 2-3 días testing en sandbox SII.
+
+## Testing del package
+
+```bash
+pnpm --filter @booster-ai/dte-provider typecheck
+pnpm --filter @booster-ai/dte-provider test
+```
+
+## Referencias
+
+- [ADR-007 — Chile Document Management](../../docs/adr/007-chile-document-management.md)
+- SII — [Formato DTE](https://www.sii.cl/factura_electronica/formato_dte.htm)
+- Ley 19.983 — [Guía de Despacho](https://bcn.cl/2jdwx)
+- Ley 20.727 — [Factura Electrónica](https://bcn.cl/2xu0f)
+- Bsale API — [https://api.bsale.dev/](https://api.bsale.dev/)

--- a/packages/dte-provider/package.json
+++ b/packages/dte-provider/package.json
@@ -12,8 +12,11 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
+    "@types/node": "^22.14.0",
     "typescript": "^5.8.2",
     "vitest": "^4.0.18"
   }

--- a/packages/dte-provider/src/errors.ts
+++ b/packages/dte-provider/src/errors.ts
@@ -1,0 +1,122 @@
+/**
+ * Errores tipados del package. Cada uno mapea a un comportamiento HTTP
+ * esperado en `apps/document-service`:
+ *
+ * | Error                            | HTTP recomendado |
+ * |----------------------------------|------------------|
+ * | DteValidationError               | 400 Bad Request  |
+ * | DteCertificateError              | 422 Unprocessable Entity |
+ * | DteRejectedBySiiError            | 422 (negocio)    |
+ * | DteFolioConflictError            | 409 Conflict     |
+ * | DteNotFoundError                 | 404 Not Found    |
+ * | DteProviderUnavailableError      | 503 (transient)  |
+ * | DteProviderError (fallback)      | 502 Bad Gateway  |
+ *
+ * Todas extienden `Error` con metadata estructurada para logs.
+ */
+
+/**
+ * Error base. Cualquier fallo del provider que no sea uno de los
+ * específicos cae acá. El caller puede ramificar `instanceof` por la
+ * subclass; si no matchea, asumir 502.
+ */
+export class DteProviderError extends Error {
+  constructor(
+    message: string,
+    public override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'DteProviderError';
+  }
+}
+
+/**
+ * El input no pasó el schema Zod o el provider rechazó por validación
+ * formato (RUT mal formado, fecha futura, items vacíos, etc.). El caller
+ * debe corregir el input antes de reintentar.
+ */
+export class DteValidationError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly fieldErrors: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = 'DteValidationError';
+  }
+}
+
+/**
+ * SII rechazó el documento por contenido (RUT no inscrito, glosa
+ * inválida, monto fuera de rango, etc.). Distinto de
+ * `DteValidationError` porque acá el formato era OK pero el negocio no.
+ */
+export class DteRejectedBySiiError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly siiErrorCode: string,
+    public readonly siiErrorDetail: string,
+  ) {
+    super(message);
+    this.name = 'DteRejectedBySiiError';
+  }
+}
+
+/**
+ * El provider devolvió un folio que ya existe (race condition entre dos
+ * intentos de emit con la misma referencia externa, o un retry sin
+ * idempotency key). El caller debe queryStatus con el folio existente.
+ */
+export class DteFolioConflictError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly folio: string,
+  ) {
+    super(message);
+    this.name = 'DteFolioConflictError';
+  }
+}
+
+/**
+ * El certificado digital del emisor no se pudo cargar, está vencido, o
+ * no coincide con el RUT del emisor. Bloqueante operativo — no se puede
+ * emitir hasta resolver.
+ */
+export class DteCertificateError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly rutEmisor: string,
+  ) {
+    super(message);
+    this.name = 'DteCertificateError';
+  }
+}
+
+/**
+ * Provider externo no responde, timeout, 5xx. Transient — el caller
+ * puede reintentar con exponential backoff.
+ */
+export class DteProviderUnavailableError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly retryAfterSeconds?: number,
+  ) {
+    super(message);
+    this.name = 'DteProviderUnavailableError';
+  }
+}
+
+/**
+ * `queryStatus` no encontró el folio para ese (rutEmisor, tipoDte).
+ * Puede significar: folio no fue emitido, expiró del cache del provider,
+ * o el RUT está mal. El caller tiene que decidir si es bug o no.
+ */
+export class DteNotFoundError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly folio: string,
+    public readonly rutEmisor: string,
+  ) {
+    super(message);
+    this.name = 'DteNotFoundError';
+  }
+}

--- a/packages/dte-provider/src/index.ts
+++ b/packages/dte-provider/src/index.ts
@@ -1,7 +1,88 @@
 /**
  * @booster-ai/dte-provider
  *
- * TODO: implementar según ADRs relacionados.
- * Este archivo es un placeholder para que el monorepo compile.
+ * Abstracción de proveedores de Documentos Tributarios Electrónicos (DTE)
+ * para el SII chileno. Implementa el adapter pattern definido en ADR-007.
+ *
+ * Booster NO emite DTEs propios — delega a un provider acreditado por SII
+ * (Bsale recomendado, alternativas: Paperless, Acepta, SovosChile). Este
+ * package define:
+ *
+ *   1. La **interface** `DteProvider` que cada adapter implementa.
+ *   2. **Schemas Zod** para validar inputs y outputs antes de cruzar la
+ *      frontera HTTP del provider externo (CLAUDE.md §5 + §7).
+ *   3. **Errores tipados** que el caller mapea a HTTP status apropiados.
+ *   4. Una implementación **`MockDteProvider`** in-memory para dev local
+ *      y tests, sin dependencia del provider real.
+ *
+ * El switch a un provider real (Bsale → Paperless u otro) es cambiar la
+ * factory en `apps/document-service` — el resto del código consume la
+ * interface, no la implementación concreta.
+ *
+ * Ver:
+ * - ADR-007 (Chile Document Management) — sección "Integración SII DTE"
+ * - HANDOFF.md §4 — bloqueante regulatorio go-live Chile
+ *
+ * @example
+ * ```ts
+ * import {
+ *   MockDteProvider,
+ *   type DteProvider,
+ * } from '@booster-ai/dte-provider';
+ *
+ * const provider: DteProvider = new MockDteProvider();
+ * const result = await provider.emitGuiaDespacho({
+ *   rutEmisor: '76123456-7',
+ *   razonSocialEmisor: 'Transportes Chile SpA',
+ *   rutReceptor: '12345678-9',
+ *   razonSocialReceptor: 'Cliente SA',
+ *   fechaEmision: new Date(),
+ *   items: [{
+ *     descripcion: 'Transporte Santiago → Concepción',
+ *     cantidad: 1,
+ *     precioUnitarioClp: 850000,
+ *     unidadMedida: 'VIAJE',
+ *   }],
+ *   transporte: {
+ *     rutChofer: '11111111-1',
+ *     nombreChofer: 'Juan Pérez',
+ *     patente: 'AB-CD-12',
+ *     direccionDestino: 'Av. Principal 123, Concepción',
+ *     comunaDestino: 'Concepción',
+ *   },
+ * });
+ * console.log(result.folio); // SII-asignado (mock: 1, 2, 3, ...)
+ * ```
  */
-export const PACKAGE_NAME = '@booster-ai/dte-provider' as const;
+
+export type {
+  DteProvider,
+  DteStatus,
+  DteEnvironment,
+  DteResult,
+  GuiaDespachoInput,
+  FacturaInput,
+  DteItem,
+  TransporteInfo,
+} from './types.js';
+
+export {
+  guiaDespachoInputSchema,
+  facturaInputSchema,
+  dteResultSchema,
+  dteStatusSchema,
+  dteItemSchema,
+  transporteInfoSchema,
+} from './types.js';
+
+export {
+  DteProviderError,
+  DteValidationError,
+  DteRejectedBySiiError,
+  DteProviderUnavailableError,
+  DteFolioConflictError,
+  DteCertificateError,
+  DteNotFoundError,
+} from './errors.js';
+
+export { MockDteProvider, type MockDteProviderOptions } from './mock.js';

--- a/packages/dte-provider/src/mock.ts
+++ b/packages/dte-provider/src/mock.ts
@@ -1,0 +1,227 @@
+/**
+ * MockDteProvider — implementación in-memory para tests + dev local.
+ *
+ * Comportamiento:
+ *   - Genera folios autoincrementales por (rutEmisor, tipoDte).
+ *   - Persiste los DTEs emitidos en un Map para que `queryStatus` los recupere.
+ *   - Computa SHA-256 real del XML "construido" (un string JSON con los
+ *     campos del input — suficiente para tests de integridad, NO es XML
+ *     SII real).
+ *   - Soporta inyección de fallos (`failNextEmit: 'rejected_sii' | ...`)
+ *     para tests de error paths sin tener que mockear todo el provider.
+ *
+ * NO usar en producción. Para producción usar el adapter real (Bsale,
+ * Paperless, etc.) que se conecta al SII.
+ */
+
+import { createHash } from 'node:crypto';
+import type { ZodError } from 'zod';
+import {
+  DteCertificateError,
+  DteFolioConflictError,
+  DteNotFoundError,
+  DteProviderUnavailableError,
+  DteRejectedBySiiError,
+  DteValidationError,
+} from './errors.js';
+import {
+  type DteEnvironment,
+  type DteProvider,
+  type DteResult,
+  type DteStatus,
+  type FacturaInput,
+  type GuiaDespachoInput,
+  facturaInputSchema,
+  guiaDespachoInputSchema,
+} from './types.js';
+
+export interface MockDteProviderOptions {
+  /**
+   * Environment a simular. Default `certification` para que ningún test
+   * pueda accidentalmente claim "production" output.
+   */
+  environment?: DteEnvironment;
+  /**
+   * Folio inicial. Default 1. Se incrementa por cada emisión exitosa.
+   */
+  startingFolio?: number;
+  /**
+   * Forzar el siguiente `emit*` (cualquier tipo) a fallar con el error
+   * especificado. Después del primer fallo se resetea automáticamente.
+   */
+  failNextEmit?: 'rejected_sii' | 'certificate_error' | 'unavailable' | 'folio_conflict';
+  /**
+   * Retraso simulado en ms en cada `emit*`. Default 0.
+   */
+  artificialLatencyMs?: number;
+}
+
+interface StoredDte {
+  result: DteResult;
+  status: DteStatus;
+}
+
+export class MockDteProvider implements DteProvider {
+  public readonly environment: DteEnvironment;
+  private nextFolioByEmisor = new Map<string, number>();
+  private store = new Map<string, StoredDte>();
+  private failNextEmit: MockDteProviderOptions['failNextEmit'];
+  private latencyMs: number;
+  private startingFolio: number;
+
+  constructor(opts: MockDteProviderOptions = {}) {
+    this.environment = opts.environment ?? 'certification';
+    this.startingFolio = opts.startingFolio ?? 1;
+    this.failNextEmit = opts.failNextEmit;
+    this.latencyMs = opts.artificialLatencyMs ?? 0;
+  }
+
+  async emitGuiaDespacho(input: GuiaDespachoInput): Promise<DteResult> {
+    const parsed = guiaDespachoInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new DteValidationError(
+        'Input inválido para Guía de Despacho',
+        flattenZodErrors(parsed.error),
+      );
+    }
+    return this.emitInternal(52, parsed.data);
+  }
+
+  async emitFactura(input: FacturaInput): Promise<DteResult> {
+    const parsed = facturaInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new DteValidationError('Input inválido para Factura', flattenZodErrors(parsed.error));
+    }
+    return this.emitInternal(parsed.data.tipoDte, parsed.data);
+  }
+
+  async queryStatus(args: {
+    folio: string;
+    rutEmisor: string;
+    tipoDte: 33 | 34 | 52;
+  }): Promise<DteStatus> {
+    const key = storeKey(args.tipoDte, args.rutEmisor, args.folio);
+    const stored = this.store.get(key);
+    if (!stored) {
+      throw new DteNotFoundError(
+        `Folio ${args.folio} no encontrado para emisor ${args.rutEmisor}`,
+        args.folio,
+        args.rutEmisor,
+      );
+    }
+    // Refresh lastCheckedAt para que el caller vea el query timestamp.
+    return { ...stored.status, lastCheckedAt: new Date() };
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private async emitInternal(
+    tipoDte: 33 | 34 | 52,
+    parsed: GuiaDespachoInput | FacturaInput,
+  ): Promise<DteResult> {
+    if (this.latencyMs > 0) {
+      await sleep(this.latencyMs);
+    }
+
+    if (this.failNextEmit) {
+      const failure = this.failNextEmit;
+      this.failNextEmit = undefined; // one-shot
+      throw this.constructFailure(failure, parsed.rutEmisor);
+    }
+
+    const folio = this.allocateFolio(parsed.rutEmisor, tipoDte);
+    const xmlSigned = this.buildPseudoXml(tipoDte, folio, parsed);
+    const sha256 = createHash('sha256').update(xmlSigned).digest('hex');
+
+    const result: DteResult = {
+      folio,
+      tipoDte,
+      rutEmisor: parsed.rutEmisor,
+      fechaEmision: parsed.fechaEmision,
+      xmlSigned,
+      sha256,
+      providerTrackId: `mock-track-${tipoDte}-${folio}`,
+      status: 'accepted',
+    };
+
+    const status: DteStatus = {
+      folio,
+      tipoDte,
+      rutEmisor: parsed.rutEmisor,
+      status: 'accepted',
+      lastCheckedAt: new Date(),
+    };
+
+    this.store.set(storeKey(tipoDte, parsed.rutEmisor, folio), { result, status });
+    return result;
+  }
+
+  private allocateFolio(rutEmisor: string, tipoDte: 33 | 34 | 52): string {
+    const key = `${rutEmisor}|${tipoDte}`;
+    const next = this.nextFolioByEmisor.get(key) ?? this.startingFolio;
+    this.nextFolioByEmisor.set(key, next + 1);
+    return String(next);
+  }
+
+  private buildPseudoXml(
+    tipoDte: 33 | 34 | 52,
+    folio: string,
+    parsed: GuiaDespachoInput | FacturaInput,
+  ): string {
+    // Pseudo-XML compacto. NO es XML SII real — solo un string
+    // determinístico que permite tests de integridad (sha256 estable
+    // para mismo input + folio).
+    const payload = {
+      tipo: tipoDte,
+      folio,
+      rutEmisor: parsed.rutEmisor,
+      receptor: parsed.rutReceptor,
+      fechaEmision: parsed.fechaEmision.toISOString(),
+      itemCount: parsed.items.length,
+      total: parsed.items.reduce((acc, item) => acc + item.cantidad * item.precioUnitarioClp, 0),
+    };
+    return `<DTE mock="true">${JSON.stringify(payload)}</DTE>`;
+  }
+
+  private constructFailure(
+    kind: NonNullable<MockDteProviderOptions['failNextEmit']>,
+    rutEmisor: string,
+  ): Error {
+    switch (kind) {
+      case 'rejected_sii':
+        return new DteRejectedBySiiError(
+          'SII rechazó el documento (mock)',
+          'MOCK_001',
+          'Forzado por failNextEmit en tests',
+        );
+      case 'certificate_error':
+        return new DteCertificateError('Certificado digital inválido (mock)', rutEmisor);
+      case 'unavailable':
+        return new DteProviderUnavailableError('Provider down (mock)', 30);
+      case 'folio_conflict':
+        return new DteFolioConflictError('Folio ya en uso (mock)', 'mock-folio-collision');
+    }
+  }
+}
+
+function storeKey(tipoDte: 33 | 34 | 52, rutEmisor: string, folio: string): string {
+  return `${tipoDte}|${rutEmisor}|${folio}`;
+}
+
+function flattenZodErrors(error: ZodError): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const issue of error.issues) {
+    const key = issue.path.join('.') || '_';
+    if (!out[key]) {
+      out[key] = [];
+    }
+    out[key].push(issue.message);
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/dte-provider/src/types.ts
+++ b/packages/dte-provider/src/types.ts
@@ -1,0 +1,284 @@
+/**
+ * Schemas Zod + types para DTEs (SII Chile).
+ *
+ * Diseñados para que el código consumer (apps/document-service) valide
+ * los inputs ANTES de enviar al provider externo y outputs ANTES de
+ * persistir en BD. Todo input externo pasa por Zod (CLAUDE.md §7).
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * RUT chileno con formato `XXXXXXXX-Y` donde Y es DV (0-9 o K).
+ * No validamos el dígito verificador acá — el provider lo hace.
+ * Solo formato sintáctico.
+ */
+const rutSchema = z.string().regex(/^\d{1,8}-[0-9Kk]$/, {
+  message: 'RUT debe tener formato XXXXXXXX-Y (Y=0-9 o K)',
+});
+
+/**
+ * Patente chilena. Acepta formatos viejos (4 letras + 2 dígitos: AB-CD-12)
+ * y nuevos (LL-LL-NN o LL-NN-NN). Lenient — el provider valida estricto.
+ */
+const patenteSchema = z
+  .string()
+  .min(6)
+  .max(10)
+  .regex(/^[A-Z0-9-]+$/i, {
+    message: 'Patente solo letras, dígitos, guiones',
+  });
+
+const moneyClpSchema = z.number().int({ message: 'CLP es entero (no fracciones)' }).nonnegative();
+
+// ---------------------------------------------------------------------------
+// DteItem (línea de la guía/factura)
+// ---------------------------------------------------------------------------
+
+export const dteItemSchema = z
+  .object({
+    descripcion: z.string().min(1).max(1000),
+    cantidad: z.number().positive(),
+    precioUnitarioClp: moneyClpSchema,
+    /**
+     * Código SKU/interno del emisor. Opcional. Si se incluye, va en el XML
+     * DTE como `<CdgItem>`.
+     */
+    codigoItem: z.string().max(35).optional(),
+    /**
+     * Unidad de medida (ej. "UN", "KG", "TON", "VIAJE", "M3"). Default "UN".
+     * SII XML schema acepta hasta 10 chars en el campo `<UnmdItem>`.
+     */
+    unidadMedida: z.string().max(10).default('UN'),
+  })
+  .strict();
+
+export type DteItem = z.infer<typeof dteItemSchema>;
+
+// ---------------------------------------------------------------------------
+// TransporteInfo (campos específicos de Guía de Despacho)
+// ---------------------------------------------------------------------------
+
+export const transporteInfoSchema = z
+  .object({
+    rutChofer: rutSchema,
+    nombreChofer: z.string().min(1).max(100),
+    patente: patenteSchema,
+    /**
+     * Dirección literal del destino. SII pide texto, no coordenadas.
+     */
+    direccionDestino: z.string().min(1).max(200),
+    comunaDestino: z.string().min(1).max(60),
+    /**
+     * RUT del transportista si distinto del emisor (cuando Booster emite
+     * en nombre del shipper pero el carrier es un tercero). Opcional.
+     */
+    rutTransportista: rutSchema.optional(),
+  })
+  .strict();
+
+export type TransporteInfo = z.infer<typeof transporteInfoSchema>;
+
+// ---------------------------------------------------------------------------
+// GuiaDespachoInput (DTE 52)
+// ---------------------------------------------------------------------------
+
+export const guiaDespachoInputSchema = z
+  .object({
+    rutEmisor: rutSchema,
+    razonSocialEmisor: z.string().min(1).max(100),
+    rutReceptor: rutSchema,
+    razonSocialReceptor: z.string().min(1).max(100),
+    fechaEmision: z.date(),
+    items: z.array(dteItemSchema).min(1, {
+      message: 'Guía de despacho requiere al menos 1 item',
+    }),
+    transporte: transporteInfoSchema,
+    /**
+     * Folio externo del caller (ej. trackingCode `BOO-XXXXXX` del trip).
+     * No es el folio SII — eso lo asigna SII al validar. Sirve para que
+     * el caller correlacione su request con el resultado en logs.
+     */
+    referenciaExterna: z.string().min(1).max(40).optional(),
+    /**
+     * Tipo de despacho según SII:
+     *   1 = "Operación constituye venta"
+     *   2 = "Ventas por efectuar"
+     *   3 = "Consignaciones"
+     *   4 = "Entrega gratuita"
+     *   5 = "Traslados internos"
+     *   6 = "Otros traslados no venta"
+     *   7 = "Guía de devolución"
+     * Default 5 (traslados internos) para retornos vacíos típicos.
+     */
+    tipoDespacho: z
+      .union([
+        z.literal(1),
+        z.literal(2),
+        z.literal(3),
+        z.literal(4),
+        z.literal(5),
+        z.literal(6),
+        z.literal(7),
+      ])
+      .default(5),
+  })
+  .strict();
+
+export type GuiaDespachoInput = z.infer<typeof guiaDespachoInputSchema>;
+
+// ---------------------------------------------------------------------------
+// FacturaInput (DTE 33 afecta IVA, DTE 34 exenta)
+// ---------------------------------------------------------------------------
+
+export const facturaInputSchema = z
+  .object({
+    tipoDte: z.union([z.literal(33), z.literal(34)]),
+    rutEmisor: rutSchema,
+    razonSocialEmisor: z.string().min(1).max(100),
+    giroEmisor: z.string().min(1).max(80),
+    rutReceptor: rutSchema,
+    razonSocialReceptor: z.string().min(1).max(100),
+    giroReceptor: z.string().min(1).max(80),
+    fechaEmision: z.date(),
+    items: z.array(dteItemSchema).min(1),
+    /**
+     * Referencia opcional a una Guía de Despacho ya emitida (folio SII).
+     * Cuando facturamos un viaje ya despachado, el SII pide vincular la
+     * factura a la guía vía referencia con tipo "DTE 52".
+     */
+    referenciaGuia: z
+      .object({
+        folio: z.string(),
+        fechaEmision: z.date(),
+      })
+      .optional(),
+    referenciaExterna: z.string().min(1).max(40).optional(),
+  })
+  .strict();
+
+export type FacturaInput = z.infer<typeof facturaInputSchema>;
+
+// ---------------------------------------------------------------------------
+// DteResult (output del emit)
+// ---------------------------------------------------------------------------
+
+export const dteResultSchema = z
+  .object({
+    /** Folio asignado por SII (único por (rutEmisor, tipoDte)). */
+    folio: z.string().min(1),
+    /** Tipo DTE del documento emitido (52=Guía, 33=Factura afecta, 34=exenta). */
+    tipoDte: z.union([z.literal(33), z.literal(34), z.literal(52)]),
+    rutEmisor: rutSchema,
+    fechaEmision: z.date(),
+    /** XML firmado del DTE — para archivo legal 6 años. */
+    xmlSigned: z.string().min(1),
+    /** SHA-256 del XML para integrity check post-storage. */
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    /** PDF visual del documento — para humanos. */
+    pdfBase64: z.string().min(1).optional(),
+    /** Track ID interno del provider (para queryStatus posterior). */
+    providerTrackId: z.string().min(1).optional(),
+    /** Estado inicial del DTE post-emisión. */
+    status: z.enum(['accepted', 'pending_sii_validation', 'rejected']),
+  })
+  .strict();
+
+export type DteResult = z.infer<typeof dteResultSchema>;
+
+// ---------------------------------------------------------------------------
+// DteStatus (output de queryStatus)
+// ---------------------------------------------------------------------------
+
+export const dteStatusSchema = z
+  .object({
+    folio: z.string(),
+    tipoDte: z.union([z.literal(33), z.literal(34), z.literal(52)]),
+    rutEmisor: rutSchema,
+    /**
+     * - `accepted`: SII validó. Documento legalmente válido.
+     * - `pending_sii_validation`: enviado, esperando respuesta SII (puede
+     *   tomar minutos a horas en producción real).
+     * - `rejected`: SII rechazó (errores en el XML, RUT inválido, etc.).
+     * - `cancelled`: anulado posteriormente (DTE de anulación emitido).
+     */
+    status: z.enum(['accepted', 'pending_sii_validation', 'rejected', 'cancelled']),
+    /** Si `rejected`, descripción del motivo. */
+    rejectionReason: z.string().optional(),
+    lastCheckedAt: z.date(),
+  })
+  .strict();
+
+export type DteStatus = z.infer<typeof dteStatusSchema>;
+
+/**
+ * Environment de SII al que apunta el provider.
+ * - `certification`: ambiente de pruebas (folios no oficiales). Usar
+ *   durante desarrollo + onboarding.
+ * - `production`: SII real, folios oficiales con valor legal.
+ */
+export type DteEnvironment = 'certification' | 'production';
+
+// ---------------------------------------------------------------------------
+// DteProvider interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Contrato de cualquier adapter de DTE. Implementaciones esperadas:
+ *
+ * - `MockDteProvider` — para tests + dev local. Incluida en este package.
+ * - `BsaleAdapter` — provider recomendado en ADR-007. **Pendiente**.
+ * - `PaperlessAdapter` — alternativa. **Pendiente**.
+ *
+ * Los adapters reales hacen HTTP calls al provider, manejan auth (API
+ * keys + certificate), serializan a XML SII, y traducen los errores del
+ * provider a las clases tipadas de `errors.ts`.
+ */
+export interface DteProvider {
+  /**
+   * Indica el environment SII al que apunta este provider. El caller
+   * típicamente no lo necesita en runtime, pero sirve para logs y para
+   * diferenciar dev vs prod en alertas.
+   */
+  readonly environment: DteEnvironment;
+
+  /**
+   * Emite una Guía de Despacho Electrónica (DTE Tipo 52). Ley 19.983.
+   *
+   * Flow esperado:
+   *   1. Validar input con `guiaDespachoInputSchema` (caller debería pre-validar).
+   *   2. Construir XML DTE según schema SII.
+   *   3. Firmar con certificado del emisor.
+   *   4. Enviar al SII (vía provider). Recibir folio.
+   *   5. Generar PDF visual (opcional pero recomendado).
+   *   6. Retornar `DteResult` con folio + xmlSigned + sha256.
+   *
+   * @throws {DteValidationError} si el input no pasa schema.
+   * @throws {DteRejectedBySiiError} si SII rechaza (formato, RUT, etc.).
+   * @throws {DteCertificateError} si el certificado del emisor falla.
+   * @throws {DteProviderUnavailableError} si el provider está down.
+   */
+  emitGuiaDespacho(input: GuiaDespachoInput): Promise<DteResult>;
+
+  /**
+   * Emite una Factura Electrónica (DTE Tipo 33 afecta IVA o 34 exenta).
+   * Ley 20.727.
+   */
+  emitFactura(input: FacturaInput): Promise<DteResult>;
+
+  /**
+   * Consulta el estado actual del DTE en SII (post-emisión, los DTEs
+   * pueden tomar minutos a horas en aceptarse formalmente).
+   *
+   * @throws {DteNotFoundError} si el folio no existe para ese RUT/tipo.
+   */
+  queryStatus(args: {
+    folio: string;
+    rutEmisor: string;
+    tipoDte: 33 | 34 | 52;
+  }): Promise<DteStatus>;
+}

--- a/packages/dte-provider/test/mock.test.ts
+++ b/packages/dte-provider/test/mock.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DteCertificateError,
+  DteFolioConflictError,
+  DteNotFoundError,
+  DteProviderUnavailableError,
+  DteRejectedBySiiError,
+  DteValidationError,
+  type FacturaInput,
+  type GuiaDespachoInput,
+  MockDteProvider,
+} from '../src/index.js';
+
+const validGuia: GuiaDespachoInput = {
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  fechaEmision: new Date('2026-05-03T10:00:00Z'),
+  items: [
+    {
+      descripcion: 'Transporte Santiago → Concepción',
+      cantidad: 1,
+      precioUnitarioClp: 850000,
+      unidadMedida: 'VIAJE',
+    },
+  ],
+  transporte: {
+    rutChofer: '11111111-1',
+    nombreChofer: 'Juan Pérez',
+    patente: 'AB-CD-12',
+    direccionDestino: 'Av. Principal 123',
+    comunaDestino: 'Concepción',
+  },
+  tipoDespacho: 5,
+};
+
+const validFactura: FacturaInput = {
+  tipoDte: 33,
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  giroEmisor: 'Transporte de Carga',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  giroReceptor: 'Comercio',
+  fechaEmision: new Date('2026-05-03T10:00:00Z'),
+  items: [
+    {
+      descripcion: 'Servicio de transporte',
+      cantidad: 1,
+      precioUnitarioClp: 850000,
+      unidadMedida: 'UN',
+    },
+  ],
+};
+
+describe('MockDteProvider — emitGuiaDespacho happy path', () => {
+  it('emite folio 1 inicial + status accepted + sha256 válido', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitGuiaDespacho(validGuia);
+
+    expect(result.folio).toBe('1');
+    expect(result.tipoDte).toBe(52);
+    expect(result.rutEmisor).toBe('76123456-7');
+    expect(result.status).toBe('accepted');
+    expect(result.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.xmlSigned).toContain('<DTE mock="true">');
+    expect(result.providerTrackId).toBe('mock-track-52-1');
+  });
+
+  it('folios autoincrementales por (rutEmisor, tipoDte)', async () => {
+    const provider = new MockDteProvider();
+    const r1 = await provider.emitGuiaDespacho(validGuia);
+    const r2 = await provider.emitGuiaDespacho(validGuia);
+    const r3 = await provider.emitGuiaDespacho(validGuia);
+    expect([r1.folio, r2.folio, r3.folio]).toEqual(['1', '2', '3']);
+  });
+
+  it('folios independientes entre emisores', async () => {
+    const provider = new MockDteProvider();
+    const r1 = await provider.emitGuiaDespacho(validGuia);
+    const r2 = await provider.emitGuiaDespacho({
+      ...validGuia,
+      rutEmisor: '99999999-9',
+      razonSocialEmisor: 'Otro Emisor',
+    });
+    expect(r1.folio).toBe('1');
+    expect(r2.folio).toBe('1'); // primer folio para emisor distinto
+  });
+
+  it('startingFolio override respeta el inicio', async () => {
+    const provider = new MockDteProvider({ startingFolio: 100 });
+    const result = await provider.emitGuiaDespacho(validGuia);
+    expect(result.folio).toBe('100');
+  });
+
+  it('sha256 determinístico para mismo input + folio', async () => {
+    const p1 = new MockDteProvider();
+    const p2 = new MockDteProvider();
+    const r1 = await p1.emitGuiaDespacho(validGuia);
+    const r2 = await p2.emitGuiaDespacho(validGuia);
+    expect(r1.sha256).toBe(r2.sha256);
+  });
+});
+
+describe('MockDteProvider — emitFactura happy path', () => {
+  it('factura DTE 33 (afecta IVA)', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitFactura(validFactura);
+    expect(result.tipoDte).toBe(33);
+    expect(result.folio).toBe('1');
+  });
+
+  it('factura DTE 34 (exenta) usa folio independiente del 33', async () => {
+    const provider = new MockDteProvider();
+    const r33 = await provider.emitFactura(validFactura);
+    const r34 = await provider.emitFactura({ ...validFactura, tipoDte: 34 });
+    expect(r33.folio).toBe('1');
+    expect(r34.folio).toBe('1'); // distinto pool
+  });
+});
+
+describe('MockDteProvider — validación Zod', () => {
+  it('rechaza RUT mal formado con DteValidationError', async () => {
+    const provider = new MockDteProvider();
+    await expect(
+      provider.emitGuiaDespacho({ ...validGuia, rutEmisor: 'no-es-rut' }),
+    ).rejects.toThrowError(DteValidationError);
+  });
+
+  it('rechaza items vacíos', async () => {
+    const provider = new MockDteProvider();
+    await expect(provider.emitGuiaDespacho({ ...validGuia, items: [] })).rejects.toThrowError(
+      DteValidationError,
+    );
+  });
+
+  it('error message incluye field errors', async () => {
+    const provider = new MockDteProvider();
+    try {
+      await provider.emitGuiaDespacho({
+        ...validGuia,
+        rutEmisor: 'no-es-rut',
+        razonSocialEmisor: '',
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(DteValidationError);
+      const e = err as DteValidationError;
+      expect(Object.keys(e.fieldErrors).length).toBeGreaterThanOrEqual(1);
+      expect(e.fieldErrors.rutEmisor).toBeDefined();
+    }
+  });
+});
+
+describe('MockDteProvider — failNextEmit (error injection)', () => {
+  it('rejected_sii throws DteRejectedBySiiError una sola vez', async () => {
+    const provider = new MockDteProvider({ failNextEmit: 'rejected_sii' });
+    await expect(provider.emitGuiaDespacho(validGuia)).rejects.toThrowError(DteRejectedBySiiError);
+    // Segundo intento debe pasar
+    const ok = await provider.emitGuiaDespacho(validGuia);
+    expect(ok.folio).toBeDefined();
+  });
+
+  it('certificate_error throws DteCertificateError con rutEmisor', async () => {
+    const provider = new MockDteProvider({ failNextEmit: 'certificate_error' });
+    try {
+      await provider.emitGuiaDespacho(validGuia);
+    } catch (err) {
+      expect(err).toBeInstanceOf(DteCertificateError);
+      expect((err as DteCertificateError).rutEmisor).toBe('76123456-7');
+    }
+  });
+
+  it('unavailable throws DteProviderUnavailableError', async () => {
+    const provider = new MockDteProvider({ failNextEmit: 'unavailable' });
+    await expect(provider.emitGuiaDespacho(validGuia)).rejects.toThrowError(
+      DteProviderUnavailableError,
+    );
+  });
+
+  it('folio_conflict throws DteFolioConflictError', async () => {
+    const provider = new MockDteProvider({ failNextEmit: 'folio_conflict' });
+    await expect(provider.emitGuiaDespacho(validGuia)).rejects.toThrowError(DteFolioConflictError);
+  });
+});
+
+describe('MockDteProvider — queryStatus', () => {
+  it('retorna status accepted post-emit', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitGuiaDespacho(validGuia);
+    const status = await provider.queryStatus({
+      folio: result.folio,
+      rutEmisor: result.rutEmisor,
+      tipoDte: 52,
+    });
+    expect(status.status).toBe('accepted');
+    expect(status.folio).toBe(result.folio);
+  });
+
+  it('throws DteNotFoundError para folio inexistente', async () => {
+    const provider = new MockDteProvider();
+    await expect(
+      provider.queryStatus({
+        folio: '999',
+        rutEmisor: '76123456-7',
+        tipoDte: 52,
+      }),
+    ).rejects.toThrowError(DteNotFoundError);
+  });
+
+  it('throws DteNotFoundError si el rutEmisor no matchea', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitGuiaDespacho(validGuia);
+    await expect(
+      provider.queryStatus({
+        folio: result.folio,
+        rutEmisor: '99999999-9', // distinto
+        tipoDte: 52,
+      }),
+    ).rejects.toThrowError(DteNotFoundError);
+  });
+
+  it('lastCheckedAt se refresca en cada query', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitGuiaDespacho(validGuia);
+    const s1 = await provider.queryStatus({
+      folio: result.folio,
+      rutEmisor: result.rutEmisor,
+      tipoDte: 52,
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const s2 = await provider.queryStatus({
+      folio: result.folio,
+      rutEmisor: result.rutEmisor,
+      tipoDte: 52,
+    });
+    expect(s2.lastCheckedAt.getTime()).toBeGreaterThan(s1.lastCheckedAt.getTime());
+  });
+});
+
+describe('MockDteProvider — environment', () => {
+  it('default certification', () => {
+    const p = new MockDteProvider();
+    expect(p.environment).toBe('certification');
+  });
+
+  it('respeta override production', () => {
+    const p = new MockDteProvider({ environment: 'production' });
+    expect(p.environment).toBe('production');
+  });
+});
+
+describe('MockDteProvider — artificial latency', () => {
+  it('simulación de latencia funciona', async () => {
+    const provider = new MockDteProvider({ artificialLatencyMs: 50 });
+    const start = Date.now();
+    await provider.emitGuiaDespacho(validGuia);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(45); // tolerancia jitter
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,7 +617,14 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/dte-provider:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.19.17
       typescript:
         specifier: ^5.8.2
         version: 5.9.3


### PR DESCRIPTION
## Resumen

Implementa `packages/dte-provider` (estaba como placeholder). Cubre el boceto del [ADR-007](../blob/feat/dte-provider-mvp/docs/adr/007-chile-document-management.md) — sección "Integración SII DTE". Avanza el bloqueante regulatorio go-live Chile (`HANDOFF.md §4`).

**Sin migración a Bsale real** — el adapter externo es PR follow-up que requiere credenciales sandbox SII + cert digital de prueba (no disponibles en este sandbox).

## Qué entrega

| Pieza | Archivo | Descripción |
|-------|---------|-------------|
| **Interface canónica** | `src/types.ts` | `DteProvider` con `emitGuiaDespacho` / `emitFactura` / `queryStatus` |
| **Schemas Zod** | `src/types.ts` | `guiaDespachoInputSchema`, `facturaInputSchema`, `dteResultSchema`, `dteStatusSchema`, `dteItemSchema`, `transporteInfoSchema` |
| **7 errores tipados** | `src/errors.ts` | Cada uno mapea a un HTTP status (400/404/409/422/503/502) |
| **MockDteProvider** | `src/mock.ts` | In-memory para dev local + tests. Folios autoincrementales, SHA-256 real, inyección de fallos, latencia simulable |
| **Tests** | `test/mock.test.ts` | 21 tests — happy path, validación, error paths inyectables, queryStatus, environment, latencia |
| **README** | `README.md` | API + ejemplos + plan de migración a Bsale |

## Errores tipados → HTTP status

```
DteValidationError              → 400 Bad Request
DteRejectedBySiiError           → 422 Unprocessable Entity (negocio)
DteCertificateError             → 422
DteFolioConflictError           → 409 Conflict
DteNotFoundError                → 404 Not Found
DteProviderUnavailableError     → 503 Service Unavailable (transient)
DteProviderError (fallback)     → 502 Bad Gateway
```

El caller (`apps/document-service`, próximo PR) los mapea con `instanceof` chain.

## API mínima

```ts
import { MockDteProvider, type DteProvider } from '@booster-ai/dte-provider';

const provider: DteProvider = new MockDteProvider();
const result = await provider.emitGuiaDespacho({
  rutEmisor: '76123456-7',
  razonSocialEmisor: 'Transportes Chile SpA',
  rutReceptor: '12345678-9',
  razonSocialReceptor: 'Cliente SA',
  fechaEmision: new Date(),
  items: [{
    descripcion: 'Transporte Santiago → Concepción',
    cantidad: 1,
    precioUnitarioClp: 850000,
    unidadMedida: 'VIAJE',
  }],
  transporte: {
    rutChofer: '11111111-1',
    nombreChofer: 'Juan Pérez',
    patente: 'AB-CD-12',
    direccionDestino: 'Av. Principal 123',
    comunaDestino: 'Concepción',
  },
});
console.log(result.folio);    // "1" (mock incremental)
console.log(result.sha256);   // hash del XML para integrity
console.log(result.xmlSigned); // XML para archivo legal 6 años
```

## MockDteProvider — features clave para tests del consumer

```ts
// Inyección de error one-shot
const provider = new MockDteProvider({ failNextEmit: 'rejected_sii' });
await expect(provider.emitGuiaDespacho(input))
  .rejects.toThrowError(DteRejectedBySiiError);

// Latencia artificial para tests de timeout
const slow = new MockDteProvider({ artificialLatencyMs: 5000 });

// Folio inicial custom
const fromN = new MockDteProvider({ startingFolio: 1000 });

// Default environment 'certification' — ningún test puede claim "production"
// accidentalmente. Override explícito si quieres simular prod:
const prod = new MockDteProvider({ environment: 'production' });
```

## Plan de migración a Bsale (PR follow-up)

Documentado en el README. Resumen:

1. Crear `src/bsale.ts` con `class BsaleAdapter implements DteProvider`.
2. Auth: API token (env var) + cert digital del emisor (Secret Manager `carrier-{id}-cert-pfx`).
3. Mapping: `GuiaDespachoInput` → request body Bsale.
4. Error mapping: HTTP del provider → errores tipados de este package.
5. Tests integración con sandbox Bsale + sandbox SII.
6. Switch en factory de `apps/document-service`: `new MockDteProvider()` → `new BsaleAdapter(...)`.

Estimación: 2-3 días dev + 2-3 días testing en sandbox SII.

## Evidencia

```
pnpm --filter @booster-ai/dte-provider typecheck  →  pass
pnpm --filter @booster-ai/dte-provider test       →  21/21 pass (~340ms)
```

## Test plan

- [x] Typecheck del package
- [x] 21 tests passing (happy + error paths)
- [ ] CI verde
- [ ] PR follow-up: BsaleAdapter con sandbox SII
- [ ] PR follow-up: integración en `apps/document-service`

## Notas

- Sin `apps/document-service` cambios — usar el package es PR independiente.
- Schema `unidadMedida` con `.max(10)` (acepta "VIAJE", "M3", etc.) — SII XML schema es laxo en este campo.
- Default `environment: 'certification'` previene errores "claim production" en tests.

https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR)_