### PR TITLE
fix(cargas): valida ventana de pickup y dirección (BUG-001)

### DIFF
--- a/apps/api/test/unit/trip-requests-v2.test.ts
+++ b/apps/api/test/unit/trip-requests-v2.test.ts
@@ -61,25 +61,38 @@ function makeStubDb(insertedRow: Record<string, unknown>): Db {
   } as unknown as Db;
 }
 
-const validBody = {
-  origin: {
-    address_raw: 'Av. Apoquindo 5550',
-    region_code: 'XIII',
-  },
-  destination: {
-    address_raw: 'Concepción centro',
-    region_code: 'VIII',
-  },
-  cargo: {
-    cargo_type: 'carga_seca',
-    weight_kg: 1500,
-  },
-  pickup_window: {
-    start_at: '2026-05-05T08:00:00Z',
-    end_at: '2026-05-05T18:00:00Z',
-  },
-  proposed_price_clp: 250000,
-};
+/**
+ * Construye un body válido con fechas relativas a `now()` para que los
+ * tests no se invaliden con el paso del tiempo. La regla del schema exige
+ * `pickup_window.start_at >= now + 30min`; usamos `now + 24h` con holgura
+ * y `end_at = start_at + 10h` para una ventana razonable.
+ */
+function makeValidBody(overrides?: { startOffsetMs?: number; endOffsetMs?: number }) {
+  const now = Date.now();
+  const startMs = now + (overrides?.startOffsetMs ?? 24 * 60 * 60 * 1000);
+  const endMs = startMs + (overrides?.endOffsetMs ?? 10 * 60 * 60 * 1000);
+  return {
+    origin: {
+      address_raw: 'Av. Apoquindo 5550',
+      region_code: 'XIII',
+    },
+    destination: {
+      address_raw: 'Concepción centro',
+      region_code: 'VIII',
+    },
+    cargo: {
+      cargo_type: 'carga_seca',
+      weight_kg: 1500,
+    },
+    pickup_window: {
+      start_at: new Date(startMs).toISOString(),
+      end_at: new Date(endMs).toISOString(),
+    },
+    proposed_price_clp: 250000,
+  };
+}
+
+const validBody = makeValidBody();
 
 interface UserContextOpts {
   userId?: string;
@@ -203,6 +216,76 @@ describe('POST /trip-requests-v2', () => {
       body: JSON.stringify({ origin: 'incomplete' }),
     });
     expect(res.status).toBe(400);
+  });
+
+  // ---------------------------------------------------------------------
+  // BUG-001 — validación reforzada de pickup_window y direcciones.
+  // ---------------------------------------------------------------------
+  describe('validación de ventana de pickup y direcciones', () => {
+    async function postBody(body: unknown) {
+      const app = await buildAppWith({
+        db: makeStubDb({}),
+        userContext: buildUserContext(),
+      });
+      return app.request('/trip-requests-v2', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    }
+
+    it('rechaza dirección de origen con menos de 5 caracteres', async () => {
+      const body = makeValidBody();
+      body.origin.address_raw = 'abc'; // 3 caracteres
+      const res = await postBody(body);
+      expect(res.status).toBe(400);
+    });
+
+    it('rechaza dirección de destino con un solo carácter', async () => {
+      const body = makeValidBody();
+      body.destination.address_raw = '.';
+      const res = await postBody(body);
+      expect(res.status).toBe(400);
+    });
+
+    it('rechaza pickup_window.start_at en el pasado', async () => {
+      const body = makeValidBody({ startOffsetMs: -24 * 60 * 60 * 1000 }); // ayer
+      const res = await postBody(body);
+      expect(res.status).toBe(400);
+    });
+
+    it('rechaza pickup_window con start_at sin lead time mínimo (10 min en el futuro)', async () => {
+      const body = makeValidBody({ startOffsetMs: 10 * 60 * 1000 });
+      const res = await postBody(body);
+      expect(res.status).toBe(400);
+    });
+
+    it('rechaza pickup_window con end_at == start_at (ventana de 0 segundos)', async () => {
+      const body = makeValidBody();
+      body.pickup_window.end_at = body.pickup_window.start_at;
+      const res = await postBody(body);
+      expect(res.status).toBe(400);
+    });
+
+    it('rechaza pickup_window con end_at < start_at (ventana invertida)', async () => {
+      const now = Date.now();
+      const startMs = now + 24 * 60 * 60 * 1000; // mañana
+      const endMs = startMs - 4 * 60 * 60 * 1000; // 4h antes
+      const body = makeValidBody();
+      body.pickup_window.start_at = new Date(startMs).toISOString();
+      body.pickup_window.end_at = new Date(endMs).toISOString();
+      const res = await postBody(body);
+      expect(res.status).toBe(400);
+    });
+
+    it('rechaza pickup_window con duración mayor a 30 días', async () => {
+      const body = makeValidBody({
+        startOffsetMs: 24 * 60 * 60 * 1000,
+        endOffsetMs: 31 * 24 * 60 * 60 * 1000, // 31 días después de start
+      });
+      const res = await postBody(body);
+      expect(res.status).toBe(400);
+    });
   });
 
   it('happy path: crea trip, dispara matching, devuelve 201', async () => {

--- a/apps/web/src/routes/cargas.tsx
+++ b/apps/web/src/routes/cargas.tsx
@@ -1,3 +1,4 @@
+import { tripRequestCreateInputSchema } from '@booster-ai/shared-schemas';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import {
@@ -342,64 +343,65 @@ function CargasListPage({ me }: { me: MeOnboarded }) {
       {tripsQ.isLoading && <p className="mt-6 text-neutral-500">Cargando…</p>}
       {tripsQ.error && <p className="mt-6 text-danger-700">Error al cargar cargas.</p>}
 
-      {tripsQ.data && (() => {
-        // Split por estado: lo que sigue activo (shipper espera/seguimiento) vs
-        // historial (terminado, cancelado, sin match). Sin esto, el listado
-        // mezcla cargas vivas con basura vieja y se vuelve ruidoso a las
-        // pocas semanas de uso.
-        const ACTIVE_STATUSES = new Set<TripStatus>([
-          'borrador',
-          'esperando_match',
-          'emparejando',
-          'ofertas_enviadas',
-          'asignado',
-          'en_proceso',
-        ]);
-        const activas = tripsQ.data.filter((t) => ACTIVE_STATUSES.has(t.status));
-        const historial = tripsQ.data.filter((t) => !ACTIVE_STATUSES.has(t.status));
+      {tripsQ.data &&
+        (() => {
+          // Split por estado: lo que sigue activo (shipper espera/seguimiento) vs
+          // historial (terminado, cancelado, sin match). Sin esto, el listado
+          // mezcla cargas vivas con basura vieja y se vuelve ruidoso a las
+          // pocas semanas de uso.
+          const ACTIVE_STATUSES = new Set<TripStatus>([
+            'borrador',
+            'esperando_match',
+            'emparejando',
+            'ofertas_enviadas',
+            'asignado',
+            'en_proceso',
+          ]);
+          const activas = tripsQ.data.filter((t) => ACTIVE_STATUSES.has(t.status));
+          const historial = tripsQ.data.filter((t) => !ACTIVE_STATUSES.has(t.status));
 
-        return (
-          <>
-            <section className="mt-6">
-              <h2 className="font-semibold text-neutral-900 text-lg">Cargas activas</h2>
-              <p className="mt-1 text-neutral-500 text-xs">
-                En proceso de match, asignadas o en ruta.
-              </p>
-              {activas.length === 0 ? (
-                <div className="mt-3 rounded-md border border-neutral-200 border-dashed bg-white p-10 text-center">
-                  <Package className="mx-auto h-10 w-10 text-neutral-400" aria-hidden />
-                  <p className="mt-3 font-medium text-neutral-900">No tienes cargas activas</p>
-                  <p className="mt-1 text-neutral-600 text-sm">
-                    Crea una carga para que el matching engine te conecte con transportistas
-                    disponibles.
-                  </p>
-                  <Link
-                    to="/app/cargas/nueva"
-                    className="mt-4 inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white"
-                  >
-                    <Plus className="h-4 w-4" aria-hidden />
-                    Crear carga
-                  </Link>
-                </div>
-              ) : (
-                <CargasTable trips={activas} />
-              )}
-            </section>
-
-            {historial.length > 0 && (
-              <section className="mt-10">
-                <h2 className="font-semibold text-neutral-900 text-lg">Historial</h2>
+          return (
+            <>
+              <section className="mt-6">
+                <h2 className="font-semibold text-lg text-neutral-900">Cargas activas</h2>
                 <p className="mt-1 text-neutral-500 text-xs">
-                  Cargas entregadas, canceladas o sin match.
+                  En proceso de match, asignadas o en ruta.
                 </p>
-                <div className="mt-3">
-                  <CargasTable trips={historial} showCertificateColumn />
-                </div>
+                {activas.length === 0 ? (
+                  <div className="mt-3 rounded-md border border-neutral-200 border-dashed bg-white p-10 text-center">
+                    <Package className="mx-auto h-10 w-10 text-neutral-400" aria-hidden />
+                    <p className="mt-3 font-medium text-neutral-900">No tienes cargas activas</p>
+                    <p className="mt-1 text-neutral-600 text-sm">
+                      Crea una carga para que el matching engine te conecte con transportistas
+                      disponibles.
+                    </p>
+                    <Link
+                      to="/app/cargas/nueva"
+                      className="mt-4 inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white"
+                    >
+                      <Plus className="h-4 w-4" aria-hidden />
+                      Crear carga
+                    </Link>
+                  </div>
+                ) : (
+                  <CargasTable trips={activas} />
+                )}
               </section>
-            )}
-          </>
-        );
-      })()}
+
+              {historial.length > 0 && (
+                <section className="mt-10">
+                  <h2 className="font-semibold text-lg text-neutral-900">Historial</h2>
+                  <p className="mt-1 text-neutral-500 text-xs">
+                    Cargas entregadas, canceladas o sin match.
+                  </p>
+                  <div className="mt-3">
+                    <CargasTable trips={historial} showCertificateColumn />
+                  </div>
+                </section>
+              )}
+            </>
+          );
+        })()}
     </Layout>
   );
 }
@@ -501,9 +503,7 @@ function DescargarCertificadoButton({
     mutationFn: descargarCertificadoDeViaje,
     onError: (err) => {
       if (err instanceof CertNotIssuedError) {
-        window.alert(
-          'El certificado todavía está generándose. Esperá unos segundos y reintentá.',
-        );
+        window.alert('El certificado todavía está generándose. Esperá unos segundos y reintentá.');
       } else if (err instanceof CertDisabledError) {
         window.alert('Los certificados están deshabilitados en este entorno.');
       } else {
@@ -610,14 +610,76 @@ function tripFormToBody(v: TripFormValues): Record<string, unknown> {
     },
     pickup_window: {
       // datetime-local devuelve "YYYY-MM-DDTHH:MM" sin TZ. Lo convertimos a
-      // ISO 8601 UTC vía Date (asume hora local del browser).
-      start_at: new Date(v.pickup_start_local).toISOString(),
-      end_at: new Date(v.pickup_end_local).toISOString(),
+      // ISO 8601 UTC vía Date (asume hora local del browser). Si el campo
+      // está vacío, `new Date('').toISOString()` lanza — el caller debe
+      // chequear antes de invocar este helper o catchear.
+      start_at: v.pickup_start_local ? new Date(v.pickup_start_local).toISOString() : '',
+      end_at: v.pickup_end_local ? new Date(v.pickup_end_local).toISOString() : '',
     },
     proposed_price_clp: v.proposed_price_clp.trim()
       ? Number.parseInt(v.proposed_price_clp, 10)
       : null,
   };
+}
+
+/**
+ * Mapeo entre el path de error que devuelve Zod y el `name` del field en el
+ * form. El schema usa estructura anidada (`origin.address_raw`) pero el form
+ * usa nombres planos (`origin_address_raw`) para simplificar el state.
+ */
+const SCHEMA_PATH_TO_FIELD: Record<string, keyof TripFormValues> = {
+  'origin.address_raw': 'origin_address_raw',
+  'origin.region_code': 'origin_region_code',
+  'destination.address_raw': 'destination_address_raw',
+  'destination.region_code': 'destination_region_code',
+  'cargo.cargo_type': 'cargo_type',
+  'cargo.weight_kg': 'cargo_weight_kg',
+  'cargo.volume_m3': 'cargo_volume_m3',
+  'cargo.description': 'cargo_description',
+  'pickup_window.start_at': 'pickup_start_local',
+  'pickup_window.end_at': 'pickup_end_local',
+  proposed_price_clp: 'proposed_price_clp',
+};
+
+type TripFieldErrors = Partial<Record<keyof TripFormValues, string>>;
+
+/**
+ * Valida el form contra el schema canónico y devuelve errores mapeados al
+ * `name` plano del form. Devuelve `null` si todo OK.
+ *
+ * Esto es defensa en profundidad: el servidor también valida el mismo
+ * schema. Pero la validación cliente da feedback inmediato y evita
+ * disparar el matching engine con datos basura.
+ */
+function validateTripForm(v: TripFormValues): TripFieldErrors | null {
+  // Si las fechas locales están vacías, marcamos error explícito antes de
+  // intentar parsearlas (un `new Date('')` da Invalid Date).
+  const earlyErrors: TripFieldErrors = {};
+  if (!v.pickup_start_local) {
+    earlyErrors.pickup_start_local = 'Selecciona una fecha y hora';
+  }
+  if (!v.pickup_end_local) {
+    earlyErrors.pickup_end_local = 'Selecciona una fecha y hora';
+  }
+  if (Object.keys(earlyErrors).length > 0) {
+    return earlyErrors;
+  }
+
+  const body = tripFormToBody(v);
+  const result = tripRequestCreateInputSchema.safeParse(body);
+  if (result.success) {
+    return null;
+  }
+
+  const errors: TripFieldErrors = {};
+  for (const issue of result.error.issues) {
+    const path = issue.path.join('.');
+    const field = SCHEMA_PATH_TO_FIELD[path];
+    if (field && !errors[field]) {
+      errors[field] = issue.message;
+    }
+  }
+  return errors;
 }
 
 function CargaNuevaPage({ me }: { me: MeOnboarded }) {
@@ -670,13 +732,30 @@ function TripForm({
   error: string | null;
 }) {
   const [values, setValues] = useState<TripFormValues>(EMPTY_FORM);
+  const [fieldErrors, setFieldErrors] = useState<TripFieldErrors>({});
 
   function update<K extends keyof TripFormValues>(key: K, val: TripFormValues[K]) {
     setValues((prev) => ({ ...prev, [key]: val }));
+    // Limpia el error del field al editarlo — feedback positivo sin
+    // re-validar todo el form en cada keystroke.
+    setFieldErrors((prev) => {
+      if (!prev[key]) {
+        return prev;
+      }
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
   }
 
   function handleSubmit(e: FormEvent) {
     e.preventDefault();
+    const errors = validateTripForm(values);
+    if (errors) {
+      setFieldErrors(errors);
+      return;
+    }
+    setFieldErrors({});
     onSubmit(values);
   }
 
@@ -688,7 +767,11 @@ function TripForm({
       <section>
         <h2 className="font-semibold text-lg text-neutral-900">Origen</h2>
         <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <Field label="Dirección de recogida *" htmlFor="origin_address_raw">
+          <Field
+            label="Dirección de recogida *"
+            htmlFor="origin_address_raw"
+            error={fieldErrors.origin_address_raw}
+          >
             <input
               id="origin_address_raw"
               type="text"
@@ -698,15 +781,21 @@ function TripForm({
               className={inputClass}
               placeholder="Av. Apoquindo 5550, Las Condes"
               maxLength={500}
+              aria-invalid={fieldErrors.origin_address_raw ? true : undefined}
             />
           </Field>
-          <Field label="Región *" htmlFor="origin_region_code">
+          <Field
+            label="Región *"
+            htmlFor="origin_region_code"
+            error={fieldErrors.origin_region_code}
+          >
             <select
               id="origin_region_code"
               required
               value={values.origin_region_code}
               onChange={(e) => update('origin_region_code', e.target.value as RegionCode | '')}
               className={inputClass}
+              aria-invalid={fieldErrors.origin_region_code ? true : undefined}
             >
               <option value="">— Seleccionar —</option>
               {REGION_OPTIONS.map((r) => (
@@ -722,7 +811,11 @@ function TripForm({
       <section>
         <h2 className="font-semibold text-lg text-neutral-900">Destino</h2>
         <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <Field label="Dirección de entrega *" htmlFor="destination_address_raw">
+          <Field
+            label="Dirección de entrega *"
+            htmlFor="destination_address_raw"
+            error={fieldErrors.destination_address_raw}
+          >
             <input
               id="destination_address_raw"
               type="text"
@@ -732,15 +825,21 @@ function TripForm({
               className={inputClass}
               placeholder="Concepción centro"
               maxLength={500}
+              aria-invalid={fieldErrors.destination_address_raw ? true : undefined}
             />
           </Field>
-          <Field label="Región *" htmlFor="destination_region_code">
+          <Field
+            label="Región *"
+            htmlFor="destination_region_code"
+            error={fieldErrors.destination_region_code}
+          >
             <select
               id="destination_region_code"
               required
               value={values.destination_region_code}
               onChange={(e) => update('destination_region_code', e.target.value as RegionCode | '')}
               className={inputClass}
+              aria-invalid={fieldErrors.destination_region_code ? true : undefined}
             >
               <option value="">— Seleccionar —</option>
               {REGION_OPTIONS.map((r) => (
@@ -756,13 +855,14 @@ function TripForm({
       <section>
         <h2 className="font-semibold text-lg text-neutral-900">Carga</h2>
         <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <Field label="Tipo de carga *" htmlFor="cargo_type">
+          <Field label="Tipo de carga *" htmlFor="cargo_type" error={fieldErrors.cargo_type}>
             <select
               id="cargo_type"
               required
               value={values.cargo_type}
               onChange={(e) => update('cargo_type', e.target.value as CargoType)}
               className={inputClass}
+              aria-invalid={fieldErrors.cargo_type ? true : undefined}
             >
               {(Object.keys(CARGO_TYPE_LABELS) as CargoType[]).map((t) => (
                 <option key={t} value={t}>
@@ -771,7 +871,7 @@ function TripForm({
               ))}
             </select>
           </Field>
-          <Field label="Peso (kg) *" htmlFor="cargo_weight_kg">
+          <Field label="Peso (kg) *" htmlFor="cargo_weight_kg" error={fieldErrors.cargo_weight_kg}>
             <input
               id="cargo_weight_kg"
               type="number"
@@ -781,9 +881,10 @@ function TripForm({
               value={values.cargo_weight_kg}
               onChange={(e) => update('cargo_weight_kg', e.target.value)}
               className={inputClass}
+              aria-invalid={fieldErrors.cargo_weight_kg ? true : undefined}
             />
           </Field>
-          <Field label="Volumen (m³)" htmlFor="cargo_volume_m3">
+          <Field label="Volumen (m³)" htmlFor="cargo_volume_m3" error={fieldErrors.cargo_volume_m3}>
             <input
               id="cargo_volume_m3"
               type="number"
@@ -792,10 +893,15 @@ function TripForm({
               value={values.cargo_volume_m3}
               onChange={(e) => update('cargo_volume_m3', e.target.value)}
               className={inputClass}
+              aria-invalid={fieldErrors.cargo_volume_m3 ? true : undefined}
             />
           </Field>
           <div className="sm:col-span-2">
-            <Field label="Descripción" htmlFor="cargo_description">
+            <Field
+              label="Descripción"
+              htmlFor="cargo_description"
+              error={fieldErrors.cargo_description}
+            >
               <textarea
                 id="cargo_description"
                 rows={2}
@@ -804,6 +910,7 @@ function TripForm({
                 className={inputClass}
                 maxLength={1000}
                 placeholder="Detalles relevantes para el transportista (opcional)"
+                aria-invalid={fieldErrors.cargo_description ? true : undefined}
               />
             </Field>
           </div>
@@ -813,7 +920,11 @@ function TripForm({
       <section>
         <h2 className="font-semibold text-lg text-neutral-900">Ventana de pickup</h2>
         <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <Field label="Desde *" htmlFor="pickup_start_local">
+          <Field
+            label="Desde *"
+            htmlFor="pickup_start_local"
+            error={fieldErrors.pickup_start_local}
+          >
             <input
               id="pickup_start_local"
               type="datetime-local"
@@ -821,9 +932,10 @@ function TripForm({
               value={values.pickup_start_local}
               onChange={(e) => update('pickup_start_local', e.target.value)}
               className={inputClass}
+              aria-invalid={fieldErrors.pickup_start_local ? true : undefined}
             />
           </Field>
-          <Field label="Hasta *" htmlFor="pickup_end_local">
+          <Field label="Hasta *" htmlFor="pickup_end_local" error={fieldErrors.pickup_end_local}>
             <input
               id="pickup_end_local"
               type="datetime-local"
@@ -831,6 +943,7 @@ function TripForm({
               value={values.pickup_end_local}
               onChange={(e) => update('pickup_end_local', e.target.value)}
               className={inputClass}
+              aria-invalid={fieldErrors.pickup_end_local ? true : undefined}
             />
           </Field>
         </div>
@@ -839,7 +952,11 @@ function TripForm({
       <section>
         <h2 className="font-semibold text-lg text-neutral-900">Precio</h2>
         <div className="mt-3 grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <Field label="Precio sugerido (CLP)" htmlFor="proposed_price_clp">
+          <Field
+            label="Precio sugerido (CLP)"
+            htmlFor="proposed_price_clp"
+            error={fieldErrors.proposed_price_clp}
+          >
             <input
               id="proposed_price_clp"
               type="number"
@@ -848,6 +965,7 @@ function TripForm({
               onChange={(e) => update('proposed_price_clp', e.target.value)}
               className={inputClass}
               placeholder="Dejar vacío si querés que pricing-engine sugiera"
+              aria-invalid={fieldErrors.proposed_price_clp ? true : undefined}
             />
           </Field>
         </div>
@@ -1042,9 +1160,7 @@ function CargaDetallePage({ me }: { me: MeOnboarded }) {
                 latitude={tripQ.data.assignment.ubicacion_actual?.latitude ?? null}
                 longitude={tripQ.data.assignment.ubicacion_actual?.longitude ?? null}
                 speedKmh={tripQ.data.assignment.ubicacion_actual?.speed_kmh ?? null}
-                timestampDevice={
-                  tripQ.data.assignment.ubicacion_actual?.timestamp_device ?? null
-                }
+                timestampDevice={tripQ.data.assignment.ubicacion_actual?.timestamp_device ?? null}
                 height={480}
               />
             </DataCard>
@@ -1163,7 +1279,7 @@ function CargaDetallePage({ me }: { me: MeOnboarded }) {
                 )}
                 {!tripQ.data.metrics.certificate_issued_at &&
                   tripQ.data.trip_request.status === 'entregado' && (
-                    <div className="sm:col-span-2 rounded-md bg-amber-50 px-3 py-2 text-amber-900 text-xs">
+                    <div className="rounded-md bg-amber-50 px-3 py-2 text-amber-900 text-xs sm:col-span-2">
                       Generando certificado de huella de carbono. Recargá en unos segundos.
                     </div>
                   )}
@@ -1275,18 +1391,26 @@ function NoShipperPermission() {
 function Field({
   label,
   htmlFor,
+  error,
   children,
 }: {
   label: string;
   htmlFor: string;
+  error?: string | undefined;
   children: ReactNode;
 }) {
+  const errorId = error ? `${htmlFor}-error` : undefined;
   return (
     <div>
       <label htmlFor={htmlFor} className="block font-medium text-neutral-700 text-sm">
         {label}
       </label>
       <div className="mt-1">{children}</div>
+      {error && (
+        <p id={errorId} role="alert" className="mt-1 text-danger-600 text-sm">
+          {error}
+        </p>
+      )}
     </div>
   );
 }

--- a/packages/shared-schemas/src/trip-request-create.ts
+++ b/packages/shared-schemas/src/trip-request-create.ts
@@ -16,38 +16,104 @@ import { regionCodeSchema } from './primitives/chile.js';
  * cubre la región origen". Slice posterior agregará comuna, distancia desde
  * base, ratings, historial.
  */
-export const tripRequestCreateInputSchema = z.object({
-  /** Origen — donde se recoge la carga. */
-  origin: z.object({
-    address_raw: z.string().min(1).max(500),
-    region_code: regionCodeSchema,
-    /** Código DPA INE de la comuna. Opcional para MVP — el matching no lo usa todavía. */
-    comuna_code: z.string().min(1).max(10).optional(),
-  }),
-  /** Destino — donde se entrega. */
-  destination: z.object({
-    address_raw: z.string().min(1).max(500),
-    region_code: regionCodeSchema,
-    comuna_code: z.string().min(1).max(10).optional(),
-  }),
-  cargo: z.object({
-    cargo_type: cargoTypeSchema,
-    /** Peso en kg. Filtra vehículos con capacidad menor. */
-    weight_kg: z.number().int().positive().max(100_000),
-    volume_m3: z.number().int().positive().max(200).optional(),
-    description: z.string().max(1_000).optional(),
-  }),
-  /**
-   * Ventana de pickup. El bot WhatsApp manda raw text; aquí esperamos ISO
-   * 8601 datetimes parseados por el cliente. Si solo hay fecha, ambos
-   * campos comparten valor (rango = día completo).
-   */
-  pickup_window: z.object({
-    start_at: z.string().datetime(),
-    end_at: z.string().datetime(),
-  }),
-  /** Precio sugerido por shipper en CLP. Null = pricing-engine sugiere. */
-  proposed_price_clp: z.number().int().nonnegative().nullable(),
-});
+
+/** Mínimo de caracteres para una dirección razonable (calle + altura o nombre). */
+const MIN_ADDRESS_LENGTH = 5;
+
+/**
+ * Lead time mínimo entre `start_at` y `now()`. 30 minutos da margen para
+ * matching + notificación a transportista, sin frustrar al shipper que
+ * está cargando algo "para ahora".
+ */
+const MIN_PICKUP_LEAD_MS = 30 * 60 * 1000;
+
+/**
+ * Ventana máxima entre `start_at` y `end_at`. 30 días es generoso para
+ * cargas planificadas; previene errores tipo "1 año" por typo.
+ */
+const MAX_PICKUP_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+
+const addressSchema = z.string().trim().min(MIN_ADDRESS_LENGTH).max(500);
+
+export const tripRequestCreateInputSchema = z
+  .object({
+    /** Origen — donde se recoge la carga. */
+    origin: z.object({
+      address_raw: addressSchema,
+      region_code: regionCodeSchema,
+      /** Código DPA INE de la comuna. Opcional para MVP — el matching no lo usa todavía. */
+      comuna_code: z.string().min(1).max(10).optional(),
+    }),
+    /** Destino — donde se entrega. */
+    destination: z.object({
+      address_raw: addressSchema,
+      region_code: regionCodeSchema,
+      comuna_code: z.string().min(1).max(10).optional(),
+    }),
+    cargo: z.object({
+      cargo_type: cargoTypeSchema,
+      /** Peso en kg. Filtra vehículos con capacidad menor. */
+      weight_kg: z.number().int().positive().max(100_000),
+      volume_m3: z.number().int().positive().max(200).optional(),
+      description: z.string().max(1_000).optional(),
+    }),
+    /**
+     * Ventana de pickup. El bot WhatsApp manda raw text; aquí esperamos ISO
+     * 8601 datetimes parseados por el cliente. Si solo hay fecha, ambos
+     * campos comparten valor (rango = día completo).
+     *
+     * Reglas adicionales (`superRefine` abajo):
+     *   - `start_at` debe ser futuro con margen (`MIN_PICKUP_LEAD_MS`).
+     *   - `end_at` debe ser estrictamente posterior a `start_at`.
+     *   - El rango total no puede exceder `MAX_PICKUP_WINDOW_MS` (30 días).
+     */
+    pickup_window: z.object({
+      start_at: z.string().datetime(),
+      end_at: z.string().datetime(),
+    }),
+    /** Precio sugerido por shipper en CLP. Null = pricing-engine sugiere. */
+    proposed_price_clp: z.number().int().nonnegative().nullable(),
+  })
+  .superRefine((data, ctx) => {
+    const startMs = Date.parse(data.pickup_window.start_at);
+    const endMs = Date.parse(data.pickup_window.end_at);
+
+    // Z.string().datetime() ya validó formato; parseInt no debería fallar.
+    if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+      return;
+    }
+
+    if (startMs <= Date.now() + MIN_PICKUP_LEAD_MS - 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['pickup_window', 'start_at'],
+        message: 'La ventana debe empezar al menos 30 minutos en el futuro',
+      });
+    }
+
+    if (endMs <= startMs) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['pickup_window', 'end_at'],
+        message: '"Hasta" debe ser estrictamente posterior a "Desde"',
+      });
+    } else if (endMs - startMs > MAX_PICKUP_WINDOW_MS) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['pickup_window', 'end_at'],
+        message: 'La ventana de pickup no puede exceder 30 días',
+      });
+    }
+  });
 
 export type TripRequestCreateInput = z.infer<typeof tripRequestCreateInputSchema>;
+
+/**
+ * Constantes exportadas para que el cliente (form) muestre el mismo
+ * mensaje y el mismo lead-time sin duplicar lógica.
+ */
+export const TRIP_REQUEST_CREATE_LIMITS = {
+  MIN_ADDRESS_LENGTH,
+  MIN_PICKUP_LEAD_MS,
+  MAX_PICKUP_WINDOW_MS,
+} as const;


### PR DESCRIPTION
## Resumen

Cierra **BUG-001** detectado en la auditoría QA del 2026-05-04 (ver
[`docs/playbooks/001-cargas-validacion.md`](https://github.com/boosterchile/booster-ai/blob/docs/fix-playbooks/docs/playbooks/001-cargas-validacion.md)).

El form de Crear carga aceptaba silenciosamente cargas con ventanas de
pickup imposibles (Hasta < Desde, ventana 0 s, en el pasado, 1 año) y
direcciones de 1 carácter. El `matching engine` real se disparaba con
datos basura, generando ofertas a transportistas reales con ventanas
imposibles.

## Cambios

### `packages/shared-schemas/src/trip-request-create.ts`

4 reglas nuevas en el schema canónico:
- `origin/destination.address_raw`: `minLength: 5` (antes 1).
- `pickup_window.start_at` ≥ `now() + 30 min`.
- `pickup_window.end_at > start_at` (estricto).
- `pickup_window`: rango ≤ 30 días.

Las reglas se exportan en una constante `TRIP_REQUEST_CREATE_LIMITS`
para que el cliente pueda referenciar los mismos números sin duplicar
lógica.

### `apps/api` — endpoint

Ningún cambio: `zValidator` existente aplica el schema actualizado
automáticamente. Defensa en profundidad ✓.

### `apps/web/src/routes/cargas.tsx` — form

- Importa `tripRequestCreateInputSchema` y corre `safeParse` en el
  submit (cliente).
- Mapea paths anidados (`origin.address_raw`) a los nombres planos del
  form (`origin_address_raw`).
- Muestra cada error inline bajo el field correspondiente con
  `role="alert"` y `aria-invalid`.
- Limpia el error del field al editarlo (mejor UX).

> **Nota**: el form sigue usando `useState` manual en vez de
> `react-hook-form`. Una migración a RHF está fuera de scope acá; la
> validación con `safeParse` da el feedback inmediato que necesitamos
> sin refactor grande.

## Tests

### Nuevos casos en `apps/api/test/unit/trip-requests-v2.test.ts`

Todos esperan `400`:
- dirección de origen < 5 chars
- dirección de destino con un solo carácter
- pickup en el pasado
- pickup con lead time insuficiente (10 min)
- end_at == start_at (ventana 0 s)
- end_at < start_at (ventana invertida)
- duración > 30 días

`validBody` se refactorizó a `makeValidBody()` con fechas relativas
a `Date.now()` para evitar tests flaky.

### Verificación local

- `tsc --noEmit` en `shared-schemas`, `api`, `web`: exit 0.
- `biome check`: sin errores nuevos en mis archivos.
- Script standalone con tsx contra el schema: **7/7 casos pass**
  (1 happy path + 6 inválidos).

## Test plan

- [ ] Pasada manual en `/app/cargas/nueva`:
  - [ ] Submit con todo OK → crea carga, redirige a detalle.
  - [ ] Hasta < Desde → error inline bajo "Hasta", botón sigue clickeable
        pero no avanza.
  - [ ] Hasta == Desde → idem.
  - [ ] Desde en pasado → error inline bajo "Desde".
  - [ ] Origen "abc" → error inline bajo dirección.
  - [ ] Submit del API con curl directo (defensa en profundidad).
- [ ] CI: ver tests del API pass (los 7 casos nuevos).

## Bonus drive-by

`biome --write --unsafe` normaliza el orden de classes Tailwind en 4
líneas preexistentes del mismo archivo (regla `useSortedClasses` que
el pre-commit hook enforza). Sin cambio de comportamiento.

## Referencias

- Playbook: `docs/playbooks/001-cargas-validacion.md` (en branch
  `docs/fix-playbooks`).
- Issue: `docs/playbooks/issues/001-cargas-validacion.md`.
- Test de regresión Playwright: `tests/bugs/cargas-validation.spec.ts`
  en la suite QA externa (5 casos que reproducen los bugs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
