### PR TITLE
docs(pii): handling de stakeholders + consentimientos + reference queries

### DIFF
--- a/docs/pii-handling-stakeholders-consents.md
+++ b/docs/pii-handling-stakeholders-consents.md
@@ -1,0 +1,253 @@
+# PII Handling — Stakeholders y Consentimientos
+
+**Snapshot**: 2026-05-04
+**Owner**: Felipe Vicencio (PO) + cualquier dev
+**Marco regulatorio**: Ley 19.628 Chile (Protección de la vida privada) + GDPR-like best practices
+
+---
+
+## Contexto
+
+Booster AI gestiona datos sensibles de empresas y usuarios:
+- RUT (identificador tributario, considerado PII en Chile bajo Ley 19.628)
+- Nombre completo, email, teléfono
+- Patentes y datos de vehículos
+- Datos de viajes (origen, destino, carga, frecuencia → revela patrones de operación)
+- Métricas ESG (consumo combustible, emisiones, eficiencia)
+
+Los **stakeholders** (mandante corporativo, sostenibilidad interna, auditor, regulador, inversor) reciben acceso a algunos de estos datos via **consentimientos explícitos** del usuario que los origina.
+
+---
+
+## Modelo de datos (ya implementado)
+
+### Tabla `stakeholders` (`apps/api/src/db/schema.ts:695`)
+
+| Columna | Tipo | Notas |
+|---------|------|-------|
+| `id` | UUID | PK |
+| `usuario_id` | UUID FK → `usuarios` | Quien creó el stakeholder |
+| `organizacion_nombre` | varchar(200) | "Cliente Mandante SA" |
+| `organizacion_rut` | varchar(20) | RUT opcional |
+| `tipo_stakeholder` | enum | `mandante_corporativo \| sostenibilidad_interna \| auditor \| regulador \| inversor` |
+| `estandares_reporte` | enum[] | `GLEC_V3 \| GHG_PROTOCOL \| ISO_14064 \| GRI \| SASB \| CDP` |
+| `cadencia_reporte` | enum | `mensual \| trimestral \| anual \| bajo_demanda` |
+| `creado_en` / `actualizado_en` | timestamptz | |
+
+### Tabla `consentimientos` (`apps/api/src/db/schema.ts:719`)
+
+| Columna | Tipo | Notas |
+|---------|------|-------|
+| `id` | UUID | PK |
+| `otorgado_por_id` | UUID FK → `usuarios` | Sujeto del consentimiento |
+| `stakeholder_id` | UUID FK → `stakeholders` | Receptor |
+| `tipo_alcance` | enum | `generador_carga \| transportista \| portafolio_viajes \| organizacion` |
+| `alcance_id` | UUID | ID del recurso scopeado (empresaId, tripId, etc.) |
+| `categorias_datos` | enum[] | Qué se comparte (mín 1 item, CHECK constraint) |
+| `otorgado_en` | timestamptz | Default `now()` |
+| `expira_en` | timestamptz | Nullable — `NULL` = sin vencimiento |
+| `revocado_en` | timestamptz | Nullable — `NULL` = activo |
+| `documento_consentimiento_url` | text | URL al PDF firmado del legal (audit trail) |
+
+### Categorías de datos (`consentDataCategoryEnum`)
+
+```
+emisiones_carbono   → tCO2eq agregado por viaje, scope 1/2/3
+rutas               → origen + destino (sin metadata de carga)
+distancias          → km totales, retornos vacíos
+combustibles        → litros consumidos, tipos
+certificados        → PDFs ESG firmados
+perfiles_vehiculos  → patentes + capacidades + euro standard
+```
+
+### Tipos de alcance (`consentScopeTypeEnum`)
+
+| Tipo | `alcance_id` apunta a | Caso de uso |
+|------|----------------------|-------------|
+| `generador_carga` | `empresas.id` (con `es_generador_carga=true`) | Shipper consiente compartir todos sus viajes con un mandante corporativo |
+| `transportista` | `empresas.id` (con `es_transportista=true`) | Carrier consiente compartir métricas con un auditor |
+| `portafolio_viajes` | UUID artificial (lista de tripIds en otro modelo, futuro) | Portafolio curado para inversor |
+| `organizacion` | `empresas.id` | Sostenibilidad interna ve toda la org |
+
+---
+
+## Reglas operativas
+
+### 1. Cada lectura de datos PII por un stakeholder DEBE validarse contra consent
+
+Patrón canónico en services (a implementar):
+
+```ts
+async function checkStakeholderConsent(
+  stakeholderId: string,
+  scopeType: ConsentScopeType,
+  scopeId: string,
+  dataCategory: ConsentDataCategory,
+): Promise<boolean> {
+  const now = new Date();
+  const result = await db
+    .select({ id: consents.id })
+    .from(consents)
+    .where(
+      and(
+        eq(consents.stakeholderId, stakeholderId),
+        eq(consents.scopeType, scopeType),
+        eq(consents.scopeId, scopeId),
+        // dataCategories es array; usar `arrayContains` de Drizzle
+        sql`${dataCategory}::categoria_dato_consentimiento = ANY(${consents.dataCategories})`,
+        isNull(consents.revokedAt),
+        or(isNull(consents.expiresAt), gt(consents.expiresAt, now)),
+      ),
+    )
+    .limit(1);
+  return result.length > 0;
+}
+```
+
+Si retorna `false` → HTTP 403 con `error: 'consent_required'` + metadata indicando qué falta.
+
+### 2. Audit log de cada acceso
+
+Cada vez que un stakeholder lee data PII vía endpoint, registrar en BigQuery `audit.stakeholder_access_log`:
+
+```sql
+INSERT INTO audit.stakeholder_access_log VALUES (
+  uuid_generate_v4(),
+  now(),
+  $stakeholder_id,
+  $consent_id,    -- el consent que autorizó
+  $scope_type,
+  $scope_id,
+  $data_category,
+  $resource_id,   -- tripId, empresaId, etc.
+  $http_method,
+  $http_path,
+  $ip_address,
+  $user_agent
+);
+```
+
+Necesario para auditorías Ley 19.628 art. 6 ("derecho a saber qué se hizo con tu data").
+
+### 3. Revocación inmediata
+
+Cuando `consentimientos.revocado_en` se setea, **todas las queries futuras del stakeholder fallan**. NO hay grace period — la revocación es efectiva al commit.
+
+Si el stakeholder está en medio de generar un reporte cuando se revoca, el reporte se trunca. Mensaje al user: "consentimiento revocado durante generación".
+
+### 4. Expiración pasiva
+
+`expira_en` se setea al firmar — típicamente `granted_at + 1 año`. Cuando vence:
+- El consent NO se borra (audit trail).
+- Las queries lo filtran out porque `expires_at < now()`.
+- Se puede "renovar" creando un nuevo consent (otro row con nuevo `granted_at`) — el stakeholder pide al user re-firmar.
+
+### 5. Documento de consentimiento (`documento_consentimiento_url`)
+
+Cada consent **debe** apuntar a un PDF firmado que el user vio y aceptó. El PDF contiene:
+- Identidad del stakeholder
+- Scope exacto (qué empresa, qué viajes, etc.)
+- Categorías de datos compartidos
+- Plazo (si aplica)
+- Firma digital del user (KMS-firmada al momento del grant)
+
+El URL es público (signed URL al GCS bucket de documentos) por lo que el user siempre puede verificar qué firmó. Mantener 6+ años (mismo retention que documentos legales — ADR-007).
+
+### 6. Default deny
+
+**Toda data PII está negada por default**. Solo se autoriza con consent explícito. El stakeholder NO ve nada de un user/empresa hasta que ese user/empresa firme un consent específico.
+
+Esto es lo opposite de "todo abierto, opt-out" — Ley 19.628 + GDPR-like exigen opt-in explícito.
+
+### 7. PII redaction en logs
+
+Cuando un endpoint del api retorna data PII (via consent), los logs Pino redactan automáticamente:
+
+```ts
+// apps/api/src/server.ts (ya configurado)
+import pino from 'pino';
+const logger = pino({
+  redact: {
+    paths: [
+      'request.body.rut',
+      'response.body.rut',
+      '*.email',
+      '*.telefono',
+      // ...
+    ],
+    censor: '[REDACTED]',
+  },
+});
+```
+
+Los logs estructurados van a Cloud Logging. Si un dev necesita ver el RUT real, queda en BD/BigQuery — los logs son intencionalmente ciegos.
+
+---
+
+## Endpoints (a implementar — gap actual)
+
+Aunque las tablas existen, **NO HAY endpoints HTTP para gestionar consents**. Backlog explícito:
+
+```
+POST   /me/stakeholders                     # crear stakeholder asociado al user
+GET    /me/stakeholders                     # listar stakeholders del user
+DELETE /me/stakeholders/:id                 # archivar stakeholder
+
+POST   /me/consents                          # otorgar consent
+GET    /me/consents                          # listar mis consents otorgados
+PATCH  /me/consents/:id/revoke              # revocar consent
+GET    /me/consents/audit                    # mis logs de acceso (Ley 19.628 art. 6)
+
+GET    /stakeholders/:id/data/emissions     # consume consent (auditor lee tCO2eq)
+GET    /stakeholders/:id/data/certificates  # consume consent (lista PDFs)
+# cada uno valida consent activo + registra audit log
+```
+
+Cada endpoint público debe:
+1. Validar Firebase Auth.
+2. Llamar `checkStakeholderConsent()`.
+3. Loggear access.
+4. Retornar data minimal-needed.
+
+---
+
+## Reference queries SQL
+
+Ver `scripts/sql/consent-reference.sql` para queries comunes:
+- Consents activos para un stakeholder
+- Consents expirando en próximos 30 días
+- Audit de revocaciones recientes
+- Detección de consents huérfanos (stakeholder borrado, scope no existe)
+
+---
+
+## Compliance checklist Ley 19.628
+
+- [x] Datos PII identificados y catalogados (este doc).
+- [x] Tablas con scoping explícito (`stakeholders` + `consentimientos`).
+- [x] Default deny — sin consent activo no hay acceso.
+- [x] Revocación inmediata (sin grace period).
+- [ ] Endpoints HTTP grant/revoke (pendiente).
+- [ ] Audit log per-access en BigQuery (pendiente — tabla no creada).
+- [ ] Documento de consentimiento firmado y archivado per-grant (pendiente — flujo PDF).
+- [ ] UI de "mis consents" en `apps/web` (pendiente).
+- [ ] Endpoint "darte de baja completamente" (right to be forgotten) — pendiente, complejo por retention SII 6 años.
+- [ ] Pino redact configurado para todos los campos PII (verificar exhaustividad).
+
+---
+
+## Riesgos abiertos
+
+- **Right to be forgotten vs SII retention**: si un user pide borrado, no podemos eliminar las DTEs históricos por obligación legal (6 años SII). Mitigación: anonimizar el row del user pero mantener referencias en DTE como string opaco. Diseño pendiente.
+- **Cross-tenant data leak**: una query mal escrita en un service podría leakear data de empresa A al stakeholder de empresa B. Mitigación: tests E2E + linter custom que detecte queries sin filtro `scopeId`. Pendiente.
+- **Consent versioning**: cuando el legal text cambie, todos los consents existentes tienen `documento_consentimiento_url` apuntando a la versión vieja. Si la versión nueva amplía scope, requerimos re-grant. Si solo aclara, no. Política: nuevo `consent_version` enum cuando el cambio sea material.
+
+---
+
+## Referencias
+
+- [`apps/api/src/db/schema.ts:215-244`](../apps/api/src/db/schema.ts) — enums
+- [`apps/api/src/db/schema.ts:695-745`](../apps/api/src/db/schema.ts) — tablas
+- [`apps/api/drizzle/0004_phase_zero_unified_schema_es.sql`](../apps/api/drizzle/0004_phase_zero_unified_schema_es.sql) — migration
+- [ADR-004 — Uber-like model and roles](./adr/004-uber-like-model-and-roles.md) — define stakeholder
+- Ley 19.628 — [Protección de la vida privada](https://bcn.cl/2f70w)

--- a/scripts/sql/consent-reference.sql
+++ b/scripts/sql/consent-reference.sql
@@ -1,0 +1,165 @@
+-- =============================================================================
+-- Reference queries SQL — stakeholders + consentimientos
+-- =============================================================================
+-- Queries comunes para operaciones manuales / audit / cleanup. Snippets
+-- para el equipo, NO se ejecutan automático.
+--
+-- Convención: usar siempre `now()` en el SELECT en vez de hardcodear fechas.
+-- Postgres lo materializa una vez por query, consistente.
+--
+-- Ver docs/pii-handling-stakeholders-consents.md para contexto.
+-- =============================================================================
+
+
+-- ---------------------------------------------------------------------------
+-- 1. CONSENTS ACTIVOS para un stakeholder
+-- ---------------------------------------------------------------------------
+-- Devuelve los consents que están vigentes (no revocados + no expirados)
+-- para un stakeholder específico. Útil para mostrar al user qué tiene
+-- acceso a sus datos.
+SELECT
+  c.id,
+  c.tipo_alcance,
+  c.alcance_id,
+  c.categorias_datos,
+  c.otorgado_en,
+  c.expira_en,
+  s.organizacion_nombre AS stakeholder_nombre,
+  s.tipo_stakeholder
+FROM consentimientos c
+JOIN stakeholders s ON s.id = c.stakeholder_id
+WHERE c.stakeholder_id = :stakeholder_id
+  AND c.revocado_en IS NULL
+  AND (c.expira_en IS NULL OR c.expira_en > now())
+ORDER BY c.otorgado_en DESC;
+
+
+-- ---------------------------------------------------------------------------
+-- 2. CONSENTS EXPIRANDO en próximos 30 días
+-- ---------------------------------------------------------------------------
+-- Para que un job nocturno notifique al user "tu consent con X vence en
+-- 30 días, ¿querés renovarlo?".
+SELECT
+  c.id,
+  c.otorgado_por_id,
+  c.expira_en,
+  EXTRACT(DAY FROM (c.expira_en - now())) AS dias_restantes,
+  s.organizacion_nombre,
+  c.categorias_datos
+FROM consentimientos c
+JOIN stakeholders s ON s.id = c.stakeholder_id
+WHERE c.revocado_en IS NULL
+  AND c.expira_en IS NOT NULL
+  AND c.expira_en > now()
+  AND c.expira_en <= now() + INTERVAL '30 days'
+ORDER BY c.expira_en ASC;
+
+
+-- ---------------------------------------------------------------------------
+-- 3. CONSENT CHECK — ¿este stakeholder tiene acceso a esta categoría
+-- de datos para este recurso?
+-- ---------------------------------------------------------------------------
+-- Patrón canónico que el service `checkStakeholderConsent` debe usar.
+-- Retorna 1 row si tiene acceso, 0 rows si no.
+SELECT 1
+FROM consentimientos c
+WHERE c.stakeholder_id = :stakeholder_id
+  AND c.tipo_alcance = :scope_type
+  AND c.alcance_id = :scope_id
+  AND :data_category::categoria_dato_consentimiento = ANY(c.categorias_datos)
+  AND c.revocado_en IS NULL
+  AND (c.expira_en IS NULL OR c.expira_en > now())
+LIMIT 1;
+
+
+-- ---------------------------------------------------------------------------
+-- 4. REVOCACIONES recientes (audit, last 7 days)
+-- ---------------------------------------------------------------------------
+-- Para detectar patrones anormales de revocación (¿alguien revocó masivo?).
+SELECT
+  c.id,
+  c.otorgado_por_id,
+  c.stakeholder_id,
+  c.revocado_en,
+  c.tipo_alcance,
+  c.categorias_datos,
+  s.organizacion_nombre
+FROM consentimientos c
+JOIN stakeholders s ON s.id = c.stakeholder_id
+WHERE c.revocado_en >= now() - INTERVAL '7 days'
+ORDER BY c.revocado_en DESC;
+
+
+-- ---------------------------------------------------------------------------
+-- 5. CONSENTS HUÉRFANOS — scope_id apunta a empresa borrada / inexistente
+-- ---------------------------------------------------------------------------
+-- Para detectar consents que ya no pueden cumplirse (porque el recurso
+-- fuente desapareció). El cron de cleanup debe revocarlos automáticamente.
+SELECT c.id, c.tipo_alcance, c.alcance_id, c.otorgado_en
+FROM consentimientos c
+LEFT JOIN empresas e
+  ON e.id = c.alcance_id
+  AND c.tipo_alcance IN ('generador_carga', 'transportista', 'organizacion')
+WHERE c.revocado_en IS NULL
+  AND c.tipo_alcance IN ('generador_carga', 'transportista', 'organizacion')
+  AND e.id IS NULL;
+
+
+-- ---------------------------------------------------------------------------
+-- 6. STAKEHOLDERS POR USER
+-- ---------------------------------------------------------------------------
+-- Cuántos stakeholders tiene cada user (útil para dashboards admin).
+SELECT
+  u.id AS user_id,
+  u.email,
+  COUNT(s.id) AS total_stakeholders,
+  COUNT(s.id) FILTER (WHERE s.tipo_stakeholder = 'mandante_corporativo') AS mandantes,
+  COUNT(s.id) FILTER (WHERE s.tipo_stakeholder = 'auditor') AS auditores,
+  COUNT(s.id) FILTER (WHERE s.tipo_stakeholder = 'regulador') AS reguladores,
+  COUNT(s.id) FILTER (WHERE s.tipo_stakeholder = 'inversor') AS inversores
+FROM usuarios u
+LEFT JOIN stakeholders s ON s.usuario_id = u.id
+GROUP BY u.id, u.email
+HAVING COUNT(s.id) > 0
+ORDER BY total_stakeholders DESC;
+
+
+-- ---------------------------------------------------------------------------
+-- 7. REVOCACIÓN MASIVA — todos los consents de un user
+-- ---------------------------------------------------------------------------
+-- En caso de "right to be forgotten" parcial: el user pide revocar TODO
+-- pero mantenemos rows (audit trail Ley 19.628 + retention SII).
+-- Correr en transacción + verificar count antes de commit.
+BEGIN;
+  UPDATE consentimientos
+  SET revocado_en = now()
+  WHERE otorgado_por_id = :user_id
+    AND revocado_en IS NULL;
+  -- Verificar: SELECT count(*) FROM consentimientos WHERE otorgado_por_id = :user_id AND revocado_en IS NULL;
+  -- Si es 0, COMMIT. Si no, investigar antes.
+ROLLBACK; -- safety: cambiar a COMMIT cuando se valide
+
+
+-- ---------------------------------------------------------------------------
+-- 8. AUDIT TRAIL — historial completo de consents otorgados/revocados por user
+-- ---------------------------------------------------------------------------
+-- Para Ley 19.628 art. 6 (derecho a saber qué se hizo con tu data).
+SELECT
+  c.id,
+  c.tipo_alcance,
+  c.alcance_id,
+  c.categorias_datos,
+  c.otorgado_en,
+  c.expira_en,
+  c.revocado_en,
+  CASE
+    WHEN c.revocado_en IS NOT NULL THEN 'revocado'
+    WHEN c.expira_en < now() THEN 'expirado'
+    ELSE 'activo'
+  END AS estado,
+  s.organizacion_nombre,
+  c.documento_consentimiento_url
+FROM consentimientos c
+JOIN stakeholders s ON s.id = c.stakeholder_id
+WHERE c.otorgado_por_id = :user_id
+ORDER BY c.otorgado_en DESC;


### PR DESCRIPTION
## Resumen

Cierra la observación de HANDOFF "stakeholders + consent_grants en Drizzle" con un **hallazgo importante**:

🎯 **Las tablas YA EXISTEN en `main`** (`apps/api/src/db/schema.ts:695-745` + migration `0004_phase_zero_unified_schema_es.sql`).

Lo que faltaba realmente era **documentación operativa + reference queries** para que el equipo (y agentes futuros) sepa cómo usar estas tablas correctamente.

## Entregables

### 1. `docs/pii-handling-stakeholders-consents.md`

Guía completa de manejo de PII alrededor de stakeholders:

- **Modelo de datos**: tablas + enums + tipos de alcance (referenciando el schema, sin duplicar)
- **7 reglas operativas**:
  1. Consent check obligatorio antes de cada lectura
  2. Audit log per-access en BigQuery
  3. Revocación inmediata sin grace period
  4. Expiración pasiva (filtrar `expires_at > now()`)
  5. Documento PDF firmado del consent (KMS)
  6. Default deny (Ley 19.628 + GDPR-like)
  7. Pino redact de campos PII en logs
- **Patrón canónico TypeScript** de `checkStakeholderConsent()`
- **Endpoints HTTP pendientes** (gap conocido — tablas existen pero no hay `/me/consents` todavía)
- **Compliance checklist Ley 19.628** con estado actual marcado
- **Riesgos abiertos**: right-to-be-forgotten vs SII retention, cross-tenant leaks, consent versioning

### 2. `scripts/sql/consent-reference.sql`

8 queries listas para usar (con comentarios in-line):

1. Consents activos para un stakeholder
2. Consents expirando en próximos 30 días (input para job de notif)
3. **CONSENT CHECK canónico** — lo que cada service debe ejecutar antes de retornar PII
4. Revocaciones recientes (audit anomaly detection)
5. Consents huérfanos (`alcance_id` apunta a recurso borrado)
6. Stakeholders por user (admin dashboard)
7. Revocación masiva por user (right-to-be-forgotten parcial, dentro de transacción con `ROLLBACK` safety)
8. Audit trail completo per-user (Ley 19.628 art. 6: derecho a saber qué se hizo con tu data)

## Sin cambios

- ❌ Sin cambios al schema Drizzle
- ❌ Sin cambios a `apps/api`
- ❌ Sin nuevas migrations

Pura documentación + reference SQL. Bajo riesgo, alta utilidad.

## Re-marca el alcance del HANDOFF

El item de `HANDOFF.md` decía:
> **Tabla `stakeholders` + `consent_grants` en Drizzle (cierra omisión crítica ADR-004).**

Pero las tablas ya están. El **gap real** es:

- ⏳ Endpoints HTTP `/me/stakeholders` y `/me/consents` (CRUD + grant/revoke).
- ⏳ Tabla BigQuery `audit.stakeholder_access_log` (no creada todavía).
- ⏳ UI "Mis consents" en `apps/web`.
- ⏳ Endpoint right-to-be-forgotten (complejo — coexiste con retention SII 6 años).
- ⏳ Tests E2E del flow grant → query con consent → revoke.

Esos son trabajos separados. Este PR documenta el **estado actual** + provee herramientas de referencia para acelerar los siguientes.

## Test plan

- [x] No requiere tests — solo docs + SQL snippets.
- [ ] CI verde (esperando — pre-existentes esperados Trivy/SBOM/npm audit).
- [ ] Validación cualitativa por Felipe (legal context check).

## Notas

- Sin breaking change.
- Las queries SQL del reference usan `:variable_name` placeholder syntax (psql-friendly). El consumer adapta a Drizzle/parameterized queries en TypeScript.
- HANDOFF.md sync (mover este item de "deuda" a "resuelto/redefinido") se hace en el próximo `/handoff` mayor, no acá.

https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR

---
_Generated by [Claude Code](https://claude.ai/code/session_01UCc8YcdZZ3sgag4Ny79XjR)_