### PR TITLE
chore(security): UID/GID 10001 en gateway (Trivy IaC AVD-KSV-0118)

### DIFF
--- a/apps/telemetry-tcp-gateway/Dockerfile
+++ b/apps/telemetry-tcp-gateway/Dockerfile
@@ -36,7 +36,9 @@ FROM node:24-alpine AS runtime
 WORKDIR /app
 # Trivy IaC: ejecutar como non-root para mitigar container escape.
 # Port 5027 > 1024 -> non-root puede bindearlo sin CAP_NET_BIND_SERVICE.
-RUN addgroup -S booster && adduser -S booster -G booster
+# UID/GID >= 10000 (AVD-KSV-0118) — coincide con runAsUser:10001 del K8s
+# pod-level securityContext y evita colisiones con UIDs reservados del SO.
+RUN addgroup -S -g 10001 booster && adduser -S -u 10001 -G booster booster
 COPY --from=deploy --chown=booster:booster /prod/gateway/dist ./dist
 COPY --from=deploy --chown=booster:booster /prod/gateway/node_modules ./node_modules
 COPY --from=deploy --chown=booster:booster /prod/gateway/package.json ./

--- a/infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
+++ b/infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
@@ -51,8 +51,13 @@ spec:
     spec:
       serviceAccountName: telemetry-gateway-sa
       # Trivy IaC hardening: pod-level security defaults.
+      # UID/GID 10001 coincide con el booster user del Dockerfile (>= 10000
+      # satisface AVD-KSV-0118).
       securityContext:
         runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
       containers:

--- a/infrastructure/k8s/telemetry-tcp-gateway.yaml
+++ b/infrastructure/k8s/telemetry-tcp-gateway.yaml
@@ -46,8 +46,13 @@ spec:
     spec:
       serviceAccountName: telemetry-gateway-sa
       # Trivy IaC hardening: pod-level security defaults.
+      # UID/GID 10001 coincide con el booster user del Dockerfile (>= 10000
+      # satisface AVD-KSV-0118; evita colisiones con UIDs reservados del SO).
       securityContext:
         runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
         seccompProfile:
           type: RuntimeDefault
       containers:


### PR DESCRIPTION
## Summary

Mitiga 3 alerts Low: **"Runs with UID/GID <= 10000"** (AVD-KSV-0118).

| Alert | Path |
|---|---|
| #82 UID | `k8s/telemetry-tcp-gateway.yaml:51` |
| #79 GID | `k8s/telemetry-tcp-gateway-dr.yaml:56` |
| #78 UID | `k8s/telemetry-tcp-gateway-dr.yaml:56` |

Cambios coordinados Dockerfile + K8s:

1. **Dockerfile** `apps/telemetry-tcp-gateway/Dockerfile`:
   ```diff
   - RUN addgroup -S booster && adduser -S booster -G booster
   + RUN addgroup -S -g 10001 booster && adduser -S -u 10001 -G booster booster
   ```

2. **K8s manifests** (gateway + DR) pod-level securityContext:
   ```yaml
   runAsUser: 10001
   runAsGroup: 10001
   fsGroup: 10001
   ```

## Sin impacto funcional

- USER booster en el container sigue siendo el mismo user lógico
- Sólo cambia el UID numérico de ~100 → 10001
- Cloud Build rebuilds la imagen en próximo deploy → kubelet match con el manifest

## Test plan

- [ ] CI verde
- [ ] Cloud Build builds gateway image con UID 10001
- [ ] kubectl rollout restart `deployment/telemetry-tcp-gateway` post-merge
- [ ] Pod arranca sin CrashLoopBackOff (UID 10001 lee /app/dist OK)
- [ ] Trivy próxima run: 3 alerts Low cierran

🤖 Generated with [Claude Code](https://claude.com/claude-code)