### PR TITLE
chore(docker): bump base node 22-alpine → 24-alpine LTS en 6 Dockerfiles

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -4,7 +4,7 @@
 # `pnpm deploy --prod` produce un árbol auto-contenido en /prod/api con
 # flat node_modules — evita el ERR_MODULE_NOT_FOUND cuando pnpm deja
 # paquetes sólo bajo node_modules/.pnpm/<pkg>/...
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
@@ -36,7 +36,7 @@ FROM build AS deploy
 RUN pnpm --filter=@booster-ai/api --prod deploy /prod/api
 
 # --- runtime stage ---
-FROM node:22-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup -S booster && adduser -S booster -G booster

--- a/apps/sms-fallback-gateway/Dockerfile
+++ b/apps/sms-fallback-gateway/Dockerfile
@@ -3,7 +3,7 @@
 # Patrón idéntico al de apps/whatsapp-bot/Dockerfile (mismo stack: Hono +
 # tsup + workspace deps config/logger/shared-schemas + pnpm deploy
 # auto-contenido). Los 3 stages son: deps → build → deploy → runtime.
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
@@ -26,7 +26,7 @@ FROM build AS deploy
 RUN pnpm --filter=@booster-ai/sms-fallback-gateway --prod deploy /prod/svc
 
 # --- runtime stage ---
-FROM node:22-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup -S booster && adduser -S booster -G booster

--- a/apps/telemetry-processor/Dockerfile
+++ b/apps/telemetry-processor/Dockerfile
@@ -4,7 +4,7 @@
 # Cloud Run alcanza para esto (no requiere TCP persistente como el
 # gateway). Health probe HTTP /health para liveness.
 
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
@@ -23,7 +23,7 @@ RUN pnpm --filter @booster-ai/telemetry-processor build
 FROM build AS deploy
 RUN pnpm --filter=@booster-ai/telemetry-processor --prod deploy /prod/processor
 
-FROM node:22-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 COPY --from=deploy /prod/processor/dist ./dist
 COPY --from=deploy /prod/processor/node_modules ./node_modules

--- a/apps/telemetry-tcp-gateway/Dockerfile
+++ b/apps/telemetry-tcp-gateway/Dockerfile
@@ -8,7 +8,7 @@
 # `pnpm deploy --prod` produce un árbol auto-contenido con flat
 # node_modules para evitar ERR_MODULE_NOT_FOUND.
 
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
@@ -32,7 +32,7 @@ FROM build AS deploy
 RUN pnpm --filter=@booster-ai/telemetry-tcp-gateway --prod deploy /prod/gateway
 
 # --- runtime stage ---
-FROM node:22-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 COPY --from=deploy /prod/gateway/dist ./dist
 COPY --from=deploy /prod/gateway/node_modules ./node_modules

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -11,7 +11,7 @@
 # por diseño. La seguridad la dan las Firebase Security Rules + el dominio
 # autorizado en Firebase Auth Settings.
 
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 

--- a/apps/whatsapp-bot/Dockerfile
+++ b/apps/whatsapp-bot/Dockerfile
@@ -8,7 +8,7 @@
 #     cualquier paquete que pnpm normalmente deja sólo en
 #     /app/node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>.
 #   - stage `runtime` solo copia /prod/bot → imagen minimal.
-FROM node:22-alpine AS base
+FROM node:24-alpine AS base
 RUN corepack enable && corepack prepare pnpm@latest --activate
 WORKDIR /app
 
@@ -32,7 +32,7 @@ FROM build AS deploy
 RUN pnpm --filter=@booster-ai/whatsapp-bot --prod deploy /prod/bot
 
 # --- runtime stage ---
-FROM node:22-alpine AS runtime
+FROM node:24-alpine AS runtime
 WORKDIR /app
 ENV NODE_ENV=production
 RUN addgroup -S booster && adduser -S booster -G booster


### PR DESCRIPTION
## Summary

Cierra #5 y #3 (Dependabot proponía bump 22 → 25, **NO LTS**, EOL oct 2026).

| Path | Before | After |
|---|---|---|
| apps/api/Dockerfile | node:22-alpine | **node:24-alpine** |
| apps/sms-fallback-gateway/Dockerfile | node:22-alpine | **node:24-alpine** |
| apps/telemetry-processor/Dockerfile | node:22-alpine | **node:24-alpine** |
| apps/telemetry-tcp-gateway/Dockerfile | node:22-alpine | **node:24-alpine** |
| apps/web/Dockerfile | node:22-alpine | **node:24-alpine** |
| apps/whatsapp-bot/Dockerfile | node:22-alpine | **node:24-alpine** |

## ¿Por qué 24 y no 25?

| Versión | Status | EOL |
|---|---|---|
| Node 22 (current) | LTS | Apr 2027 |
| **Node 24** | **LTS activa hoy** | **Apr 2028** |
| Node 25 | Current, NO LTS | Oct 2026 |

Bumpear a 25 sería ir hacia atrás en estabilidad. 24 LTS extiende la ventana de soporte ~12 meses adicionales sin riesgo extra.

## Out of scope

Workflows CI/Security siguen en `node-version: '22'` — no tengo scope `workflow` en el PAT. PR separada alineará todo después.

## Test plan

- [ ] CI verde (build images, integration con Cloud Build)
- [ ] Smoke staging post-merge: API + web + whatsapp-bot levantan
- [ ] Cerrar #5, #3 como redundantes

🤖 Generated with [Claude Code](https://claude.com/claude-code)