### PR TITLE
feat(dte): dte-provider con PaperlessAdapter + ADR-015 (Sprint 1.3)

### DIFF
--- a/docs/adr/015-paperless-dte-provider.md
+++ b/docs/adr/015-paperless-dte-provider.md
@@ -1,0 +1,89 @@
+# ADR-015 — Paperless seleccionado como proveedor DTE
+
+**Fecha:** 2026-05-04
+**Estado:** Aceptado
+**Decider:** Felipe Vicencio (Product Owner)
+**Related:** [ADR-007 Gestión Documental Obligatoria Chile](./007-chile-document-management.md)
+
+## Contexto
+
+ADR-007 dejó abierta la decisión final del proveedor DTE (Documento Tributario Electrónico) acreditado por SII Chile, recomendando Bsale pero "pendiente de benchmarking comercial". Sprint 1.3 lo necesita resuelto para habilitar la emisión legal de Guía de Despacho (DTE Tipo 52) y Factura Electrónica (DTE Tipo 33/34) — ambos bloqueantes para go-live en Chile (Ley 19.983, Ley 20.727, Resolución Exenta SII N°80/2014).
+
+Booster **no es Emisor Electrónico Tipo I propio** (proceso de meses de certificación con SII). Necesita un proveedor acreditado que actúe como intermediario:
+
+- Firma los DTEs con el **certificado tributario electrónico** del emisor (Booster como facturador, o el RUT del transportista cuando aplica)
+- Envía al SII vía web service oficial
+- Recibe el **folio autorizado** y devuelve el XML firmado + PDF visual
+- Mantiene infraestructura para volúmenes altos sin que Booster gestione web services SII directamente
+
+### Opciones evaluadas
+
+| Provider | Pricing | API | Sandbox | Curva | Foco |
+|---|---|---|---|---|---|
+| **Bsale** | Plan mensual + por doc | REST + JSON | ✅ | Mayor superficie (ERP completo) | ERP integral con DTE incluido |
+| **Paperless** | Pay-as-you-go por doc | REST + JSON | ✅ | Menor (DTE-first) | DTE + integraciones |
+| Acepta | Plan + por doc | SOAP/REST mix | ✅ | Mayor (legacy) | Empresa establecida |
+| SovosChile | Enterprise | SOAP | ✅ | Alta | Multinacionales |
+
+## Decisión
+
+**Paperless** es el provider DTE seleccionado para Booster AI.
+
+### Rationale
+
+1. **Modelo pay-as-you-go**: alinea costos con volumen real. Booster en early stage (TRL 9-10 piloto) emite pocos docs/mes; pagar plan mensual a Bsale tendría costo fijo desproporcionado al uso.
+2. **API DTE-first**: el scope que necesitamos es estrictamente emisión de DTE 52/33/34. Bsale tiene un superficie mucho mayor (POS, inventario, CRM) que no usamos y agrega curva de integración innecesaria.
+3. **Curva de integración menor**: documentación enfocada en DTE permite implementar el adapter en un sprint vs varios para Bsale.
+4. **Cambio de provider future-proof**: la abstracción `DteEmitter` (ver ADR-007) permite swapear adapter sin tocar el resto del sistema. Si Paperless no escala, migramos a Bsale o Acepta cambiando el adapter, no el dominio.
+
+### Riesgos asumidos
+
+- **Pricing per-doc puede ser más caro a escala alta**: si Booster crece a >10k DTEs/mes, plan mensual de Bsale puede ser más económico. Re-evaluar en TRL 10+.
+- **Dependencia de un solo provider**: implementamos `MockAdapter` (para tests + dev) + `PaperlessAdapter` (producción). Si Paperless tiene incidente, los DTEs pendientes quedan en cola hasta que vuelva — no es failover automático. Mitigación: monitoreo + alerta de cola crece >N min.
+- **Calibración real de la API**: al momento de este ADR no tenemos cuenta sandbox abierta. La implementación inicial del `PaperlessAdapter` se construye con shape genérico DTE-SII; calibración fina requiere ejecutar contra sandbox real. Sprint 1.4 (wireado) cierra ese loop.
+
+## Implementación
+
+`packages/dte-provider`:
+
+```typescript
+export interface DteEmitter {
+  emitGuiaDespacho(input: GuiaDespachoInput): Promise<DteResult>;
+  emitFactura(input: FacturaInput): Promise<DteResult>;
+  queryStatus(folio: string, rutEmisor: string): Promise<DteStatus>;
+}
+
+// Adapters
+export class PaperlessAdapter implements DteEmitter { ... }
+export class MockAdapter implements DteEmitter { ... }
+
+// Factory según env
+export function createDteEmitter(config): DteEmitter {
+  if (config.provider === 'paperless') return new PaperlessAdapter(config);
+  return new MockAdapter(); // tests + dev local
+}
+```
+
+### Configuración por environment
+
+- **dev / test**: `DTE_PROVIDER=mock` — `MockAdapter` retorna folios determinísticos.
+- **staging**: `DTE_PROVIDER=paperless` + `PAPERLESS_API_KEY=...` (sandbox) + `PAPERLESS_BASE_URL=https://api.sandbox.paperless.cl/v1`.
+- **prod**: `DTE_PROVIDER=paperless` + `PAPERLESS_API_KEY=...` (producción) + `PAPERLESS_BASE_URL=https://api.paperless.cl/v1`.
+
+API keys via Secret Manager, nunca en el repo (CLAUDE.md §"Sin secretos en el repo").
+
+### Identidad de firma DTE
+
+A diferencia de la firma PAdES de cartas de porte y certificados ESG (que usa la KMS key de Booster como Software Generator), la firma SII de DTEs usa el **certificado tributario electrónico del emisor real** (RUT del transportista que está despachando, no Booster). Paperless gestiona esos certs por RUT en su lado — Booster pasa el RUT del emisor en cada request, Paperless usa el cert correcto.
+
+Configuración por empresa en BD (`empresas.rut_emisor_dte` + `empresas.paperless_emisor_id`) — fuera de scope para Sprint 1.3, se agrega en Sprint 1.4 cuando el wireado lo requiera.
+
+## Consecuencias
+
+- **Positivas**: time-to-market corto, costos alineados a uso real, abstracción permite cambio futuro.
+- **Negativas**: dependencia de servicio externo single-vendor; calibración fina pendiente hasta tener sandbox.
+- **Acciones de seguimiento**:
+  - Crear cuenta sandbox Paperless (Felipe).
+  - Calibrar `PaperlessAdapter` contra API real en Sprint 1.4.
+  - Definir `empresas.rut_emisor_dte` schema en Sprint 1.4.
+  - Re-evaluar economía pay-as-you-go vs plan mensual al alcanzar volumen ≥1k DTEs/mes.

--- a/packages/dte-provider/package.json
+++ b/packages/dte-provider/package.json
@@ -12,8 +12,12 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@booster-ai/shared-schemas": "workspace:*",
+    "zod": "^3.25.76"
+  },
   "devDependencies": {
+    "@types/node": "^22.14.0",
     "typescript": "^5.8.2",
     "vitest": "^4.0.18"
   }

