### PR TITLE
test(dte-provider): integration test BsaleAdapter sandbox + runbook

### DIFF
--- a/docs/runbooks/dte-bsale-validation.md
+++ b/docs/runbooks/dte-bsale-validation.md
@@ -1,0 +1,121 @@
+# Runbook — Validación BsaleAdapter contra sandbox SII
+
+**Snapshot**: 2026-05-04
+**Owner**: equipo backend Booster AI
+**Frecuencia**: pre-merge de PR #29, post-cambios de spec Bsale, pre-go-live producción
+
+---
+
+## Cuándo correr
+
+1. **Pre-merge** de PR #29 (`feat/dte-provider-bsale-adapter`) — confirmar que el field mapping en `packages/dte-provider/src/bsale.ts` matchea la API real de Bsale al momento del merge.
+2. **Cuando Bsale anuncie breaking changes** en su API (revisar https://api.bsale.dev/changelog periódicamente).
+3. **Pre-promoción a producción** — al transicionar de sandbox SII (https://maullin.sii.cl) a producción SII (https://palena.sii.cl).
+4. **Después de rotar el certificado digital del emisor** en Secret Manager.
+
+## Prerrequisitos
+
+- [ ] Cuenta Bsale activa (o sandbox account si Bsale lo expone públicamente).
+- [ ] API token Bsale generado en panel admin de la cuenta. Persistido en pass manager / env local; NUNCA en el repo.
+- [ ] RUT emisor de prueba inscrito en SII certification (`https://maullin.sii.cl`). Si no existe, registrarlo siguiendo [SII docs](https://www.sii.cl/factura_electronica/inscripcion_facturador_electronico.htm).
+- [ ] Certificado digital `.pfx` del emisor de prueba subido a Bsale via su panel admin (Bsale internamente lo usa para firmar — no lo manejamos directo).
+- [ ] RUT receptor de prueba — cualquier RUT válido (Bsale solo valida formato, no presencia en SII).
+- [ ] Acceso shell a una máquina con `pnpm` + `node 22` (Mac de Felipe o sandbox seguro).
+
+## Procedimiento
+
+### 1. Setear env vars en la máquina (NO en el repo)
+
+```bash
+# En tu shell local — NO commitear
+export BSALE_API_TOKEN="<token-sandbox-bsale>"
+export BSALE_TEST_RUT_EMISOR="76123456-7"        # RUT inscrito SII certification
+export BSALE_TEST_RUT_RECEPTOR="12345678-9"      # RUT cualquier (solo formato)
+export BSALE_TEST_RUN_INTEGRATION=true
+```
+
+### 2. Checkout del branch del PR #29
+
+```bash
+cd ~/path/to/booster-ai
+git fetch origin
+git checkout feat/dte-provider-bsale-adapter
+pnpm install
+```
+
+### 3. Correr el test de integración
+
+```bash
+pnpm --filter @booster-ai/dte-provider test bsale.integration
+```
+
+**Tiempo esperado**: 10-30 segundos (Bsale + SII pueden tardar).
+
+**Output esperado** (si todo OK):
+
+```
+✓ BsaleAdapter — integration test (sandbox SII) > emitGuiaDespacho contra sandbox real → folio asignado por SII
+
+ Test Files  1 passed (1)
+      Tests  1 passed (1)
+```
+
+**Output esperado** (si las env vars no están):
+
+```
+↓ BsaleAdapter — integration test (sandbox SII) [skipped]
+
+ Test Files  1 passed (1)
+      Tests  1 skipped (1)
+```
+
+### 4. Verificar el DTE emitido
+
+El test emite un folio real en sandbox SII. Para verificarlo:
+
+1. Login al panel Bsale → Documentos.
+2. Filtrar por fecha de hoy + tipo "Guía de Despacho".
+3. Confirmar que aparece el documento con la `referenciaExterna` `BOO-INT-<timestamp>`.
+4. Status esperado: `accepted` o `pending_sii_validation` (puede tomar minutos).
+
+### 5. Si el test FALLA
+
+Posibles causas:
+
+| Síntoma | Causa probable | Fix |
+|---------|----------------|-----|
+| `DteValidationError: 400` | Field mapping cambió en API Bsale | Revisar `packages/dte-provider/src/bsale.ts` `emitGuiaDespacho` body — comparar con [docs Bsale actuales](https://api.bsale.dev/?bash#documentos) |
+| `DteCertificateError: 401` | API token inválido o cert digital vencido | Regenerar token en panel Bsale; verificar cert no vencido en SII |
+| `DteRejectedBySiiError: 422` | RUT emisor no inscrito SII certification | Inscribir vía SII o usar otro RUT de prueba |
+| `DteProviderUnavailableError: 503` | Bsale o SII certification con downtime | Reintentar más tarde; consultar [status Bsale](https://status.bsale.io/) |
+| Timeout 30s | Latencia anormal SII | Aumentar timeout en el test si recurrente |
+| `DteFolioConflictError: 409` | RUT sin folios disponibles en SII | Solicitar nuevos folios via panel SII |
+
+Si el field mapping cambió, ajustar `bsale.ts` + commit + re-test. **NO mergear** el PR #29 hasta que el test pase.
+
+## Validación de queryStatus
+
+El test corre 5s después del emit + ejecuta `queryStatus`. Verifica que:
+
+1. El folio retornado coincide con el del emit.
+2. El status está en `[accepted, pending_sii_validation, rejected]`.
+
+`rejected` en sandbox puede ser legítimo (RUT receptor inválido, glosa rara). El test no afirma `accepted` estricto — afirma que el flow completo retorna respuesta válida.
+
+## Promoción a producción
+
+⚠️ **NUNCA correr este test contra producción SII** (https://palena.sii.cl) sin coordinación explícita. Producción emite folios oficiales con valor legal y consume el rango disponible del emisor. El test usa `environment: 'certification'` por default; cambiar a `'production'` requiere:
+
+1. PR dedicado que documenta el switch.
+2. Aprobación del PO (Felipe) por escrito en el PR.
+3. Cert digital del emisor REAL (no de prueba) cargado a Bsale.
+4. Validación post-emit que el folio NO es de testing.
+
+## Referencias
+
+- [packages/dte-provider/src/bsale.ts](../../packages/dte-provider/src/bsale.ts) — implementación
+- [packages/dte-provider/test/bsale.integration.test.ts](../../packages/dte-provider/test/bsale.integration.test.ts) — test
+- [ADR-007 § "Integración SII DTE"](../adr/007-chile-document-management.md)
+- [Bsale API docs](https://api.bsale.dev/)
+- [SII Chile — Formato DTE](https://www.sii.cl/factura_electronica/formato_dte.htm)
+- [SII Inscripción facturador electrónico](https://www.sii.cl/factura_electronica/inscripcion_facturador_electronico.htm)

--- a/packages/dte-provider/test/bsale.integration.test.ts
+++ b/packages/dte-provider/test/bsale.integration.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Integration test del BsaleAdapter contra el sandbox real de Bsale + SII
+ * certification (https://maullin.sii.cl).
+ *
+ * **NO corre en CI por default** — requiere credenciales sandbox que solo
+ * existen en máquinas con acceso a las cuentas Bsale + cert digital del
+ * emisor de prueba. El test se skipea si las env vars necesarias no están.
+ *
+ * Cuándo correr:
+ *   - Antes de mergear PR del BsaleAdapter (#29) a main para validar que
+ *     el field mapping de `bsale.ts` matchea la API real.
+ *   - Cuando la spec de Bsale cambie (anuncian breaking change, etc.).
+ *   - Antes de promover a producción (con cert SII real).
+ *
+ * Cómo correr (en máquina con acceso):
+ *   ```bash
+ *   export BSALE_API_TOKEN=<sandbox-token>
+ *   export BSALE_TEST_RUT_EMISOR=<rut-emisor-sandbox>     # ej. 76123456-7
+ *   export BSALE_TEST_RUT_RECEPTOR=<rut-receptor>          # ej. 12345678-9
+ *   export BSALE_TEST_RUN_INTEGRATION=true
+ *   pnpm --filter @booster-ai/dte-provider test bsale.integration
+ *   ```
+ *
+ * Si BSALE_TEST_RUN_INTEGRATION no está seteada, vitest reporta "skipped"
+ * sin failure — útil para que el dev local NO accidentalmente emita DTEs
+ * contra SII al correr el test suite completo.
+ *
+ * El test emite UN folio en sandbox SII por corrida — barato, no produce
+ * efectos legales reales (es ambiente certification).
+ *
+ * Runbook detallado: docs/runbooks/dte-bsale-validation.md
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BsaleAdapter, type GuiaDespachoInput } from '../src/index.js';
+
+const RUN_INTEGRATION = process.env.BSALE_TEST_RUN_INTEGRATION === 'true';
+const apiToken = process.env.BSALE_API_TOKEN;
+const rutEmisor = process.env.BSALE_TEST_RUT_EMISOR;
+const rutReceptor = process.env.BSALE_TEST_RUT_RECEPTOR;
+
+const skipMessage =
+  '⏭️  Skipped — requiere BSALE_TEST_RUN_INTEGRATION=true + BSALE_API_TOKEN + BSALE_TEST_RUT_EMISOR + BSALE_TEST_RUT_RECEPTOR. Ver docs/runbooks/dte-bsale-validation.md';
+
+describe.skipIf(!RUN_INTEGRATION || !apiToken || !rutEmisor || !rutReceptor)(
+  'BsaleAdapter — integration test (sandbox SII)',
+  () => {
+    it.skipIf(!apiToken)(skipMessage, () => {
+      // Placeholder para que el "describe" tenga al menos un it cuando
+      // skipea — Vitest reporta el skip más limpio.
+    });
+
+    it('emitGuiaDespacho contra sandbox real → folio asignado por SII', async () => {
+      const adapter = new BsaleAdapter({
+        // biome-ignore lint/style/noNonNullAssertion: validated by skipIf above
+        apiToken: apiToken!,
+        environment: 'certification',
+      });
+
+      const input: GuiaDespachoInput = {
+        // biome-ignore lint/style/noNonNullAssertion: validated by skipIf above
+        rutEmisor: rutEmisor!,
+        razonSocialEmisor: 'Booster AI Sandbox Emisor',
+        // biome-ignore lint/style/noNonNullAssertion: validated by skipIf above
+        rutReceptor: rutReceptor!,
+        razonSocialReceptor: 'Booster AI Sandbox Receptor',
+        fechaEmision: new Date(),
+        items: [
+          {
+            descripcion: `Test integration ${new Date().toISOString()}`,
+            cantidad: 1,
+            precioUnitarioClp: 10_000,
+            unidadMedida: 'VIAJE',
+          },
+        ],
+        transporte: {
+          rutChofer: '11111111-1',
+          nombreChofer: 'Chofer de Prueba',
+          patente: 'AB-CD-12',
+          direccionDestino: 'Calle Test 123',
+          comunaDestino: 'Santiago',
+        },
+        tipoDespacho: 5,
+        referenciaExterna: `BOO-INT-${Date.now()}`,
+      };
+
+      const result = await adapter.emitGuiaDespacho(input);
+
+      expect(result.folio).toMatch(/^\d+$/);
+      expect(result.tipoDte).toBe(52);
+      expect(result.rutEmisor).toBe(input.rutEmisor);
+      expect(['accepted', 'pending_sii_validation']).toContain(result.status);
+
+      // Si Bsale ya devolvió XML firmado, el sha256 debe ser hex válido.
+      if (result.xmlSigned && result.xmlSigned.length > 0) {
+        expect(result.sha256).toMatch(/^[a-f0-9]{64}$/);
+      } else {
+        // Algunas configuraciones de Bsale entregan el XML asíncrono —
+        // el caller debería poll-ear queryStatus + GET separado.
+        expect(result.sha256).toBe('pending');
+      }
+
+      // Esperar a que SII responda (hasta 10s en sandbox)
+      await new Promise((r) => setTimeout(r, 5000));
+
+      const status = await adapter.queryStatus({
+        folio: result.folio,
+        // biome-ignore lint/style/noNonNullAssertion: validated by skipIf above
+        rutEmisor: rutEmisor!,
+        tipoDte: 52,
+      });
+      expect(status.folio).toBe(result.folio);
+      expect(['accepted', 'pending_sii_validation', 'rejected']).toContain(status.status);
+      // En sandbox SII, "rejected" puede ser legítimo si el RUT no está
+      // inscrito o glosa rara. El test no afirma "accepted" estricto —
+      // afirma que hay una respuesta válida del flow completo.
+    }, 30_000); // timeout 30s — Bsale + SII pueden tardar
+  },
+);


### PR DESCRIPTION
## Resumen

**Stacked sobre PR #29.** Agrega un test de integración del `BsaleAdapter` que valida contra **Bsale + SII certification real** (`https://maullin.sii.cl`). El test se **skipea por default** sin las env vars adecuadas — sin riesgo de emitir DTEs accidentalmente al correr suite completa.

Resuelve la observación "BsaleAdapter validation real: requiere credenciales sandbox SII" del HANDOFF: ahora hay un entregable concreto (test + runbook) que **se activa** cuando alguien con credenciales lo corre.

## Activación

```bash
# Sin esto, vitest reporta "skipped" — sin failure
export BSALE_TEST_RUN_INTEGRATION=true
export BSALE_API_TOKEN="<sandbox-token>"
export BSALE_TEST_RUT_EMISOR="76123456-7"      # RUT inscrito SII certification
export BSALE_TEST_RUT_RECEPTOR="12345678-9"

pnpm --filter @booster-ai/dte-provider test bsale.integration
```

## Qué valida

1. **`emitGuiaDespacho`** contra sandbox real → folio asignado por SII (formato numérico).
2. **Status post-emit** está en `[accepted, pending_sii_validation]`.
3. **Si XML embedded** → `sha256` hex válido. Sino, `'pending'`.
4. **`queryStatus`** 5s después → folio coincide + status en `[accepted, pending_sii_validation, rejected]`.

`rejected` en sandbox puede ser legítimo (RUT receptor inválido, glosa rara). El test afirma que el flow completo retorna respuesta válida, no `accepted` estricto.

## Runbook

`docs/runbooks/dte-bsale-validation.md` documenta:

- **Cuándo correr** — pre-merge #29, pre-promoción a prod, post-cambios spec Bsale.
- **Prerrequisitos** — cuenta Bsale, cert digital, RUT inscrito SII certification.
- **Setup env vars** en máquina (NO en repo).
- **Procedimiento** step-by-step.
- **Troubleshooting** — tabla de 6 síntomas + causa probable + fix.
- **Validación queryStatus** post-emit.
- **Promoción a producción SII** — disclaimer fuerte: nunca correr contra `palena.sii.cl` sin coordinación explícita + aprobación PO.

## Por qué `skipIf` y no `xtest`

- `xtest` deshabilita permanentemente — necesitamos que el test corra sí o sí cuando hay credenciales.
- `describe.skipIf(...)` evalúa en tiempo de import — vitest reporta `skipped` claramente sin failure.
- Doble protección: `BSALE_TEST_RUN_INTEGRATION` flag explícito + presencia de credenciales. Aún si alguien tiene token cargado por accidente, sin el flag no se ejecuta.

## Test plan

- [x] Typecheck pass
- [x] Suite del package: 41 pass + 2 skipped (1 placeholder + 1 integration real, ambos skipped en CI)
- [ ] CI verde
- [ ] **PRÓXIMO: corre el test** en máquina con credenciales, antes de mergear PR #29 (o a más tardar pre-go-live)
- [ ] Si el test falla por field mapping change, ajustar `bsale.ts` + nuevo PR
- [ ] Validar en panel Bsale que el documento aparece con la `referenciaExterna` `BOO-INT-<timestamp>`

## Stacking

Este PR apunta a `feat/dte-provider-bsale-adapter` (PR #29) como base. Cuando #29 mergee, este PR rebasea automáticamente. Si #29 cambia field mapping, este test detecta el drift en runtime real.

## Notas

- Sin breaking change.
- Sin nuevas deps.
- El test emite **1 folio sandbox** por corrida — costo cero, sin efectos legales.
- El runbook explícitamente prohíbe correr contra `palena.sii.cl` sin aprobación PO.

https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR)_