### PR TITLE
chore(security): Cloud SQL Postgres logging flags (Trivy IaC #21-25)

### DIFF
--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -118,6 +118,33 @@ resource "google_sql_database_instance" "main" {
       value = "on"
     }
 
+    # Trivy IaC: logging granular para audit + troubleshooting (#21-25).
+    # Estos flags impactan tamano de logs en Cloud Logging — costo modesto
+    # en piloto, pero visible. Si en produccion crece mucho, considerar
+    # desactivar log_temp_files (el mas verboso) o subir el threshold.
+    database_flags {
+      name  = "log_checkpoints"
+      value = "on"
+    }
+    database_flags {
+      name  = "log_connections"
+      value = "on"
+    }
+    database_flags {
+      name  = "log_disconnections"
+      value = "on"
+    }
+    database_flags {
+      name  = "log_lock_waits"
+      value = "on"
+    }
+    database_flags {
+      # 0 = log todos los archivos temporales (consultas que spillan a disk).
+      # >0 = solo logs si tamano excede ese valor (en KB).
+      name  = "log_temp_files"
+      value = "0"
+    }
+
     insights_config {
       query_insights_enabled  = true
       query_string_length     = 1024


### PR DESCRIPTION
## Summary

Mitiga 5 alerts Medium del Trivy IaC scan en `infrastructure/data.tf:73`:

| Alert | Flag agregado |
|---|---|
| #25 logging of checkpoints | `log_checkpoints = on` |
| #24 logging of disconnections | `log_disconnections = on` |
| #23 logging of lock waits | `log_lock_waits = on` |
| #22 logging of connections | `log_connections = on` |
| #21 temporary file logging | `log_temp_files = 0` (todos) |

## Impacto

- **Cloud Logging cost**: crecimiento modesto en piloto. En prod, si crece mucho, `log_temp_files` es el primero a desactivar.
- **Downtime**: ninguno. HA regional (configurado en prod) maneja el restart del replica sin perceptible.

## Test plan

- [ ] CI verde
- [ ] `terraform plan` muestra `+ database_flags` × 5 sin recreación
- [ ] `terraform apply -target=google_sql_database_instance.main`
- [ ] Cloud Logging Postgres entries muestran `connection authenticated`, `checkpoint complete` etc
- [ ] Trivy próxima run: 5 alerts cierran (46 → 41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)