### PR TITLE
chore(security): non-root user en 3 Dockerfiles (Trivy IaC AVD-DS-0002)

### DIFF
--- a/apps/telemetry-processor/Dockerfile
+++ b/apps/telemetry-processor/Dockerfile
@@ -25,11 +25,14 @@ RUN pnpm --filter=@booster-ai/telemetry-processor --prod deploy /prod/processor
 
 FROM node:24-alpine AS runtime
 WORKDIR /app
-COPY --from=deploy /prod/processor/dist ./dist
-COPY --from=deploy /prod/processor/node_modules ./node_modules
-COPY --from=deploy /prod/processor/package.json ./
+# Trivy IaC: ejecutar como non-root para mitigar container escape.
+RUN addgroup -S booster && adduser -S booster -G booster
+COPY --from=deploy --chown=booster:booster /prod/processor/dist ./dist
+COPY --from=deploy --chown=booster:booster /prod/processor/node_modules ./node_modules
+COPY --from=deploy --chown=booster:booster /prod/processor/package.json ./
 
 ENV NODE_ENV=production
+USER booster
 EXPOSE 8080
 
 CMD ["node", "dist/main.js"]

--- a/apps/telemetry-tcp-gateway/Dockerfile
+++ b/apps/telemetry-tcp-gateway/Dockerfile
@@ -34,11 +34,15 @@ RUN pnpm --filter=@booster-ai/telemetry-tcp-gateway --prod deploy /prod/gateway
 # --- runtime stage ---
 FROM node:24-alpine AS runtime
 WORKDIR /app
-COPY --from=deploy /prod/gateway/dist ./dist
-COPY --from=deploy /prod/gateway/node_modules ./node_modules
-COPY --from=deploy /prod/gateway/package.json ./
+# Trivy IaC: ejecutar como non-root para mitigar container escape.
+# Port 5027 > 1024 -> non-root puede bindearlo sin CAP_NET_BIND_SERVICE.
+RUN addgroup -S booster && adduser -S booster -G booster
+COPY --from=deploy --chown=booster:booster /prod/gateway/dist ./dist
+COPY --from=deploy --chown=booster:booster /prod/gateway/node_modules ./node_modules
+COPY --from=deploy --chown=booster:booster /prod/gateway/package.json ./
 
 ENV NODE_ENV=production
+USER booster
 EXPOSE 5027
 
 CMD ["node", "dist/main.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -46,32 +46,43 @@ ENV VITE_API_URL=$VITE_API_URL \
 COPY . .
 RUN pnpm --filter @booster-ai/web build
 
-# --- runtime stage: nginx-alpine sirviendo el bundle ---
-FROM nginx:1.27-alpine AS runtime
+# --- runtime stage: nginx-unprivileged sirviendo el bundle ---
+# Trivy IaC: nginxinc/nginx-unprivileged corre como user `nginx` (UID 101)
+# por defecto y bindea 8080 sin CAP_NET_BIND_SERVICE — non-root nativo.
+# Mismos paths que nginx:1.27-alpine (templates, conf.d, html) — drop-in.
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
 
-# Cloud Run inyecta PORT (por defecto 8080); nginx tiene que escuchar ahí.
+# Cloud Run inyecta PORT (por defecto 8080); nginx-unprivileged ya escucha
+# en 8080 nativo. Mantenemos la var para que envsubst la resuelva en
+# nginx.conf.template si está parametrizado.
 ENV PORT=8080
 
-# Borrar el default.conf que viene con nginx-alpine para evitar conflicto:
-# escucha en :80 (no permitido en Cloud Run) y puede competir con nuestra
-# config si el envsubst del entrypoint no procesa el template a tiempo.
+# Operaciones de setup requieren root (modificar /etc/nginx, /usr/share/nginx).
+# Volvemos a non-root antes del CMD.
+USER root
+
+# Borrar el default.conf que viene con la imagen para evitar conflicto con
+# nuestra config si el envsubst del entrypoint no procesa el template a tiempo.
 RUN rm -f /etc/nginx/conf.d/default.conf
 
-# Copiar nuestro template — el entrypoint de nginx-alpine ejecuta envsubst
-# sobre /etc/nginx/templates/*.template y deposita el resultado procesado
+# Copiar nuestro template — el entrypoint ejecuta envsubst sobre
+# /etc/nginx/templates/*.template y deposita el resultado procesado
 # (con $PORT resuelto) en /etc/nginx/conf.d/.
 COPY apps/web/nginx.conf.template /etc/nginx/templates/default.conf.template
 
 # Asegurar que /usr/share/nginx/html arranca limpio (sin index.html default
 # del image) y después poblar con el dist de Vite.
 RUN rm -rf /usr/share/nginx/html/* /usr/share/nginx/html/.[!.]*
-COPY --from=build /app/apps/web/dist/ /usr/share/nginx/html/
+COPY --from=build --chown=nginx:nginx /app/apps/web/dist/ /usr/share/nginx/html/
 
 # Sanity check al build: listar lo que quedó (sale en logs de Cloud Build).
 RUN echo '--- /usr/share/nginx/html ---' && ls -la /usr/share/nginx/html/ && \
     echo '--- head index.html ---' && head -5 /usr/share/nginx/html/index.html && \
     echo '--- /etc/nginx/conf.d ---' && ls -la /etc/nginx/conf.d/ && \
     echo '--- /etc/nginx/templates ---' && ls -la /etc/nginx/templates/
+
+# Volver a non-root para runtime.
+USER nginx
 
 # Cloud Run health check: la propia request del LB pega a / esperando 200.
 # nginx sirve index.html (200) por SPA fallback. Suficiente para liveness.


### PR DESCRIPTION
## Summary

Mitiga 3 findings HIGH del Trivy config scan: **"Image user should not be 'root'"** (AVD-DS-0002).

| Dockerfile | Fix |
|---|---|
| `apps/telemetry-processor/Dockerfile` | Add `USER booster` (mismo patrón que `apps/api`) |
| `apps/telemetry-tcp-gateway/Dockerfile` | Add `USER booster` (port 5027 > 1024 OK) |
| `apps/web/Dockerfile` | Switch base `nginx:1.27-alpine` → `nginxinc/nginx-unprivileged:1.27-alpine` |

## ¿Por qué nginx-unprivileged para web?

- Imagen oficial mantenida por Nginx Inc.
- Corre como `nginx` (UID 101) por defecto
- Escucha en **8080 nativo** (sin `CAP_NET_BIND_SERVICE`)
- Mismo entrypoint `/docker-entrypoint.d` → envsubst sigue funcionando
- Drop-in replacement: paths idénticos a la imagen estándar

## Out of scope (próximos PRs de hardening IaC)

- "Default security context configured" — ~6 K8s manifests
- "Root file system is not read-only" — ~2 K8s manifests
- "GKE Control Plane should not be publicly accessible" — `infrastructure/compute.tf`, `dr-region.tf`
- "Cloud Storage Bucket Versioning Disabled" — `infrastructure/storage.tf`

## Test plan

- [ ] CI verde (Cloud Build construye las 3 imágenes con USER non-root)
- [ ] Smoke staging post-merge: telemetry-processor `/health` 200, gateway TCP 5027 conecta, web sirve `index.html`
- [ ] Trivy en próxima run: 3 alerts HIGH "Image user should not be 'root'" cierran

🤖 Generated with [Claude Code](https://claude.com/claude-code)