### PR TITLE
fix(ci): hardcode Google Maps API key en cloudbuild.production.yaml

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,17 +1,18 @@
 # Gitleaks config para Booster AI.
 #
 # Hereda todas las reglas default de gitleaks (8.x) y añade allowlist para
-# las claves de Firebase web hardcodeadas en cloudbuild.production.yaml.
+# las claves "públicas por diseño" hardcodeadas en cloudbuild.production.yaml:
 #
-# Justificación: las Firebase Web API Keys NO son secretos. Viajan al cliente
-# en el bundle JavaScript por diseño — la seguridad la dan Firebase Security
-# Rules + el dominio autorizado en Firebase Auth Settings, no la confidencialidad
-# de la key. La doc oficial de Google lo dice explícitamente:
-# https://firebase.google.com/docs/projects/api-keys#api-keys-for-firebase-are-different
+#   - Firebase Web API Keys: protegidas por Firebase Security Rules + dominio
+#     autorizado en Firebase Auth Settings, no por confidencialidad de la key.
+#     https://firebase.google.com/docs/projects/api-keys#api-keys-for-firebase-are-different
+#   - Google Maps JS API Key: protegida por HTTP referrer restriction en GCP
+#     API Credentials (solo acepta requests desde app.boosterchile.com/*).
 #
-# El rationale completo del por qué se hardcodean también está documentado en
-# apps/web/Dockerfile y en el comentario de la sección `substitutions` de
-# cloudbuild.production.yaml.
+# Ambas viajan en el bundle JavaScript al cliente — son inevitablemente
+# públicas. El rationale completo del por qué se hardcodean también está
+# documentado en apps/web/Dockerfile y en los comentarios de la sección
+# `substitutions` de cloudbuild.production.yaml.
 #
 # Sin este allowlist, gitleaks dispara la regla `gcp-api-key` (que matchea
 # `AIza[0-9A-Za-z_-]{35}` — formato estándar de cualquier Google API key) y
@@ -23,7 +24,7 @@
 useDefault = true
 
 [allowlist]
-description = "Firebase web config públicas — no son secretos por diseño"
+description = "Firebase + Google Maps web keys — públicas por diseño"
 paths = [
   '''cloudbuild\.production\.yaml''',
 ]

--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -306,10 +306,15 @@ substitutions:
   _VITE_FIREBASE_STORAGE_BUCKET: booster-ai-494222.firebasestorage.app
   _VITE_FIREBASE_MESSAGING_SENDER_ID: '469283083998'
   _VITE_FIREBASE_APP_ID: '1:469283083998:web:6a872c7a366ca78a07144f'
-  # VITE_GOOGLE_MAPS_API_KEY queda vacío: el schema lo marca opcional y
-  # los mapas en /vehiculos/:id y /cargas/:id caen al fallback "no
-  # configurado". Setear cuando se aprovisione la API key de Maps.
-  _VITE_GOOGLE_MAPS_API_KEY: ''
+  # Google Maps JS API key — pública por diseño (viaja en el bundle al
+  # cliente). La seguridad la da el HTTP referrer restriction configurado
+  # en GCP API Credentials: solo se acepta desde https://app.boosterchile.com/*.
+  # Si una key sin restringir se filtra puede generar billing abuse; ésta
+  # tiene la restricción aplicada (revisar en GCP > APIs > Credentials >
+  # "Booster Maps - Web (PWA)" antes de rotar).
+  # Sin esta substitution los mapas en /vehiculos/:id y /cargas/:id caen
+  # al fallback "Mapa no disponible" del componente VehicleMap.
+  _VITE_GOOGLE_MAPS_API_KEY: AIzaSyAVy84hArL08alVL2JEGfNCgTSqu4eTyNg
 
 images:
   - ${_REGISTRY}/api:${_COMMIT_SHA}


### PR DESCRIPTION
## Resumen

Fix del bug en prod: \`app.boosterchile.com\` muestra **\"Mapa no disponible — La key de Google Maps no está configurada\"** en \`/vehiculos/:id\`, \`/cargas/:id\` y \`/cargas/:id/track\`.

## Causa raíz

El commit [\`6567867\`](../commit/6567867) hardcodeó las claves Firebase para destrabar el build (default \`''\` estaba abortando el bundle vía schema Zod) pero **dejó \`_VITE_GOOGLE_MAPS_API_KEY: ''\` vacío** con un comentario \"Setear cuando se aprovisione la API key de Maps\".

La key ya estaba aprovisionada desde el 2 may 2026 (\"Booster Maps - Web (PWA)\", restricted by HTTP referrer a \`app.boosterchile.com/*\`) y se usó en el deploy manual del fix anterior de mapas, pero cada build automático posterior regenera el bundle con la key vacía → el componente \`VehicleMap\` cae al fallback \"no configurada\" en cada deploy automático.

## Fix

1. **\`cloudbuild.production.yaml\`** — hardcodear la key con el mismo rationale que las Firebase keys: pública por diseño (viaja en el bundle), protegida por HTTP referrer restriction en GCP API Credentials, NO por confidencialidad.
2. **\`.gitleaks.toml\`** — actualizar descripción y comentario para reflejar que el allowlist por path ahora cubre tanto Firebase como Maps.

## Test plan post-deploy

- [ ] Abrir \`https://app.boosterchile.com/app/vehiculos/<id>\` con un vehículo con telemetría → mapa renderiza con la posición del vehículo (no fallback \"Mapa no disponible\")
- [ ] Drag/zoom + botón Recentrar (del fix anterior) deben seguir funcionando
- [ ] Mismo flujo en \`/app/cargas/:id/track\`

## Rollback

Si la key se filtra y hay billing abuse (improbable por el HTTP referrer restriction): rotar en GCP Console → APIs → Credentials → \"Booster Maps - Web (PWA)\" → regenerar key + actualizar este archivo + redeployar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)