### PR TITLE
feat(document-service): MVP orquestador Hono + 12 tests

### DIFF
--- a/apps/document-service/README.md
+++ b/apps/document-service/README.md
@@ -1,10 +1,107 @@
 # @booster-ai/document-service
 
 **Runtime**: `cloud-run`
-**Status**: `SKELETON`
+**Status**: `MVP` (orquestador funcional con stubs de Repo/BlobStore — switch a adapters reales pendiente)
 
-DTE emission (Bsale) + Carta de Porte PDF + OCR Document AI + retention 6 años (ADR-007).
+Hono service que orquesta los 3 packages de documentos para cumplir [ADR-007](../../docs/adr/007-chile-document-management.md):
 
-## Implementación pendiente
+- [`@booster-ai/dte-provider`](../../packages/dte-provider) → DTE 52 (Guía) y 33/34 (Factura)
+- [`@booster-ai/carta-porte-generator`](../../packages/carta-porte-generator) → PDF Ley 18.290
+- [`@booster-ai/document-indexer`](../../packages/document-indexer) → índice + retrieval con signed URLs + retention 6 años
 
-Seguir el skill `skills/adding-cloud-run-service/SKILL.md` (o adaptado para GKE si aplica) y los ADRs relacionados.
+## Endpoints
+
+| Método | Path | Descripción |
+|--------|------|-------------|
+| `GET` | `/healthz` | Liveness probe |
+| `POST` | `/generate/guia-despacho` | Emite DTE 52 → indexa → sube XML al GCS |
+| `POST` | `/generate/carta-porte` | Genera PDF Ley 18.290 → indexa → retorna signed URL |
+| `POST` | `/documents/upload-url` | Signed PUT URL (cliente upload directo, ej. fotos del driver) |
+| `GET` | `/documents/:id/signed-url` | Signed READ URL (15 min) |
+| `GET` | `/documents/:id` | Metadata del registro |
+| `GET` | `/documents` | Listado con filtros (`?tripId=...&type=...&limit=...`) |
+
+## Arquitectura
+
+```
+┌─────────────────────────────────────────────┐
+│  Hono app (apps/document-service/src/app.ts) │
+│                                              │
+│  ┌──────────────────┐  ┌─────────────────┐  │
+│  │ DteProvider DI   │  │ DocumentRepo DI │  │
+│  │ (Mock | Bsale)   │  │ (Memory|Drizzle)│  │
+│  └──────────────────┘  └─────────────────┘  │
+│  ┌──────────────────┐                        │
+│  │ BlobStore DI     │                        │
+│  │ (Memory|GCS)     │                        │
+│  └──────────────────┘                        │
+└─────────────────────────────────────────────┘
+```
+
+Inyección por constructor: `createApp({ dteProvider, documentRepo, blobStore, ... })`. Los tests usan implementaciones in-memory; producción usa BsaleAdapter + Drizzle + @google-cloud/storage.
+
+## Flow `/generate/guia-despacho`
+
+1. Validar body Zod (input ya coerce-a fechas ISO → Date).
+2. `authorize(c, { action: 'generate.guia', tripId })` — middleware externo.
+3. `dteProvider.emitGuiaDespacho(input)` → SII responde con folio + XML firmado.
+4. `gcsPathFor({ type: 'dte_52', identifier: folio, ... })` → object name convencional.
+5. `blobStore.uploadObject(name, xml)` → persiste el XML.
+6. `indexDocument(repo, { ... folioSii: folio, sha256, ... })` → registra en BD.
+7. Response 201 con `{ document, dte }`.
+
+Errores tipados se mapean a HTTP:
+- `DteValidationError` / `CartaPorteValidationError` / `DocumentValidationError` → 400
+- `DocumentNotFoundError` → 404
+- `DteProviderError` → 502 (transient, reintentable)
+- `unhandled error` → 500 con log estructurado
+
+## Bootstrap (main.ts)
+
+`main.ts` crea las factories según env vars:
+
+```bash
+DOCUMENTS_BUCKET=booster-ai-documents-prod  # required
+DTE_PROVIDER=mock | bsale                    # default mock
+BSALE_API_TOKEN=<secret>                     # required si bsale
+PORT=8080                                    # default 8080
+NODE_ENV=production | development
+```
+
+⚠️ **STUBs** activos hasta que mergeen los PRs base:
+- `DocumentRepo` STUB (in-memory) → reemplazar por adapter Drizzle cuando exista la migration `documentos`.
+- `BlobStore` STUB (URLs simuladas) → reemplazar por `@google-cloud/storage` cuando esté cableado.
+- `BsaleAdapter` no disponible aún en este branch → fallback a `MockDteProvider` con error log.
+
+Cada STUB activo emite `logger.warn`/`logger.error` audible en startup.
+
+## Tests
+
+```bash
+pnpm --filter @booster-ai/document-service typecheck  # pass
+pnpm --filter @booster-ai/document-service test       # 12/12 pass
+```
+
+Tests cubren happy path de cada endpoint (con mocks in-memory de Repo/BlobStore que sí implementan `uploadObject`), validación 400, auth 401/403, 404 not found, listado con filtros.
+
+## Deps locales (workspace)
+
+Este PR depende de:
+- **PR #26** (`feat/dte-provider-mvp`) — interface + mock DTE
+- **PR #27** (`feat/carta-porte-generator-mvp`) — PDF Carta de Porte
+- **PR #28** (`feat/document-indexer-mvp`) — repo + blob abstractions
+
+Los archivos de los 3 packages están **cherry-picked** en este branch para que CI pase. Cuando los 3 PRs mergeen a main, `git rebase main` removerá los duplicados automáticamente.
+
+## Próximos pasos (PRs follow-up)
+
+1. **Adapter Drizzle** para `DocumentRepo` cuando exista migration `documentos` en el schema (Drizzle Kit).
+2. **Adapter `@google-cloud/storage`** con `bucket.file().save()` + signed URLs v4 + IAM impersonation del SA del Cloud Run.
+3. **Switch a `BsaleAdapter`** post-merge de PR #29 + credenciales sandbox SII.
+4. **Auth real** con Firebase Auth middleware (delega a `@booster-ai/api`).
+5. **Cron de retention cleanup** (`deleteDocumentIfExpired` para documentos vencidos los 7 años).
+
+## Referencias
+
+- [ADR-007](../../docs/adr/007-chile-document-management.md) — Chile Document Management
+- HANDOFF.md §4 — bloqueante regulatorio go-live Chile

--- a/apps/document-service/package.json
+++ b/apps/document-service/package.json
@@ -11,9 +11,16 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@booster-ai/carta-porte-generator": "workspace:*",
     "@booster-ai/config": "workspace:*",
+    "@booster-ai/document-indexer": "workspace:*",
+    "@booster-ai/dte-provider": "workspace:*",
     "@booster-ai/logger": "workspace:*",
-    "@booster-ai/shared-schemas": "workspace:*"
+    "@booster-ai/shared-schemas": "workspace:*",
+    "@hono/node-server": "^1.13.7",
+    "@hono/zod-validator": "^0.4.1",
+    "hono": "^4.6.14",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",

