### PR TITLE
chore(security): VPC Flow Logs en 2 subnets (Trivy IaC #27, #31)

### DIFF
--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -30,6 +30,15 @@ resource "google_compute_subnetwork" "private" {
     range_name    = "gke-services"
     ip_cidr_range = "10.24.0.0/20"
   }
+
+  # Trivy IaC: VPC Flow Logs habilitados para audit + investigacion de
+  # incidentes (#27). Sampling 0.5 + 10-min aggregation reduce costos
+  # ~10x vs full sampling — suficiente para anomaly detection.
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
 }
 
 # VPC peering range para Cloud SQL privada

--- a/infrastructure/dr-region.tf
+++ b/infrastructure/dr-region.tf
@@ -45,6 +45,14 @@ resource "google_compute_subnetwork" "dr_private" {
   }
 
   private_ip_google_access = true
+
+  # Trivy IaC: VPC Flow Logs habilitados (#31). Mismos parametros que la
+  # subnet primary para consistencia (10-min agg + 0.5 sampling).
+  log_config {
+    aggregation_interval = "INTERVAL_10_MIN"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
+  }
 }
 
 resource "google_container_cluster" "telemetry_dr" {


### PR DESCRIPTION
## Summary

Mitiga 2 alerts Medium del Trivy IaC scan: **"Google Compute Subnetwork Logging Disabled"**.

| Subnet | Archivo |
|---|---|
| `booster-ai-private` (primary) | `infrastructure/data.tf:15` |
| `booster-ai-dr-private` (DR) | `infrastructure/dr-region.tf:27` |

Ambas reciben el mismo `log_config`:

\`\`\`hcl
log_config {
  aggregation_interval = "INTERVAL_10_MIN"
  flow_sampling        = 0.5
  metadata             = "INCLUDE_ALL_METADATA"
}
\`\`\`

**~10x más barato que el default** (1-min agg + 1.0 sampling), suficiente para anomaly detection.

## Costo estimado

~$5-10/mo combinado en piloto. Si crece, opciones de tunning:
- Bajar `flow_sampling` a 0.25
- Subir a `INTERVAL_15_MIN`

## Test plan

- [ ] CI verde
- [ ] `terraform plan` muestra `+ log_config` en ambas subnets
- [ ] `terraform apply -target=...` genera flow logs en Cloud Logging
- [ ] Trivy: 2 alerts cierran (46 → 44 visible, después también baja por SQL flags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)