--- a/packages/dte-provider/src/dte-emitter.ts
+++ b/packages/dte-provider/src/dte-emitter.ts
@@ -1,0 +1,40 @@
+/**
+ * Interface principal del package — implementada por adapters concretos
+ * (PaperlessAdapter, MockAdapter, futuros). Permite swap de provider
+ * sin tocar dominio. Ver ADR-007 §"Integración SII DTE" + ADR-015.
+ */
+
+import type { DteResult, DteStatus, FacturaInput, GuiaDespachoInput } from './tipos.js';
+
+export interface DteEmitter {
+  /**
+   * Emite una Guía de Despacho (DTE Tipo 52) vía el provider acreditado.
+   * El provider firma con cert tributario, envía al SII, y devuelve el
+   * folio asignado + URLs al XML firmado y PDF visual.
+   *
+   * Idempotencia: si `input.idempotencyKey` se provee, el provider
+   * deduplica reintentos. Sin la key, dos invocaciones del mismo input
+   * pueden emitir 2 DTEs distintos (y consumir 2 folios SII).
+   *
+   * Errores:
+   *   - `DteValidationError`: SII o provider rechaza por contenido
+   *     (RUT inválido, items mal formados, etc). NO retry.
+   *   - `DteProviderError`: HTTP/network/timeout. Retry-safe si
+   *     `idempotencyKey` está presente.
+   */
+  emitGuiaDespacho(input: GuiaDespachoInput): Promise<DteResult>;
+
+  /**
+   * Emite una Factura Electrónica afecta (33) o exenta (34).
+   * Misma semántica de idempotencia y errores que `emitGuiaDespacho`.
+   */
+  emitFactura(input: FacturaInput): Promise<DteResult>;
+
+  /**
+   * Consulta el estado actual del DTE. Útil porque el flujo SII es
+   * asíncrono — un DTE puede estar `pendiente` por minutos hasta que
+   * SII lo procesa. La capa caller suele encolarlo (Pub/Sub) y
+   * actualizar la BD cuando el estado cambia.
+   */
+  queryStatus(folio: string, rutEmisor: string): Promise<DteStatus>;
+}

--- a/packages/dte-provider/src/factory.test.ts
+++ b/packages/dte-provider/src/factory.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { createDteEmitter } from './factory.js';
+import { MockAdapter } from './mock-adapter.js';
+import { PaperlessAdapter } from './paperless-adapter.js';
+
+describe('createDteEmitter', () => {
+  it('provider=mock → MockAdapter', () => {
+    const emitter = createDteEmitter({ provider: 'mock' });
+    expect(emitter).toBeInstanceOf(MockAdapter);
+  });
+
+  it('provider=paperless → PaperlessAdapter', () => {
+    const emitter = createDteEmitter({
+      provider: 'paperless',
+      apiKey: 'test-key',
+      baseUrl: 'https://api.sandbox.paperless.cl/v1',
+    });
+    expect(emitter).toBeInstanceOf(PaperlessAdapter);
+  });
+
+  it('respeta timeoutMs explícito', () => {
+    const emitter = createDteEmitter({
+      provider: 'paperless',
+      apiKey: 'k',
+      baseUrl: 'https://x',
+      timeoutMs: 5000,
+    });
+    expect((emitter as PaperlessAdapter).getTimeoutMs()).toBe(5000);
+  });
+
+  it('default timeoutMs = 30000', () => {
+    const emitter = createDteEmitter({
+      provider: 'paperless',
+      apiKey: 'k',
+      baseUrl: 'https://x',
+    });
+    expect((emitter as PaperlessAdapter).getTimeoutMs()).toBe(30_000);
+  });
+});

--- a/packages/dte-provider/src/factory.ts
+++ b/packages/dte-provider/src/factory.ts
@@ -1,0 +1,31 @@
+/**
+ * Factory: lee config de env y construye el adapter correcto.
+ * Llamar una vez al startup; cachear la instancia.
+ *
+ * dev/test:    DTE_PROVIDER=mock                       → MockAdapter
+ * staging/prod: DTE_PROVIDER=paperless + PAPERLESS_*   → PaperlessAdapter
+ */
+
+import type { DteEmitter } from './dte-emitter.js';
+import { MockAdapter } from './mock-adapter.js';
+import { PaperlessAdapter } from './paperless-adapter.js';
+
+export type DteProviderConfig =
+  | { provider: 'mock' }
+  | {
+      provider: 'paperless';
+      apiKey: string;
+      baseUrl: string;
+      timeoutMs?: number;
+    };
+
+export function createDteEmitter(config: DteProviderConfig): DteEmitter {
+  if (config.provider === 'mock') {
+    return new MockAdapter();
+  }
+  return new PaperlessAdapter({
+    apiKey: config.apiKey,
+    baseUrl: config.baseUrl,
+    ...(config.timeoutMs !== undefined && { timeoutMs: config.timeoutMs }),
+  });
+}

--- a/packages/dte-provider/src/index.ts
+++ b/packages/dte-provider/src/index.ts
@@ -1,7 +1,56 @@
 /**
  * @booster-ai/dte-provider
  *
- * TODO: implementar según ADRs relacionados.
- * Este archivo es un placeholder para que el monorepo compile.
+ * Abstracción sobre proveedores DTE acreditados SII Chile (Paperless,
+ * Bsale, etc.). Ver ADR-007 §"Integración SII DTE" + ADR-015 §"Paperless
+ * seleccionado".
+ *
+ * Uso:
+ *
+ *   import { createDteEmitter } from '@booster-ai/dte-provider';
+ *
+ *   const emitter = createDteEmitter({
+ *     provider: 'paperless',
+ *     apiKey: env.PAPERLESS_API_KEY,
+ *     baseUrl: env.PAPERLESS_BASE_URL,
+ *   });
+ *
+ *   const result = await emitter.emitGuiaDespacho({
+ *     rutEmisor: '76543210-3',
+ *     receptor: { rut, razonSocial, giro, direccion, ... },
+ *     items: [...],
+ *     origen: { direccion, comuna },
+ *     destino: { direccion, comuna },
+ *     patenteVehiculo: 'AB1234',
+ *     rutConductor: '11111111-1',
+ *     idempotencyKey: `gd-${tripId}`,
+ *   });
+ *
+ *   // result.folio, result.providerRef, result.pdfUrl, result.status
  */
-export const PACKAGE_NAME = '@booster-ai/dte-provider' as const;
+
+export { createDteEmitter } from './factory.js';
+export type { DteProviderConfig } from './factory.js';
+export { MockAdapter } from './mock-adapter.js';
+export type { MockAdapterOptions } from './mock-adapter.js';
+export { PaperlessAdapter } from './paperless-adapter.js';
+export type { HttpClient, PaperlessAdapterOptions } from './paperless-adapter.js';
+export type { DteEmitter } from './dte-emitter.js';
+export {
+  DteProviderError,
+  DteValidationError,
+  dteLineItemSchema,
+  dteReceptorSchema,
+  dteResultSchema,
+  dteStatusSchema,
+  dteTypeSchema,
+  facturaInputSchema,
+  guiaDespachoInputSchema,
+  type DteLineItem,
+  type DteReceptor,
+  type DteResult,
+  type DteStatus,
+  type DteType,
+  type FacturaInput,
+  type GuiaDespachoInput,
+} from './tipos.js';