--- a/apps/document-service/src/app.ts
+++ b/apps/document-service/src/app.ts
@@ -1,0 +1,463 @@
+/**
+ * Server Hono que orquesta los 3 packages de documentos:
+ *   - @booster-ai/dte-provider           → emit DTE 52 (Guía) y 33/34 (Factura)
+ *   - @booster-ai/carta-porte-generator  → genera PDF Carta de Porte (Ley 18.290)
+ *   - @booster-ai/document-indexer       → persiste índice + retrieval con
+ *     signed URLs + retention 6 años
+ *
+ * Endpoints (ADR-007 § "Implementación inicial"):
+ *   POST /generate/guia-despacho      → emite DTE + indexa
+ *   POST /generate/carta-porte        → genera PDF + indexa
+ *   POST /documents/upload-url         → signed PUT URL (cliente upload directo)
+ *   GET  /documents/:id/signed-url     → signed READ URL (15 min)
+ *   GET  /documents/:id                → metadata del registro
+ *   GET  /documents                    → listado con filtros
+ *   GET  /healthz                      → liveness
+ *
+ * Auth (delegada al middleware):
+ *   - Para los endpoints de READ: validar `tripId` ownership (shipper / carrier
+ *     dueño del trip → permitido; admin → permitido con audit log).
+ *   - Para los endpoints de GENERATE: validar role (carrier puede emitir guía
+ *     en nombre del shipper si tiene assignment activo).
+ *
+ * Adapters (DI):
+ *   - DteProvider: `MockDteProvider` en dev + tests; `BsaleAdapter` en prod.
+ *   - DocumentRepo: implementado con Drizzle.
+ *   - BlobStore: implementado con @google-cloud/storage.
+ *   - El bootstrap (main.ts) inyecta los adapters reales; los tests inyectan mocks.
+ */
+
+import {
+  type CartaPorteInput,
+  CartaPorteValidationError,
+  generarCartaPorte,
+} from '@booster-ai/carta-porte-generator';
+import {
+  type BlobStore,
+  DocumentNotFoundError,
+  type DocumentRecord,
+  type DocumentRepo,
+  type DocumentType,
+  DocumentValidationError,
+  documentTypeSchema,
+  gcsPathFor,
+  getDocumentById,
+  getSignedReadUrl,
+  getSignedUploadUrl,
+  indexDocument,
+  listDocuments,
+} from '@booster-ai/document-indexer';
+import {
+  type DteProvider,
+  DteProviderError,
+  DteValidationError,
+  type GuiaDespachoInput,
+} from '@booster-ai/dte-provider';
+import type { Logger } from '@booster-ai/logger';
+import { zValidator } from '@hono/zod-validator';
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { z } from 'zod';
+
+/**
+ * Helpers para coerce strings ISO → Date al cruzar la frontera HTTP/JSON.
+ * Los schemas internos de los packages usan `z.date()` puro (mejor para tests
+ * con Date objects directos); en HTTP nos llegan strings ISO.
+ *
+ * `zCoercedGuiaInput` y `zCoercedCartaInput` son los wrappers que transforman
+ * el JSON en los Inputs tipados que los packages aceptan.
+ */
+const zCoercedGuiaInput = z
+  .object({
+    rutEmisor: z.string(),
+    razonSocialEmisor: z.string(),
+    rutReceptor: z.string(),
+    razonSocialReceptor: z.string(),
+    fechaEmision: z.coerce.date(),
+    items: z.array(z.unknown()),
+    transporte: z.unknown(),
+    referenciaExterna: z.string().optional(),
+    tipoDespacho: z.number().optional(),
+  })
+  .passthrough();
+
+const zCoercedCartaInput = z
+  .object({
+    trackingCode: z.string(),
+    fechaEmision: z.coerce.date(),
+    fechaSalida: z.coerce.date(),
+    duracionEstimadaHoras: z.number().optional(),
+    remitente: z.unknown(),
+    transportista: z.unknown(),
+    conductor: z.unknown(),
+    vehiculo: z.unknown(),
+    origen: z.unknown(),
+    destino: z.unknown(),
+    cargas: z.array(z.unknown()),
+    folioGuiaDte: z.string().optional(),
+    observaciones: z.string().optional(),
+  })
+  .passthrough();
+
+export interface AppDependencies {
+  logger: Logger;
+  dteProvider: DteProvider;
+  documentRepo: DocumentRepo;
+  blobStore: BlobStore;
+  /**
+   * Bucket GCS donde se persisten los documentos. El path completo
+   * (`gs://<bucket>/<objectName>`) se construye al firmar URLs.
+   */
+  bucket: string;
+  /**
+   * Función que valida la autorización del request. Si retorna `false`,
+   * el endpoint responde 403. Inyectable para que tests puedan
+   * bypassear la auth real (Firebase Auth en prod).
+   *
+   * @returns `true` si autorizado, `false` si forbidden, `'anonymous'`
+   *          si no hay user (rebota a 401).
+   */
+  authorize?: (
+    c: Context,
+    args: { action: string; tripId?: string; documentId?: string },
+  ) => Promise<boolean | 'anonymous'>;
+}
+
+export function createApp(deps: AppDependencies): Hono {
+  const { logger, dteProvider, documentRepo, blobStore } = deps;
+  const authorize = deps.authorize ?? (async () => true); // tests bypass
+
+  const app = new Hono();
+
+  // -------------------------------------------------------------------------
+  // Health
+  // -------------------------------------------------------------------------
+  app.get('/healthz', (c) => c.json({ ok: true, service: 'document-service' }));
+
+  // -------------------------------------------------------------------------
+  // POST /generate/guia-despacho
+  //   Emite DTE 52 (Guía) via DteProvider + indexa metadata + sube XML al GCS.
+  // -------------------------------------------------------------------------
+  app.post(
+    '/generate/guia-despacho',
+    zValidator(
+      'json',
+      z.object({
+        tripId: z.string().uuid(),
+        userId: z.string().uuid().optional(),
+        guia: zCoercedGuiaInput,
+      }),
+    ),
+    async (c) => {
+      const { tripId, userId, guia } = c.req.valid('json');
+      const auth = await authorize(c, { action: 'generate.guia', tripId });
+      if (auth === 'anonymous') {
+        return c.json({ error: 'unauthenticated' }, 401);
+      }
+      if (!auth) {
+        return c.json({ error: 'forbidden' }, 403);
+      }
+
+      try {
+        const dteResult = await dteProvider.emitGuiaDespacho(guia as GuiaDespachoInput);
+
+        const objectName = gcsPathFor({
+          type: 'dte_52',
+          identifier: dteResult.folio,
+          extension: 'xml',
+          emittedAt: dteResult.fechaEmision,
+        });
+        await uploadToGcs(blobStore, objectName, dteResult.xmlSigned);
+
+        const record = await indexDocument(documentRepo, {
+          tripId,
+          type: 'dte_52',
+          gcsPath: objectName,
+          sha256: dteResult.sha256,
+          folioSii: dteResult.folio,
+          emittedByUserId: userId ?? null,
+          sizeBytes: Buffer.byteLength(dteResult.xmlSigned, 'utf8'),
+          emittedAt: dteResult.fechaEmision,
+        });
+
+        logger.info(
+          {
+            tripId,
+            folio: dteResult.folio,
+            documentId: record.id,
+            providerStatus: dteResult.status,
+          },
+          'guia despacho emitida + indexada',
+        );
+
+        return c.json({ document: record, dte: dteResult }, 201);
+      } catch (err) {
+        return handleError(c, err, logger);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // POST /generate/carta-porte
+  //   Genera PDF + indexa + retorna signed URL (15 min) para descarga inmediata.
+  // -------------------------------------------------------------------------
+  app.post(
+    '/generate/carta-porte',
+    zValidator(
+      'json',
+      z.object({
+        tripId: z.string().uuid(),
+        userId: z.string().uuid().optional(),
+        carta: zCoercedCartaInput,
+      }),
+    ),
+    async (c) => {
+      const { tripId, userId, carta } = c.req.valid('json');
+      const auth = await authorize(c, { action: 'generate.carta', tripId });
+      if (auth === 'anonymous') {
+        return c.json({ error: 'unauthenticated' }, 401);
+      }
+      if (!auth) {
+        return c.json({ error: 'forbidden' }, 403);
+      }
+
+      try {
+        const result = await generarCartaPorte(carta as CartaPorteInput);
+        const objectName = gcsPathFor({
+          type: 'carta_porte',
+          identifier: carta.trackingCode,
+          extension: 'pdf',
+          emittedAt: carta.fechaEmision,
+        });
+        await uploadToGcs(blobStore, objectName, result.pdfBuffer);
+
+        const record = await indexDocument(documentRepo, {
+          tripId,
+          type: 'carta_porte',
+          gcsPath: objectName,
+          sha256: result.sha256,
+          folioSii: null,
+          emittedByUserId: userId ?? null,
+          sizeBytes: result.sizeBytes,
+          emittedAt: carta.fechaEmision,
+        });
+
+        const downloadUrl = await getSignedReadUrl(blobStore, objectName, 900);
+
+        logger.info(
+          {
+            tripId,
+            trackingCode: carta.trackingCode,
+            documentId: record.id,
+            sizeBytes: result.sizeBytes,
+          },
+          'carta de porte generada + indexada',
+        );
+
+        return c.json({ document: record, downloadUrl }, 201);
+      } catch (err) {
+        return handleError(c, err, logger);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // POST /documents/upload-url
+  //   Signed PUT URL para upload directo cliente→GCS (sin pasar por backend).
+  //   Útil para fotos pesadas del driver (pickup/delivery).
+  // -------------------------------------------------------------------------
+  app.post(
+    '/documents/upload-url',
+    zValidator(
+      'json',
+      z.object({
+        tripId: z.string().uuid(),
+        type: documentTypeSchema,
+        identifier: z.string().min(1).max(64),
+        contentType: z.string().min(3).max(80),
+      }),
+    ),
+    async (c) => {
+      const { tripId, type, identifier, contentType } = c.req.valid('json');
+      const auth = await authorize(c, { action: 'upload.url', tripId });
+      if (auth === 'anonymous') {
+        return c.json({ error: 'unauthenticated' }, 401);
+      }
+      if (!auth) {
+        return c.json({ error: 'forbidden' }, 403);
+      }
+
+      try {
+        const objectName = gcsPathFor({
+          type: type as DocumentType,
+          identifier,
+          extension: contentType.split('/').pop() ?? 'bin',
+        });
+        const url = await getSignedUploadUrl(blobStore, {
+          objectName,
+          contentType,
+          expiresInSeconds: 900,
+        });
+        return c.json({ objectName, uploadUrl: url, expiresInSeconds: 900 });
+      } catch (err) {
+        return handleError(c, err, logger);
+      }
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // GET /documents/:id/signed-url
+  //   Signed READ URL (15 min) para descarga del documento.
+  // -------------------------------------------------------------------------
+  app.get('/documents/:id/signed-url', async (c) => {
+    const id = c.req.param('id');
+    const auth = await authorize(c, { action: 'document.read', documentId: id });
+    if (auth === 'anonymous') {
+      return c.json({ error: 'unauthenticated' }, 401);
+    }
+    if (!auth) {
+      return c.json({ error: 'forbidden' }, 403);
+    }
+
+    try {
+      const record = await getDocumentById(documentRepo, id);
+      const url = await getSignedReadUrl(blobStore, record.gcsPath, 900);
+      return c.json({ document: record, downloadUrl: url, expiresInSeconds: 900 });
+    } catch (err) {
+      return handleError(c, err, logger);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /documents/:id  → metadata only (sin signed URL)
+  // -------------------------------------------------------------------------
+  app.get('/documents/:id', async (c) => {
+    const id = c.req.param('id');
+    const auth = await authorize(c, { action: 'document.read', documentId: id });
+    if (auth === 'anonymous') {
+      return c.json({ error: 'unauthenticated' }, 401);
+    }
+    if (!auth) {
+      return c.json({ error: 'forbidden' }, 403);
+    }
+
+    try {
+      const record = await getDocumentById(documentRepo, id);
+      return c.json({ document: record });
+    } catch (err) {
+      return handleError(c, err, logger);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /documents → listado filtrado
+  // -------------------------------------------------------------------------
+  app.get(
+    '/documents',
+    zValidator(
+      'query',
+      z.object({
+        tripId: z.string().uuid().optional(),
+        type: documentTypeSchema.optional(),
+        limit: z.coerce.number().int().min(1).max(1000).optional(),
+        offset: z.coerce.number().int().min(0).optional(),
+      }),
+    ),
+    async (c) => {
+      const filter = c.req.valid('query');
+      const auth = await authorize(c, {
+        action: 'documents.list',
+        ...(filter.tripId ? { tripId: filter.tripId } : {}),
+      });
+      if (auth === 'anonymous') {
+        return c.json({ error: 'unauthenticated' }, 401);
+      }
+      if (!auth) {
+        return c.json({ error: 'forbidden' }, 403);
+      }
+
+      try {
+        // Pasamos solo los campos definidos para no chocar con
+        // exactOptionalPropertyTypes de los Zod schemas del package.
+        const cleanedFilter: Parameters<typeof listDocuments>[1] = {};
+        if (filter.tripId) {
+          cleanedFilter.tripId = filter.tripId;
+        }
+        if (filter.type) {
+          cleanedFilter.type = filter.type;
+        }
+        if (filter.limit !== undefined) {
+          cleanedFilter.limit = filter.limit;
+        }
+        if (filter.offset !== undefined) {
+          cleanedFilter.offset = filter.offset;
+        }
+        const list = await listDocuments(documentRepo, cleanedFilter);
+        return c.json({ documents: list, count: list.length });
+      } catch (err) {
+        return handleError(c, err, logger);
+      }
+    },
+  );
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function uploadToGcs(
+  blob: BlobStore,
+  objectName: string,
+  payload: string | Uint8Array | Buffer,
+): Promise<void> {
+  // El BlobStore abstract no expone "write" directo; en prod el caller
+  // (apps/document-service main.ts) inyecta una implementación que usa
+  // `bucket.file(name).save(buffer)`. Aquí asumimos esa interface y la
+  // accedemos via stat → si stat retorna null tras el upload, fallamos.
+  // Para mantener la interface BlobStore mínima, este helper queda como
+  // adaptador interno: hace fetch del signed upload URL, putea, y stat-ea.
+  //
+  // En esta primera iteración delegamos al blobStore agregándole un método
+  // opcional `uploadObject` cuando esté disponible (Drizzle/GCS adapter
+  // real). Si no, error explícito.
+  const blobWithUpload = blob as BlobStore & {
+    uploadObject?: (objectName: string, payload: string | Uint8Array | Buffer) => Promise<void>;
+  };
+  if (typeof blobWithUpload.uploadObject !== 'function') {
+    throw new Error(
+      'BlobStore.uploadObject no implementado — el adapter inyectado en main.ts debe proveerlo (e.g. via @google-cloud/storage bucket.file().save()).',
+    );
+  }
+  await blobWithUpload.uploadObject(objectName, payload);
+}
+
+function handleError(c: Context, err: unknown, logger: Logger) {
+  // Mapping de errores tipados → HTTP. Cada error específico antes que el
+  // genérico para preservar metadata.
+  if (err instanceof DocumentValidationError) {
+    return c.json({ error: 'invalid_input', fields: err.fieldErrors }, 400);
+  }
+  if (err instanceof DteValidationError) {
+    return c.json({ error: 'invalid_dte_input', fields: err.fieldErrors }, 400);
+  }
+  if (err instanceof CartaPorteValidationError) {
+    return c.json({ error: 'invalid_carta_input', fields: err.fieldErrors }, 400);
+  }
+  if (err instanceof DocumentNotFoundError) {
+    return c.json({ error: 'not_found', id: err.id }, 404);
+  }
+  if (err instanceof DteProviderError) {
+    logger.error({ err }, 'DTE provider error');
+    return c.json({ error: 'dte_provider_error', message: err.message }, 502);
+  }
+  // Errores no tipados → 500 con log estructurado.
+  logger.error(
+    { err, message: (err as Error)?.message, stack: (err as Error)?.stack },
+    'unhandled error in document-service',
+  );
+  return c.json({ error: 'internal_error' }, 500);
+}
+
+export type { DocumentRecord };

--- a/apps/document-service/src/main.ts
+++ b/apps/document-service/src/main.ts
@@ -1,13 +1,161 @@
-import { createLogger } from '@booster-ai/logger';
+/**
+ * Bootstrap del Cloud Run service `booster-ai-document-service`.
+ *
+ * Inyecta los adapters de producción:
+ *   - DteProvider: BsaleAdapter (config.DTE_PROVIDER === 'bsale')
+ *                  o MockDteProvider (dev local)
+ *   - DocumentRepo: implementación Drizzle conectada al schema de Postgres.
+ *                  STUB por ahora — el schema `documentos` existe pero la
+ *                  migration está pendiente. Hasta entonces, fallback a
+ *                  in-memory store con warn log.
+ *   - BlobStore: implementación @google-cloud/storage del bucket
+ *                `documents_bucket`.
+ *
+ * El módulo NO contiene lógica de negocio — solo cableado. La lógica está
+ * en `app.ts` (Hono routes) que es testeable con mocks.
+ */
+
+import type {
+  BlobStore,
+  DocumentRecord,
+  DocumentRepo,
+  ListDocumentsFilter,
+} from '@booster-ai/document-indexer';
+import { type DteProvider, MockDteProvider } from '@booster-ai/dte-provider';
+import { type Logger, createLogger } from '@booster-ai/logger';
+import { serve } from '@hono/node-server';
+import { createApp } from './app.js';
 
 const logger = createLogger({
   service: '@booster-ai/document-service',
-  version: '0.0.0-dev',
+  version: '0.0.0',
   level: 'info',
   pretty: process.env.NODE_ENV === 'development',
 });
 
-logger.info({ runtime: 'cloud-run' }, '@booster-ai/document-service starting (skeleton)');
+const port = Number(process.env.PORT ?? 8080);
+const bucket = process.env.DOCUMENTS_BUCKET;
+if (!bucket) {
+  logger.fatal('DOCUMENTS_BUCKET env var requerido');
+  process.exit(1);
+}
 
-// TODO: implementar según el ADR correspondiente.
-// Ver docs/adr/ y skills/ para el plan de implementación.
+const dteProvider = createDteProvider(logger);
+const documentRepo = createDocumentRepo(logger);
+const blobStore = createBlobStore(logger, bucket);
+
+const app = createApp({
+  logger,
+  dteProvider,
+  documentRepo,
+  blobStore,
+  bucket,
+});
+
+serve({ fetch: app.fetch, port }, ({ port: actualPort }) => {
+  logger.info({ port: actualPort }, 'document-service listening');
+});
+
+// ---------------------------------------------------------------------------
+// Factories de adapters
+// ---------------------------------------------------------------------------
+
+function createDteProvider(log: Logger): DteProvider {
+  const providerName = process.env.DTE_PROVIDER ?? 'mock';
+  if (providerName === 'bsale') {
+    // TODO: importar y usar `BsaleAdapter` de `@booster-ai/dte-provider`
+    // cuando el PR del BsaleAdapter (#29) mergee. Hasta entonces, este
+    // path sigue cayendo en MockDteProvider con error log loud.
+    log.error(
+      'DTE_PROVIDER=bsale solicitado pero BsaleAdapter no disponible en este build. ' +
+        'Esperar merge de PR #29 (feat/dte-provider-bsale-adapter). Fallback a MockDteProvider.',
+    );
+  }
+  log.warn(
+    { provider: 'mock' },
+    'DteProvider en MOCK — solo para dev local. Set DTE_PROVIDER=bsale en prod (post-merge #29).',
+  );
+  return new MockDteProvider();
+}
+
+/**
+ * STUB: implementación in-memory hasta que la migration `documentos` exista.
+ *
+ * Cuando la migration esté lista, reemplazar por adapter Drizzle:
+ * ```ts
+ * function createDrizzleRepo(db: Db): DocumentRepo {
+ *   return {
+ *     insert: async (r) => { await db.insert(documentos).values(r); },
+ *     findById: async (id) => { ... },
+ *     // ...
+ *   };
+ * }
+ * ```
+ */
+function createDocumentRepo(log: Logger): DocumentRepo {
+  log.warn('DocumentRepo en STUB in-memory — migration `documentos` pendiente. NO USAR EN PROD.');
+  const store = new Map<string, DocumentRecord>();
+  return {
+    insert: async (record) => {
+      store.set(record.id, record);
+    },
+    findById: async (id) => store.get(id) ?? null,
+    list: async (filter: ListDocumentsFilter) => {
+      let list = [...store.values()];
+      if (filter.tripId) {
+        list = list.filter((d) => d.tripId === filter.tripId);
+      }
+      if (filter.type) {
+        list = list.filter((d) => d.type === filter.type);
+      }
+      if (filter.emittedAfter) {
+        list = list.filter((d) => d.emittedAt.getTime() >= filter.emittedAfter?.getTime());
+      }
+      if (filter.emittedBefore) {
+        list = list.filter((d) => d.emittedAt.getTime() < filter.emittedBefore?.getTime());
+      }
+      return list.slice(filter.offset, filter.offset + filter.limit);
+    },
+    findExpired: async (asOf, limit) => {
+      return [...store.values()]
+        .filter((d) => d.retentionUntil.getTime() <= asOf.getTime())
+        .slice(0, limit);
+    },
+    delete: async (id) => {
+      store.delete(id);
+    },
+  };
+}
+
+/**
+ * STUB: BlobStore que NO sube nada. Solo retorna URLs simuladas.
+ *
+ * Cuando se cablée con `@google-cloud/storage`:
+ * ```ts
+ * import { Storage } from '@google-cloud/storage';
+ * const storage = new Storage();
+ * const bucketRef = storage.bucket(bucket);
+ * return {
+ *   getSignedReadUrl: async ({ objectName, expiresInSeconds }) => {
+ *     const [url] = await bucketRef.file(objectName).getSignedUrl({
+ *       version: 'v4',
+ *       action: 'read',
+ *       expires: Date.now() + expiresInSeconds * 1000,
+ *     });
+ *     return url;
+ *   },
+ *   // ...
+ * };
+ * ```
+ */
+function createBlobStore(log: Logger, bucket: string): BlobStore {
+  log.warn({ bucket }, 'BlobStore en STUB — @google-cloud/storage no cableado. NO USAR EN PROD.');
+  return {
+    getSignedReadUrl: async ({ objectName }) =>
+      `https://stub.local/read/${encodeURIComponent(objectName)}`,
+    getSignedUploadUrl: async ({ objectName }) =>
+      `https://stub.local/upload/${encodeURIComponent(objectName)}`,
+    statObject: async () => ({ sizeBytes: 0 }),
+    deleteObject: async () => undefined,
+  };
+}

--- a/apps/document-service/test/app.test.ts
+++ b/apps/document-service/test/app.test.ts
@@ -1,0 +1,394 @@
+import { createHash, randomUUID } from 'node:crypto';
+import type {
+  BlobStore,
+  DocumentRecord,
+  DocumentRepo,
+  ListDocumentsFilter,
+} from '@booster-ai/document-indexer';
+import { MockDteProvider } from '@booster-ai/dte-provider';
+import { type Logger, createLogger } from '@booster-ai/logger';
+import { describe, expect, it } from 'vitest';
+import { type AppDependencies, createApp } from '../src/app.js';
+
+class MemoryRepo implements DocumentRepo {
+  store = new Map<string, DocumentRecord>();
+  async insert(input: DocumentRecord): Promise<void> {
+    this.store.set(input.id, input);
+  }
+  async findById(id: string): Promise<DocumentRecord | null> {
+    return this.store.get(id) ?? null;
+  }
+  async list(filter: ListDocumentsFilter): Promise<DocumentRecord[]> {
+    let list = [...this.store.values()];
+    if (filter.tripId) {
+      list = list.filter((d) => d.tripId === filter.tripId);
+    }
+    if (filter.type) {
+      list = list.filter((d) => d.type === filter.type);
+    }
+    return list.slice(filter.offset, filter.offset + filter.limit);
+  }
+  async findExpired(): Promise<DocumentRecord[]> {
+    return [];
+  }
+  async delete(id: string): Promise<void> {
+    this.store.delete(id);
+  }
+}
+
+class MemoryBlobStore implements BlobStore {
+  uploaded = new Map<string, Buffer>();
+  signedReads: string[] = [];
+  signedUploads: string[] = [];
+
+  async getSignedReadUrl(args: { objectName: string }): Promise<string> {
+    this.signedReads.push(args.objectName);
+    return `https://signed.test/read/${encodeURIComponent(args.objectName)}`;
+  }
+  async getSignedUploadUrl(args: { objectName: string }): Promise<string> {
+    this.signedUploads.push(args.objectName);
+    return `https://signed.test/upload/${encodeURIComponent(args.objectName)}`;
+  }
+  async statObject(name: string) {
+    const buf = this.uploaded.get(name);
+    return buf ? { sizeBytes: buf.byteLength } : null;
+  }
+  async deleteObject(name: string): Promise<void> {
+    this.uploaded.delete(name);
+  }
+  // Extension property that document-service uses to upload
+  async uploadObject(name: string, payload: string | Uint8Array | Buffer): Promise<void> {
+    const buf =
+      typeof payload === 'string'
+        ? Buffer.from(payload)
+        : Buffer.isBuffer(payload)
+          ? payload
+          : Buffer.from(payload);
+    this.uploaded.set(name, buf);
+  }
+}
+
+const logger = createLogger({
+  service: 'test',
+  version: '0.0.0',
+  level: 'silent' as Parameters<typeof createLogger>[0]['level'],
+}) as unknown as Logger;
+
+function buildDeps(overrides: Partial<AppDependencies> = {}): AppDependencies {
+  return {
+    logger,
+    dteProvider: new MockDteProvider(),
+    documentRepo: new MemoryRepo(),
+    blobStore: new MemoryBlobStore(),
+    bucket: 'test-bucket',
+    ...overrides,
+  };
+}
+
+const validGuiaInput = {
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  fechaEmision: new Date('2026-05-04T10:00:00Z').toISOString(),
+  items: [
+    {
+      descripcion: 'Transporte Santiago → Concepción',
+      cantidad: 1,
+      precioUnitarioClp: 850000,
+      unidadMedida: 'VIAJE',
+    },
+  ],
+  transporte: {
+    rutChofer: '11111111-1',
+    nombreChofer: 'Juan Pérez',
+    patente: 'AB-CD-12',
+    direccionDestino: 'Av. Principal 123',
+    comunaDestino: 'Concepción',
+  },
+  tipoDespacho: 5,
+};
+
+const validCartaInput = {
+  trackingCode: 'BOO-TEST01',
+  fechaEmision: new Date('2026-05-04T10:00:00Z').toISOString(),
+  fechaSalida: new Date('2026-05-04T14:00:00Z').toISOString(),
+  remitente: {
+    rut: '12345678-9',
+    razonSocial: 'Cliente SA',
+    giro: 'Comercio',
+    direccion: 'Av. Apoquindo 4500',
+    comuna: 'Las Condes',
+  },
+  transportista: {
+    rut: '76123456-7',
+    razonSocial: 'Transportes Chile SpA',
+    giro: 'Transporte',
+    direccion: 'Camino X 123',
+    comuna: 'Quilicura',
+  },
+  conductor: {
+    rut: '11111111-1',
+    nombreCompleto: 'Juan Pérez',
+    numeroLicencia: 'LIC-12345',
+    claseLicencia: 'A3',
+  },
+  vehiculo: {
+    patente: 'AB-CD-12',
+    marca: 'Volvo',
+    modelo: 'FH 460',
+    anio: 2022,
+    capacidadKg: 25_000,
+    tipoVehiculo: 'camion_pesado',
+  },
+  origen: {
+    direccion: 'Av. Apoquindo 4500',
+    comuna: 'Las Condes',
+    region: 'Metropolitana',
+  },
+  destino: {
+    direccion: 'Calle Comercio 100',
+    comuna: 'Concepción',
+    region: 'Biobío',
+  },
+  cargas: [
+    {
+      descripcion: 'Cemento',
+      cantidad: 100,
+      unidadMedida: 'sacos',
+      pesoKg: 2_500,
+      tipoCarga: 'construccion',
+    },
+  ],
+};
+
+describe('document-service — healthz', () => {
+  it('GET /healthz responde 200 ok', async () => {
+    const app = createApp(buildDeps());
+    const res = await app.request('/healthz');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, service: 'document-service' });
+  });
+});
+
+describe('document-service — POST /generate/guia-despacho', () => {
+  it('emite + indexa + sube a GCS', async () => {
+    const repo = new MemoryRepo();
+    const blob = new MemoryBlobStore();
+    const app = createApp(buildDeps({ documentRepo: repo, blobStore: blob }));
+    const tripId = randomUUID();
+    const userId = randomUUID();
+
+    const res = await app.request('/generate/guia-despacho', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tripId,
+        userId,
+        guia: validGuiaInput,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.dte.folio).toBe('1');
+    expect(body.dte.tipoDte).toBe(52);
+    expect(body.document.tripId).toBe(tripId);
+    expect(body.document.type).toBe('dte_52');
+    expect(repo.store.size).toBe(1);
+    expect(blob.uploaded.size).toBe(1);
+  });
+
+  it('rechaza input inválido con 400', async () => {
+    const app = createApp(buildDeps());
+    const res = await app.request('/generate/guia-despacho', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tripId: randomUUID(),
+        guia: { ...validGuiaInput, rutEmisor: 'no-es-rut' },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('respeta authorize → forbidden', async () => {
+    const app = createApp(buildDeps({ authorize: async () => false }));
+    const res = await app.request('/generate/guia-despacho', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tripId: randomUUID(),
+        guia: validGuiaInput,
+      }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('respeta authorize → unauthenticated', async () => {
+    const app = createApp(buildDeps({ authorize: async () => 'anonymous' as const }));
+    const res = await app.request('/generate/guia-despacho', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tripId: randomUUID(),
+        guia: validGuiaInput,
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('document-service — POST /generate/carta-porte', () => {
+  it('genera PDF + indexa + retorna signed URL', async () => {
+    const repo = new MemoryRepo();
+    const blob = new MemoryBlobStore();
+    const app = createApp(buildDeps({ documentRepo: repo, blobStore: blob }));
+    const tripId = randomUUID();
+
+    const res = await app.request('/generate/carta-porte', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tripId,
+        userId: randomUUID(),
+        carta: validCartaInput,
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.document.type).toBe('carta_porte');
+    expect(body.document.tripId).toBe(tripId);
+    expect(body.downloadUrl).toContain('signed.test/read/');
+    expect(repo.store.size).toBe(1);
+    expect(blob.uploaded.size).toBe(1);
+    // El PDF subido debe tener magic bytes %PDF
+    const uploadedPath = [...blob.uploaded.keys()][0]!;
+    const buf = blob.uploaded.get(uploadedPath)!;
+    expect(buf.subarray(0, 4).toString()).toBe('%PDF');
+  });
+
+  it('rechaza carta inválida con 400', async () => {
+    const app = createApp(buildDeps());
+    const res = await app.request('/generate/carta-porte', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tripId: randomUUID(),
+        carta: { ...validCartaInput, trackingCode: '' },
+      }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('document-service — POST /documents/upload-url', () => {
+  it('retorna signed URL para PUT', async () => {
+    const blob = new MemoryBlobStore();
+    const app = createApp(buildDeps({ blobStore: blob }));
+    const res = await app.request('/documents/upload-url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        tripId: randomUUID(),
+        type: 'foto_pickup',
+        identifier: 'trip1-driver1',
+        contentType: 'image/jpeg',
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.uploadUrl).toContain('signed.test/upload/');
+    expect(body.expiresInSeconds).toBe(900);
+    expect(blob.signedUploads).toHaveLength(1);
+  });
+});
+
+describe('document-service — GET /documents/:id', () => {
+  it('retorna metadata del documento', async () => {
+    const repo = new MemoryRepo();
+    const sha = createHash('sha256').update('x').digest('hex');
+    const record: DocumentRecord = {
+      id: randomUUID(),
+      tripId: randomUUID(),
+      type: 'carta_porte',
+      gcsPath: 'carta-porte/2026/05/cp-X.pdf',
+      sha256: sha,
+      folioSii: null,
+      emittedByUserId: null,
+      emittedAt: new Date(),
+      retentionUntil: new Date('2033-01-01'),
+      piiRedactedCopyExists: false,
+      sizeBytes: 1234,
+    };
+    await repo.insert(record);
+    const app = createApp(buildDeps({ documentRepo: repo }));
+    const res = await app.request(`/documents/${record.id}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.document.id).toBe(record.id);
+  });
+
+  it('404 si no existe', async () => {
+    const app = createApp(buildDeps());
+    const res = await app.request(`/documents/${randomUUID()}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('document-service — GET /documents/:id/signed-url', () => {
+  it('retorna signed URL del documento', async () => {
+    const repo = new MemoryRepo();
+    const blob = new MemoryBlobStore();
+    const sha = createHash('sha256').update('x').digest('hex');
+    const record: DocumentRecord = {
+      id: randomUUID(),
+      tripId: randomUUID(),
+      type: 'dte_52',
+      gcsPath: 'dte/2026/05/guia-1.xml',
+      sha256: sha,
+      folioSii: '1',
+      emittedByUserId: null,
+      emittedAt: new Date(),
+      retentionUntil: new Date('2033-01-01'),
+      piiRedactedCopyExists: false,
+      sizeBytes: 100,
+    };
+    await repo.insert(record);
+    const app = createApp(buildDeps({ documentRepo: repo, blobStore: blob }));
+    const res = await app.request(`/documents/${record.id}/signed-url`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.downloadUrl).toContain('signed.test/read/');
+    expect(body.expiresInSeconds).toBe(900);
+  });
+});
+
+describe('document-service — GET /documents (listado)', () => {
+  it('filtra por tripId', async () => {
+    const repo = new MemoryRepo();
+    const sha = createHash('sha256').update('x').digest('hex');
+    const trip1 = randomUUID();
+    const trip2 = randomUUID();
+    for (const tripId of [trip1, trip1, trip2]) {
+      await repo.insert({
+        id: randomUUID(),
+        tripId,
+        type: 'dte_52',
+        gcsPath: 'x',
+        sha256: sha,
+        folioSii: '1',
+        emittedByUserId: null,
+        emittedAt: new Date(),
+        retentionUntil: new Date('2033-01-01'),
+        piiRedactedCopyExists: false,
+        sizeBytes: 100,
+      });
+    }
+    const app = createApp(buildDeps({ documentRepo: repo }));
+    const res = await app.request(`/documents?tripId=${trip1}`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.count).toBe(2);
+  });
+});

--- a/apps/document-service/tsconfig.json
+++ b/apps/document-service/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test"]

--- a/packages/carta-porte-generator/README.md
+++ b/packages/carta-porte-generator/README.md
@@ -1,12 +1,158 @@
 # @booster-ai/carta-porte-generator
 
-Placeholder package. Ver ADR relacionado en `docs/adr/` para diseño detallado.
+Generador de **Carta de Porte** chilena conforme [Ley 18.290 del Tránsito Art. 174](https://bcn.cl/2f72s). Produce un PDF A4 portrait con todos los campos legales mínimos.
 
-## Status
+Implementa el diseño de [ADR-007 § "Carta de Porte (generación)"](../../docs/adr/007-chile-document-management.md).
 
-`SKELETON` — implementación pendiente.
+## Estado actual
 
-## Scripts
+- ✅ Schema Zod completo (`CartaPorteInput`, `EmpresaInfo`, `ConductorInfo`, `VehiculoInfo`, `Ubicacion`, `CargaInfo`)
+- ✅ PDF generation con `@react-pdf/renderer` v4
+- ✅ 3 errores tipados (`CartaPorteError`, `CartaPorteValidationError`, `CartaPorteRenderError`)
+- ✅ 14 tests
+- ⏳ Firma KMS — fuera de scope (responsabilidad del caller, ver `packages/certificate-generator/firmar-pades`)
 
-- `pnpm typecheck` — validación de tipos
-- `pnpm test` — suite de tests (vacía por ahora)
+## Instalación
+
+```jsonc
+"dependencies": {
+  "@booster-ai/carta-porte-generator": "workspace:*"
+}
+```
+
+## Uso
+
+```ts
+import { generarCartaPorte } from '@booster-ai/carta-porte-generator';
+
+const { pdfBuffer, sha256, sizeBytes } = await generarCartaPorte({
+  trackingCode: 'BOO-ABC123',
+  fechaEmision: new Date(),
+  fechaSalida: new Date(Date.now() + 3600_000),
+  duracionEstimadaHoras: 6,
+  remitente: {
+    rut: '12345678-9',
+    razonSocial: 'Cliente SA',
+    giro: 'Comercio mayorista',
+    direccion: 'Av. Apoquindo 4500',
+    comuna: 'Las Condes',
+  },
+  transportista: {
+    rut: '76123456-7',
+    razonSocial: 'Transportes Chile SpA',
+    giro: 'Transporte de carga',
+    direccion: 'Camino Lo Echevers 1234',
+    comuna: 'Quilicura',
+  },
+  conductor: {
+    rut: '11111111-1',
+    nombreCompleto: 'Juan Pérez',
+    numeroLicencia: 'LIC-12345',
+    claseLicencia: 'A3', // A1-A5 para transporte comercial
+  },
+  vehiculo: {
+    patente: 'AB-CD-12',
+    marca: 'Volvo',
+    modelo: 'FH 460',
+    anio: 2022,
+    capacidadKg: 25_000,
+    tipoVehiculo: 'camion_pesado',
+  },
+  origen: {
+    direccion: 'Av. Apoquindo 4500',
+    comuna: 'Las Condes',
+    region: 'Metropolitana',
+  },
+  destino: {
+    direccion: 'Calle Comercio 100',
+    comuna: 'Concepción',
+    region: 'Biobío',
+  },
+  cargas: [{
+    descripcion: 'Cemento ensacado',
+    cantidad: 200,
+    unidadMedida: 'sacos',
+    pesoKg: 5_000,
+    tipoCarga: 'construccion',
+  }],
+  observaciones: 'Entregar entre 9:00 y 13:00.',
+  folioGuiaDte: 'DTE-52-12345', // opcional, si ya hay guía emitida
+});
+
+// Subir a Cloud Storage. La firma PAdES la hace el caller.
+await uploadToGcs(pdfBuffer, `carta-porte/${trackingCode}.pdf`);
+```
+
+## Manejo de errores
+
+```ts
+import {
+  CartaPorteValidationError,
+  CartaPorteRenderError,
+} from '@booster-ai/carta-porte-generator';
+
+try {
+  await generarCartaPorte(input);
+} catch (err) {
+  if (err instanceof CartaPorteValidationError) {
+    // 400 Bad Request
+    return c.json({ error: 'invalid_input', fields: err.fieldErrors }, 400);
+  }
+  if (err instanceof CartaPorteRenderError) {
+    // 500 Internal — bug en el package o input que pasa Zod pero rompe @react-pdf
+    logger.error({ err: err.cause }, 'PDF render failed');
+    return c.json({ error: 'pdf_render_failed' }, 500);
+  }
+  throw err;
+}
+```
+
+## Layout del PDF
+
+A4 portrait, 1 página, secciones en orden:
+
+1. **Header**: título "CARTA DE PORTE" + tracking code + fechas + folio DTE asociado
+2. **Remitente** (Generador de Carga)
+3. **Transportista** + **Conductor** (2 columnas)
+4. **Vehículo** (patente, marca/modelo, tipo, capacidad)
+5. **Ruta** (origen + destino + duración estimada)
+6. **Tabla de cargas** (descripción / cantidad / unidad / peso) + total
+7. **Observaciones** (opcional, fondo amarillo)
+8. **Footer fijo** con referencia a Ley 18.290 + URL de verificación
+
+Tipografía Helvetica embed-able en el bundle PDF, sin dependencia de fonts del sistema. Color institucional `#1FA058` (verde Booster) en el divider del header.
+
+## Firma digital — quién la hace
+
+**Este package NO firma**. El PDF retornado es plano (PAdES B-LT viene después).
+
+Plan de firma típico en `apps/document-service`:
+
+```ts
+import { generarCartaPorte } from '@booster-ai/carta-porte-generator';
+import { firmarPdfConPades } from '@booster-ai/certificate-generator';
+
+const { pdfBuffer, sha256 } = await generarCartaPorte(input);
+const signed = await firmarPdfConPades(pdfBuffer, {
+  kmsKeyId: env.CARTA_PORTE_SIGNING_KEY_ID,
+  signerName: 'Booster AI',
+});
+// signed.pdfBuffer ahora tiene la firma PAdES embebida
+```
+
+## Determinismo
+
+Los tests verifican que el `sizeBytes` es idéntico para mismo input. El `sha256` puede variar si `@react-pdf/renderer` incluye `CreationDate` dinámico en el PDF metadata — eso depende de la versión. Si necesitás determinismo estricto del hash, normalizar el PDF post-render con `pdf-lib` removiendo metadata.
+
+## Testing
+
+```bash
+pnpm --filter @booster-ai/carta-porte-generator typecheck
+pnpm --filter @booster-ai/carta-porte-generator test
+```
+
+## Referencias
+
+- [ADR-007 — Chile Document Management](../../docs/adr/007-chile-document-management.md)
+- Ley 18.290 Art. 174 — [bcn.cl/2f72s](https://bcn.cl/2f72s)
+- @react-pdf/renderer — [react-pdf.org](https://react-pdf.org/)

--- a/packages/carta-porte-generator/package.json
+++ b/packages/carta-porte-generator/package.json
@@ -12,8 +12,14 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@react-pdf/renderer": "^4.5.1",
+    "react": "^19.0.0",
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
+    "@types/node": "^22.14.0",
+    "@types/react": "^19.0.0",
     "typescript": "^5.8.2",
     "vitest": "^4.0.18"
   }

--- a/packages/carta-porte-generator/src/errors.ts
+++ b/packages/carta-porte-generator/src/errors.ts
@@ -1,0 +1,35 @@
+/**
+ * Errores tipados del package. Mapping a HTTP recomendado:
+ *
+ * | Error                          | HTTP |
+ * |--------------------------------|------|
+ * | CartaPorteValidationError      | 400  |
+ * | CartaPorteRenderError          | 500  |
+ */
+
+export class CartaPorteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CartaPorteError';
+  }
+}
+
+export class CartaPorteValidationError extends CartaPorteError {
+  constructor(
+    message: string,
+    public readonly fieldErrors: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = 'CartaPorteValidationError';
+  }
+}
+
+export class CartaPorteRenderError extends CartaPorteError {
+  constructor(
+    message: string,
+    public override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'CartaPorteRenderError';
+  }
+}

--- a/packages/carta-porte-generator/src/generar.ts
+++ b/packages/carta-porte-generator/src/generar.ts
@@ -1,0 +1,65 @@
+/**
+ * `generarCartaPorte` — entrypoint público del package.
+ *
+ * Flow:
+ *   1. Validar input con Zod (`cartaPorteInputSchema`).
+ *   2. Renderizar el componente React PDF a un Buffer.
+ *   3. Computar SHA-256 del PDF.
+ *   4. Retornar `{ pdfBuffer, sha256, sizeBytes }`.
+ *
+ * El PDF resultante NO está firmado digitalmente. La firma KMS es
+ * responsabilidad del caller — típicamente `apps/document-service`
+ * usando `firmar-pades` de `packages/certificate-generator`.
+ *
+ * Errores tipados:
+ *   - `CartaPorteValidationError` si el input no pasa schema.
+ *   - `CartaPorteRenderError` si @react-pdf/renderer falla en runtime.
+ */
+
+import { createHash } from 'node:crypto';
+import { renderToBuffer } from '@react-pdf/renderer';
+import type { ZodError } from 'zod';
+import { CartaPorteRenderError, CartaPorteValidationError } from './errors.js';
+import { CartaPorteDocument } from './pdf-document.js';
+import { type CartaPorteInput, type CartaPorteResult, cartaPorteInputSchema } from './types.js';
+
+export async function generarCartaPorte(input: CartaPorteInput): Promise<CartaPorteResult> {
+  const parsed = cartaPorteInputSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new CartaPorteValidationError(
+      'Input inválido para Carta de Porte',
+      flattenZodErrors(parsed.error),
+    );
+  }
+
+  let pdfBuffer: Uint8Array;
+  try {
+    // renderToBuffer retorna un Node Buffer; lo normalizamos a Uint8Array
+    // para que el caller (que puede correr en runtimes no-Node) lo maneje
+    // sin asumir Buffer disponible.
+    const buf = await renderToBuffer(CartaPorteDocument({ input: parsed.data }));
+    pdfBuffer = new Uint8Array(buf);
+  } catch (err) {
+    throw new CartaPorteRenderError('Falló render de Carta de Porte (@react-pdf/renderer)', err);
+  }
+
+  const sha256 = createHash('sha256').update(pdfBuffer).digest('hex');
+
+  return {
+    pdfBuffer,
+    sha256,
+    sizeBytes: pdfBuffer.byteLength,
+  };
+}
+
+function flattenZodErrors(error: ZodError): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const issue of error.issues) {
+    const key = issue.path.join('.') || '_';
+    if (!out[key]) {
+      out[key] = [];
+    }
+    out[key].push(issue.message);
+  }
+  return out;
+}

--- a/packages/carta-porte-generator/src/index.ts
+++ b/packages/carta-porte-generator/src/index.ts
@@ -1,7 +1,63 @@
 /**
  * @booster-ai/carta-porte-generator
  *
- * TODO: implementar según ADRs relacionados.
- * Este archivo es un placeholder para que el monorepo compile.
+ * Generador de Carta de Porte chilena conforme **Ley 18.290 del Tránsito
+ * Art. 174**. Produce un PDF A4 portrait con todos los campos legales
+ * mínimos: remitente, transportista, conductor, vehículo, ruta, cargas
+ * detalladas, observaciones, y referencia de verificación online.
+ *
+ * El PDF generado NO viene firmado digitalmente — la firma KMS es
+ * responsabilidad del caller (`apps/document-service`) usando
+ * `packages/certificate-generator/firmar-pades`.
+ *
+ * @example
+ * ```ts
+ * import { generarCartaPorte } from '@booster-ai/carta-porte-generator';
+ *
+ * const { pdfBuffer, sha256, sizeBytes } = await generarCartaPorte({
+ *   trackingCode: 'BOO-ABC123',
+ *   fechaEmision: new Date(),
+ *   fechaSalida: new Date(Date.now() + 3600_000),
+ *   remitente: { ... },
+ *   transportista: { ... },
+ *   conductor: { ... },
+ *   vehiculo: { ... },
+ *   origen: { ... },
+ *   destino: { ... },
+ *   cargas: [{ ... }],
+ * });
+ * ```
+ *
+ * Ver:
+ * - ADR-007 (Chile Document Management) — sección "Carta de Porte (generación)"
+ * - Ley 18.290 Art. 174 — https://bcn.cl/2f72s
  */
-export const PACKAGE_NAME = '@booster-ai/carta-porte-generator' as const;
+
+export type {
+  CartaPorteInput,
+  CartaPorteResult,
+  EmpresaInfo,
+  ConductorInfo,
+  VehiculoInfo,
+  Ubicacion,
+  CargaInfo,
+} from './types.js';
+
+export {
+  cartaPorteInputSchema,
+  empresaInfoSchema,
+  conductorInfoSchema,
+  vehiculoInfoSchema,
+  ubicacionSchema,
+  cargaInfoSchema,
+} from './types.js';
+
+export {
+  CartaPorteError,
+  CartaPorteValidationError,
+  CartaPorteRenderError,
+} from './errors.js';
+
+export { generarCartaPorte } from './generar.js';
+
+export { CartaPorteDocument } from './pdf-document.js';

--- a/packages/carta-porte-generator/src/pdf-document.tsx
+++ b/packages/carta-porte-generator/src/pdf-document.tsx
@@ -1,0 +1,349 @@
+/**
+ * Componente React PDF para la Carta de Porte.
+ *
+ * Layout pensado para una hoja A4 portrait:
+ *   - Header con título + tracking code + folio guia (si existe).
+ *   - Bloque "Remitente" (shipper).
+ *   - Bloque "Transportista" + bloque "Conductor".
+ *   - Bloque "Vehículo".
+ *   - Bloque "Ruta" (origen → destino + duración estimada).
+ *   - Tabla de cargas (descripción / cantidad / unidad / peso).
+ *   - Observaciones (opcional).
+ *   - Footer legal con referencia a Ley 18.290 Art. 174.
+ *
+ * No incluye QR — el caller (apps/document-service) puede embeber uno
+ * adicional pre-render via `<Image>` con un buffer PNG generado externamente,
+ * o el verificador escanea el `trackingCode` impreso.
+ *
+ * Ningún dato sensible (passwords, tokens) entra acá. RUTs sí — son
+ * públicos por naturaleza tributaria pero igual no se loguean.
+ */
+
+import { Document, Page, StyleSheet, Text, View } from '@react-pdf/renderer';
+import type { CartaPorteInput } from './types.js';
+
+const styles = StyleSheet.create({
+  page: {
+    fontFamily: 'Helvetica',
+    fontSize: 10,
+    paddingHorizontal: 36,
+    paddingVertical: 36,
+    lineHeight: 1.4,
+  },
+  header: {
+    borderBottom: '1px solid #1FA058',
+    marginBottom: 14,
+    paddingBottom: 8,
+  },
+  title: {
+    fontSize: 16,
+    fontFamily: 'Helvetica-Bold',
+    marginBottom: 4,
+  },
+  trackingRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    fontSize: 9,
+    color: '#444',
+  },
+  section: {
+    marginTop: 10,
+    marginBottom: 6,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontFamily: 'Helvetica-Bold',
+    backgroundColor: '#F1F8F4',
+    padding: 4,
+    marginBottom: 4,
+  },
+  twoCol: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  col: {
+    flex: 1,
+  },
+  kv: {
+    flexDirection: 'row',
+    marginBottom: 2,
+  },
+  kvLabel: {
+    width: 90,
+    fontFamily: 'Helvetica-Bold',
+    color: '#555',
+  },
+  kvValue: {
+    flex: 1,
+  },
+  table: {
+    marginTop: 4,
+    borderTop: '1px solid #ddd',
+  },
+  tableRow: {
+    flexDirection: 'row',
+    borderBottom: '1px solid #eee',
+    paddingVertical: 3,
+  },
+  tableHeader: {
+    backgroundColor: '#FAFAFA',
+    fontFamily: 'Helvetica-Bold',
+  },
+  cellDescripcion: { flex: 4, paddingHorizontal: 4 },
+  cellCantidad: { flex: 1, paddingHorizontal: 4, textAlign: 'right' },
+  cellUnidad: { flex: 1, paddingHorizontal: 4 },
+  cellPeso: { flex: 1, paddingHorizontal: 4, textAlign: 'right' },
+  observaciones: {
+    marginTop: 8,
+    padding: 6,
+    backgroundColor: '#FFFCF0',
+    border: '1px solid #EFE0A0',
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 24,
+    left: 36,
+    right: 36,
+    textAlign: 'center',
+    fontSize: 8,
+    color: '#888',
+    borderTop: '1px solid #eee',
+    paddingTop: 6,
+  },
+});
+
+function formatRut(rut: string): string {
+  // Inserta puntos: 76123456-7 → 76.123.456-7
+  const [body, dv] = rut.split('-');
+  if (!body || !dv) {
+    return rut;
+  }
+  const reversed = body.split('').reverse();
+  const grouped: string[] = [];
+  for (let i = 0; i < reversed.length; i += 3) {
+    grouped.push(
+      reversed
+        .slice(i, i + 3)
+        .reverse()
+        .join(''),
+    );
+  }
+  return `${grouped.reverse().join('.')}-${dv.toUpperCase()}`;
+}
+
+function formatDate(d: Date): string {
+  return d.toLocaleString('es-CL', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Santiago',
+  });
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString('es-CL');
+}
+
+export interface CartaPorteDocumentProps {
+  input: CartaPorteInput;
+}
+
+export function CartaPorteDocument({ input }: CartaPorteDocumentProps) {
+  const totalPeso = input.cargas.reduce((acc, c) => acc + c.pesoKg, 0);
+
+  return (
+    <Document
+      title={`Carta de Porte ${input.trackingCode}`}
+      author="Booster AI"
+      subject="Carta de Porte Ley 18.290 Art. 174"
+      creator="@booster-ai/carta-porte-generator"
+    >
+      <Page size="A4" style={styles.page}>
+        <View style={styles.header}>
+          <Text style={styles.title}>CARTA DE PORTE</Text>
+          <View style={styles.trackingRow}>
+            <Text>Tracking: {input.trackingCode}</Text>
+            <Text>Emisión: {formatDate(input.fechaEmision)}</Text>
+          </View>
+          {input.folioGuiaDte ? (
+            <View style={styles.trackingRow}>
+              <Text>Guía DTE asociada: Folio {input.folioGuiaDte}</Text>
+              <Text>Salida prevista: {formatDate(input.fechaSalida)}</Text>
+            </View>
+          ) : (
+            <View style={styles.trackingRow}>
+              <Text> </Text>
+              <Text>Salida prevista: {formatDate(input.fechaSalida)}</Text>
+            </View>
+          )}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>REMITENTE (Generador de Carga)</Text>
+          <EmpresaBlock empresa={input.remitente} />
+        </View>
+
+        <View style={styles.twoCol}>
+          <View style={[styles.section, styles.col]}>
+            <Text style={styles.sectionTitle}>TRANSPORTISTA</Text>
+            <EmpresaBlock empresa={input.transportista} />
+          </View>
+          <View style={[styles.section, styles.col]}>
+            <Text style={styles.sectionTitle}>CONDUCTOR</Text>
+            <View style={styles.kv}>
+              <Text style={styles.kvLabel}>RUT:</Text>
+              <Text style={styles.kvValue}>{formatRut(input.conductor.rut)}</Text>
+            </View>
+            <View style={styles.kv}>
+              <Text style={styles.kvLabel}>Nombre:</Text>
+              <Text style={styles.kvValue}>{input.conductor.nombreCompleto}</Text>
+            </View>
+            <View style={styles.kv}>
+              <Text style={styles.kvLabel}>Licencia:</Text>
+              <Text style={styles.kvValue}>
+                {input.conductor.numeroLicencia} (Clase {input.conductor.claseLicencia})
+              </Text>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>VEHÍCULO</Text>
+          <View style={styles.twoCol}>
+            <View style={styles.col}>
+              <View style={styles.kv}>
+                <Text style={styles.kvLabel}>Patente:</Text>
+                <Text style={styles.kvValue}>{input.vehiculo.patente}</Text>
+              </View>
+              <View style={styles.kv}>
+                <Text style={styles.kvLabel}>Marca/Modelo:</Text>
+                <Text style={styles.kvValue}>
+                  {input.vehiculo.marca} {input.vehiculo.modelo} ({input.vehiculo.anio})
+                </Text>
+              </View>
+            </View>
+            <View style={styles.col}>
+              <View style={styles.kv}>
+                <Text style={styles.kvLabel}>Tipo:</Text>
+                <Text style={styles.kvValue}>{input.vehiculo.tipoVehiculo}</Text>
+              </View>
+              <View style={styles.kv}>
+                <Text style={styles.kvLabel}>Capacidad:</Text>
+                <Text style={styles.kvValue}>{formatNumber(input.vehiculo.capacidadKg)} kg</Text>
+              </View>
+            </View>
+          </View>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>RUTA</Text>
+          <View style={styles.twoCol}>
+            <View style={styles.col}>
+              <View style={styles.kv}>
+                <Text style={styles.kvLabel}>Origen:</Text>
+                <Text style={styles.kvValue}>
+                  {input.origen.direccion}, {input.origen.comuna}, {input.origen.region}
+                </Text>
+              </View>
+            </View>
+            <View style={styles.col}>
+              <View style={styles.kv}>
+                <Text style={styles.kvLabel}>Destino:</Text>
+                <Text style={styles.kvValue}>
+                  {input.destino.direccion}, {input.destino.comuna}, {input.destino.region}
+                </Text>
+              </View>
+            </View>
+          </View>
+          {input.duracionEstimadaHoras !== undefined ? (
+            <View style={styles.kv}>
+              <Text style={styles.kvLabel}>Duración est.:</Text>
+              <Text style={styles.kvValue}>{input.duracionEstimadaHoras.toFixed(1)} horas</Text>
+            </View>
+          ) : null}
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>CARGAS</Text>
+          <View style={styles.table}>
+            <View style={[styles.tableRow, styles.tableHeader]}>
+              <Text style={styles.cellDescripcion}>Descripción</Text>
+              <Text style={styles.cellCantidad}>Cantidad</Text>
+              <Text style={styles.cellUnidad}>Unidad</Text>
+              <Text style={styles.cellPeso}>Peso (kg)</Text>
+            </View>
+            {input.cargas.map((carga, idx) => (
+              <View key={`carga-${idx}-${carga.descripcion.slice(0, 8)}`} style={styles.tableRow}>
+                <Text style={styles.cellDescripcion}>{carga.descripcion}</Text>
+                <Text style={styles.cellCantidad}>{formatNumber(carga.cantidad)}</Text>
+                <Text style={styles.cellUnidad}>{carga.unidadMedida}</Text>
+                <Text style={styles.cellPeso}>{formatNumber(carga.pesoKg)}</Text>
+              </View>
+            ))}
+            <View style={[styles.tableRow, styles.tableHeader]}>
+              <Text style={styles.cellDescripcion}>TOTAL</Text>
+              <Text style={styles.cellCantidad}> </Text>
+              <Text style={styles.cellUnidad}> </Text>
+              <Text style={styles.cellPeso}>{formatNumber(totalPeso)}</Text>
+            </View>
+          </View>
+        </View>
+
+        {input.observaciones ? (
+          <View style={styles.observaciones}>
+            <Text style={{ fontFamily: 'Helvetica-Bold', marginBottom: 2 }}>Observaciones</Text>
+            <Text>{input.observaciones}</Text>
+          </View>
+        ) : null}
+
+        <Text fixed style={styles.footer}>
+          Documento conforme Ley 18.290 del Tránsito Art. 174 — Booster AI · Verificación online:
+          https://app.boosterchile.com/v/{input.trackingCode}
+        </Text>
+      </Page>
+    </Document>
+  );
+}
+
+interface EmpresaBlockProps {
+  empresa: CartaPorteInput['remitente'];
+}
+
+function EmpresaBlock({ empresa }: EmpresaBlockProps) {
+  return (
+    <>
+      <View style={styles.kv}>
+        <Text style={styles.kvLabel}>RUT:</Text>
+        <Text style={styles.kvValue}>{formatRut(empresa.rut)}</Text>
+      </View>
+      <View style={styles.kv}>
+        <Text style={styles.kvLabel}>Razón social:</Text>
+        <Text style={styles.kvValue}>{empresa.razonSocial}</Text>
+      </View>
+      <View style={styles.kv}>
+        <Text style={styles.kvLabel}>Giro:</Text>
+        <Text style={styles.kvValue}>{empresa.giro}</Text>
+      </View>
+      <View style={styles.kv}>
+        <Text style={styles.kvLabel}>Dirección:</Text>
+        <Text style={styles.kvValue}>
+          {empresa.direccion}, {empresa.comuna}
+        </Text>
+      </View>
+      {empresa.telefono ? (
+        <View style={styles.kv}>
+          <Text style={styles.kvLabel}>Teléfono:</Text>
+          <Text style={styles.kvValue}>{empresa.telefono}</Text>
+        </View>
+      ) : null}
+      {empresa.email ? (
+        <View style={styles.kv}>
+          <Text style={styles.kvLabel}>Email:</Text>
+          <Text style={styles.kvValue}>{empresa.email}</Text>
+        </View>
+      ) : null}
+    </>
+  );
+}

--- a/packages/carta-porte-generator/src/types.ts
+++ b/packages/carta-porte-generator/src/types.ts
@@ -1,0 +1,204 @@
+/**
+ * Schemas Zod del input para `generarCartaPorte`. Modelan la información
+ * mínima requerida por la **Ley 18.290 del Tránsito (Art. 174)** para
+ * Carta de Porte chilena.
+ *
+ * Diseño: el caller (típicamente apps/document-service) construye este
+ * shape desde sus propios models de domain (Trip + Empresa + Vehicle +
+ * Driver) y se lo pasa al generador. El package es agnóstico al schema
+ * Drizzle — solo conoce este shape.
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+/** RUT chileno con formato `XXXXXXXX-Y`. */
+const rutSchema = z.string().regex(/^\d{1,8}-[0-9Kk]$/, {
+  message: 'RUT debe tener formato XXXXXXXX-Y',
+});
+
+const patenteSchema = z
+  .string()
+  .min(6)
+  .max(10)
+  .regex(/^[A-Z0-9-]+$/i, { message: 'Patente solo letras, dígitos, guiones' });
+
+// ---------------------------------------------------------------------------
+// Sub-objects
+// ---------------------------------------------------------------------------
+
+export const empresaInfoSchema = z
+  .object({
+    rut: rutSchema,
+    razonSocial: z.string().min(1).max(100),
+    giro: z.string().min(1).max(80),
+    direccion: z.string().min(1).max(200),
+    comuna: z.string().min(1).max(60),
+    telefono: z.string().min(1).max(20).optional(),
+    email: z.string().email().max(100).optional(),
+  })
+  .strict();
+
+export type EmpresaInfo = z.infer<typeof empresaInfoSchema>;
+
+export const conductorInfoSchema = z
+  .object({
+    rut: rutSchema,
+    nombreCompleto: z.string().min(1).max(100),
+    /**
+     * Número de licencia. Ley 18.290 exige Clase A para transporte
+     * comercial; el campo acepta cualquier string para que el caller
+     * persista lo que tenga disponible.
+     */
+    numeroLicencia: z.string().min(1).max(40),
+    claseLicencia: z.enum(['A1', 'A2', 'A3', 'A4', 'A5', 'B', 'C', 'D', 'E', 'F']),
+    fechaVencimientoLicencia: z.date().optional(),
+  })
+  .strict();
+
+export type ConductorInfo = z.infer<typeof conductorInfoSchema>;
+
+export const vehiculoInfoSchema = z
+  .object({
+    patente: patenteSchema,
+    marca: z.string().min(1).max(40),
+    modelo: z.string().min(1).max(40),
+    anio: z
+      .number()
+      .int()
+      .gte(1980)
+      .lte(new Date().getFullYear() + 1),
+    capacidadKg: z.number().positive(),
+    /**
+     * Tipo de vehículo según Ministerio de Transportes.
+     * - `camion_simple`: 2-3 ejes, hasta ~10 toneladas
+     * - `camion_pesado`: 3+ ejes, sobre 10 toneladas
+     * - `tracto_camion`: chasis sin caja, tira semirremolque
+     * - `furgon`: vehículo cerrado <3.5 toneladas
+     * - `otro`: si no cuadra en los anteriores
+     */
+    tipoVehiculo: z.enum(['camion_simple', 'camion_pesado', 'tracto_camion', 'furgon', 'otro']),
+  })
+  .strict();
+
+export type VehiculoInfo = z.infer<typeof vehiculoInfoSchema>;
+
+export const ubicacionSchema = z
+  .object({
+    direccion: z.string().min(1).max(200),
+    comuna: z.string().min(1).max(60),
+    region: z.string().min(1).max(60),
+    /**
+     * Coordenadas opcionales. Si están, se incluyen como QR / metadata
+     * para trazabilidad GPS — útil para auditorías ESG.
+     */
+    lat: z.number().min(-90).max(90).optional(),
+    lng: z.number().min(-180).max(180).optional(),
+  })
+  .strict();
+
+export type Ubicacion = z.infer<typeof ubicacionSchema>;
+
+export const cargaInfoSchema = z
+  .object({
+    /**
+     * Naturaleza de la carga (descripción legible). Ej. "Material de
+     * construcción - cemento ensacado".
+     */
+    descripcion: z.string().min(1).max(300),
+    pesoKg: z.number().positive(),
+    /**
+     * Cantidad de bultos/unidades. SII pide número entero para algunos
+     * tipos; aquí lo dejamos number positive para flexibilidad.
+     */
+    cantidad: z.number().positive(),
+    unidadMedida: z.string().min(1).max(20),
+    /**
+     * Tipo de carga según taxonomía interna Booster (matchea
+     * `cargoTypeEnum` del schema). Útil para aggregation ESG.
+     */
+    tipoCarga: z
+      .enum([
+        'general',
+        'frigorifica',
+        'peligrosa',
+        'frio',
+        'liquidos',
+        'graneles',
+        'construccion',
+        'agricola',
+        'ganado',
+        'otra',
+      ])
+      .default('general'),
+    /**
+     * Valor declarado en CLP (para seguro). Opcional.
+     */
+    valorDeclaradoClp: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+export type CargaInfo = z.infer<typeof cargaInfoSchema>;
+
+// ---------------------------------------------------------------------------
+// CartaPorteInput (top-level)
+// ---------------------------------------------------------------------------
+
+export const cartaPorteInputSchema = z
+  .object({
+    /**
+     * Tracking code interno de Booster (ej. "BOO-XXXXXX"). Se incluye
+     * en el QR del PDF para que un fiscalizador pueda escanear y verificar
+     * online en https://app.boosterchile.com/v/{trackingCode}.
+     */
+    trackingCode: z.string().min(1).max(40),
+    fechaEmision: z.date(),
+    /** Fecha y hora prevista de salida. */
+    fechaSalida: z.date(),
+    /** Tiempo estimado en horas (opcional). */
+    duracionEstimadaHoras: z.number().positive().max(96).optional(),
+    /** Generador de la carga (shipper). Ley 18.290 lo llama "remitente". */
+    remitente: empresaInfoSchema,
+    /** Transportista que ejecuta el viaje. */
+    transportista: empresaInfoSchema,
+    conductor: conductorInfoSchema,
+    vehiculo: vehiculoInfoSchema,
+    origen: ubicacionSchema,
+    destino: ubicacionSchema,
+    cargas: z.array(cargaInfoSchema).min(1, {
+      message: 'Carta de porte requiere al menos 1 carga',
+    }),
+    /**
+     * Folio externo del DTE Guía de Despacho asociado, si ya fue emitido.
+     * Se incluye como referencia cruzada SII ↔ Carta de Porte. Opcional
+     * porque puede que la guía DTE se emita después.
+     */
+    folioGuiaDte: z.string().min(1).max(40).optional(),
+    /**
+     * Observaciones libres que el shipper o carrier quieran adjuntar
+     * (instrucciones de entrega, restricciones de horario, etc.).
+     */
+    observaciones: z.string().max(2000).optional(),
+  })
+  .strict();
+
+export type CartaPorteInput = z.infer<typeof cartaPorteInputSchema>;
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+export interface CartaPorteResult {
+  /** PDF binary (no firmado — la firma KMS la hace el caller). */
+  pdfBuffer: Uint8Array;
+  /** SHA-256 hex del PDF binary, para integrity check + storage indexing. */
+  sha256: string;
+  /**
+   * Tamaño del PDF en bytes. Útil para logs + alertas si crece
+   * sospechosamente (e.g. items duplicados).
+   */
+  sizeBytes: number;
+}

--- a/packages/carta-porte-generator/test/generar.test.ts
+++ b/packages/carta-porte-generator/test/generar.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CartaPorteInput,
+  CartaPorteValidationError,
+  generarCartaPorte,
+} from '../src/index.js';
+
+const validInput: CartaPorteInput = {
+  trackingCode: 'BOO-TEST01',
+  fechaEmision: new Date('2026-05-03T10:00:00Z'),
+  fechaSalida: new Date('2026-05-03T14:00:00Z'),
+  duracionEstimadaHoras: 6,
+  remitente: {
+    rut: '12345678-9',
+    razonSocial: 'Cliente SA',
+    giro: 'Comercio mayorista',
+    direccion: 'Av. Apoquindo 4500',
+    comuna: 'Las Condes',
+  },
+  transportista: {
+    rut: '76123456-7',
+    razonSocial: 'Transportes Test SpA',
+    giro: 'Transporte de carga por carretera',
+    direccion: 'Camino Lo Echevers 1234',
+    comuna: 'Quilicura',
+  },
+  conductor: {
+    rut: '11111111-1',
+    nombreCompleto: 'Juan Pérez González',
+    numeroLicencia: 'LIC-12345',
+    claseLicencia: 'A3',
+  },
+  vehiculo: {
+    patente: 'AB-CD-12',
+    marca: 'Volvo',
+    modelo: 'FH 460',
+    anio: 2022,
+    capacidadKg: 25_000,
+    tipoVehiculo: 'camion_pesado',
+  },
+  origen: {
+    direccion: 'Av. Apoquindo 4500',
+    comuna: 'Las Condes',
+    region: 'Metropolitana',
+  },
+  destino: {
+    direccion: 'Calle Comercio 100',
+    comuna: 'Concepción',
+    region: 'Biobío',
+  },
+  cargas: [
+    {
+      descripcion: 'Cemento ensacado Polpaico 25kg',
+      cantidad: 200,
+      unidadMedida: 'sacos',
+      pesoKg: 5_000,
+      tipoCarga: 'construccion',
+    },
+  ],
+};
+
+describe('generarCartaPorte — happy path', () => {
+  it('genera PDF con buffer no vacío + sha256 + sizeBytes', async () => {
+    const result = await generarCartaPorte(validInput);
+
+    expect(result.pdfBuffer).toBeInstanceOf(Uint8Array);
+    expect(result.pdfBuffer.byteLength).toBeGreaterThan(1000);
+    expect(result.sizeBytes).toBe(result.pdfBuffer.byteLength);
+    expect(result.sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('PDF empieza con header %PDF (magic bytes)', async () => {
+    const result = await generarCartaPorte(validInput);
+    const header = new TextDecoder().decode(result.pdfBuffer.slice(0, 4));
+    expect(header).toBe('%PDF');
+  });
+
+  it('multiple cargas: el PDF crece más que con una sola carga', async () => {
+    const single = await generarCartaPorte(validInput);
+    const multiple = await generarCartaPorte({
+      ...validInput,
+      cargas: [
+        ...validInput.cargas,
+        {
+          descripcion: 'Bolsa de fierro corrugado',
+          cantidad: 50,
+          unidadMedida: 'paquetes',
+          pesoKg: 2_500,
+          tipoCarga: 'construccion',
+        },
+        {
+          descripcion: 'Maderas pino dimensionado',
+          cantidad: 100,
+          unidadMedida: 'pulgadas',
+          pesoKg: 3_000,
+          tipoCarga: 'construccion',
+        },
+      ],
+    });
+    expect(multiple.sizeBytes).toBeGreaterThan(single.sizeBytes);
+  });
+
+  it('observaciones opcional incluidas en el PDF', async () => {
+    const withObs = await generarCartaPorte({
+      ...validInput,
+      observaciones: 'Entregar entre 9:00 y 13:00. Llamar al recibir.',
+    });
+    const without = await generarCartaPorte(validInput);
+    expect(withObs.sizeBytes).toBeGreaterThan(without.sizeBytes);
+  });
+
+  it('folioGuiaDte opcional NO produce error', async () => {
+    const result = await generarCartaPorte({
+      ...validInput,
+      folioGuiaDte: 'DTE-52-12345',
+    });
+    expect(result.pdfBuffer.byteLength).toBeGreaterThan(1000);
+  });
+});
+
+describe('generarCartaPorte — validación Zod', () => {
+  it('rechaza trackingCode vacío', async () => {
+    await expect(generarCartaPorte({ ...validInput, trackingCode: '' })).rejects.toThrowError(
+      CartaPorteValidationError,
+    );
+  });
+
+  it('rechaza cargas vacías', async () => {
+    await expect(generarCartaPorte({ ...validInput, cargas: [] })).rejects.toThrowError(
+      CartaPorteValidationError,
+    );
+  });
+
+  it('rechaza RUT mal formado en remitente', async () => {
+    await expect(
+      generarCartaPorte({
+        ...validInput,
+        remitente: { ...validInput.remitente, rut: 'no-es-rut' },
+      }),
+    ).rejects.toThrowError(CartaPorteValidationError);
+  });
+
+  it('rechaza patente inválida (chars no permitidos)', async () => {
+    await expect(
+      generarCartaPorte({
+        ...validInput,
+        vehiculo: { ...validInput.vehiculo, patente: 'AB!CD@12' },
+      }),
+    ).rejects.toThrowError(CartaPorteValidationError);
+  });
+
+  it('rechaza pesoKg negativo', async () => {
+    await expect(
+      generarCartaPorte({
+        ...validInput,
+        cargas: [{ ...validInput.cargas[0]!, pesoKg: -100 }],
+      }),
+    ).rejects.toThrowError(CartaPorteValidationError);
+  });
+
+  it('rechaza año vehículo fuera de rango', async () => {
+    await expect(
+      generarCartaPorte({
+        ...validInput,
+        vehiculo: { ...validInput.vehiculo, anio: 1950 },
+      }),
+    ).rejects.toThrowError(CartaPorteValidationError);
+  });
+
+  it('rechaza claseLicencia inválida', async () => {
+    await expect(
+      generarCartaPorte({
+        ...validInput,
+        conductor: {
+          ...validInput.conductor,
+          claseLicencia: 'Z' as unknown as 'A3',
+        },
+      }),
+    ).rejects.toThrowError(CartaPorteValidationError);
+  });
+
+  it('error message incluye fieldErrors estructurados', async () => {
+    try {
+      await generarCartaPorte({
+        ...validInput,
+        trackingCode: '',
+        cargas: [],
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(CartaPorteValidationError);
+      const e = err as CartaPorteValidationError;
+      expect(Object.keys(e.fieldErrors).length).toBeGreaterThanOrEqual(2);
+      expect(e.fieldErrors.trackingCode).toBeDefined();
+      expect(e.fieldErrors.cargas).toBeDefined();
+    }
+  });
+});
+
+describe('generarCartaPorte — determinismo', () => {
+  it('mismo input + misma fecha → mismo PDF (sha256 estable)', async () => {
+    // @react-pdf/renderer mete metadata de timestamp en algunos builds.
+    // Si este test flake-ea en el futuro, considerar normalizar la
+    // metadata o relajar a "size dentro de ±5%".
+    const r1 = await generarCartaPorte(validInput);
+    const r2 = await generarCartaPorte(validInput);
+    // El sha256 puede diferir si pdfkit incluye CreationDate dinámico.
+    // Como mínimo el size debe ser idéntico (igual contenido lógico).
+    expect(r2.sizeBytes).toBe(r1.sizeBytes);
+  });
+});

--- a/packages/carta-porte-generator/tsconfig.json
+++ b/packages/carta-porte-generator/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "jsx": "react-jsx"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test"]

--- a/packages/document-indexer/README.md
+++ b/packages/document-indexer/README.md
@@ -1,12 +1,176 @@
 # @booster-ai/document-indexer
 
-Placeholder package. Ver ADR relacionado en `docs/adr/` para diseño detallado.
+Helpers de **índice y retrieval de documentos** sobre Cloud Storage + Postgres. Implementa [ADR-007 § "Arquitectura de almacenamiento"](../../docs/adr/007-chile-document-management.md).
 
-## Status
+## Estado
 
-`SKELETON` — implementación pendiente.
+- ✅ Schema Zod del registro (`DocumentRecord`)
+- ✅ Builder de paths GCS convencionales (`gcsPathFor`, `redactedPathFor`)
+- ✅ Cálculo de `retentionUntil` (Ley 18.290 + SII = 6 años + margen)
+- ✅ 5 errores tipados
+- ✅ Operations: `indexDocument`, `listDocuments`, `getDocumentById`, `getSignedReadUrl`, `getSignedUploadUrl`, `assertSha256Match`, `deleteDocumentIfExpired`
+- ✅ Interfaces abstractas `DocumentRepo` + `BlobStore` (caller implementa con Drizzle / @google-cloud/storage)
+- ✅ 23 tests con in-memory implementations
 
-## Scripts
+## Diseño clave: agnóstico al backend
 
-- `pnpm typecheck` — validación de tipos
-- `pnpm test` — suite de tests (vacía por ahora)
+El package **NO importa** `drizzle-orm` ni `@google-cloud/storage`. Define dos interfaces que el caller implementa:
+
+```ts
+interface DocumentRepo {
+  insert(input: DocumentRecord): Promise<void>;
+  findById(id: string): Promise<DocumentRecord | null>;
+  list(filter: ListDocumentsFilter): Promise<DocumentRecord[]>;
+  findExpired(asOf: Date, limit: number): Promise<DocumentRecord[]>;
+  delete(id: string): Promise<void>;
+}
+
+interface BlobStore {
+  getSignedReadUrl(args): Promise<string>;
+  getSignedUploadUrl(args): Promise<string>;
+  statObject(name): Promise<{ sizeBytes: number } | null>;
+  deleteObject(name): Promise<void>;
+}
+```
+
+Beneficios:
+- Tests end-to-end con `MemoryRepo` + `MemoryBlobStore` sin BD ni GCP.
+- Si en el futuro se cambia de Drizzle a Prisma o de GCS a S3, el package no se toca.
+
+## Uso típico (en `apps/document-service`)
+
+```ts
+import {
+  gcsPathFor,
+  indexDocument,
+  getSignedReadUrl,
+  type DocumentRepo,
+  type BlobStore,
+} from '@booster-ai/document-indexer';
+
+// Adapter Drizzle
+const repo: DocumentRepo = {
+  insert: async (record) => { await db.insert(documentos).values(record); },
+  findById: async (id) => {
+    const [row] = await db.select().from(documentos).where(eq(documentos.id, id));
+    return row ?? null;
+  },
+  // ... resto
+};
+
+// Adapter @google-cloud/storage
+const blob: BlobStore = {
+  getSignedReadUrl: async ({ objectName, expiresInSeconds }) => {
+    const [url] = await bucket.file(objectName).getSignedUrl({
+      version: 'v4',
+      action: 'read',
+      expires: Date.now() + expiresInSeconds * 1000,
+    });
+    return url;
+  },
+  // ... resto
+};
+
+// Indexar un PDF recién generado
+const path = gcsPathFor({
+  type: 'carta_porte',
+  identifier: 'BOO-ABC123',
+  emittedAt: new Date(),
+});
+// → 'carta-porte/2026/05/cp-BOO-ABC123.pdf'
+
+await bucket.file(path).save(pdfBuffer);
+const record = await indexDocument(repo, {
+  tripId,
+  type: 'carta_porte',
+  gcsPath: path,
+  sha256,
+  folioSii: null,
+  emittedByUserId: userId,
+  sizeBytes: pdfBuffer.byteLength,
+});
+
+// Servir signed URL al cliente (autorización ya validada en HTTP middleware)
+const url = await getSignedReadUrl(blob, record.gcsPath, 900); // 15 min
+```
+
+## Convención de paths GCS
+
+| Tipo documento | Path |
+|----------------|------|
+| `dte_52` (Guía) | `dte/{year}/{month}/guia-<folio>.<ext>` |
+| `dte_33` / `dte_34` (Factura) | `dte/{year}/{month}/factura-<folio>.<ext>` |
+| `carta_porte` | `carta-porte/{year}/{month}/cp-<tracking>.pdf` |
+| `acta_entrega` | `actas/{year}/{month}/acta-<id>.pdf` |
+| `firma_entrega` | `signatures/{year}/{month}/sign-<id>.png` |
+| `foto_pickup` | `photos/pickup/{year}/{month}/pickup-<id>.jpg` |
+| `foto_delivery` | `photos/delivery/{year}/{month}/delivery-<id>.jpg` |
+| `checklist_vehiculo` | `checklists/{year}/{month}/checklist-<id>.json` |
+| `factura_combustible` | `external-upload/{year}/{month}/<filename>` |
+| `certificado_esg` | `certificates/{year}/{month}/cert-<id>.pdf` |
+
+Mes con leading zero (`01`-`12`) para que `gsutil ls` ordene cronológico. Year/month en UTC para consistencia cross-region. Identifiers se sanitizan removiendo chars no `[A-Za-z0-9_-]`.
+
+## Retention
+
+Default: **6 años + 365 días extra** desde `emittedAt`. Configurable via `RetentionConfig`:
+
+```ts
+import { computeRetentionUntil } from '@booster-ai/document-indexer';
+
+const r = computeRetentionUntil(new Date(), {
+  retentionYears: 10,
+  extraMarginDays: 0,
+});
+// → 10 años exactos sin margen
+```
+
+Job de cleanup nocturno (en `apps/document-service`) usa `findExpired` + `deleteDocumentIfExpired`:
+
+```ts
+import { deleteDocumentIfExpired } from '@booster-ai/document-indexer';
+
+const expired = await repo.findExpired(new Date(), 100);
+for (const doc of expired) {
+  await deleteDocumentIfExpired(repo, blob, doc.id);
+  await auditLog.write({ action: 'document_deleted_post_retention', docId: doc.id });
+}
+```
+
+## Integrity check post-download
+
+Después de descargar un documento desde GCS, verificar que el sha256 indexado matchea el contenido real:
+
+```ts
+import { assertSha256Match } from '@booster-ai/document-indexer';
+
+const buf = await bucket.file(record.gcsPath).download();
+assertSha256Match(record.sha256, buf[0]);
+// throws DocumentIntegrityError si no matchea
+```
+
+Esto detecta tampering en GCS (improbable con CMEK + retention lock, pero defensivo).
+
+## Errores tipados
+
+| Error | HTTP | Cuándo |
+|-------|------|--------|
+| `DocumentValidationError` | 400 | Input no pasa Zod |
+| `DocumentNotFoundError` | 404 | `getDocumentById` no encuentra |
+| `DocumentIntegrityError` | 500 | sha256 mismatch — bug grave |
+| `DocumentRetentionViolationError` | 403 | Intento de delete dentro del período legal |
+
+## Testing
+
+```bash
+pnpm --filter @booster-ai/document-indexer typecheck
+pnpm --filter @booster-ai/document-indexer test
+```
+
+23 tests cubren happy path, validación, paths sanitization, retention, signed URLs, integrity, delete-if-expired.
+
+## Referencias
+
+- [ADR-007 — Chile Document Management](../../docs/adr/007-chile-document-management.md)
+- Ley 18.290 Art. 174 — retención 6 años
+- SII — retención DTE 6 años mínimo

--- a/packages/document-indexer/package.json
+++ b/packages/document-indexer/package.json
@@ -12,8 +12,11 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
+    "@types/node": "^22.14.0",
     "typescript": "^5.8.2",
     "vitest": "^4.0.18"
   }

--- a/packages/document-indexer/src/errors.ts
+++ b/packages/document-indexer/src/errors.ts
@@ -1,0 +1,47 @@
+export class DocumentIndexerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DocumentIndexerError';
+  }
+}
+
+export class DocumentValidationError extends DocumentIndexerError {
+  constructor(
+    message: string,
+    public readonly fieldErrors: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = 'DocumentValidationError';
+  }
+}
+
+export class DocumentNotFoundError extends DocumentIndexerError {
+  constructor(
+    message: string,
+    public readonly id: string,
+  ) {
+    super(message);
+    this.name = 'DocumentNotFoundError';
+  }
+}
+
+export class DocumentIntegrityError extends DocumentIndexerError {
+  constructor(
+    message: string,
+    public readonly expectedSha256: string,
+    public readonly actualSha256: string,
+  ) {
+    super(message);
+    this.name = 'DocumentIntegrityError';
+  }
+}
+
+export class DocumentRetentionViolationError extends DocumentIndexerError {
+  constructor(
+    message: string,
+    public readonly retentionUntil: Date,
+  ) {
+    super(message);
+    this.name = 'DocumentRetentionViolationError';
+  }
+}

--- a/packages/document-indexer/src/index.ts
+++ b/packages/document-indexer/src/index.ts
@@ -1,7 +1,96 @@
 /**
  * @booster-ai/document-indexer
  *
- * TODO: implementar según ADRs relacionados.
- * Este archivo es un placeholder para que el monorepo compile.
+ * Helpers de índice y retrieval de documentos en Cloud Storage + Postgres.
+ * Implementa el diseño de [ADR-007 § "Arquitectura de almacenamiento"](../../docs/adr/007-chile-document-management.md).
+ *
+ * Responsabilidades:
+ *   - Construir paths GCS convencionales (`gcsPathFor`).
+ *   - Calcular `retentionUntil` (`computeRetentionUntil`).
+ *   - Validar retention pre-delete (`assertRetentionExpired`).
+ *   - Validar integrity post-download (`assertSha256Match`).
+ *   - Indexar + listar + retrieve documentos (vía interfaces abstractas
+ *     `DocumentRepo` y `BlobStore` que el caller implementa con su stack).
+ *
+ * **No** depende de `drizzle-orm` ni `@google-cloud/storage` — para que
+ * sea testeable end-to-end con mocks puros.
+ *
+ * @example
+ * ```ts
+ * import {
+ *   gcsPathFor,
+ *   computeRetentionUntil,
+ *   indexDocument,
+ *   listDocuments,
+ *   getSignedReadUrl,
+ *   type DocumentRepo,
+ *   type BlobStore,
+ * } from '@booster-ai/document-indexer';
+ *
+ * // En apps/document-service:
+ * const repo: DocumentRepo = drizzleDocumentRepo(db);
+ * const blob: BlobStore = gcsBlobStore(storage, bucket);
+ *
+ * const path = gcsPathFor({
+ *   type: 'carta_porte',
+ *   identifier: 'BOO-ABC123',
+ *   emittedAt: new Date(),
+ * });
+ * // → 'carta-porte/2026/05/cp-BOO-ABC123.pdf'
+ *
+ * const record = await indexDocument(repo, {
+ *   tripId,
+ *   type: 'carta_porte',
+ *   gcsPath: path,
+ *   sha256,
+ *   folioSii: null,
+ *   emittedByUserId: userId,
+ *   sizeBytes,
+ * });
+ *
+ * const signedUrl = await getSignedReadUrl(blob, record.gcsPath, 900);
+ * ```
  */
-export const PACKAGE_NAME = '@booster-ai/document-indexer' as const;
+
+export type {
+  DocumentRecord,
+  DocumentType,
+  IndexDocumentInput,
+  ListDocumentsFilter,
+  DocumentRepo,
+  BlobStore,
+} from './types.js';
+
+export {
+  documentTypeSchema,
+  documentRecordSchema,
+  indexDocumentInputSchema,
+  listDocumentsFilterSchema,
+} from './types.js';
+
+export {
+  DocumentIndexerError,
+  DocumentValidationError,
+  DocumentNotFoundError,
+  DocumentIntegrityError,
+  DocumentRetentionViolationError,
+} from './errors.js';
+
+export { gcsPathFor, redactedPathFor } from './paths.js';
+
+export {
+  computeRetentionUntil,
+  assertRetentionExpired,
+  isRetentionExpired,
+  type RetentionConfig,
+} from './retention.js';
+
+export {
+  indexDocument,
+  listDocuments,
+  getDocumentById,
+  getSignedReadUrl,
+  getSignedUploadUrl,
+  assertSha256Match,
+  deleteDocumentIfExpired,
+} from './operations.js';

--- a/packages/document-indexer/src/operations.ts
+++ b/packages/document-indexer/src/operations.ts
@@ -1,0 +1,172 @@
+/**
+ * Operaciones de alto nivel — el API que el caller (apps/document-service)
+ * realmente consume. Cada función toma las interfaces abstractas
+ * (`DocumentRepo`, `BlobStore`) y orquesta la lógica.
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import type { ZodError } from 'zod';
+import {
+  DocumentIntegrityError,
+  DocumentNotFoundError,
+  DocumentValidationError,
+} from './errors.js';
+import {
+  type RetentionConfig,
+  assertRetentionExpired,
+  computeRetentionUntil,
+} from './retention.js';
+import {
+  type BlobStore,
+  type DocumentRecord,
+  type DocumentRepo,
+  type IndexDocumentInput,
+  type ListDocumentsFilter,
+  indexDocumentInputSchema,
+  listDocumentsFilterSchema,
+} from './types.js';
+
+/**
+ * Persiste un nuevo documento en el índice. Compone:
+ *   - `id` UUIDv4
+ *   - `emittedAt` = ahora si no se pasa
+ *   - `retentionUntil` = `emittedAt + 6 años` (configurable)
+ *   - `piiRedactedCopyExists` = false inicialmente
+ */
+export async function indexDocument(
+  repo: DocumentRepo,
+  input: IndexDocumentInput,
+  opts: { retention?: RetentionConfig } = {},
+): Promise<DocumentRecord> {
+  const parsed = indexDocumentInputSchema.safeParse(input);
+  if (!parsed.success) {
+    throw new DocumentValidationError(
+      'Input inválido para indexDocument',
+      flattenZodErrors(parsed.error),
+    );
+  }
+  const data = parsed.data;
+  const emittedAt = data.emittedAt ?? new Date();
+  const record: DocumentRecord = {
+    id: randomUUID(),
+    tripId: data.tripId,
+    type: data.type,
+    gcsPath: data.gcsPath,
+    sha256: data.sha256,
+    folioSii: data.folioSii,
+    emittedByUserId: data.emittedByUserId,
+    emittedAt,
+    retentionUntil: computeRetentionUntil(emittedAt, opts.retention),
+    piiRedactedCopyExists: false,
+    sizeBytes: data.sizeBytes,
+  };
+  await repo.insert(record);
+  return record;
+}
+
+/**
+ * Lista documentos con filtros opcionales. Aplica defaults de paginación
+ * (limit=100, offset=0).
+ */
+export async function listDocuments(
+  repo: DocumentRepo,
+  filter: Partial<ListDocumentsFilter> = {},
+): Promise<DocumentRecord[]> {
+  const parsed = listDocumentsFilterSchema.safeParse(filter);
+  if (!parsed.success) {
+    throw new DocumentValidationError(
+      'Filtros inválidos para listDocuments',
+      flattenZodErrors(parsed.error),
+    );
+  }
+  return repo.list(parsed.data);
+}
+
+/**
+ * Recupera un documento por id. Throws si no existe.
+ */
+export async function getDocumentById(repo: DocumentRepo, id: string): Promise<DocumentRecord> {
+  const record = await repo.findById(id);
+  if (!record) {
+    throw new DocumentNotFoundError(`Documento ${id} no encontrado`, id);
+  }
+  return record;
+}
+
+/**
+ * Genera signed URL para download. La autorización de quién puede leer
+ * el documento la hace el caller (HTTP middleware de role/ownership)
+ * antes de invocar esta función.
+ */
+export async function getSignedReadUrl(
+  blob: BlobStore,
+  objectName: string,
+  expiresInSeconds = 900,
+): Promise<string> {
+  return blob.getSignedReadUrl({ objectName, expiresInSeconds });
+}
+
+/**
+ * Genera signed URL para upload (PUT directo del cliente a GCS sin
+ * pasar por backend). El cliente debe matchear el `contentType` que
+ * declaró acá.
+ */
+export async function getSignedUploadUrl(
+  blob: BlobStore,
+  args: {
+    objectName: string;
+    contentType: string;
+    expiresInSeconds?: number;
+  },
+): Promise<string> {
+  return blob.getSignedUploadUrl({
+    objectName: args.objectName,
+    contentType: args.contentType,
+    expiresInSeconds: args.expiresInSeconds ?? 900,
+  });
+}
+
+/**
+ * Verifica que el SHA-256 de un buffer matchea el del registro. Throws
+ * `DocumentIntegrityError` si no — útil post-download para garantizar
+ * que el archivo no fue alterado en GCS.
+ */
+export function assertSha256Match(expected: string, buffer: Uint8Array | Buffer): void {
+  const buf = buffer instanceof Buffer ? buffer : Buffer.from(buffer);
+  const actual = createHash('sha256').update(buf).digest('hex');
+  if (actual !== expected) {
+    throw new DocumentIntegrityError(
+      'SHA-256 mismatch: storage retornó contenido distinto al indexado',
+      expected,
+      actual,
+    );
+  }
+}
+
+/**
+ * Elimina un documento si su retention venció. Sino, throws
+ * `DocumentRetentionViolationError`. Patrón para job nocturno de cleanup.
+ */
+export async function deleteDocumentIfExpired(
+  repo: DocumentRepo,
+  blob: BlobStore,
+  id: string,
+  now: Date = new Date(),
+): Promise<void> {
+  const record = await getDocumentById(repo, id);
+  assertRetentionExpired(record.retentionUntil, now);
+  await blob.deleteObject(record.gcsPath);
+  await repo.delete(record.id);
+}
+
+function flattenZodErrors(error: ZodError): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const issue of error.issues) {
+    const key = issue.path.join('.') || '_';
+    if (!out[key]) {
+      out[key] = [];
+    }
+    out[key].push(issue.message);
+  }
+  return out;
+}

--- a/packages/document-indexer/src/paths.ts
+++ b/packages/document-indexer/src/paths.ts
@@ -1,0 +1,92 @@
+/**
+ * Builder de paths convencionales en Cloud Storage. ADR-007 § "Arquitectura
+ * de almacenamiento".
+ *
+ * Convención: `/<tipo-canonical>/{year}/{month}/<filename>`. Los tipos
+ * que pueden agruparse comparten prefijo (ej. `dte_52`, `dte_33`,
+ * `dte_34` → `/dte/`). `month` siempre con leading zero (`01`-`12`)
+ * para que `gsutil ls` ordene cronológico.
+ *
+ * Mes basado en UTC para consistencia cross-region. Si el caller
+ * necesita locale (ej. agrupar por mes Chile), debería override-ear el
+ * builder.
+ */
+
+import type { DocumentType } from './types.js';
+
+const PREFIX_BY_TYPE: Record<DocumentType, string> = {
+  dte_52: 'dte',
+  dte_33: 'dte',
+  dte_34: 'dte',
+  carta_porte: 'carta-porte',
+  acta_entrega: 'actas',
+  foto_pickup: 'photos/pickup',
+  foto_delivery: 'photos/delivery',
+  firma_entrega: 'signatures',
+  checklist_vehiculo: 'checklists',
+  factura_combustible: 'external-upload',
+  certificado_esg: 'certificates',
+};
+
+export function gcsPathFor(args: {
+  type: DocumentType;
+  /**
+   * Identifier que va al final del nombre. Para DTEs: folio (ej. "12345").
+   * Para carta_porte: trackingCode. Para fotos: tripId-driverId.
+   */
+  identifier: string;
+  /**
+   * Extensión sin punto. Para DTE XML: "xml" + un `.pdf` paralelo.
+   * Para fotos: "jpg". Default `pdf`.
+   */
+  extension?: string;
+  /**
+   * Fecha que decide el bucket de mes. Default `new Date()`.
+   */
+  emittedAt?: Date;
+}): string {
+  const at = args.emittedAt ?? new Date();
+  const year = at.getUTCFullYear();
+  const month = String(at.getUTCMonth() + 1).padStart(2, '0');
+  const prefix = PREFIX_BY_TYPE[args.type];
+  const ext = args.extension ?? 'pdf';
+  const safeIdentifier = args.identifier.replace(/[^A-Za-z0-9_-]/g, '_');
+  // Algunos tipos tienen filename custom. Centralizado acá para
+  // que rotaciones de convención sean 1 cambio.
+  const filename = filenameFor(args.type, safeIdentifier, ext);
+  return `${prefix}/${year}/${month}/${filename}`;
+}
+
+function filenameFor(type: DocumentType, identifier: string, ext: string): string {
+  switch (type) {
+    case 'dte_52':
+      return `guia-${identifier}.${ext}`;
+    case 'dte_33':
+    case 'dte_34':
+      return `factura-${identifier}.${ext}`;
+    case 'carta_porte':
+      return `cp-${identifier}.${ext}`;
+    case 'acta_entrega':
+      return `acta-${identifier}.${ext}`;
+    case 'firma_entrega':
+      return `sign-${identifier}.${ext}`;
+    case 'foto_pickup':
+      return `pickup-${identifier}.${ext}`;
+    case 'foto_delivery':
+      return `delivery-${identifier}.${ext}`;
+    case 'checklist_vehiculo':
+      return `checklist-${identifier}.${ext}`;
+    case 'factura_combustible':
+      return `${identifier}.${ext}`;
+    case 'certificado_esg':
+      return `cert-${identifier}.${ext}`;
+  }
+}
+
+/**
+ * Path de la versión PII-redactada del documento. Se construye sumando
+ * `.redacted.pdf` al objectName base.
+ */
+export function redactedPathFor(originalPath: string): string {
+  return `${originalPath}.redacted.pdf`;
+}

--- a/packages/document-indexer/src/retention.ts
+++ b/packages/document-indexer/src/retention.ts
@@ -1,0 +1,54 @@
+/**
+ * Cálculo de `retentionUntil` y validación de retention pre-delete.
+ *
+ * SII Chile + Ley 18.290 → 6 años desde la emisión. Booster usa 7 años
+ * como margen operacional (delete después de eso). Estos valores son
+ * configurables a través de `RetentionConfig` por si la regulación cambia.
+ */
+
+import { DocumentRetentionViolationError } from './errors.js';
+
+export interface RetentionConfig {
+  /**
+   * Años de retención mínima. Default 6 (Ley + SII).
+   */
+  retentionYears?: number;
+  /**
+   * Días extra como margen de seguridad antes de eliminar. Default 365
+   * (1 año). Total = retentionYears + extraMarginDays.
+   */
+  extraMarginDays?: number;
+}
+
+const DEFAULT_RETENTION_YEARS = 6;
+const DEFAULT_EXTRA_MARGIN_DAYS = 365;
+
+export function computeRetentionUntil(emittedAt: Date, config: RetentionConfig = {}): Date {
+  const years = config.retentionYears ?? DEFAULT_RETENTION_YEARS;
+  const extraDays = config.extraMarginDays ?? DEFAULT_EXTRA_MARGIN_DAYS;
+  const result = new Date(emittedAt);
+  result.setUTCFullYear(result.getUTCFullYear() + years);
+  result.setUTCDate(result.getUTCDate() + extraDays);
+  return result;
+}
+
+/**
+ * Throws si el documento aún está dentro del período legal de retención.
+ * Patrón: invocar antes de `deleteDocument` para evitar borrar algo
+ * que SII puede pedir.
+ */
+export function assertRetentionExpired(retentionUntil: Date, now: Date = new Date()): void {
+  if (retentionUntil.getTime() > now.getTime()) {
+    throw new DocumentRetentionViolationError(
+      `Documento bajo retención legal hasta ${retentionUntil.toISOString()}`,
+      retentionUntil,
+    );
+  }
+}
+
+/**
+ * `true` si la retention venció.
+ */
+export function isRetentionExpired(retentionUntil: Date, now: Date = new Date()): boolean {
+  return retentionUntil.getTime() <= now.getTime();
+}

--- a/packages/document-indexer/src/types.ts
+++ b/packages/document-indexer/src/types.ts
@@ -1,0 +1,167 @@
+/**
+ * Tipos públicos del package. El registro `Document` matchea la tabla
+ * `documentos` declarada en ADR-007 § "Postgres - Índice y metadata".
+ *
+ * Decisión de diseño: el package es **agnóstico al backend** — no
+ * importa Drizzle ni `@google-cloud/storage`. El caller implementa las
+ * interfaces `DocumentRepo` y `BlobStore` con su stack real, y el
+ * package solo orquesta la lógica.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Tipos canónicos de documentos manejados por la plataforma. Matchea
+ * (extiende) el enum del schema Drizzle. Si agregás un tipo nuevo:
+ *   1. Sumar acá.
+ *   2. Sumar en el enum SQL (`tipo_documento`).
+ *   3. Definir el path GCS en `gcsPathFor()`.
+ */
+export const documentTypeSchema = z.enum([
+  'dte_52', // Guía de Despacho
+  'dte_33', // Factura Afecta
+  'dte_34', // Factura Exenta
+  'carta_porte', // Carta de Porte Ley 18.290
+  'acta_entrega', // Conformidad de recepción
+  'foto_pickup', // Foto pre-pickup
+  'foto_delivery', // Foto post-delivery
+  'firma_entrega', // Firma táctil del receptor
+  'checklist_vehiculo', // Inspección pre-viaje
+  'factura_combustible', // Externo, post-OCR
+  'certificado_esg', // Certificado de carbono Booster
+]);
+export type DocumentType = z.infer<typeof documentTypeSchema>;
+
+export const documentRecordSchema = z
+  .object({
+    id: z.string().uuid(),
+    tripId: z.string().uuid().nullable(),
+    type: documentTypeSchema,
+    /**
+     * Path completo en Cloud Storage (sin gs://, sin bucket — solo el
+     * objectName). El bucket lo conoce el caller via env var.
+     */
+    gcsPath: z.string().min(1),
+    /** SHA-256 hex del contenido del documento — para integrity check. */
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    /**
+     * Folio SII si aplica (DTE 52/33/34). Null para los otros tipos.
+     */
+    folioSii: z.string().nullable(),
+    /**
+     * UUID del user que originó la emisión. Para audit + filtrado por
+     * empresa via join de `users → empresas`.
+     */
+    emittedByUserId: z.string().uuid().nullable(),
+    emittedAt: z.date(),
+    /**
+     * `emittedAt + 6 años` (Ley 18.290 + SII). El job de retention
+     * cleanup compara contra `now()` para decidir delete.
+     */
+    retentionUntil: z.date(),
+    /**
+     * `true` si existe una versión PII-redactada del documento (para
+     * compartir fuera del proyecto, ej. con auditor externo). El path
+     * de la versión redactada se infiere por convención:
+     * `<gcsPath>.redacted.pdf`.
+     */
+    piiRedactedCopyExists: z.boolean().default(false),
+    sizeBytes: z.number().int().positive(),
+  })
+  .strict();
+export type DocumentRecord = z.infer<typeof documentRecordSchema>;
+
+/**
+ * Filtros para listar documentos. Todos opcionales; sin filtros lista
+ * todo (el caller debería autorizar previamente).
+ */
+export const listDocumentsFilterSchema = z
+  .object({
+    tripId: z.string().uuid().optional(),
+    type: documentTypeSchema.optional(),
+    /** Filtrar por documentos emitidos en o después de esta fecha. */
+    emittedAfter: z.date().optional(),
+    /** Filtrar por documentos emitidos antes de esta fecha. */
+    emittedBefore: z.date().optional(),
+    /** Limit de resultados. Default 100, max 1000. */
+    limit: z.number().int().min(1).max(1000).default(100),
+    /** Offset para paginación. Default 0. */
+    offset: z.number().int().min(0).default(0),
+  })
+  .strict();
+export type ListDocumentsFilter = z.infer<typeof listDocumentsFilterSchema>;
+
+/**
+ * Información para registrar un documento nuevo en el índice.
+ * Se compone con `emittedAt` + cálculo de `retentionUntil`.
+ */
+export const indexDocumentInputSchema = z
+  .object({
+    tripId: z.string().uuid().nullable(),
+    type: documentTypeSchema,
+    gcsPath: z.string().min(1),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    folioSii: z.string().nullable().default(null),
+    emittedByUserId: z.string().uuid().nullable(),
+    sizeBytes: z.number().int().positive(),
+    /**
+     * `emittedAt` opcional — si no se da, usa `new Date()`. Útil para
+     * tests con clock fijo.
+     */
+    emittedAt: z.date().optional(),
+  })
+  .strict();
+export type IndexDocumentInput = z.infer<typeof indexDocumentInputSchema>;
+
+/**
+ * Backend abstracto de persistencia. El caller (apps/document-service)
+ * lo implementa con Drizzle.
+ */
+export interface DocumentRepo {
+  insert(input: DocumentRecord): Promise<void>;
+  findById(id: string): Promise<DocumentRecord | null>;
+  list(filter: ListDocumentsFilter): Promise<DocumentRecord[]>;
+  /**
+   * Documentos cuya `retentionUntil` ya venció. Para el job de cleanup.
+   */
+  findExpired(asOf: Date, limit: number): Promise<DocumentRecord[]>;
+  delete(id: string): Promise<void>;
+}
+
+/**
+ * Backend abstracto de Cloud Storage. El caller lo implementa con
+ * `@google-cloud/storage` (o un mock en tests).
+ */
+export interface BlobStore {
+  /**
+   * URL firmada para download/read del objeto. Expiración en
+   * segundos. El caller decide la lib (default 900s = 15 min según
+   * ADR-007 — pero el package no asume default, es responsabilidad
+   * del caller pasar el TTL).
+   */
+  getSignedReadUrl(args: {
+    objectName: string;
+    expiresInSeconds: number;
+  }): Promise<string>;
+  /**
+   * URL firmada para upload (PUT). Misma firma. El caller la usa para
+   * ingesta directa cliente → GCS sin pasar por backend (e.g. fotos
+   * pesadas del driver).
+   */
+  getSignedUploadUrl(args: {
+    objectName: string;
+    expiresInSeconds: number;
+    contentType: string;
+  }): Promise<string>;
+  /**
+   * Existencia + tamaño del objeto. Para verificar post-upload que el
+   * cliente realmente subió antes de indexar.
+   */
+  statObject(objectName: string): Promise<{ sizeBytes: number } | null>;
+  /**
+   * Delete del objeto. NO se debe llamar si tiene retention lock activo
+   * (Cloud Storage retornará 403). El job de cleanup chequea
+   * `retentionUntil` antes.
+   */
+  deleteObject(objectName: string): Promise<void>;
+}

--- a/packages/document-indexer/test/document-indexer.test.ts
+++ b/packages/document-indexer/test/document-indexer.test.ts
@@ -1,0 +1,407 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  type BlobStore,
+  DocumentIntegrityError,
+  DocumentNotFoundError,
+  type DocumentRecord,
+  type DocumentRepo,
+  DocumentRetentionViolationError,
+  DocumentValidationError,
+  assertRetentionExpired,
+  assertSha256Match,
+  computeRetentionUntil,
+  deleteDocumentIfExpired,
+  gcsPathFor,
+  getDocumentById,
+  getSignedReadUrl,
+  getSignedUploadUrl,
+  indexDocument,
+  isRetentionExpired,
+  listDocuments,
+  redactedPathFor,
+} from '../src/index.js';
+
+// ---------------------------------------------------------------------------
+// In-memory implementations para tests
+// ---------------------------------------------------------------------------
+
+class MemoryRepo implements DocumentRepo {
+  private store = new Map<string, DocumentRecord>();
+  async insert(input: DocumentRecord): Promise<void> {
+    this.store.set(input.id, input);
+  }
+  async findById(id: string): Promise<DocumentRecord | null> {
+    return this.store.get(id) ?? null;
+  }
+  async list(filter: {
+    tripId?: string;
+    type?: string;
+    emittedAfter?: Date;
+    emittedBefore?: Date;
+    limit: number;
+    offset: number;
+  }): Promise<DocumentRecord[]> {
+    let list = [...this.store.values()];
+    if (filter.tripId) {
+      list = list.filter((d) => d.tripId === filter.tripId);
+    }
+    if (filter.type) {
+      list = list.filter((d) => d.type === filter.type);
+    }
+    if (filter.emittedAfter) {
+      list = list.filter((d) => d.emittedAt.getTime() >= filter.emittedAfter?.getTime());
+    }
+    if (filter.emittedBefore) {
+      list = list.filter((d) => d.emittedAt.getTime() < filter.emittedBefore?.getTime());
+    }
+    return list.slice(filter.offset, filter.offset + filter.limit);
+  }
+  async findExpired(asOf: Date, limit: number): Promise<DocumentRecord[]> {
+    return [...this.store.values()]
+      .filter((d) => d.retentionUntil.getTime() <= asOf.getTime())
+      .slice(0, limit);
+  }
+  async delete(id: string): Promise<void> {
+    this.store.delete(id);
+  }
+}
+
+class MemoryBlobStore implements BlobStore {
+  blobs = new Map<string, Uint8Array>();
+  signedReads: string[] = [];
+  signedUploads: string[] = [];
+  deleted: string[] = [];
+
+  async getSignedReadUrl(args: { objectName: string }): Promise<string> {
+    this.signedReads.push(args.objectName);
+    return `https://signed.test/read/${encodeURIComponent(args.objectName)}`;
+  }
+  async getSignedUploadUrl(args: { objectName: string }): Promise<string> {
+    this.signedUploads.push(args.objectName);
+    return `https://signed.test/upload/${encodeURIComponent(args.objectName)}`;
+  }
+  async statObject(name: string): Promise<{ sizeBytes: number } | null> {
+    const blob = this.blobs.get(name);
+    return blob ? { sizeBytes: blob.byteLength } : null;
+  }
+  async deleteObject(name: string): Promise<void> {
+    this.deleted.push(name);
+    this.blobs.delete(name);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// gcsPathFor
+// ---------------------------------------------------------------------------
+
+describe('gcsPathFor', () => {
+  it('DTE 52 → /dte/{year}/{month}/guia-<folio>.xml', () => {
+    const path = gcsPathFor({
+      type: 'dte_52',
+      identifier: '12345',
+      extension: 'xml',
+      emittedAt: new Date('2026-05-15T10:00:00Z'),
+    });
+    expect(path).toBe('dte/2026/05/guia-12345.xml');
+  });
+
+  it('Carta de Porte → /carta-porte/{year}/{month}/cp-<tracking>.pdf', () => {
+    const path = gcsPathFor({
+      type: 'carta_porte',
+      identifier: 'BOO-ABC123',
+      emittedAt: new Date('2026-01-05T00:00:00Z'),
+    });
+    expect(path).toBe('carta-porte/2026/01/cp-BOO-ABC123.pdf');
+  });
+
+  it('Foto pickup → /photos/pickup/{year}/{month}/pickup-<id>.jpg', () => {
+    const path = gcsPathFor({
+      type: 'foto_pickup',
+      identifier: 'trip1-driver1',
+      extension: 'jpg',
+      emittedAt: new Date('2026-12-31T23:59:59Z'),
+    });
+    expect(path).toBe('photos/pickup/2026/12/pickup-trip1-driver1.jpg');
+  });
+
+  it('sanitiza identificadores con chars peligrosos', () => {
+    const path = gcsPathFor({
+      type: 'carta_porte',
+      identifier: '../../../etc/passwd',
+      emittedAt: new Date('2026-05-01T00:00:00Z'),
+    });
+    expect(path).not.toContain('..');
+    expect(path).not.toContain('/etc');
+  });
+
+  it('redactedPathFor agrega .redacted.pdf', () => {
+    expect(redactedPathFor('dte/2026/05/guia-1.xml')).toBe('dte/2026/05/guia-1.xml.redacted.pdf');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeRetentionUntil
+// ---------------------------------------------------------------------------
+
+describe('retention', () => {
+  it('default: 6 años + 365 días desde emittedAt → 2033', () => {
+    // 2026-05-04 + 6 años = 2032-05-04 + 365 días = ~2033-05-04
+    const emittedAt = new Date('2026-05-04T10:00:00Z');
+    const r = computeRetentionUntil(emittedAt);
+    expect(r.getUTCFullYear()).toBe(2033);
+  });
+
+  it('config custom: 10 años, sin margen extra', () => {
+    const emittedAt = new Date('2026-05-04T10:00:00Z');
+    const r = computeRetentionUntil(emittedAt, {
+      retentionYears: 10,
+      extraMarginDays: 0,
+    });
+    expect(r.getUTCFullYear()).toBe(2036);
+    expect(r.getUTCMonth()).toBe(4); // mayo (0-indexed)
+    expect(r.getUTCDate()).toBe(4);
+  });
+
+  it('isRetentionExpired retorna true para fecha pasada', () => {
+    expect(isRetentionExpired(new Date('2020-01-01'))).toBe(true);
+    expect(isRetentionExpired(new Date('2099-01-01'))).toBe(false);
+  });
+
+  it('assertRetentionExpired throws DocumentRetentionViolationError si no venció', () => {
+    expect(() => assertRetentionExpired(new Date('2099-01-01'))).toThrowError(
+      DocumentRetentionViolationError,
+    );
+    expect(() => assertRetentionExpired(new Date('2020-01-01'))).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// indexDocument
+// ---------------------------------------------------------------------------
+
+describe('indexDocument', () => {
+  let repo: MemoryRepo;
+  beforeEach(() => {
+    repo = new MemoryRepo();
+  });
+
+  it('persiste documento con id UUID + retentionUntil calculado', async () => {
+    const sha = createHash('sha256').update('payload').digest('hex');
+    const record = await indexDocument(repo, {
+      tripId: randomUUID(),
+      type: 'carta_porte',
+      gcsPath: 'carta-porte/2026/05/cp-X.pdf',
+      sha256: sha,
+      folioSii: null,
+      emittedByUserId: randomUUID(),
+      sizeBytes: 4096,
+    });
+    expect(record.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/);
+    expect(record.retentionUntil.getUTCFullYear()).toBeGreaterThanOrEqual(2032);
+    expect(record.piiRedactedCopyExists).toBe(false);
+  });
+
+  it('respeta emittedAt explícito si se pasa', async () => {
+    const sha = createHash('sha256').update('payload').digest('hex');
+    const fixedDate = new Date('2024-01-01T00:00:00Z');
+    const record = await indexDocument(repo, {
+      tripId: null,
+      type: 'dte_52',
+      gcsPath: 'dte/2024/01/guia-1.xml',
+      sha256: sha,
+      folioSii: '1',
+      emittedByUserId: null,
+      sizeBytes: 1234,
+      emittedAt: fixedDate,
+    });
+    expect(record.emittedAt.toISOString()).toBe('2024-01-01T00:00:00.000Z');
+  });
+
+  it('rechaza sha256 mal formado', async () => {
+    await expect(
+      indexDocument(repo, {
+        tripId: null,
+        type: 'dte_52',
+        gcsPath: 'x',
+        sha256: 'short',
+        folioSii: null,
+        emittedByUserId: null,
+        sizeBytes: 100,
+      }),
+    ).rejects.toThrowError(DocumentValidationError);
+  });
+
+  it('rechaza tipo no permitido', async () => {
+    const sha = createHash('sha256').update('x').digest('hex');
+    await expect(
+      indexDocument(repo, {
+        tripId: null,
+        type: 'wat' as unknown as 'dte_52',
+        gcsPath: 'x',
+        sha256: sha,
+        folioSii: null,
+        emittedByUserId: null,
+        sizeBytes: 100,
+      }),
+    ).rejects.toThrowError(DocumentValidationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listDocuments
+// ---------------------------------------------------------------------------
+
+describe('listDocuments', () => {
+  it('filtra por tripId', async () => {
+    const repo = new MemoryRepo();
+    const sha = createHash('sha256').update('x').digest('hex');
+    const trip1 = randomUUID();
+    const trip2 = randomUUID();
+    await indexDocument(repo, {
+      tripId: trip1,
+      type: 'carta_porte',
+      gcsPath: 'a',
+      sha256: sha,
+      folioSii: null,
+      emittedByUserId: null,
+      sizeBytes: 1,
+    });
+    await indexDocument(repo, {
+      tripId: trip2,
+      type: 'carta_porte',
+      gcsPath: 'b',
+      sha256: sha,
+      folioSii: null,
+      emittedByUserId: null,
+      sizeBytes: 1,
+    });
+    const list = await listDocuments(repo, { tripId: trip1 });
+    expect(list).toHaveLength(1);
+    expect(list[0]?.tripId).toBe(trip1);
+  });
+
+  it('respeta limit + offset', async () => {
+    const repo = new MemoryRepo();
+    const sha = createHash('sha256').update('x').digest('hex');
+    for (let i = 0; i < 10; i++) {
+      await indexDocument(repo, {
+        tripId: null,
+        type: 'carta_porte',
+        gcsPath: `p${i}`,
+        sha256: sha,
+        folioSii: null,
+        emittedByUserId: null,
+        sizeBytes: 1,
+      });
+    }
+    const page1 = await listDocuments(repo, { limit: 3, offset: 0 });
+    const page2 = await listDocuments(repo, { limit: 3, offset: 3 });
+    expect(page1).toHaveLength(3);
+    expect(page2).toHaveLength(3);
+    expect(page1[0]?.id).not.toBe(page2[0]?.id);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getDocumentById
+// ---------------------------------------------------------------------------
+
+describe('getDocumentById', () => {
+  it('throws DocumentNotFoundError si no existe', async () => {
+    const repo = new MemoryRepo();
+    await expect(getDocumentById(repo, randomUUID())).rejects.toThrowError(DocumentNotFoundError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// signed URLs
+// ---------------------------------------------------------------------------
+
+describe('signed URLs', () => {
+  it('getSignedReadUrl retorna URL firmada del backend abstract', async () => {
+    const blob = new MemoryBlobStore();
+    const url = await getSignedReadUrl(blob, 'dte/2026/05/guia-1.xml');
+    expect(url).toContain('signed.test/read/');
+    expect(blob.signedReads).toContain('dte/2026/05/guia-1.xml');
+  });
+
+  it('getSignedUploadUrl pasa contentType al backend', async () => {
+    const blob = new MemoryBlobStore();
+    const url = await getSignedUploadUrl(blob, {
+      objectName: 'photos/pickup/2026/05/pickup-x.jpg',
+      contentType: 'image/jpeg',
+    });
+    expect(url).toContain('signed.test/upload/');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertSha256Match
+// ---------------------------------------------------------------------------
+
+describe('assertSha256Match', () => {
+  it('no throwea si matchea', () => {
+    const buf = Buffer.from('payload');
+    const sha = createHash('sha256').update(buf).digest('hex');
+    expect(() => assertSha256Match(sha, buf)).not.toThrow();
+  });
+
+  it('throws DocumentIntegrityError si no matchea', () => {
+    const buf = Buffer.from('payload');
+    expect(() => assertSha256Match('a'.repeat(64), buf)).toThrowError(DocumentIntegrityError);
+  });
+
+  it('acepta Uint8Array además de Buffer', () => {
+    const u8 = new Uint8Array([1, 2, 3, 4]);
+    const sha = createHash('sha256').update(Buffer.from(u8)).digest('hex');
+    expect(() => assertSha256Match(sha, u8)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deleteDocumentIfExpired
+// ---------------------------------------------------------------------------
+
+describe('deleteDocumentIfExpired', () => {
+  it('borra del repo + blob si retention venció', async () => {
+    const repo = new MemoryRepo();
+    const blob = new MemoryBlobStore();
+    const sha = createHash('sha256').update('x').digest('hex');
+    const oldDate = new Date('2010-01-01T00:00:00Z');
+    const record = await indexDocument(repo, {
+      tripId: null,
+      type: 'dte_52',
+      gcsPath: 'old',
+      sha256: sha,
+      folioSii: '1',
+      emittedByUserId: null,
+      sizeBytes: 1,
+      emittedAt: oldDate,
+    });
+    blob.blobs.set('old', new Uint8Array());
+
+    await deleteDocumentIfExpired(repo, blob, record.id);
+    expect(blob.deleted).toContain('old');
+    expect(await repo.findById(record.id)).toBeNull();
+  });
+
+  it('throws DocumentRetentionViolationError si retention vigente', async () => {
+    const repo = new MemoryRepo();
+    const blob = new MemoryBlobStore();
+    const sha = createHash('sha256').update('x').digest('hex');
+    const record = await indexDocument(repo, {
+      tripId: null,
+      type: 'dte_52',
+      gcsPath: 'recent',
+      sha256: sha,
+      folioSii: '1',
+      emittedByUserId: null,
+      sizeBytes: 1,
+    });
+    await expect(deleteDocumentIfExpired(repo, blob, record.id)).rejects.toThrowError(
+      DocumentRetentionViolationError,
+    );
+    expect(blob.deleted).not.toContain('recent');
+  });
+});

--- a/packages/dte-provider/README.md
+++ b/packages/dte-provider/README.md
@@ -1,12 +1,205 @@
 # @booster-ai/dte-provider
 
-Placeholder package. Ver ADR relacionado en `docs/adr/` para diseño detallado.
+Abstracción de proveedores de Documentos Tributarios Electrónicos (DTE) para el SII chileno. Implementa el adapter pattern definido en [ADR-007](../../docs/adr/007-chile-document-management.md).
 
-## Status
+Booster **NO emite DTEs propios** — delega a un provider acreditado por SII (Bsale recomendado, alternativas: Paperless, Acepta, SovosChile).
 
-`SKELETON` — implementación pendiente.
+## Estado actual
 
-## Scripts
+- ✅ Interface `DteProvider` definida
+- ✅ Schemas Zod (`GuiaDespachoInput`, `FacturaInput`, `DteResult`, `DteStatus`)
+- ✅ 7 errores tipados (`DteValidationError`, `DteRejectedBySiiError`, `DteCertificateError`, `DteProviderUnavailableError`, `DteFolioConflictError`, `DteNotFoundError`, `DteProviderError` base)
+- ✅ `MockDteProvider` (in-memory) con 21 tests
+- ⏳ `BsaleAdapter` — pendiente, se conecta al provider real
+- ⏳ `PaperlessAdapter` — alternativa pendiente
 
-- `pnpm typecheck` — validación de tipos
-- `pnpm test` — suite de tests (vacía por ahora)
+## Instalación
+
+```jsonc
+// apps/document-service/package.json
+"dependencies": {
+  "@booster-ai/dte-provider": "workspace:*"
+}
+```
+
+## API
+
+### Emit Guía de Despacho (DTE 52)
+
+```ts
+import {
+  MockDteProvider,
+  type DteProvider,
+  type GuiaDespachoInput,
+} from '@booster-ai/dte-provider';
+
+const provider: DteProvider = new MockDteProvider();
+const input: GuiaDespachoInput = {
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  fechaEmision: new Date(),
+  items: [{
+    descripcion: 'Transporte Santiago → Concepción',
+    cantidad: 1,
+    precioUnitarioClp: 850000,
+    unidadMedida: 'VIAJE',
+  }],
+  transporte: {
+    rutChofer: '11111111-1',
+    nombreChofer: 'Juan Pérez',
+    patente: 'AB-CD-12',
+    direccionDestino: 'Av. Principal 123',
+    comunaDestino: 'Concepción',
+  },
+  tipoDespacho: 5, // traslados internos
+};
+
+const result = await provider.emitGuiaDespacho(input);
+console.log(result.folio);     // "1" (mock) o folio SII real
+console.log(result.sha256);    // hash del XML para integrity check
+console.log(result.xmlSigned); // XML firmado para archivo legal 6 años
+```
+
+### Emit Factura Electrónica (DTE 33 / 34)
+
+```ts
+const factura = await provider.emitFactura({
+  tipoDte: 33, // 33 = afecta IVA, 34 = exenta
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  giroEmisor: 'Transporte de Carga',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  giroReceptor: 'Comercio',
+  fechaEmision: new Date(),
+  items: [{
+    descripcion: 'Servicio de transporte',
+    cantidad: 1,
+    precioUnitarioClp: 850000,
+    unidadMedida: 'UN',
+  }],
+  // Vincular a una guía ya emitida (opcional pero recomendado para auditoría):
+  referenciaGuia: {
+    folio: result.folio,
+    fechaEmision: result.fechaEmision,
+  },
+});
+```
+
+### Query Status
+
+```ts
+const status = await provider.queryStatus({
+  folio: '1',
+  rutEmisor: '76123456-7',
+  tipoDte: 52,
+});
+// status.status: 'accepted' | 'pending_sii_validation' | 'rejected' | 'cancelled'
+```
+
+### Manejo de errores
+
+```ts
+import {
+  DteValidationError,
+  DteRejectedBySiiError,
+  DteCertificateError,
+  DteProviderUnavailableError,
+  DteFolioConflictError,
+  DteNotFoundError,
+} from '@booster-ai/dte-provider';
+
+try {
+  await provider.emitGuiaDespacho(input);
+} catch (err) {
+  if (err instanceof DteValidationError) {
+    // 400 Bad Request — input inválido
+    return c.json({ error: 'invalid_input', fields: err.fieldErrors }, 400);
+  }
+  if (err instanceof DteRejectedBySiiError) {
+    // 422 Unprocessable Entity — SII rechazó por contenido
+    return c.json({
+      error: 'sii_rejected',
+      sii_code: err.siiErrorCode,
+      detail: err.siiErrorDetail,
+    }, 422);
+  }
+  if (err instanceof DteCertificateError) {
+    // 422 — certificado del emisor inválido o vencido
+    return c.json({ error: 'certificate_invalid', rut: err.rutEmisor }, 422);
+  }
+  if (err instanceof DteFolioConflictError) {
+    // 409 Conflict — folio ya en uso
+    return c.json({ error: 'folio_conflict', folio: err.folio }, 409);
+  }
+  if (err instanceof DteProviderUnavailableError) {
+    // 503 Service Unavailable — transient, reintentar
+    return c.json({
+      error: 'provider_down',
+      retry_after_seconds: err.retryAfterSeconds,
+    }, 503);
+  }
+  if (err instanceof DteNotFoundError) {
+    // 404 Not Found
+    return c.json({ error: 'dte_not_found' }, 404);
+  }
+  // Fallback 502
+  throw err;
+}
+```
+
+## MockDteProvider
+
+Para tests + desarrollo local. Genera folios autoincrementales por `(rutEmisor, tipoDte)`, persiste en memoria, y soporta inyección de fallos:
+
+```ts
+// Tests del flujo de error
+const provider = new MockDteProvider({
+  failNextEmit: 'rejected_sii', // o 'certificate_error', 'unavailable', 'folio_conflict'
+});
+await expect(provider.emitGuiaDespacho(input)).rejects.toThrowError(
+  DteRejectedBySiiError,
+);
+
+// Simulación de latencia para tests de timeout
+const slow = new MockDteProvider({ artificialLatencyMs: 5000 });
+
+// Folio inicial custom
+const fromN = new MockDteProvider({ startingFolio: 1000 });
+```
+
+`environment` por default es `'certification'` para que ningún test claim "production" output accidentalmente. Si querés simular prod (sin emitir nada real, obvio): `new MockDteProvider({ environment: 'production' })`.
+
+## Plan de migración a Bsale
+
+Para implementar el adapter real:
+
+1. **Crear `packages/dte-provider/src/bsale.ts`** con clase `BsaleAdapter implements DteProvider`.
+2. **Auth**: Bsale usa API token + certificado digital del emisor. Token via env var; cert via Secret Manager (`carrier-{id}-cert-pfx` según ADR-007).
+3. **Mapping**: traducir `GuiaDespachoInput` → request body Bsale (formato propio que Bsale convierte a XML SII).
+4. **Error mapping**: traducir respuestas Bsale → errores tipados de este package:
+   - HTTP 400 → `DteValidationError`
+   - HTTP 422 con código SII → `DteRejectedBySiiError`
+   - HTTP 401/403 sobre cert → `DteCertificateError`
+   - HTTP 5xx → `DteProviderUnavailableError`
+5. **Tests de integración** con sandbox Bsale (no production). Usar idempotency key para reintentos seguros.
+6. **Switch en factory**: `apps/document-service` reemplaza `new MockDteProvider()` por `new BsaleAdapter({ apiKey, environment })`.
+
+Estimación: 2-3 días dev + 2-3 días testing en sandbox SII.
+
+## Testing del package
+
+```bash
+pnpm --filter @booster-ai/dte-provider typecheck
+pnpm --filter @booster-ai/dte-provider test
+```
+
+## Referencias
+
+- [ADR-007 — Chile Document Management](../../docs/adr/007-chile-document-management.md)
+- SII — [Formato DTE](https://www.sii.cl/factura_electronica/formato_dte.htm)
+- Ley 19.983 — [Guía de Despacho](https://bcn.cl/2jdwx)
+- Ley 20.727 — [Factura Electrónica](https://bcn.cl/2xu0f)
+- Bsale API — [https://api.bsale.dev/](https://api.bsale.dev/)

--- a/packages/dte-provider/package.json
+++ b/packages/dte-provider/package.json
@@ -12,8 +12,11 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
-  "dependencies": {},
+  "dependencies": {
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
+    "@types/node": "^22.14.0",
     "typescript": "^5.8.2",
     "vitest": "^4.0.18"
   }

--- a/packages/dte-provider/src/errors.ts
+++ b/packages/dte-provider/src/errors.ts
@@ -1,0 +1,122 @@
+/**
+ * Errores tipados del package. Cada uno mapea a un comportamiento HTTP
+ * esperado en `apps/document-service`:
+ *
+ * | Error                            | HTTP recomendado |
+ * |----------------------------------|------------------|
+ * | DteValidationError               | 400 Bad Request  |
+ * | DteCertificateError              | 422 Unprocessable Entity |
+ * | DteRejectedBySiiError            | 422 (negocio)    |
+ * | DteFolioConflictError            | 409 Conflict     |
+ * | DteNotFoundError                 | 404 Not Found    |
+ * | DteProviderUnavailableError      | 503 (transient)  |
+ * | DteProviderError (fallback)      | 502 Bad Gateway  |
+ *
+ * Todas extienden `Error` con metadata estructurada para logs.
+ */
+
+/**
+ * Error base. Cualquier fallo del provider que no sea uno de los
+ * específicos cae acá. El caller puede ramificar `instanceof` por la
+ * subclass; si no matchea, asumir 502.
+ */
+export class DteProviderError extends Error {
+  constructor(
+    message: string,
+    public override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = 'DteProviderError';
+  }
+}
+
+/**
+ * El input no pasó el schema Zod o el provider rechazó por validación
+ * formato (RUT mal formado, fecha futura, items vacíos, etc.). El caller
+ * debe corregir el input antes de reintentar.
+ */
+export class DteValidationError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly fieldErrors: Record<string, string[]>,
+  ) {
+    super(message);
+    this.name = 'DteValidationError';
+  }
+}
+
+/**
+ * SII rechazó el documento por contenido (RUT no inscrito, glosa
+ * inválida, monto fuera de rango, etc.). Distinto de
+ * `DteValidationError` porque acá el formato era OK pero el negocio no.
+ */
+export class DteRejectedBySiiError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly siiErrorCode: string,
+    public readonly siiErrorDetail: string,
+  ) {
+    super(message);
+    this.name = 'DteRejectedBySiiError';
+  }
+}
+
+/**
+ * El provider devolvió un folio que ya existe (race condition entre dos
+ * intentos de emit con la misma referencia externa, o un retry sin
+ * idempotency key). El caller debe queryStatus con el folio existente.
+ */
+export class DteFolioConflictError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly folio: string,
+  ) {
+    super(message);
+    this.name = 'DteFolioConflictError';
+  }
+}
+
+/**
+ * El certificado digital del emisor no se pudo cargar, está vencido, o
+ * no coincide con el RUT del emisor. Bloqueante operativo — no se puede
+ * emitir hasta resolver.
+ */
+export class DteCertificateError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly rutEmisor: string,
+  ) {
+    super(message);
+    this.name = 'DteCertificateError';
+  }
+}
+
+/**
+ * Provider externo no responde, timeout, 5xx. Transient — el caller
+ * puede reintentar con exponential backoff.
+ */
+export class DteProviderUnavailableError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly retryAfterSeconds?: number,
+  ) {
+    super(message);
+    this.name = 'DteProviderUnavailableError';
+  }
+}
+
+/**
+ * `queryStatus` no encontró el folio para ese (rutEmisor, tipoDte).
+ * Puede significar: folio no fue emitido, expiró del cache del provider,
+ * o el RUT está mal. El caller tiene que decidir si es bug o no.
+ */
+export class DteNotFoundError extends DteProviderError {
+  constructor(
+    message: string,
+    public readonly folio: string,
+    public readonly rutEmisor: string,
+  ) {
+    super(message);
+    this.name = 'DteNotFoundError';
+  }
+}

--- a/packages/dte-provider/src/index.ts
+++ b/packages/dte-provider/src/index.ts
@@ -1,7 +1,88 @@
 /**
  * @booster-ai/dte-provider
  *
- * TODO: implementar según ADRs relacionados.
- * Este archivo es un placeholder para que el monorepo compile.
+ * Abstracción de proveedores de Documentos Tributarios Electrónicos (DTE)
+ * para el SII chileno. Implementa el adapter pattern definido en ADR-007.
+ *
+ * Booster NO emite DTEs propios — delega a un provider acreditado por SII
+ * (Bsale recomendado, alternativas: Paperless, Acepta, SovosChile). Este
+ * package define:
+ *
+ *   1. La **interface** `DteProvider` que cada adapter implementa.
+ *   2. **Schemas Zod** para validar inputs y outputs antes de cruzar la
+ *      frontera HTTP del provider externo (CLAUDE.md §5 + §7).
+ *   3. **Errores tipados** que el caller mapea a HTTP status apropiados.
+ *   4. Una implementación **`MockDteProvider`** in-memory para dev local
+ *      y tests, sin dependencia del provider real.
+ *
+ * El switch a un provider real (Bsale → Paperless u otro) es cambiar la
+ * factory en `apps/document-service` — el resto del código consume la
+ * interface, no la implementación concreta.
+ *
+ * Ver:
+ * - ADR-007 (Chile Document Management) — sección "Integración SII DTE"
+ * - HANDOFF.md §4 — bloqueante regulatorio go-live Chile
+ *
+ * @example
+ * ```ts
+ * import {
+ *   MockDteProvider,
+ *   type DteProvider,
+ * } from '@booster-ai/dte-provider';
+ *
+ * const provider: DteProvider = new MockDteProvider();
+ * const result = await provider.emitGuiaDespacho({
+ *   rutEmisor: '76123456-7',
+ *   razonSocialEmisor: 'Transportes Chile SpA',
+ *   rutReceptor: '12345678-9',
+ *   razonSocialReceptor: 'Cliente SA',
+ *   fechaEmision: new Date(),
+ *   items: [{
+ *     descripcion: 'Transporte Santiago → Concepción',
+ *     cantidad: 1,
+ *     precioUnitarioClp: 850000,
+ *     unidadMedida: 'VIAJE',
+ *   }],
+ *   transporte: {
+ *     rutChofer: '11111111-1',
+ *     nombreChofer: 'Juan Pérez',
+ *     patente: 'AB-CD-12',
+ *     direccionDestino: 'Av. Principal 123, Concepción',
+ *     comunaDestino: 'Concepción',
+ *   },
+ * });
+ * console.log(result.folio); // SII-asignado (mock: 1, 2, 3, ...)
+ * ```
  */
-export const PACKAGE_NAME = '@booster-ai/dte-provider' as const;
+
+export type {
+  DteProvider,
+  DteStatus,
+  DteEnvironment,
+  DteResult,
+  GuiaDespachoInput,
+  FacturaInput,
+  DteItem,
+  TransporteInfo,
+} from './types.js';
+
+export {
+  guiaDespachoInputSchema,
+  facturaInputSchema,
+  dteResultSchema,
+  dteStatusSchema,
+  dteItemSchema,
+  transporteInfoSchema,
+} from './types.js';
+
+export {
+  DteProviderError,
+  DteValidationError,
+  DteRejectedBySiiError,
+  DteProviderUnavailableError,
+  DteFolioConflictError,
+  DteCertificateError,
+  DteNotFoundError,
+} from './errors.js';
+
+export { MockDteProvider, type MockDteProviderOptions } from './mock.js';

--- a/packages/dte-provider/src/mock.ts
+++ b/packages/dte-provider/src/mock.ts
@@ -1,0 +1,227 @@
+/**
+ * MockDteProvider — implementación in-memory para tests + dev local.
+ *
+ * Comportamiento:
+ *   - Genera folios autoincrementales por (rutEmisor, tipoDte).
+ *   - Persiste los DTEs emitidos en un Map para que `queryStatus` los recupere.
+ *   - Computa SHA-256 real del XML "construido" (un string JSON con los
+ *     campos del input — suficiente para tests de integridad, NO es XML
+ *     SII real).
+ *   - Soporta inyección de fallos (`failNextEmit: 'rejected_sii' | ...`)
+ *     para tests de error paths sin tener que mockear todo el provider.
+ *
+ * NO usar en producción. Para producción usar el adapter real (Bsale,
+ * Paperless, etc.) que se conecta al SII.
+ */
+
+import { createHash } from 'node:crypto';
+import type { ZodError } from 'zod';
+import {
+  DteCertificateError,
+  DteFolioConflictError,
+  DteNotFoundError,
+  DteProviderUnavailableError,
+  DteRejectedBySiiError,
+  DteValidationError,
+} from './errors.js';
+import {
+  type DteEnvironment,
+  type DteProvider,
+  type DteResult,
+  type DteStatus,
+  type FacturaInput,
+  type GuiaDespachoInput,
+  facturaInputSchema,
+  guiaDespachoInputSchema,
+} from './types.js';
+
+export interface MockDteProviderOptions {
+  /**
+   * Environment a simular. Default `certification` para que ningún test
+   * pueda accidentalmente claim "production" output.
+   */
+  environment?: DteEnvironment;
+  /**
+   * Folio inicial. Default 1. Se incrementa por cada emisión exitosa.
+   */
+  startingFolio?: number;
+  /**
+   * Forzar el siguiente `emit*` (cualquier tipo) a fallar con el error
+   * especificado. Después del primer fallo se resetea automáticamente.
+   */
+  failNextEmit?: 'rejected_sii' | 'certificate_error' | 'unavailable' | 'folio_conflict';
+  /**
+   * Retraso simulado en ms en cada `emit*`. Default 0.
+   */
+  artificialLatencyMs?: number;
+}
+
+interface StoredDte {
+  result: DteResult;
+  status: DteStatus;
+}
+
+export class MockDteProvider implements DteProvider {
+  public readonly environment: DteEnvironment;
+  private nextFolioByEmisor = new Map<string, number>();
+  private store = new Map<string, StoredDte>();
+  private failNextEmit: MockDteProviderOptions['failNextEmit'];
+  private latencyMs: number;
+  private startingFolio: number;
+
+  constructor(opts: MockDteProviderOptions = {}) {
+    this.environment = opts.environment ?? 'certification';
+    this.startingFolio = opts.startingFolio ?? 1;
+    this.failNextEmit = opts.failNextEmit;
+    this.latencyMs = opts.artificialLatencyMs ?? 0;
+  }
+
+  async emitGuiaDespacho(input: GuiaDespachoInput): Promise<DteResult> {
+    const parsed = guiaDespachoInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new DteValidationError(
+        'Input inválido para Guía de Despacho',
+        flattenZodErrors(parsed.error),
+      );
+    }
+    return this.emitInternal(52, parsed.data);
+  }
+
+  async emitFactura(input: FacturaInput): Promise<DteResult> {
+    const parsed = facturaInputSchema.safeParse(input);
+    if (!parsed.success) {
+      throw new DteValidationError('Input inválido para Factura', flattenZodErrors(parsed.error));
+    }
+    return this.emitInternal(parsed.data.tipoDte, parsed.data);
+  }
+
+  async queryStatus(args: {
+    folio: string;
+    rutEmisor: string;
+    tipoDte: 33 | 34 | 52;
+  }): Promise<DteStatus> {
+    const key = storeKey(args.tipoDte, args.rutEmisor, args.folio);
+    const stored = this.store.get(key);
+    if (!stored) {
+      throw new DteNotFoundError(
+        `Folio ${args.folio} no encontrado para emisor ${args.rutEmisor}`,
+        args.folio,
+        args.rutEmisor,
+      );
+    }
+    // Refresh lastCheckedAt para que el caller vea el query timestamp.
+    return { ...stored.status, lastCheckedAt: new Date() };
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  private async emitInternal(
+    tipoDte: 33 | 34 | 52,
+    parsed: GuiaDespachoInput | FacturaInput,
+  ): Promise<DteResult> {
+    if (this.latencyMs > 0) {
+      await sleep(this.latencyMs);
+    }
+
+    if (this.failNextEmit) {
+      const failure = this.failNextEmit;
+      this.failNextEmit = undefined; // one-shot
+      throw this.constructFailure(failure, parsed.rutEmisor);
+    }
+
+    const folio = this.allocateFolio(parsed.rutEmisor, tipoDte);
+    const xmlSigned = this.buildPseudoXml(tipoDte, folio, parsed);
+    const sha256 = createHash('sha256').update(xmlSigned).digest('hex');
+
+    const result: DteResult = {
+      folio,
+      tipoDte,
+      rutEmisor: parsed.rutEmisor,
+      fechaEmision: parsed.fechaEmision,
+      xmlSigned,
+      sha256,
+      providerTrackId: `mock-track-${tipoDte}-${folio}`,
+      status: 'accepted',
+    };
+
+    const status: DteStatus = {
+      folio,
+      tipoDte,
+      rutEmisor: parsed.rutEmisor,
+      status: 'accepted',
+      lastCheckedAt: new Date(),
+    };
+
+    this.store.set(storeKey(tipoDte, parsed.rutEmisor, folio), { result, status });
+    return result;
+  }
+
+  private allocateFolio(rutEmisor: string, tipoDte: 33 | 34 | 52): string {
+    const key = `${rutEmisor}|${tipoDte}`;
+    const next = this.nextFolioByEmisor.get(key) ?? this.startingFolio;
+    this.nextFolioByEmisor.set(key, next + 1);
+    return String(next);
+  }
+
+  private buildPseudoXml(
+    tipoDte: 33 | 34 | 52,
+    folio: string,
+    parsed: GuiaDespachoInput | FacturaInput,
+  ): string {
+    // Pseudo-XML compacto. NO es XML SII real — solo un string
+    // determinístico que permite tests de integridad (sha256 estable
+    // para mismo input + folio).
+    const payload = {
+      tipo: tipoDte,
+      folio,
+      rutEmisor: parsed.rutEmisor,
+      receptor: parsed.rutReceptor,
+      fechaEmision: parsed.fechaEmision.toISOString(),
+      itemCount: parsed.items.length,
+      total: parsed.items.reduce((acc, item) => acc + item.cantidad * item.precioUnitarioClp, 0),
+    };
+    return `<DTE mock="true">${JSON.stringify(payload)}</DTE>`;
+  }
+
+  private constructFailure(
+    kind: NonNullable<MockDteProviderOptions['failNextEmit']>,
+    rutEmisor: string,
+  ): Error {
+    switch (kind) {
+      case 'rejected_sii':
+        return new DteRejectedBySiiError(
+          'SII rechazó el documento (mock)',
+          'MOCK_001',
+          'Forzado por failNextEmit en tests',
+        );
+      case 'certificate_error':
+        return new DteCertificateError('Certificado digital inválido (mock)', rutEmisor);
+      case 'unavailable':
+        return new DteProviderUnavailableError('Provider down (mock)', 30);
+      case 'folio_conflict':
+        return new DteFolioConflictError('Folio ya en uso (mock)', 'mock-folio-collision');
+    }
+  }
+}
+
+function storeKey(tipoDte: 33 | 34 | 52, rutEmisor: string, folio: string): string {
+  return `${tipoDte}|${rutEmisor}|${folio}`;
+}
+
+function flattenZodErrors(error: ZodError): Record<string, string[]> {
+  const out: Record<string, string[]> = {};
+  for (const issue of error.issues) {
+    const key = issue.path.join('.') || '_';
+    if (!out[key]) {
+      out[key] = [];
+    }
+    out[key].push(issue.message);
+  }
+  return out;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/dte-provider/src/types.ts
+++ b/packages/dte-provider/src/types.ts
@@ -1,0 +1,284 @@
+/**
+ * Schemas Zod + types para DTEs (SII Chile).
+ *
+ * Diseñados para que el código consumer (apps/document-service) valide
+ * los inputs ANTES de enviar al provider externo y outputs ANTES de
+ * persistir en BD. Todo input externo pasa por Zod (CLAUDE.md §7).
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Primitives
+// ---------------------------------------------------------------------------
+
+/**
+ * RUT chileno con formato `XXXXXXXX-Y` donde Y es DV (0-9 o K).
+ * No validamos el dígito verificador acá — el provider lo hace.
+ * Solo formato sintáctico.
+ */
+const rutSchema = z.string().regex(/^\d{1,8}-[0-9Kk]$/, {
+  message: 'RUT debe tener formato XXXXXXXX-Y (Y=0-9 o K)',
+});
+
+/**
+ * Patente chilena. Acepta formatos viejos (4 letras + 2 dígitos: AB-CD-12)
+ * y nuevos (LL-LL-NN o LL-NN-NN). Lenient — el provider valida estricto.
+ */
+const patenteSchema = z
+  .string()
+  .min(6)
+  .max(10)
+  .regex(/^[A-Z0-9-]+$/i, {
+    message: 'Patente solo letras, dígitos, guiones',
+  });
+
+const moneyClpSchema = z.number().int({ message: 'CLP es entero (no fracciones)' }).nonnegative();
+
+// ---------------------------------------------------------------------------
+// DteItem (línea de la guía/factura)
+// ---------------------------------------------------------------------------
+
+export const dteItemSchema = z
+  .object({
+    descripcion: z.string().min(1).max(1000),
+    cantidad: z.number().positive(),
+    precioUnitarioClp: moneyClpSchema,
+    /**
+     * Código SKU/interno del emisor. Opcional. Si se incluye, va en el XML
+     * DTE como `<CdgItem>`.
+     */
+    codigoItem: z.string().max(35).optional(),
+    /**
+     * Unidad de medida (ej. "UN", "KG", "TON", "VIAJE", "M3"). Default "UN".
+     * SII XML schema acepta hasta 10 chars en el campo `<UnmdItem>`.
+     */
+    unidadMedida: z.string().max(10).default('UN'),
+  })
+  .strict();
+
+export type DteItem = z.infer<typeof dteItemSchema>;
+
+// ---------------------------------------------------------------------------
+// TransporteInfo (campos específicos de Guía de Despacho)
+// ---------------------------------------------------------------------------
+
+export const transporteInfoSchema = z
+  .object({
+    rutChofer: rutSchema,
+    nombreChofer: z.string().min(1).max(100),
+    patente: patenteSchema,
+    /**
+     * Dirección literal del destino. SII pide texto, no coordenadas.
+     */
+    direccionDestino: z.string().min(1).max(200),
+    comunaDestino: z.string().min(1).max(60),
+    /**
+     * RUT del transportista si distinto del emisor (cuando Booster emite
+     * en nombre del shipper pero el carrier es un tercero). Opcional.
+     */
+    rutTransportista: rutSchema.optional(),
+  })
+  .strict();
+
+export type TransporteInfo = z.infer<typeof transporteInfoSchema>;
+
+// ---------------------------------------------------------------------------
+// GuiaDespachoInput (DTE 52)
+// ---------------------------------------------------------------------------
+
+export const guiaDespachoInputSchema = z
+  .object({
+    rutEmisor: rutSchema,
+    razonSocialEmisor: z.string().min(1).max(100),
+    rutReceptor: rutSchema,
+    razonSocialReceptor: z.string().min(1).max(100),
+    fechaEmision: z.date(),
+    items: z.array(dteItemSchema).min(1, {
+      message: 'Guía de despacho requiere al menos 1 item',
+    }),
+    transporte: transporteInfoSchema,
+    /**
+     * Folio externo del caller (ej. trackingCode `BOO-XXXXXX` del trip).
+     * No es el folio SII — eso lo asigna SII al validar. Sirve para que
+     * el caller correlacione su request con el resultado en logs.
+     */
+    referenciaExterna: z.string().min(1).max(40).optional(),
+    /**
+     * Tipo de despacho según SII:
+     *   1 = "Operación constituye venta"
+     *   2 = "Ventas por efectuar"
+     *   3 = "Consignaciones"
+     *   4 = "Entrega gratuita"
+     *   5 = "Traslados internos"
+     *   6 = "Otros traslados no venta"
+     *   7 = "Guía de devolución"
+     * Default 5 (traslados internos) para retornos vacíos típicos.
+     */
+    tipoDespacho: z
+      .union([
+        z.literal(1),
+        z.literal(2),
+        z.literal(3),
+        z.literal(4),
+        z.literal(5),
+        z.literal(6),
+        z.literal(7),
+      ])
+      .default(5),
+  })
+  .strict();
+
+export type GuiaDespachoInput = z.infer<typeof guiaDespachoInputSchema>;
+
+// ---------------------------------------------------------------------------
+// FacturaInput (DTE 33 afecta IVA, DTE 34 exenta)
+// ---------------------------------------------------------------------------
+
+export const facturaInputSchema = z
+  .object({
+    tipoDte: z.union([z.literal(33), z.literal(34)]),
+    rutEmisor: rutSchema,
+    razonSocialEmisor: z.string().min(1).max(100),
+    giroEmisor: z.string().min(1).max(80),
+    rutReceptor: rutSchema,
+    razonSocialReceptor: z.string().min(1).max(100),
+    giroReceptor: z.string().min(1).max(80),
+    fechaEmision: z.date(),
+    items: z.array(dteItemSchema).min(1),
+    /**
+     * Referencia opcional a una Guía de Despacho ya emitida (folio SII).
+     * Cuando facturamos un viaje ya despachado, el SII pide vincular la
+     * factura a la guía vía referencia con tipo "DTE 52".
+     */
+    referenciaGuia: z
+      .object({
+        folio: z.string(),
+        fechaEmision: z.date(),
+      })
+      .optional(),
+    referenciaExterna: z.string().min(1).max(40).optional(),
+  })
+  .strict();
+
+export type FacturaInput = z.infer<typeof facturaInputSchema>;
+
+// ---------------------------------------------------------------------------
+// DteResult (output del emit)
+// ---------------------------------------------------------------------------
+
+export const dteResultSchema = z
+  .object({
+    /** Folio asignado por SII (único por (rutEmisor, tipoDte)). */
+    folio: z.string().min(1),
+    /** Tipo DTE del documento emitido (52=Guía, 33=Factura afecta, 34=exenta). */
+    tipoDte: z.union([z.literal(33), z.literal(34), z.literal(52)]),
+    rutEmisor: rutSchema,
+    fechaEmision: z.date(),
+    /** XML firmado del DTE — para archivo legal 6 años. */
+    xmlSigned: z.string().min(1),
+    /** SHA-256 del XML para integrity check post-storage. */
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    /** PDF visual del documento — para humanos. */
+    pdfBase64: z.string().min(1).optional(),
+    /** Track ID interno del provider (para queryStatus posterior). */
+    providerTrackId: z.string().min(1).optional(),
+    /** Estado inicial del DTE post-emisión. */
+    status: z.enum(['accepted', 'pending_sii_validation', 'rejected']),
+  })
+  .strict();
+
+export type DteResult = z.infer<typeof dteResultSchema>;
+
+// ---------------------------------------------------------------------------
+// DteStatus (output de queryStatus)
+// ---------------------------------------------------------------------------
+
+export const dteStatusSchema = z
+  .object({
+    folio: z.string(),
+    tipoDte: z.union([z.literal(33), z.literal(34), z.literal(52)]),
+    rutEmisor: rutSchema,
+    /**
+     * - `accepted`: SII validó. Documento legalmente válido.
+     * - `pending_sii_validation`: enviado, esperando respuesta SII (puede
+     *   tomar minutos a horas en producción real).
+     * - `rejected`: SII rechazó (errores en el XML, RUT inválido, etc.).
+     * - `cancelled`: anulado posteriormente (DTE de anulación emitido).
+     */
+    status: z.enum(['accepted', 'pending_sii_validation', 'rejected', 'cancelled']),
+    /** Si `rejected`, descripción del motivo. */
+    rejectionReason: z.string().optional(),
+    lastCheckedAt: z.date(),
+  })
+  .strict();
+
+export type DteStatus = z.infer<typeof dteStatusSchema>;
+
+/**
+ * Environment de SII al que apunta el provider.
+ * - `certification`: ambiente de pruebas (folios no oficiales). Usar
+ *   durante desarrollo + onboarding.
+ * - `production`: SII real, folios oficiales con valor legal.
+ */
+export type DteEnvironment = 'certification' | 'production';
+
+// ---------------------------------------------------------------------------
+// DteProvider interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Contrato de cualquier adapter de DTE. Implementaciones esperadas:
+ *
+ * - `MockDteProvider` — para tests + dev local. Incluida en este package.
+ * - `BsaleAdapter` — provider recomendado en ADR-007. **Pendiente**.
+ * - `PaperlessAdapter` — alternativa. **Pendiente**.
+ *
+ * Los adapters reales hacen HTTP calls al provider, manejan auth (API
+ * keys + certificate), serializan a XML SII, y traducen los errores del
+ * provider a las clases tipadas de `errors.ts`.
+ */
+export interface DteProvider {
+  /**
+   * Indica el environment SII al que apunta este provider. El caller
+   * típicamente no lo necesita en runtime, pero sirve para logs y para
+   * diferenciar dev vs prod en alertas.
+   */
+  readonly environment: DteEnvironment;
+
+  /**
+   * Emite una Guía de Despacho Electrónica (DTE Tipo 52). Ley 19.983.
+   *
+   * Flow esperado:
+   *   1. Validar input con `guiaDespachoInputSchema` (caller debería pre-validar).
+   *   2. Construir XML DTE según schema SII.
+   *   3. Firmar con certificado del emisor.
+   *   4. Enviar al SII (vía provider). Recibir folio.
+   *   5. Generar PDF visual (opcional pero recomendado).
+   *   6. Retornar `DteResult` con folio + xmlSigned + sha256.
+   *
+   * @throws {DteValidationError} si el input no pasa schema.
+   * @throws {DteRejectedBySiiError} si SII rechaza (formato, RUT, etc.).
+   * @throws {DteCertificateError} si el certificado del emisor falla.
+   * @throws {DteProviderUnavailableError} si el provider está down.
+   */
+  emitGuiaDespacho(input: GuiaDespachoInput): Promise<DteResult>;
+
+  /**
+   * Emite una Factura Electrónica (DTE Tipo 33 afecta IVA o 34 exenta).
+   * Ley 20.727.
+   */
+  emitFactura(input: FacturaInput): Promise<DteResult>;
+
+  /**
+   * Consulta el estado actual del DTE en SII (post-emisión, los DTEs
+   * pueden tomar minutos a horas en aceptarse formalmente).
+   *
+   * @throws {DteNotFoundError} si el folio no existe para ese RUT/tipo.
+   */
+  queryStatus(args: {
+    folio: string;
+    rutEmisor: string;
+    tipoDte: 33 | 34 | 52;
+  }): Promise<DteStatus>;
+}

--- a/packages/dte-provider/test/mock.test.ts
+++ b/packages/dte-provider/test/mock.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DteCertificateError,
+  DteFolioConflictError,
+  DteNotFoundError,
+  DteProviderUnavailableError,
+  DteRejectedBySiiError,
+  DteValidationError,
+  type FacturaInput,
+  type GuiaDespachoInput,
+  MockDteProvider,
+} from '../src/index.js';
+
+const validGuia: GuiaDespachoInput = {
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  fechaEmision: new Date('2026-05-03T10:00:00Z'),
+  items: [
+    {
+      descripcion: 'Transporte Santiago → Concepción',
+      cantidad: 1,
+      precioUnitarioClp: 850000,
+      unidadMedida: 'VIAJE',
+    },
+  ],
+  transporte: {
+    rutChofer: '11111111-1',
+    nombreChofer: 'Juan Pérez',
+    patente: 'AB-CD-12',
+    direccionDestino: 'Av. Principal 123',
+    comunaDestino: 'Concepción',
+  },
+  tipoDespacho: 5,
+};
+
+const validFactura: FacturaInput = {
+  tipoDte: 33,
+  rutEmisor: '76123456-7',
+  razonSocialEmisor: 'Transportes Test SpA',
+  giroEmisor: 'Transporte de Carga',
+  rutReceptor: '12345678-9',
+  razonSocialReceptor: 'Cliente SA',
+  giroReceptor: 'Comercio',
+  fechaEmision: new Date('2026-05-03T10:00:00Z'),
+  items: [
+    {
+      descripcion: 'Servicio de transporte',
+      cantidad: 1,
+      precioUnitarioClp: 850000,
+      unidadMedida: 'UN',
+    },
+  ],
+};
+
+describe('MockDteProvider — emitGuiaDespacho happy path', () => {
+  it('emite folio 1 inicial + status accepted + sha256 válido', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitGuiaDespacho(validGuia);
+
+    expect(result.folio).toBe('1');
+    expect(result.tipoDte).toBe(52);
+    expect(result.rutEmisor).toBe('76123456-7');
+    expect(result.status).toBe('accepted');
+    expect(result.sha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(result.xmlSigned).toContain('<DTE mock="true">');
+    expect(result.providerTrackId).toBe('mock-track-52-1');
+  });
+
+  it('folios autoincrementales por (rutEmisor, tipoDte)', async () => {
+    const provider = new MockDteProvider();
+    const r1 = await provider.emitGuiaDespacho(validGuia);
+    const r2 = await provider.emitGuiaDespacho(validGuia);
+    const r3 = await provider.emitGuiaDespacho(validGuia);
+    expect([r1.folio, r2.folio, r3.folio]).toEqual(['1', '2', '3']);
+  });
+
+  it('folios independientes entre emisores', async () => {
+    const provider = new MockDteProvider();
+    const r1 = await provider.emitGuiaDespacho(validGuia);
+    const r2 = await provider.emitGuiaDespacho({
+      ...validGuia,
+      rutEmisor: '99999999-9',
+      razonSocialEmisor: 'Otro Emisor',
+    });
+    expect(r1.folio).toBe('1');
+    expect(r2.folio).toBe('1'); // primer folio para emisor distinto
+  });
+
+  it('startingFolio override respeta el inicio', async () => {
+    const provider = new MockDteProvider({ startingFolio: 100 });
+    const result = await provider.emitGuiaDespacho(validGuia);
+    expect(result.folio).toBe('100');
+  });
+
+  it('sha256 determinístico para mismo input + folio', async () => {
+    const p1 = new MockDteProvider();
+    const p2 = new MockDteProvider();
+    const r1 = await p1.emitGuiaDespacho(validGuia);
+    const r2 = await p2.emitGuiaDespacho(validGuia);
+    expect(r1.sha256).toBe(r2.sha256);
+  });
+});
+
+describe('MockDteProvider — emitFactura happy path', () => {
+  it('factura DTE 33 (afecta IVA)', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitFactura(validFactura);
+    expect(result.tipoDte).toBe(33);
+    expect(result.folio).toBe('1');
+  });
+
+  it('factura DTE 34 (exenta) usa folio independiente del 33', async () => {
+    const provider = new MockDteProvider();
+    const r33 = await provider.emitFactura(validFactura);
+    const r34 = await provider.emitFactura({ ...validFactura, tipoDte: 34 });
+    expect(r33.folio).toBe('1');
+    expect(r34.folio).toBe('1'); // distinto pool
+  });
+});
+
+describe('MockDteProvider — validación Zod', () => {
+  it('rechaza RUT mal formado con DteValidationError', async () => {
+    const provider = new MockDteProvider();
+    await expect(
+      provider.emitGuiaDespacho({ ...validGuia, rutEmisor: 'no-es-rut' }),
+    ).rejects.toThrowError(DteValidationError);
+  });
+
+  it('rechaza items vacíos', async () => {
+    const provider = new MockDteProvider();
+    await expect(provider.emitGuiaDespacho({ ...validGuia, items: [] })).rejects.toThrowError(
+      DteValidationError,
+    );
+  });
+
+  it('error message incluye field errors', async () => {
+    const provider = new MockDteProvider();
+    try {
+      await provider.emitGuiaDespacho({
+        ...validGuia,
+        rutEmisor: 'no-es-rut',
+        razonSocialEmisor: '',
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(DteValidationError);
+      const e = err as DteValidationError;
+      expect(Object.keys(e.fieldErrors).length).toBeGreaterThanOrEqual(1);
+      expect(e.fieldErrors.rutEmisor).toBeDefined();
+    }
+  });
+});
+
+describe('MockDteProvider — failNextEmit (error injection)', () => {
+  it('rejected_sii throws DteRejectedBySiiError una sola vez', async () => {
+    const provider = new MockDteProvider({ failNextEmit: 'rejected_sii' });
+    await expect(provider.emitGuiaDespacho(validGuia)).rejects.toThrowError(DteRejectedBySiiError);
+    // Segundo intento debe pasar
+    const ok = await provider.emitGuiaDespacho(validGuia);
+    expect(ok.folio).toBeDefined();
+  });
+
+  it('certificate_error throws DteCertificateError con rutEmisor', async () => {
+    const provider = new MockDteProvider({ failNextEmit: 'certificate_error' });
+    try {
+      await provider.emitGuiaDespacho(validGuia);
+    } catch (err) {
+      expect(err).toBeInstanceOf(DteCertificateError);
+      expect((err as DteCertificateError).rutEmisor).toBe('76123456-7');
+    }
+  });
+
+  it('unavailable throws DteProviderUnavailableError', async () => {
+    const provider = new MockDteProvider({ failNextEmit: 'unavailable' });
+    await expect(provider.emitGuiaDespacho(validGuia)).rejects.toThrowError(
+      DteProviderUnavailableError,
+    );
+  });
+
+  it('folio_conflict throws DteFolioConflictError', async () => {
+    const provider = new MockDteProvider({ failNextEmit: 'folio_conflict' });
+    await expect(provider.emitGuiaDespacho(validGuia)).rejects.toThrowError(DteFolioConflictError);
+  });
+});
+
+describe('MockDteProvider — queryStatus', () => {
+  it('retorna status accepted post-emit', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitGuiaDespacho(validGuia);
+    const status = await provider.queryStatus({
+      folio: result.folio,
+      rutEmisor: result.rutEmisor,
+      tipoDte: 52,
+    });
+    expect(status.status).toBe('accepted');
+    expect(status.folio).toBe(result.folio);
+  });
+
+  it('throws DteNotFoundError para folio inexistente', async () => {
+    const provider = new MockDteProvider();
+    await expect(
+      provider.queryStatus({
+        folio: '999',
+        rutEmisor: '76123456-7',
+        tipoDte: 52,
+      }),
+    ).rejects.toThrowError(DteNotFoundError);
+  });
+
+  it('throws DteNotFoundError si el rutEmisor no matchea', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitGuiaDespacho(validGuia);
+    await expect(
+      provider.queryStatus({
+        folio: result.folio,
+        rutEmisor: '99999999-9', // distinto
+        tipoDte: 52,
+      }),
+    ).rejects.toThrowError(DteNotFoundError);
+  });
+
+  it('lastCheckedAt se refresca en cada query', async () => {
+    const provider = new MockDteProvider();
+    const result = await provider.emitGuiaDespacho(validGuia);
+    const s1 = await provider.queryStatus({
+      folio: result.folio,
+      rutEmisor: result.rutEmisor,
+      tipoDte: 52,
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const s2 = await provider.queryStatus({
+      folio: result.folio,
+      rutEmisor: result.rutEmisor,
+      tipoDte: 52,
+    });
+    expect(s2.lastCheckedAt.getTime()).toBeGreaterThan(s1.lastCheckedAt.getTime());
+  });
+});
+
+describe('MockDteProvider — environment', () => {
+  it('default certification', () => {
+    const p = new MockDteProvider();
+    expect(p.environment).toBe('certification');
+  });
+
+  it('respeta override production', () => {
+    const p = new MockDteProvider({ environment: 'production' });
+    expect(p.environment).toBe('production');
+  });
+});
+
+describe('MockDteProvider — artificial latency', () => {
+  it('simulación de latencia funciona', async () => {
+    const provider = new MockDteProvider({ artificialLatencyMs: 50 });
+    const start = Date.now();
+    await provider.emitGuiaDespacho(validGuia);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(45); // tolerancia jitter
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,7 +617,14 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/dte-provider:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.19.17
       typescript:
         specifier: ^5.8.2
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,15 +165,36 @@ importers:
 
   apps/document-service:
     dependencies:
+      '@booster-ai/carta-porte-generator':
+        specifier: workspace:*
+        version: link:../../packages/carta-porte-generator
       '@booster-ai/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@booster-ai/document-indexer':
+        specifier: workspace:*
+        version: link:../../packages/document-indexer
+      '@booster-ai/dte-provider':
+        specifier: workspace:*
+        version: link:../../packages/dte-provider
       '@booster-ai/logger':
         specifier: workspace:*
         version: link:../../packages/logger
       '@booster-ai/shared-schemas':
         specifier: workspace:*
         version: link:../../packages/shared-schemas
+      '@hono/node-server':
+        specifier: ^1.13.7
+        version: 1.19.14(hono@4.12.14)
+      '@hono/zod-validator':
+        specifier: ^0.4.1
+        version: 0.4.3(hono@4.12.14)(zod@3.25.76)
+      hono:
+        specifier: ^4.6.14
+        version: 4.12.14
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: ^22.14.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
         version: 3.3.0
       drizzle-orm:
         specifier: ^0.38.3
-        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@18.3.28)(pg@8.20.0)(react@18.3.1)
+        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@19.2.14)(pg@8.20.0)(react@19.2.5)
       firebase-admin:
         specifier: ^13.7.0
         version: 13.8.0
@@ -263,7 +263,7 @@ importers:
         version: 4.11.0
       drizzle-orm:
         specifier: ^0.38.3
-        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@18.3.28)(pg@8.20.0)(react@18.3.1)
+        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@19.2.14)(pg@8.20.0)(react@19.2.5)
       pg:
         specifier: ^8.13.1
         version: 8.20.0
@@ -312,7 +312,7 @@ importers:
         version: 4.11.0
       drizzle-orm:
         specifier: ^0.38.3
-        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@18.3.28)(pg@8.20.0)(react@18.3.1)
+        version: 0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@19.2.14)(pg@8.20.0)(react@19.2.5)
       pg:
         specifier: ^8.13.1
         version: 8.20.0
@@ -540,7 +540,23 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/carta-porte-generator:
+    dependencies:
+      '@react-pdf/renderer':
+        specifier: ^4.5.1
+        version: 4.5.1(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
       typescript:
         specifier: ^5.8.2
         version: 5.9.3
@@ -2403,6 +2419,14 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
@@ -3055,6 +3079,49 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@react-pdf/fns@3.1.3':
+    resolution: {integrity: sha512-0I7pApDr1/RLAKbizuLy/IHTEa93LSPy/bEwYniboC3Xqnp6Od8xFJKbKEzGw2wh/5zKFFwl00g4t9RwgIMc3w==}
+
+  '@react-pdf/font@4.0.8':
+    resolution: {integrity: sha512-deNd+emtZAJho1IlzKL9bRoLAGv/6oXOIKO2oZfs4RuXUrK1onLHbJO7e2YoVLPFP/sQxisRTnzdJFtd35iKwA==}
+
+  '@react-pdf/image@3.1.0':
+    resolution: {integrity: sha512-ks7Ry8v711r8NvKWSELehj0BXBNPRihSnWsM09nDD8Ur175zbWBCK217LLwQMKDNYDVpkZaipdoJPom1LGaE9g==}
+
+  '@react-pdf/layout@4.6.1':
+    resolution: {integrity: sha512-gN6PmWoEffvlIkifLfEhMsVucRywVMyH3rnxdyOVOhGy0nWJKKGpHyPc4plbDdpP6EfZ0r8prHXujDSkIG2nSA==}
+
+  '@react-pdf/pdfkit@5.1.1':
+    resolution: {integrity: sha512-wNcdSsNlNYyGHGAgIdt453egBF7fiF9UxpRlklUfVvu8OWCrUppG9xiUrPLVoKiqWet5tMi0w6LmuFUJuYqjEg==}
+
+  '@react-pdf/primitives@4.3.0':
+    resolution: {integrity: sha512-nYXoZ36pvwNzbc54+DbL8RCn15jU7woJ9D/svnh5tpUXekJ+CbI4mZLo6boSv24CvJgychOu6h7gxX03B4ps0A==}
+
+  '@react-pdf/reconciler@2.0.0':
+    resolution: {integrity: sha512-7zaPRujpbHSmCpIrZ+b9HSTJHthcVZzX0Wx7RzvQGsGBUbHP4p6s5itXrAIOuQuPvDepoHGNOvf6xUuMVvdoyw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/render@4.5.1':
+    resolution: {integrity: sha512-IW/N4HWJWtioBXCf7n02IR24VJJ8gbdS3jGypf+vW/rSErEx3/URRzh9UK6Ma8Fpog9+T/W6GE2NHJ5AAKHhVA==}
+
+  '@react-pdf/renderer@4.5.1':
+    resolution: {integrity: sha512-5r1VQrE6FRLXX5wWUxwZzM24E2BJMo6g8AQWuS8WyPs9ugu5yMnb2g8/RpPYka/Z6J+RUEWc32wty2NoUJF42Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@react-pdf/stylesheet@6.2.1':
+    resolution: {integrity: sha512-2+UEk+7e+z8baaWi2l5kPLWmwtJeOI+T5wW9GGeN3iDH7vd3kbTqOpN1yt9mmfNVZFxQsnDHpznFb5v5UF983A==}
+
+  '@react-pdf/svg@1.1.0':
+    resolution: {integrity: sha512-cTIHXiz9x1HrbfqzfxfZP3FRdDwUXG77QWF6Fb5MP/lV3ONxR+g0Z3hwtBatCS9HeGBQCpxX/Lzb8wHE+co1PA==}
+
+  '@react-pdf/textkit@6.3.0':
+    resolution: {integrity: sha512-v6+V8nAcVwm7s2s1jIG2MD3Iw//x/k+XrH1foWOELBE4b32pyDgKyPXN/6KJE0dnX7+fVy27uctLNCLNMvzKzQ==}
+
+  '@react-pdf/types@2.11.1':
+    resolution: {integrity: sha512-i9xQgfaDU9QoeNnbp6rltXCWg1huEh195rpOuN8cE4BZ2FuLdQrsIcb2dhFF9aOxXf+XBA6LOSpIW051MDD/bw==}
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -3258,6 +3325,9 @@ packages:
 
   '@swc/helpers@0.3.17':
     resolution: {integrity: sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==}
+
+  '@swc/helpers@0.5.21':
+    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
   '@tailwindcss/node@4.2.4':
     resolution: {integrity: sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==}
@@ -3569,6 +3639,9 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
 
@@ -3638,6 +3711,9 @@ packages:
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
+
+  abs-svg-path@0.1.1:
+    resolution: {integrity: sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==}
 
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
@@ -3820,6 +3896,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
@@ -3847,6 +3926,9 @@ packages:
 
   brotli@1.3.3:
     resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -3947,6 +4029,14 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  color-name@2.1.0:
+    resolution: {integrity: sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==}
+    engines: {node: '>=12.20'}
+
+  color-string@2.1.4:
+    resolution: {integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==}
+    engines: {node: '>=18'}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -4266,6 +4356,9 @@ packages:
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
+  emoji-regex-xs@1.0.0:
+    resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
+
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
@@ -4515,6 +4608,9 @@ packages:
   fontkit@1.9.0:
     resolution: {integrity: sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==}
 
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
+
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
@@ -4728,6 +4824,12 @@ packages:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
+  hsl-to-hex@1.0.0:
+    resolution: {integrity: sha512-K6GVpucS5wFf44X0h2bLVRDsycgJmf9FF2elg+CrqD8GcFU8c6vYhgXn8NjUkFCwj+xDFb70qgLbTUm6sxwPmA==}
+
+  hsl-to-rgb-for-reals@1.1.1:
+    resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
+
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
@@ -4770,6 +4872,9 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  hyphen@1.14.1:
+    resolution: {integrity: sha512-kvL8xYl5QMTh+LwohVN72ciOxC0OEV79IPdJSTwEXok9y9QHebXGdFgrED4sWfiax/ODx++CAMk3hMy4XPJPOw==}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -4969,6 +5074,9 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -5011,6 +5119,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  jay-peg@1.1.1:
+    resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -5021,6 +5132,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -5177,6 +5291,9 @@ packages:
   linebreak@0.3.0:
     resolution: {integrity: sha512-zt8pzlM3oq4moDN8U5mP1SbZ44yKV6dXCu44Ez6iTXmxUl8/jRFWeho2SDqL5YDBv0TBKPgU/XGovZwnXAKlOQ==}
 
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -5314,6 +5431,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-engine@1.0.3:
+    resolution: {integrity: sha512-aa5tG6sDoK+k70B9iEX1NeyfT8ObCKhNDs6lJVpwF6r8vhUfuKMslIcirq6HIUYuuUYLefcEQOn9bSBOvawtwg==}
+
   meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
     engines: {node: '>=16.10'}
@@ -5424,6 +5544,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  normalize-svg-path@1.1.0:
+    resolution: {integrity: sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==}
 
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
@@ -5543,6 +5666,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse-svg-path@0.1.2:
+    resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
@@ -5759,6 +5885,9 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proto3-json-serializer@2.0.2:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
@@ -5779,6 +5908,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  queue@6.0.2:
+    resolution: {integrity: sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
@@ -5801,6 +5933,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
@@ -5810,6 +5945,10 @@ packages:
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -5912,6 +6051,9 @@ packages:
   restructure@2.0.1:
     resolution: {integrity: sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg==}
 
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
+
   retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
     engines: {node: '>=14'}
@@ -5974,6 +6116,9 @@ packages:
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  scheduler@0.25.0-rc-603e6108-20241029:
+    resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
 
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
@@ -6215,6 +6360,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svg-arc-to-cubic-bezier@3.2.0:
+    resolution: {integrity: sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -6474,6 +6622,10 @@ packages:
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
+
+  vite-compatible-readable-stream@3.6.1:
+    resolution: {integrity: sha512-t20zYkrSf868+j/p31cRIGN28Phrjm3nRSLR2fyc2tiWi4cZGVdv68yNlwnIINTkMTmPoMiSlc0OadaO7DXZaQ==}
+    engines: {node: '>= 6'}
 
   vite-plugin-pwa@0.21.2:
     resolution: {integrity: sha512-vFhH6Waw8itNu37hWUJxL50q+CBbNcMVzsKaYHQVrfxTt3ihk3PeLO22SbiP1UNWzcEPaTQv+YVxe4G0KOjAkg==}
@@ -6778,6 +6930,9 @@ packages:
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -8595,6 +8750,10 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@noble/ciphers@1.3.0': {}
+
+  '@noble/hashes@1.8.0': {}
+
   '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -9507,6 +9666,110 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@react-pdf/fns@3.1.3': {}
+
+  '@react-pdf/font@4.0.8':
+    dependencies:
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/types': 2.11.1
+      fontkit: 2.0.4
+      is-url: 1.2.4
+
+  '@react-pdf/image@3.1.0':
+    dependencies:
+      '@react-pdf/svg': 1.1.0
+      jay-peg: 1.1.1
+      png-js: 2.0.0
+
+  '@react-pdf/layout@4.6.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/image': 3.1.0
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      emoji-regex-xs: 1.0.0
+      queue: 6.0.2
+      yoga-layout: 3.2.1
+
+  '@react-pdf/pdfkit@5.1.1':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      browserify-zlib: 0.2.0
+      fontkit: 2.0.4
+      jay-peg: 1.1.1
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 2.0.0
+      vite-compatible-readable-stream: 3.6.1
+
+  '@react-pdf/primitives@4.3.0': {}
+
+  '@react-pdf/reconciler@2.0.0(react@19.2.5)':
+    dependencies:
+      object-assign: 4.1.1
+      react: 19.2.5
+      scheduler: 0.25.0-rc-603e6108-20241029
+
+  '@react-pdf/render@4.5.1':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/textkit': 6.3.0
+      '@react-pdf/types': 2.11.1
+      abs-svg-path: 0.1.1
+      color-string: 2.1.4
+      normalize-svg-path: 1.1.0
+      parse-svg-path: 0.1.2
+      svg-arc-to-cubic-bezier: 3.2.0
+
+  '@react-pdf/renderer@4.5.1(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/layout': 4.6.1
+      '@react-pdf/pdfkit': 5.1.1
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/reconciler': 2.0.0(react@19.2.5)
+      '@react-pdf/render': 4.5.1
+      '@react-pdf/types': 2.11.1
+      events: 3.3.0
+      object-assign: 4.1.1
+      prop-types: 15.8.1
+      queue: 6.0.2
+      react: 19.2.5
+
+  '@react-pdf/stylesheet@6.2.1':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      '@react-pdf/types': 2.11.1
+      color-string: 2.1.4
+      hsl-to-hex: 1.0.0
+      media-engine: 1.0.3
+      postcss-value-parser: 4.2.0
+
+  '@react-pdf/svg@1.1.0':
+    dependencies:
+      '@react-pdf/primitives': 4.3.0
+
+  '@react-pdf/textkit@6.3.0':
+    dependencies:
+      '@react-pdf/fns': 3.1.3
+      bidi-js: 1.0.3
+      hyphen: 1.14.1
+      unicode-properties: 1.4.1
+
+  '@react-pdf/types@2.11.1':
+    dependencies:
+      '@react-pdf/font': 4.0.8
+      '@react-pdf/primitives': 4.3.0
+      '@react-pdf/stylesheet': 6.2.1
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@2.80.0)':
@@ -9662,6 +9925,10 @@ snapshots:
       string.prototype.matchall: 4.0.12
 
   '@swc/helpers@0.3.17':
+    dependencies:
+      tslib: 2.8.1
+
+  '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
 
@@ -9977,6 +10244,10 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
@@ -10069,6 +10340,8 @@ snapshots:
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
+
+  abs-svg-path@0.1.1: {}
 
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
@@ -10238,6 +10511,10 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
@@ -10266,6 +10543,10 @@ snapshots:
   brotli@1.3.3:
     dependencies:
       base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
 
   browserslist@4.28.2:
     dependencies:
@@ -10364,6 +10645,12 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  color-name@2.1.0: {}
+
+  color-string@2.1.4:
+    dependencies:
+      color-name: 2.1.0
 
   colorette@2.0.20: {}
 
@@ -10565,13 +10852,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  drizzle-orm@0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@18.3.28)(pg@8.20.0)(react@18.3.1):
+  drizzle-orm@0.38.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@19.2.14)(pg@8.20.0)(react@19.2.5):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
-      '@types/react': 18.3.28
+      '@types/react': 19.2.14
       pg: 8.20.0
-      react: 18.3.1
+      react: 19.2.5
 
   dunder-proto@1.0.1:
     dependencies:
@@ -10599,6 +10886,8 @@ snapshots:
       jake: 10.9.4
 
   electron-to-chromium@1.5.344: {}
+
+  emoji-regex-xs@1.0.0: {}
 
   emoji-regex@10.6.0: {}
 
@@ -11045,6 +11334,18 @@ snapshots:
       unicode-properties: 1.4.1
       unicode-trie: 2.0.0
 
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.21
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
+
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
@@ -11321,6 +11622,12 @@ snapshots:
 
   hono@4.12.14: {}
 
+  hsl-to-hex@1.0.0:
+    dependencies:
+      hsl-to-rgb-for-reals: 1.1.1
+
+  hsl-to-rgb-for-reals@1.1.1: {}
+
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
@@ -11365,6 +11672,8 @@ snapshots:
   human-signals@5.0.0: {}
 
   husky@9.1.7: {}
+
+  hyphen@1.14.1: {}
 
   iconv-lite@0.6.3:
     dependencies:
@@ -11562,6 +11871,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-url@1.2.4: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -11595,11 +11906,17 @@ snapshots:
       filelist: 1.0.6
       picocolors: 1.1.1
 
+  jay-peg@1.1.1:
+    dependencies:
+      restructure: 3.0.2
+
   jiti@2.6.1: {}
 
   jose@4.15.9: {}
 
   joycon@3.1.1: {}
+
+  js-md5@0.8.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -11765,6 +12082,11 @@ snapshots:
       brfs: 1.6.1
       unicode-trie: 0.3.1
 
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
+
   lines-and-columns@1.2.4: {}
 
   lint-staged@15.5.2:
@@ -11894,6 +12216,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-engine@1.0.3: {}
+
   meow@12.1.1: {}
 
   merge-source-map@1.0.4:
@@ -11975,6 +12299,10 @@ snapshots:
   node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
+
+  normalize-svg-path@1.1.0:
+    dependencies:
+      svg-arc-to-cubic-bezier: 3.2.0
 
   npm-run-path@5.3.0:
     dependencies:
@@ -12089,6 +12417,8 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse-svg-path@0.1.2: {}
 
   parse5@7.3.0:
     dependencies:
@@ -12289,6 +12619,12 @@ snapshots:
 
   process@0.11.10: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   proto3-json-serializer@2.0.2:
     dependencies:
       protobufjs: 7.5.5
@@ -12319,6 +12655,10 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  queue@6.0.2:
+    dependencies:
+      inherits: 2.0.4
+
   quick-format-unescaped@4.0.4: {}
 
   quote-stream@1.0.2:
@@ -12341,6 +12681,8 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
 
   react-refresh@0.17.0: {}
@@ -12348,6 +12690,8 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
+
+  react@19.2.5: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -12472,6 +12816,8 @@ snapshots:
 
   restructure@2.0.1: {}
 
+  restructure@3.0.2: {}
+
   retry-request@7.0.2:
     dependencies:
       '@types/request': 2.48.13
@@ -12562,6 +12908,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  scheduler@0.25.0-rc-603e6108-20241029: {}
 
   secure-json-parse@2.7.0: {}
 
@@ -12832,6 +13180,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-arc-to-cubic-bezier@3.2.0: {}
+
   symbol-tree@3.2.4: {}
 
   tailwind-merge@2.6.1: {}
@@ -13097,6 +13447,12 @@ snapshots:
   uuid@8.3.2: {}
 
   uuid@9.0.1: {}
+
+  vite-compatible-readable-stream@3.6.1:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   vite-plugin-pwa@0.21.2(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
     dependencies:
@@ -13429,6 +13785,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.2.2: {}
+
+  yoga-layout@3.2.1: {}
 
   zod@3.25.76: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -624,7 +624,14 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/document-indexer:
+    dependencies:
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.19.17
       typescript:
         specifier: ^5.8.2
         version: 5.9.3


### PR DESCRIPTION
## Resumen

Implementa `apps/document-service` MVP — el orquestador Hono que conecta los 3 packages de documentos:
- [`@booster-ai/dte-provider`](../tree/feat/dte-provider-mvp/packages/dte-provider) (PR #26)
- [`@booster-ai/carta-porte-generator`](../tree/feat/carta-porte-generator-mvp/packages/carta-porte-generator) (PR #27)
- [`@booster-ai/document-indexer`](../tree/feat/document-indexer-mvp/packages/document-indexer) (PR #28)

Cubre [ADR-007 § "Implementación inicial"](../blob/feat/document-service-mvp/docs/adr/007-chile-document-management.md). Cierra parcialmente bloqueante regulatorio go-live Chile (`HANDOFF.md §4`).

## Stacking

⚠️ **Este PR cherry-pickea los commits de #26, #27, #28** porque sus packages aún no están en `main`. Resultado: PR auto-contenido con typecheck/tests verde local.

Cuando los 3 PRs base mergeen, hacer `git rebase main` removerá los duplicados automáticamente.

## Endpoints

| Método | Path | Descripción |
|--------|------|-------------|
| `GET` | `/healthz` | Liveness probe |
| `POST` | `/generate/guia-despacho` | Emite DTE 52 → indexa → sube XML al GCS |
| `POST` | `/generate/carta-porte` | Genera PDF Ley 18.290 → indexa → retorna signed URL |
| `POST` | `/documents/upload-url` | Signed PUT URL (cliente upload directo) |
| `GET` | `/documents/:id/signed-url` | Signed READ URL (15 min) |
| `GET` | `/documents/:id` | Metadata del registro |
| `GET` | `/documents` | Listado con filtros |

## Decisiones clave

### Inyección de dependencias

`createApp({ dteProvider, documentRepo, blobStore, ... })` — testeable sin BD ni GCP. Los tests inyectan implementaciones in-memory; producción cablea Bsale + Drizzle + `@google-cloud/storage`.

### Coercion Zod fechas

Schemas internos de los packages usan `z.date()` puro (mejor para tests con `Date` objects directos). En el endpoint HTTP nos llegan strings ISO. Wrapper `z.coerce.date()` traduce.

### STUBs activos en main.ts

Hasta cablear adapters reales:
- `DocumentRepo` → in-memory (warn log loud)
- `BlobStore` → URLs simuladas (warn log)
- `BsaleAdapter` no disponible → fallback `MockDteProvider` (error log loud)

Cada STUB emite log audible en startup. Deploy a prod fallará visiblemente sin sustituirlos.

### Error mapping HTTP

```
DocumentValidationError      → 400
DteValidationError           → 400
CartaPorteValidationError    → 400
DocumentNotFoundError        → 404
DteProviderError             → 502
unhandled                    → 500 + log estructurado
```

## Evidencia

```
pnpm --filter @booster-ai/document-service typecheck  →  pass
pnpm --filter @booster-ai/document-service test       →  12/12 pass (~950ms)
```

Tests cubren: happy path de cada endpoint con mocks in-memory, validación 400, auth 401/403 (vía `deps.authorize` injectable), 404 not found, listado con filtros, PDF magic bytes `%PDF` post-generation.

## Test plan

- [x] Typecheck pass
- [x] 12 tests passing
- [ ] CI verde
- [ ] Validar manualmente que `pnpm --filter document-service dev` arranca con STUBs (warns audibles) — local smoke
- [ ] PR follow-up: adapter Drizzle real para `DocumentRepo` (necesita migration `documentos`)
- [ ] PR follow-up: adapter `@google-cloud/storage` real
- [ ] PR follow-up: switch a `BsaleAdapter` post-merge de PR #29 + credenciales sandbox SII
- [ ] PR follow-up: middleware Firebase Auth real

## Próximos pasos post-merge

1. Mergear PRs #26 + #27 + #28 a main
2. Rebasear este PR sobre main → duplicados desaparecen
3. Cablear Drizzle adapter cuando esté la migration `documentos`
4. Cablear @google-cloud/storage adapter
5. Switch a BsaleAdapter (post #29)
6. Auth real

## Deps añadidas

- `@hono/node-server` ^1.13.7
- `@hono/zod-validator` ^0.4.1
- `hono` ^4.6.14
- `zod` ^3.25.76
- Workspace deps a los 3 packages

## Notas

- Sin breaking change a otros services.
- El `@booster-ai/api` (Hono también) sigue siendo el endpoint público; `document-service` es interno (NEG protegido o invocado vía OIDC desde api).

https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR)_