### PR TITLE
chore(security): K8s securityContext + readOnlyRootFilesystem (Trivy IaC)

### DIFF
--- a/infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
+++ b/infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
@@ -50,8 +50,21 @@ spec:
         role: disaster-recovery
     spec:
       serviceAccountName: telemetry-gateway-sa
+      # Trivy IaC hardening: pod-level security defaults.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: gateway
+          # Trivy IaC hardening: container-level locked-down defaults.
+          # readOnlyRootFilesystem requiere emptyDir para /tmp (Node v8-cache).
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           # Imagen vive en Artifact Registry de southamerica-west1 — cross-region pull
           # desde us-central1. Hay latencia inicial al primer pull (~2-3s) pero el
           # caché del nodo lo evita en restarts subsiguientes. Crear repo separado en
@@ -98,6 +111,9 @@ spec:
             - name: tls-cert
               mountPath: /etc/tls
               readOnly: true
+            # /tmp writable para readOnlyRootFilesystem: true.
+            - name: tmp
+              mountPath: /tmp
           resources:
             requests:
               cpu: "500m"
@@ -128,6 +144,10 @@ spec:
           secret:
             secretName: telemetry-tls-cert
             optional: true
+        # /tmp writable (readOnlyRootFilesystem requiere mount aparte).
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
 ---
 # Service único en DR con dos puertos en la misma IP
 # `136.116.208.86` (Terraform output `dr_lb_ip`).

--- a/infrastructure/k8s/telemetry-tcp-gateway.yaml
+++ b/infrastructure/k8s/telemetry-tcp-gateway.yaml
@@ -45,8 +45,22 @@ spec:
         app: telemetry-tcp-gateway
     spec:
       serviceAccountName: telemetry-gateway-sa
+      # Trivy IaC hardening: pod-level security defaults.
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: gateway
+          # Trivy IaC hardening: container-level locked-down defaults.
+          # readOnlyRootFilesystem requiere emptyDir para /tmp (Node escribe
+          # v8-compile-cache + npm-related artefactos en startup).
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           # IMAGEN actualizada por Cloud Build con kubectl set image:
           #   kubectl set image deployment/telemetry-tcp-gateway \
           #     gateway=southamerica-west1-docker.pkg.dev/booster-ai-494222/containers/telemetry-tcp-gateway:$_COMMIT_SHA \
@@ -104,6 +118,9 @@ spec:
             - name: tls-cert
               mountPath: /etc/tls
               readOnly: true
+            # /tmp writable para readOnlyRootFilesystem: true (Node v8-cache).
+            - name: tmp
+              mountPath: /tmp
           resources:
             # GKE Autopilot solo permite ratios CPU:RAM específicos.
             # 0.5 CPU + 1Gi RAM es válido y suficiente para piloto.
@@ -145,6 +162,10 @@ spec:
           secret:
             secretName: telemetry-tls-cert
             optional: true
+        # /tmp writable (readOnlyRootFilesystem requiere mount aparte).
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

Mitiga 6 alerts HIGH del Trivy config scan en los 2 manifests del telemetry-tcp-gateway (primary + DR):

| Rule | Alerts |
|---|---|
| **AVD-KSV-0021** "Default security context configured" | #43, #46, #48, #51 |
| **AVD-KSV-0014** "Root file system is not read-only" | #46, #51 |

## Cambios aplicados

### Pod-level
\`\`\`yaml
securityContext:
  runAsNonRoot: true
  seccompProfile:
    type: RuntimeDefault
\`\`\`

### Container-level
\`\`\`yaml
securityContext:
  allowPrivilegeEscalation: false
  readOnlyRootFilesystem: true
  capabilities:
    drop: [ALL]
\`\`\`

### Volume `/tmp` writable
\`\`\`yaml
volumes:
  - name: tmp
    emptyDir:
      sizeLimit: 64Mi
\`\`\`

Necesario porque `readOnlyRootFilesystem: true` impide a Node escribir en /tmp (v8-compile-cache + pnpm artefactos en startup).

## Sin impacto funcional esperado

- Gateway sigue escuchando 5027/5061
- Cert-manager Secret se monta igual en /etc/tls (read-only)
- USER booster del Dockerfile (PR #52) ya satisface `runAsNonRoot: true`

## Test plan

- [ ] CI verde
- [ ] Smoke staging post-merge: gateway pod arranca sin CrashLoopBackOff
- [ ] Telemetry packets fluyen normalmente (TCP 5027 conecta y procesa)
- [ ] Trivy próxima run: 6 alerts cierran (69 → 63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)