--- a/packages/dte-provider/src/mock-adapter.test.ts
+++ b/packages/dte-provider/src/mock-adapter.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { MockAdapter } from './mock-adapter.js';
+import { DteProviderError, DteValidationError } from './tipos.js';
+import type { FacturaInput, GuiaDespachoInput } from './tipos.js';
+
+const VALID_GUIA: GuiaDespachoInput = {
+  rutEmisor: '76543210-3',
+  receptor: {
+    rut: '11111111-1',
+    razonSocial: 'Distribuidora Norte SpA',
+    giro: 'Distribución mayorista',
+    direccion: 'Av. Norte 100',
+    comuna: 'Antofagasta',
+    region: 'II',
+    email: 'compras@dnorte.cl',
+  },
+  items: [
+    {
+      nombre: 'Materiales eléctricos',
+      cantidad: 50,
+      unidad: 'cajas',
+      precioUnitarioClp: 12000,
+      exento: false,
+    },
+  ],
+  origen: { direccion: 'Av. Industrias 1', comuna: 'Quilicura' },
+  destino: { direccion: 'Av. Norte 100', comuna: 'Antofagasta' },
+  patenteVehiculo: 'AB1234',
+  rutConductor: '11111111-1',
+  indicadorTraslado: 5,
+};
+
+const VALID_FACTURA: FacturaInput = {
+  rutEmisor: '76543210-3',
+  tipo: 'factura_33',
+  receptor: {
+    rut: '11111111-1',
+    razonSocial: 'Distribuidora Norte SpA',
+    giro: 'Distribución mayorista',
+    direccion: 'Av. Norte 100',
+    comuna: 'Antofagasta',
+    region: 'II',
+  },
+  items: [
+    {
+      nombre: 'Servicio de transporte',
+      cantidad: 1,
+      unidad: 'flete',
+      precioUnitarioClp: 850000,
+      exento: false,
+    },
+  ],
+};
+
+describe('MockAdapter.emitGuiaDespacho', () => {
+  let adapter: MockAdapter;
+  beforeEach(() => {
+    adapter = new MockAdapter({ now: () => new Date('2026-05-04T10:00:00Z') });
+  });
+
+  it('emite folio incremental empezando en 1000', async () => {
+    const r1 = await adapter.emitGuiaDespacho(VALID_GUIA);
+    const r2 = await adapter.emitGuiaDespacho(VALID_GUIA);
+    expect(r1.folio).toBe('1000');
+    expect(r2.folio).toBe('1001');
+  });
+
+  it('retorna providerRef y type=guia_despacho_52', async () => {
+    const r = await adapter.emitGuiaDespacho(VALID_GUIA);
+    expect(r.providerRef).toBe('mock-1000');
+    expect(r.type).toBe('guia_despacho_52');
+    expect(r.rutEmisor).toBe('76543210-3');
+  });
+
+  it('default status = aceptado', async () => {
+    const r = await adapter.emitGuiaDespacho(VALID_GUIA);
+    expect(r.status).toBe('aceptado');
+  });
+
+  it('respeta defaultStatus configurado', async () => {
+    const a = new MockAdapter({ defaultStatus: 'pendiente' });
+    const r = await a.emitGuiaDespacho(VALID_GUIA);
+    expect(r.status).toBe('pendiente');
+  });
+
+  it('idempotencia: misma key → mismo folio', async () => {
+    const r1 = await adapter.emitGuiaDespacho({
+      ...VALID_GUIA,
+      idempotencyKey: 'gd-trip-1',
+    });
+    const r2 = await adapter.emitGuiaDespacho({
+      ...VALID_GUIA,
+      idempotencyKey: 'gd-trip-1',
+    });
+    expect(r1.folio).toBe(r2.folio);
+    expect(r1.providerRef).toBe(r2.providerRef);
+  });
+
+  it('rechaza input con RUT inválido', async () => {
+    await expect(
+      adapter.emitGuiaDespacho({
+        ...VALID_GUIA,
+        rutEmisor: '12345678-X' as GuiaDespachoInput['rutEmisor'],
+      }),
+    ).rejects.toThrow(/RUT/i);
+  });
+
+  it('rechaza input sin items', async () => {
+    await expect(adapter.emitGuiaDespacho({ ...VALID_GUIA, items: [] })).rejects.toThrow();
+  });
+
+  it('failNext(validation) → DteValidationError', async () => {
+    adapter.failNext('validation', 'Folio agotado');
+    await expect(adapter.emitGuiaDespacho(VALID_GUIA)).rejects.toBeInstanceOf(DteValidationError);
+  });
+
+  it('failNext(provider) → DteProviderError', async () => {
+    adapter.failNext('provider', 'SII timeout');
+    await expect(adapter.emitGuiaDespacho(VALID_GUIA)).rejects.toBeInstanceOf(DteProviderError);
+  });
+});
+
+describe('MockAdapter.emitFactura', () => {
+  let adapter: MockAdapter;
+  beforeEach(() => {
+    adapter = new MockAdapter();
+  });
+
+  it('emite folio para factura 33', async () => {
+    const r = await adapter.emitFactura(VALID_FACTURA);
+    expect(r.type).toBe('factura_33');
+    expect(r.folio).toBe('1000');
+  });
+
+  it('emite folio para factura 34 exenta', async () => {
+    const r = await adapter.emitFactura({ ...VALID_FACTURA, tipo: 'factura_34' });
+    expect(r.type).toBe('factura_34');
+  });
+});
+
+describe('MockAdapter.queryStatus', () => {
+  let adapter: MockAdapter;
+  beforeEach(() => {
+    adapter = new MockAdapter();
+  });
+
+  it('retorna estado del DTE emitido', async () => {
+    const emitted = await adapter.emitGuiaDespacho(VALID_GUIA);
+    const status = await adapter.queryStatus(emitted.folio, emitted.rutEmisor);
+    expect(status.folio).toBe(emitted.folio);
+    expect(status.status).toBe('aceptado');
+  });
+
+  it('refleja setStatus subsiguiente', async () => {
+    const emitted = await adapter.emitGuiaDespacho(VALID_GUIA);
+    adapter.setStatus(emitted.folio, emitted.rutEmisor, 'rechazado', 'RUT receptor inactivo');
+    const status = await adapter.queryStatus(emitted.folio, emitted.rutEmisor);
+    expect(status.status).toBe('rechazado');
+    expect(status.siiMessage).toBe('RUT receptor inactivo');
+  });
+
+  it('throw para folio inexistente', async () => {
+    await expect(adapter.queryStatus('99999', '76543210-3')).rejects.toThrow(/no encontrado/);
+  });
+});

--- a/packages/dte-provider/src/mock-adapter.ts
+++ b/packages/dte-provider/src/mock-adapter.ts
@@ -1,0 +1,168 @@
+/**
+ * Adapter in-memory para tests + dev local. Determinístico: dado el
+ * mismo input + idempotencyKey, devuelve el mismo folio y status.
+ *
+ * Default behaviour: todos los DTEs devuelven `status='aceptado'`
+ * inmediatamente. Tests pueden sobreescribir con
+ * `MockAdapter.failNext()` o configurar respuestas específicas.
+ */
+
+import type { DteEmitter } from './dte-emitter.js';
+import {
+  type DteResult,
+  type DteStatus,
+  type DteType,
+  DteValidationError,
+  type FacturaInput,
+  type GuiaDespachoInput,
+  facturaInputSchema,
+  guiaDespachoInputSchema,
+} from './tipos.js';
+
+interface StoredDte {
+  folio: string;
+  type: DteType;
+  rutEmisor: string;
+  emittedAt: string;
+  status: DteStatus['status'];
+  siiMessage?: string | undefined;
+}
+
+export interface MockAdapterOptions {
+  /** Folio inicial. Se incrementa por cada emisión. Default = 1000. */
+  startFolio?: number;
+  /** Default status de DTEs nuevos. */
+  defaultStatus?: DteStatus['status'];
+  /** Date factory (para tests determinísticos). */
+  now?: () => Date;
+}
+
+export class MockAdapter implements DteEmitter {
+  private nextFolio: number;
+  private readonly defaultStatus: DteStatus['status'];
+  private readonly now: () => Date;
+  private readonly store = new Map<string, StoredDte>();
+  private readonly idempotencyMap = new Map<string, string>();
+  private failQueue: Array<{ kind: 'validation' | 'provider'; message: string }> = [];
+
+  constructor(opts: MockAdapterOptions = {}) {
+    this.nextFolio = opts.startFolio ?? 1000;
+    this.defaultStatus = opts.defaultStatus ?? 'aceptado';
+    this.now = opts.now ?? (() => new Date());
+  }
+
+  /**
+   * Encola un fallo para la próxima invocación. Útil en tests para
+   * simular SII rechaza un DTE específico.
+   */
+  failNext(kind: 'validation' | 'provider', message: string): void {
+    this.failQueue.push({ kind, message });
+  }
+
+  /** Resetea el store (útil entre tests). */
+  reset(): void {
+    this.store.clear();
+    this.idempotencyMap.clear();
+    this.failQueue = [];
+    this.nextFolio = 1000;
+  }
+
+  async emitGuiaDespacho(input: GuiaDespachoInput): Promise<DteResult> {
+    guiaDespachoInputSchema.parse(input);
+    return this.emit('guia_despacho_52', input.rutEmisor, input.idempotencyKey, input.fechaEmision);
+  }
+
+  async emitFactura(input: FacturaInput): Promise<DteResult> {
+    facturaInputSchema.parse(input);
+    return this.emit(input.tipo, input.rutEmisor, input.idempotencyKey, input.fechaEmision);
+  }
+
+  async queryStatus(folio: string, rutEmisor: string): Promise<DteStatus> {
+    const stored = this.store.get(this.storeKey(folio, rutEmisor));
+    if (!stored) {
+      throw new Error(`DTE no encontrado: folio=${folio} rutEmisor=${rutEmisor}`);
+    }
+    return {
+      folio: stored.folio,
+      status: stored.status,
+      siiMessage: stored.siiMessage,
+      updatedAt: this.now().toISOString(),
+    };
+  }
+
+  /**
+   * Test helper: setea el status de un DTE existente. Simula que SII
+   * cambió de pendiente a aceptado/rechazado.
+   */
+  setStatus(
+    folio: string,
+    rutEmisor: string,
+    status: DteStatus['status'],
+    siiMessage?: string,
+  ): void {
+    const key = this.storeKey(folio, rutEmisor);
+    const stored = this.store.get(key);
+    if (!stored) {
+      throw new Error(`DTE no encontrado: folio=${folio}`);
+    }
+    stored.status = status;
+    stored.siiMessage = siiMessage;
+  }
+
+  private async emit(
+    type: DteType,
+    rutEmisor: string,
+    idempotencyKey: string | undefined,
+    fechaEmisionInput: string | undefined,
+  ): Promise<DteResult> {
+    const failure = this.failQueue.shift();
+    if (failure) {
+      if (failure.kind === 'validation') {
+        throw new DteValidationError('MOCK_VALIDATION', failure.message);
+      }
+      const ProviderErrorClass = (await import('./tipos.js')).DteProviderError;
+      throw new ProviderErrorClass(503, failure.message);
+    }
+
+    if (idempotencyKey) {
+      const cached = this.idempotencyMap.get(idempotencyKey);
+      if (cached) {
+        const stored = this.store.get(cached);
+        if (stored) {
+          return this.toResult(stored);
+        }
+      }
+    }
+
+    const folio = String(this.nextFolio++);
+    const emittedAt = fechaEmisionInput ?? this.now().toISOString();
+    const stored: StoredDte = {
+      folio,
+      type,
+      rutEmisor,
+      emittedAt,
+      status: this.defaultStatus,
+    };
+    const key = this.storeKey(folio, rutEmisor);
+    this.store.set(key, stored);
+    if (idempotencyKey) {
+      this.idempotencyMap.set(idempotencyKey, key);
+    }
+    return this.toResult(stored);
+  }
+
+  private toResult(stored: StoredDte): DteResult {
+    return {
+      folio: stored.folio,
+      type: stored.type,
+      rutEmisor: stored.rutEmisor as DteResult['rutEmisor'],
+      emittedAt: stored.emittedAt,
+      providerRef: `mock-${stored.folio}`,
+      status: stored.status,
+    };
+  }
+
+  private storeKey(folio: string, rutEmisor: string): string {
+    return `${rutEmisor}::${folio}`;
+  }
+}

--- a/packages/dte-provider/src/paperless-adapter.test.ts
+++ b/packages/dte-provider/src/paperless-adapter.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type HttpClient, PaperlessAdapter } from './paperless-adapter.js';
+import { DteProviderError, DteValidationError } from './tipos.js';
+import type { FacturaInput, GuiaDespachoInput } from './tipos.js';
+
+const VALID_GUIA: GuiaDespachoInput = {
+  rutEmisor: '76543210-3',
+  receptor: {
+    rut: '11111111-1',
+    razonSocial: 'Distribuidora Norte SpA',
+    giro: 'Distribución mayorista',
+    direccion: 'Av. Norte 100',
+    comuna: 'Antofagasta',
+    region: 'II',
+  },
+  items: [
+    {
+      nombre: 'Materiales',
+      cantidad: 50,
+      unidad: 'cajas',
+      precioUnitarioClp: 12000,
+      exento: false,
+    },
+  ],
+  origen: { direccion: 'Av. 1', comuna: 'Quilicura' },
+  destino: { direccion: 'Av. 2', comuna: 'Antofagasta' },
+  patenteVehiculo: 'AB1234',
+  rutConductor: '11111111-1',
+  indicadorTraslado: 5,
+};
+
+function makeFakeHttp(responses: Array<{ status: number; body: string }>): {
+  http: HttpClient;
+  calls: Array<Parameters<HttpClient['request']>[0]>;
+} {
+  const calls: Array<Parameters<HttpClient['request']>[0]> = [];
+  let i = 0;
+  const http: HttpClient = {
+    request: vi.fn(async (opts) => {
+      calls.push(opts);
+      const r = responses[i++];
+      if (!r) {
+        throw new Error('Sin response disponible');
+      }
+      return r;
+    }),
+  };
+  return { http, calls };
+}
+
+describe('PaperlessAdapter.emitGuiaDespacho', () => {
+  let adapter: PaperlessAdapter;
+  let httpStub: ReturnType<typeof makeFakeHttp>;
+
+  beforeEach(() => {
+    httpStub = makeFakeHttp([
+      {
+        status: 200,
+        body: JSON.stringify({
+          folio: 1234,
+          trackId: 'pl-trk-abc',
+          emittedAt: '2026-05-04T10:00:00.000Z',
+          status: 'pending',
+          pdfUrl: 'https://api.paperless.cl/pdf/abc',
+          xmlUrl: 'https://api.paperless.cl/xml/abc',
+        }),
+      },
+    ]);
+    adapter = new PaperlessAdapter({
+      apiKey: 'test-key-123',
+      baseUrl: 'https://api.sandbox.paperless.cl/v1',
+      httpClient: httpStub.http,
+    });
+  });
+
+  it('hace POST al endpoint correcto con Bearer auth', async () => {
+    await adapter.emitGuiaDespacho(VALID_GUIA);
+    const call = httpStub.calls[0];
+    expect(call?.url).toBe('https://api.sandbox.paperless.cl/v1/dte/guia-despacho');
+    expect(call?.method).toBe('POST');
+    expect(call?.headers.Authorization).toBe('Bearer test-key-123');
+    expect(call?.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('parsea folio + status + pdfUrl + xmlUrl del response', async () => {
+    const r = await adapter.emitGuiaDespacho(VALID_GUIA);
+    expect(r.folio).toBe('1234');
+    expect(r.providerRef).toBe('pl-trk-abc');
+    expect(r.status).toBe('pendiente');
+    expect(r.pdfUrl).toBe('https://api.paperless.cl/pdf/abc');
+    expect(r.xmlUrl).toBe('https://api.paperless.cl/xml/abc');
+    expect(r.type).toBe('guia_despacho_52');
+  });
+
+  it('mapea indicadorTraslado y transporte al payload', async () => {
+    await adapter.emitGuiaDespacho(VALID_GUIA);
+    const body = JSON.parse(httpStub.calls[0]?.body ?? '{}');
+    expect(body.indicadorTraslado).toBe(5);
+    expect(body.transporte.patente).toBe('AB1234');
+    expect(body.transporte.origen.comuna).toBe('Quilicura');
+    expect(body.transporte.destino.comuna).toBe('Antofagasta');
+  });
+
+  it('idempotencyKey va en header Idempotency-Key', async () => {
+    await adapter.emitGuiaDespacho({ ...VALID_GUIA, idempotencyKey: 'gd-trip-1' });
+    expect(httpStub.calls[0]?.headers['Idempotency-Key']).toBe('gd-trip-1');
+  });
+
+  it('omite Idempotency-Key si no se provee', async () => {
+    await adapter.emitGuiaDespacho(VALID_GUIA);
+    expect(httpStub.calls[0]?.headers['Idempotency-Key']).toBeUndefined();
+  });
+});
+
+describe('PaperlessAdapter — error handling', () => {
+  it('4xx → DteValidationError con siiCode', async () => {
+    const stub = makeFakeHttp([
+      {
+        status: 400,
+        body: JSON.stringify({ message: 'RUT receptor no válido', siiCode: 'SII-005' }),
+      },
+    ]);
+    const adapter = new PaperlessAdapter({
+      apiKey: 'k',
+      baseUrl: 'https://x',
+      httpClient: stub.http,
+    });
+    try {
+      await adapter.emitGuiaDespacho(VALID_GUIA);
+      throw new Error('debería haber lanzado');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DteValidationError);
+      expect((err as DteValidationError).siiCode).toBe('SII-005');
+    }
+  });
+
+  it('5xx → DteProviderError con httpStatus', async () => {
+    const stub = makeFakeHttp([{ status: 503, body: 'gateway timeout' }]);
+    const adapter = new PaperlessAdapter({
+      apiKey: 'k',
+      baseUrl: 'https://x',
+      httpClient: stub.http,
+    });
+    try {
+      await adapter.emitGuiaDespacho(VALID_GUIA);
+      throw new Error('debería haber lanzado');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DteProviderError);
+      expect((err as DteProviderError).httpStatus).toBe(503);
+    }
+  });
+});
+
+describe('PaperlessAdapter.queryStatus', () => {
+  it('hace GET al path correcto y mapea estado', async () => {
+    const stub = makeFakeHttp([
+      {
+        status: 200,
+        body: JSON.stringify({
+          folio: '1234',
+          status: 'rejected',
+          siiMessage: 'Folio agotado',
+          updatedAt: '2026-05-04T10:00:00.000Z',
+        }),
+      },
+    ]);
+    const adapter = new PaperlessAdapter({
+      apiKey: 'k',
+      baseUrl: 'https://x',
+      httpClient: stub.http,
+    });
+    const status = await adapter.queryStatus('1234', '76543210-3');
+    expect(status.folio).toBe('1234');
+    expect(status.status).toBe('rechazado');
+    expect(status.siiMessage).toBe('Folio agotado');
+    expect(stub.calls[0]?.method).toBe('GET');
+    expect(stub.calls[0]?.url).toContain('/dte/76543210-3/1234/status');
+  });
+});
+
+describe('PaperlessAdapter — facturas', () => {
+  const VALID_FACTURA: FacturaInput = {
+    rutEmisor: '76543210-3',
+    tipo: 'factura_33',
+    receptor: {
+      rut: '11111111-1',
+      razonSocial: 'Cliente',
+      giro: 'Servicios',
+      direccion: 'Av. 3',
+      comuna: 'Santiago',
+      region: 'XIII',
+    },
+    items: [
+      {
+        nombre: 'Servicio',
+        cantidad: 1,
+        unidad: 'unidad',
+        precioUnitarioClp: 100000,
+        exento: false,
+      },
+    ],
+  };
+
+  it('mapea tipoDte=33 al payload', async () => {
+    const stub = makeFakeHttp([
+      { status: 200, body: JSON.stringify({ folio: 1, trackId: 't', status: 'accepted' }) },
+    ]);
+    const adapter = new PaperlessAdapter({
+      apiKey: 'k',
+      baseUrl: 'https://x',
+      httpClient: stub.http,
+    });
+    await adapter.emitFactura(VALID_FACTURA);
+    const body = JSON.parse(stub.calls[0]?.body ?? '{}');
+    expect(body.tipoDte).toBe(33);
+  });
+
+  it('mapea tipoDte=34 para factura exenta', async () => {
+    const stub = makeFakeHttp([
+      { status: 200, body: JSON.stringify({ folio: 1, trackId: 't', status: 'accepted' }) },
+    ]);
+    const adapter = new PaperlessAdapter({
+      apiKey: 'k',
+      baseUrl: 'https://x',
+      httpClient: stub.http,
+    });
+    await adapter.emitFactura({ ...VALID_FACTURA, tipo: 'factura_34' });
+    const body = JSON.parse(stub.calls[0]?.body ?? '{}');
+    expect(body.tipoDte).toBe(34);
+  });
+
+  it('incluye referencia a guía cuando refFolioGuia se provee', async () => {
+    const stub = makeFakeHttp([
+      { status: 200, body: JSON.stringify({ folio: 1, trackId: 't', status: 'accepted' }) },
+    ]);
+    const adapter = new PaperlessAdapter({
+      apiKey: 'k',
+      baseUrl: 'https://x',
+      httpClient: stub.http,
+    });
+    await adapter.emitFactura({ ...VALID_FACTURA, refFolioGuia: '1000' });
+    const body = JSON.parse(stub.calls[0]?.body ?? '{}');
+    expect(body.referencias).toEqual([{ tipoDocumento: 52, folio: '1000' }]);
+  });
+});

--- a/packages/dte-provider/src/paperless-adapter.ts
+++ b/packages/dte-provider/src/paperless-adapter.ts
@@ -1,0 +1,279 @@
+/**
+ * Adapter para Paperless (paperless.cl) — provider DTE acreditado SII
+ * Chile seleccionado en ADR-015. Implementa `DteEmitter` traduciendo
+ * los inputs canónicos del package a las llamadas REST del API
+ * Paperless.
+ *
+ * Calibración pendiente: este adapter se construye con shape genérico
+ * DTE-SII derivado de la docs pública de Paperless. La calibración
+ * fina (nombres exactos de campos en payload, paths de endpoints,
+ * shape de respuesta) se hace en Sprint 1.4 cuando esté la cuenta
+ * sandbox abierta. Ver el método `mapInput*` para puntos de ajuste.
+ *
+ * Diseño:
+ *   - Constructor recibe `apiKey`, `baseUrl`, `httpClient` (inyectable
+ *     para tests). Default httpClient usa `fetch` global (Node 22+).
+ *   - Errores HTTP 4xx → `DteValidationError` (rechazo legal).
+ *   - Errores HTTP 5xx / network → `DteProviderError` (retry-safe).
+ */
+
+import type { DteEmitter } from './dte-emitter.js';
+import {
+  DteProviderError,
+  type DteResult,
+  type DteStatus,
+  DteValidationError,
+  type FacturaInput,
+  type GuiaDespachoInput,
+  facturaInputSchema,
+  guiaDespachoInputSchema,
+} from './tipos.js';
+
+export interface HttpClient {
+  request(opts: {
+    method: 'GET' | 'POST';
+    url: string;
+    headers: Record<string, string>;
+    body?: string;
+  }): Promise<{ status: number; body: string }>;
+}
+
+export interface PaperlessAdapterOptions {
+  /** API key del cliente Paperless (Secret Manager). */
+  apiKey: string;
+  /**
+   * Base URL. Sandbox: https://api.sandbox.paperless.cl/v1
+   * Producción: https://api.paperless.cl/v1
+   */
+  baseUrl: string;
+  /** HTTP client inyectable. Default = fetch nativo. */
+  httpClient?: HttpClient;
+  /** Timeout por request en ms. Default 30s. */
+  timeoutMs?: number;
+}
+
+export class PaperlessAdapter implements DteEmitter {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly http: HttpClient;
+  private readonly timeoutMs: number;
+
+  constructor(opts: PaperlessAdapterOptions) {
+    this.apiKey = opts.apiKey;
+    this.baseUrl = opts.baseUrl.replace(/\/$/, '');
+    this.http = opts.httpClient ?? defaultHttpClient();
+    this.timeoutMs = opts.timeoutMs ?? 30_000;
+  }
+
+  async emitGuiaDespacho(input: GuiaDespachoInput): Promise<DteResult> {
+    guiaDespachoInputSchema.parse(input);
+    const payload = this.mapInputGuiaDespacho(input);
+    const resp = await this.http.request({
+      method: 'POST',
+      url: `${this.baseUrl}/dte/guia-despacho`,
+      headers: this.headers(input.idempotencyKey),
+      body: JSON.stringify(payload),
+    });
+    return this.parseEmissionResponse(resp, 'guia_despacho_52', input.rutEmisor);
+  }
+
+  async emitFactura(input: FacturaInput): Promise<DteResult> {
+    facturaInputSchema.parse(input);
+    const payload = this.mapInputFactura(input);
+    const resp = await this.http.request({
+      method: 'POST',
+      url: `${this.baseUrl}/dte/factura`,
+      headers: this.headers(input.idempotencyKey),
+      body: JSON.stringify(payload),
+    });
+    return this.parseEmissionResponse(resp, input.tipo, input.rutEmisor);
+  }
+
+  async queryStatus(folio: string, rutEmisor: string): Promise<DteStatus> {
+    const url = `${this.baseUrl}/dte/${encodeURIComponent(rutEmisor)}/${encodeURIComponent(folio)}/status`;
+    const resp = await this.http.request({
+      method: 'GET',
+      url,
+      headers: this.headers(),
+    });
+    if (resp.status >= 400) {
+      this.throwHttpError(resp);
+    }
+    const body = JSON.parse(resp.body) as {
+      folio: string;
+      status: string;
+      siiMessage?: string;
+      updatedAt: string;
+    };
+    return {
+      folio: body.folio,
+      status: this.mapStatus(body.status),
+      siiMessage: body.siiMessage,
+      updatedAt: body.updatedAt,
+    };
+  }
+
+  // --------------------------------------------------------------------------
+  // Mapping (calibrar contra API real en Sprint 1.4)
+  // --------------------------------------------------------------------------
+
+  private mapInputGuiaDespacho(input: GuiaDespachoInput): Record<string, unknown> {
+    return {
+      emisor: { rut: input.rutEmisor },
+      receptor: {
+        rut: input.receptor.rut,
+        razonSocial: input.receptor.razonSocial,
+        giro: input.receptor.giro,
+        direccion: input.receptor.direccion,
+        comuna: input.receptor.comuna,
+        region: input.receptor.region,
+        email: input.receptor.email,
+      },
+      indicadorTraslado: input.indicadorTraslado,
+      fechaEmision: input.fechaEmision,
+      transporte: {
+        origen: input.origen,
+        destino: input.destino,
+        patente: input.patenteVehiculo,
+        rutTransportista: input.rutTransportista ?? input.rutEmisor,
+        rutConductor: input.rutConductor,
+      },
+      detalle: input.items.map((it, idx) => ({
+        nroLinea: idx + 1,
+        nombre: it.nombre,
+        cantidad: it.cantidad,
+        unidadMedida: it.unidad,
+        precioUnitario: it.precioUnitarioClp,
+        exento: it.exento,
+      })),
+    };
+  }
+
+  private mapInputFactura(input: FacturaInput): Record<string, unknown> {
+    return {
+      emisor: { rut: input.rutEmisor },
+      tipoDte: input.tipo === 'factura_33' ? 33 : 34,
+      receptor: {
+        rut: input.receptor.rut,
+        razonSocial: input.receptor.razonSocial,
+        giro: input.receptor.giro,
+        direccion: input.receptor.direccion,
+        comuna: input.receptor.comuna,
+        region: input.receptor.region,
+        email: input.receptor.email,
+      },
+      fechaEmision: input.fechaEmision,
+      referencias: input.refFolioGuia
+        ? [{ tipoDocumento: 52, folio: input.refFolioGuia }]
+        : undefined,
+      detalle: input.items.map((it, idx) => ({
+        nroLinea: idx + 1,
+        nombre: it.nombre,
+        cantidad: it.cantidad,
+        unidadMedida: it.unidad,
+        precioUnitario: it.precioUnitarioClp,
+        exento: it.exento,
+      })),
+    };
+  }
+
+  private parseEmissionResponse(
+    resp: { status: number; body: string },
+    type: DteResult['type'],
+    rutEmisor: string,
+  ): DteResult {
+    if (resp.status >= 400) {
+      this.throwHttpError(resp);
+    }
+    const body = JSON.parse(resp.body) as {
+      folio: string | number;
+      trackId: string;
+      emittedAt?: string;
+      status?: string;
+      pdfUrl?: string;
+      xmlUrl?: string;
+    };
+    return {
+      folio: String(body.folio),
+      type,
+      rutEmisor: rutEmisor as DteResult['rutEmisor'],
+      emittedAt: body.emittedAt ?? new Date().toISOString(),
+      providerRef: body.trackId,
+      pdfUrl: body.pdfUrl,
+      xmlUrl: body.xmlUrl,
+      status: this.mapStatus(body.status ?? 'pendiente'),
+    };
+  }
+
+  private mapStatus(provider: string): DteStatus['status'] {
+    const map: Record<string, DteStatus['status']> = {
+      pending: 'pendiente',
+      pendiente: 'pendiente',
+      accepted: 'aceptado',
+      aceptado: 'aceptado',
+      accepted_with_warnings: 'aceptado_con_reparos',
+      aceptado_con_reparos: 'aceptado_con_reparos',
+      rejected: 'rechazado',
+      rechazado: 'rechazado',
+    };
+    return map[provider.toLowerCase()] ?? 'pendiente';
+  }
+
+  private headers(idempotencyKey?: string): Record<string, string> {
+    const h: Record<string, string> = {
+      Authorization: `Bearer ${this.apiKey}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+    if (idempotencyKey) {
+      h['Idempotency-Key'] = idempotencyKey;
+    }
+    return h;
+  }
+
+  private throwHttpError(resp: { status: number; body: string }): never {
+    let message = resp.body;
+    let siiCode = 'UNKNOWN';
+    try {
+      const parsed = JSON.parse(resp.body) as { message?: string; siiCode?: string };
+      if (parsed.message) {
+        message = parsed.message;
+      }
+      if (parsed.siiCode) {
+        siiCode = parsed.siiCode;
+      }
+    } catch {
+      /* body no es JSON, dejarlo como texto */
+    }
+    if (resp.status >= 400 && resp.status < 500) {
+      throw new DteValidationError(siiCode, `Paperless 4xx: ${message}`);
+    }
+    throw new DteProviderError(resp.status, `Paperless ${resp.status}: ${message}`);
+  }
+
+  /** Test helper: expone timeoutMs para inspección. */
+  getTimeoutMs(): number {
+    return this.timeoutMs;
+  }
+}
+
+function defaultHttpClient(): HttpClient {
+  return {
+    async request(opts) {
+      const controller = new AbortController();
+      const t = setTimeout(() => controller.abort(), 30_000);
+      try {
+        const res = await fetch(opts.url, {
+          method: opts.method,
+          headers: opts.headers,
+          ...(opts.body !== undefined && { body: opts.body }),
+          signal: controller.signal,
+        });
+        const body = await res.text();
+        return { status: res.status, body };
+      } finally {
+        clearTimeout(t);
+      }
+    },
+  };
+}

--- a/packages/dte-provider/src/tipos.ts
+++ b/packages/dte-provider/src/tipos.ts
@@ -1,0 +1,170 @@
+import { rutSchema } from '@booster-ai/shared-schemas';
+import { z } from 'zod';
+
+/**
+ * Tipos públicos del package. Modelan las entradas/salidas de un
+ * proveedor DTE (Documento Tributario Electrónico) acreditado por SII
+ * Chile, abstractos del provider concreto (Paperless, Bsale, etc.).
+ *
+ * Ver ADR-007 §"Integración SII DTE" + ADR-015 §"Implementación".
+ */
+
+export const dteTypeSchema = z.enum([
+  'guia_despacho_52', // DTE Tipo 52 — Ley 19.983
+  'factura_33', // DTE Tipo 33 — Factura Electrónica afecta
+  'factura_34', // DTE Tipo 34 — Factura Electrónica exenta
+]);
+
+export type DteType = z.infer<typeof dteTypeSchema>;
+
+/**
+ * Item de detalle de un DTE. Cada DTE puede tener N items.
+ * Las facturas tienen items de productos/servicios; las guías de
+ * despacho tienen items que describen la mercadería transportada.
+ */
+export const dteLineItemSchema = z.object({
+  /** Descripción del item. */
+  nombre: z.string().min(1).max(200),
+  cantidad: z.number().positive(),
+  unidad: z.string().min(1).max(20),
+  /** Precio unitario neto en CLP. */
+  precioUnitarioClp: z.number().int().nonnegative(),
+  /** Indicador de exento de IVA. */
+  exento: z.boolean().default(false),
+});
+
+export type DteLineItem = z.infer<typeof dteLineItemSchema>;
+
+/**
+ * Datos del receptor del DTE. Para guía de despacho = consignatario;
+ * para factura = comprador.
+ */
+export const dteReceptorSchema = z.object({
+  rut: rutSchema,
+  razonSocial: z.string().min(2).max(200),
+  giro: z.string().min(2).max(80),
+  direccion: z.string().min(5).max(300),
+  comuna: z.string().min(2).max(100),
+  region: z.string().min(2).max(100),
+  email: z.string().email().optional(),
+});
+
+export type DteReceptor = z.infer<typeof dteReceptorSchema>;
+
+/**
+ * Input específico para Guía de Despacho. Incluye datos de transporte
+ * que la factura no tiene (origen, destino, vehículo, conductor).
+ */
+export const guiaDespachoInputSchema = z.object({
+  /** RUT del emisor (transportista o Booster como facturador). */
+  rutEmisor: rutSchema,
+  receptor: dteReceptorSchema,
+  /** Detalle de la mercadería transportada. */
+  items: z.array(dteLineItemSchema).min(1).max(60),
+  /** Origen del transporte. */
+  origen: z.object({
+    direccion: z.string().min(5).max(300),
+    comuna: z.string().min(2).max(100),
+  }),
+  /** Destino del transporte. */
+  destino: z.object({
+    direccion: z.string().min(5).max(300),
+    comuna: z.string().min(2).max(100),
+  }),
+  /** Patente del vehículo que transporta. */
+  patenteVehiculo: z.string().min(4).max(8),
+  /** RUT del transportista (si distinto del emisor). */
+  rutTransportista: rutSchema.optional(),
+  /** RUT del conductor. */
+  rutConductor: rutSchema,
+  /** ID interno opcional para idempotencia (deduplica reintentos). */
+  idempotencyKey: z.string().min(1).max(80).optional(),
+  /** Fecha de emisión (ISO 8601). Default = now() del adapter. */
+  fechaEmision: z.string().datetime().optional(),
+  /**
+   * Indicador de traslado de bienes (Tabla Indicador de Traslado del SII):
+   * 1=operación constituye venta, 2=ventas por efectuar, 3=consignaciones,
+   * 4=entrega gratuita, 5=traslados internos, 6=otros traslados no venta,
+   * 7=guía de devolución, 8=traslado para exportación, 9=venta para
+   * exportación.
+   */
+  indicadorTraslado: z.number().int().min(1).max(9).default(5),
+});
+
+export type GuiaDespachoInput = z.infer<typeof guiaDespachoInputSchema>;
+
+export const facturaInputSchema = z.object({
+  rutEmisor: rutSchema,
+  /** 33 = afecta a IVA, 34 = exenta. */
+  tipo: z.enum(['factura_33', 'factura_34']),
+  receptor: dteReceptorSchema,
+  items: z.array(dteLineItemSchema).min(1).max(60),
+  /** Si la factura asocia un viaje (referencia interna Booster). */
+  tripId: z.string().uuid().optional(),
+  /** Folio de la guía de despacho que sustenta la factura (cuando aplica). */
+  refFolioGuia: z.string().max(40).optional(),
+  idempotencyKey: z.string().min(1).max(80).optional(),
+  fechaEmision: z.string().datetime().optional(),
+});
+
+export type FacturaInput = z.infer<typeof facturaInputSchema>;
+
+/**
+ * Resultado de emitir un DTE: folio asignado por SII vía proveedor +
+ * track_id para consultar status. El XML firmado y el PDF visual los
+ * descarga el caller con `getXml(folio)` / `getPdf(folio)` en flujos
+ * separados (lazy: muchas veces no hace falta el XML inmediatamente).
+ */
+export const dteResultSchema = z.object({
+  folio: z.string().min(1).max(40),
+  type: dteTypeSchema,
+  rutEmisor: rutSchema,
+  /** Timestamp en que el provider asignó el folio. */
+  emittedAt: z.string().datetime(),
+  /** ID interno del provider (Paperless trackId, etc) para queries posteriores. */
+  providerRef: z.string().min(1).max(120),
+  /** URL al PDF visual (signed, expira). */
+  pdfUrl: z.string().url().optional(),
+  /** URL al XML firmado (signed, expira). */
+  xmlUrl: z.string().url().optional(),
+  /** Estado SII al momento de respuesta. Asíncrono — usar queryStatus para refresh. */
+  status: z.enum(['pendiente', 'aceptado', 'aceptado_con_reparos', 'rechazado']),
+});
+
+export type DteResult = z.infer<typeof dteResultSchema>;
+
+export const dteStatusSchema = z.object({
+  folio: z.string().min(1).max(40),
+  status: z.enum(['pendiente', 'aceptado', 'aceptado_con_reparos', 'rechazado']),
+  /** Mensaje del SII si rechazó (motivo). */
+  siiMessage: z.string().optional(),
+  /** Timestamp de la última actualización del estado. */
+  updatedAt: z.string().datetime(),
+});
+
+export type DteStatus = z.infer<typeof dteStatusSchema>;
+
+/**
+ * Error semántico. Discriminamos error de validación SII (rechazo
+ * legal — el DTE está mal formado o tiene datos inválidos para SII)
+ * vs error de transporte (proveedor caído, timeout, auth fallida).
+ */
+export class DteValidationError extends Error {
+  constructor(
+    public readonly siiCode: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DteValidationError';
+  }
+}
+
+export class DteProviderError extends Error {
+  constructor(
+    public readonly httpStatus: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DteProviderError';
+  }
+}

--- a/packages/dte-provider/tsconfig.json
+++ b/packages/dte-provider/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,7 +617,17 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/dte-provider:
+    dependencies:
+      '@booster-ai/shared-schemas':
+        specifier: workspace:*
+        version: link:../shared-schemas
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
+      '@types/node':
+        specifier: ^22.14.0
+        version: 22.19.17
       typescript:
         specifier: ^5.8.2
         version: 5.9.3


### PR DESCRIPTION
## Summary

**Sprint 1.3** — Cierra la decisión del proveedor DTE acreditado SII y entrega el package `dte-provider` listo para emitir Guías de Despacho (DTE 52) y Facturas (DTE 33/34) vía Paperless.

### ADR-015 — decisión

**Paperless** es el provider seleccionado (decisión Felipe 2026-05-04). Rationale:
- Pay-as-you-go aligned con TRL 9-10 piloto (vs plan mensual de Bsale)
- API DTE-first (vs ERP integral de Bsale, scope inflado)
- Curva de integración menor

Trade-off: pricing per-doc puede ser más caro a escala alta — re-evaluar al alcanzar volumen ≥1k DTEs/mes.

### Cambios

1. **`docs/adr/015-paperless-dte-provider.md`** — ADR completa con opciones evaluadas (Paperless, Bsale, Acepta, SovosChile), rationale, riesgos asumidos, configuración por env.

2. **`packages/dte-provider`** (placeholder → implementado):
   - `tipos.ts`: `DteType` (52/33/34), `DteLineItem`, `DteReceptor`, `GuiaDespachoInput` (con datos de transporte: origen, destino, patente, rutConductor, `indicadorTraslado` SII), `FacturaInput` (con `tipo` 33|34, `refFolioGuia` opcional), `DteResult`, `DteStatus`. Errors: `DteValidationError` (4xx, no retry) vs `DteProviderError` (5xx/network, retry-safe con `idempotencyKey`).
   - `dte-emitter.ts`: interface `DteEmitter` con `emitGuiaDespacho`, `emitFactura`, `queryStatus`.
   - `mock-adapter.ts`: in-memory determinístico para tests + dev local. Folios incrementales desde 1000, idempotencyMap, `failNext()` para simular fallos, `setStatus()` para simular cambios async SII.
   - `paperless-adapter.ts`: real adapter contra REST API Paperless. HTTP client inyectable (default = `fetch` nativo Node 22+). Mapping de inputs canónicos → payload Paperless. Headers Bearer auth + `Idempotency-Key`. 4xx → `DteValidationError`, 5xx → `DteProviderError`. **Calibración fina pendiente vs cuenta sandbox real (Sprint 1.4)**.
   - `factory.ts`: `createDteEmitter(config)` que selecciona adapter según env (mock / paperless).

### API

```typescript
import { createDteEmitter } from '@booster-ai/dte-provider';

const emitter = createDteEmitter({
  provider: 'paperless',
  apiKey: env.PAPERLESS_API_KEY,
  baseUrl: env.PAPERLESS_BASE_URL,  // sandbox o prod
});

const result = await emitter.emitGuiaDespacho({
  rutEmisor: '76543210-3',
  receptor: { rut, razonSocial, giro, direccion, comuna, region },
  items: [{ nombre, cantidad, unidad, precioUnitarioClp, exento }],
  origen: { direccion, comuna },
  destino: { direccion, comuna },
  patenteVehiculo: 'AB1234',
  rutConductor: '11111111-1',
  indicadorTraslado: 5,
  idempotencyKey: `gd-${tripId}`,
});

// → { folio, providerRef, pdfUrl, xmlUrl, status: 'pendiente'|'aceptado'|... }
```

## Evidencia

```
$ pnpm --filter @booster-ai/dte-provider typecheck
(clean)

$ pnpm --filter @booster-ai/dte-provider test
 Test Files  3 passed (3)
      Tests  29 passed (29)
```

29 tests:
- `mock-adapter.test.ts` (15): folio incremental, providerRef, status, idempotencia, RUT inválido, items vacíos, `failNext`, `queryStatus` con `setStatus`, factura 33/34.
- `paperless-adapter.test.ts` (10): POST endpoint, Bearer auth, parse response, mapping payload (`indicadorTraslado`, `transporte`), `idempotencyKey` header, 4xx → validation, 5xx → provider, `queryStatus` path + `mapStatus`, `refFolioGuia` en facturas.
- `factory.test.ts` (4): mock → MockAdapter, paperless → PaperlessAdapter, `timeoutMs` explícito vs default.

## Test plan

- [ ] Felipe abre cuenta sandbox Paperless y comparte API key + RUT emisor de prueba.
- [ ] (Sprint 1.4) Calibrar `PaperlessAdapter` contra API real — los nombres de campos del payload son inferidos de docs públicas; ajustes posibles.
- [ ] (Sprint 1.4) Smoke E2E: emitir 1 guía de despacho de prueba en sandbox, verificar folio asignado por SII, descargar XML firmado y validar firma.

## Pendiente Sprint 1.4

- Wireado `apps/api` con env `DTE_PROVIDER` + endpoint `POST /viajes/:id/guia-despacho` que orquesta `emitter.emitGuiaDespacho` + `documentIndexer.upload(type='dte_guia_despacho')`.
- `empresas.rut_emisor_dte` schema + migration (multi-tenant: cada empresa puede tener su propio RUT emisor de DTEs).
- `Terraform` Secret Manager para `PAPERLESS_API_KEY` por env.

## Riesgos

- **Calibración fina pendiente**: el shape del payload Paperless (nombres exactos de campos, paths) viene de docs públicas + conocimiento general DTE-SII. Espera ajustes al ejecutar contra sandbox real.
- **Single vendor dependency**: si Paperless tiene incidente, los DTEs pendientes quedan en cola hasta que vuelva. No hay failover automático. Mitigación documentada en ADR-015 (alerta + monitoreo).
- **Identidad de firma DTE**: a diferencia de cartas de porte y certificados ESG (firmados con KMS Booster), los DTEs usan el cert tributario del **RUT emisor real** (transportista). Paperless gestiona certs por RUT en su lado — Booster pasa el RUT en cada request. Configuración por empresa (`empresas.rut_emisor_dte`) queda para Sprint 1.4.

https://claude.ai/code/session_012KaaZERzTgbne8gUXAEnQt

---
_Generated by [Claude Code](https://claude.ai/code/session_012KaaZERzTgbne8gUXAEnQt)_