### PR TITLE
chore(security): HEALTHCHECK en 4 Dockerfiles (Trivy IaC AVD-DS-0026)

### DIFF
--- a/apps/telemetry-processor/Dockerfile
+++ b/apps/telemetry-processor/Dockerfile
@@ -35,4 +35,9 @@ ENV NODE_ENV=production
 USER booster
 EXPOSE 8080
 
+# Trivy IaC AVD-DS-0026: HEALTHCHECK requerido para detectar runtime issues.
+# Node http.get a /health del processor — Pub/Sub consumer expone health probe.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:8080/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+
 CMD ["node", "dist/main.js"]

--- a/apps/telemetry-tcp-gateway/Dockerfile
+++ b/apps/telemetry-tcp-gateway/Dockerfile
@@ -47,4 +47,11 @@ ENV NODE_ENV=production
 USER booster
 EXPOSE 5027
 
+# Trivy IaC AVD-DS-0026: HEALTHCHECK requerido. Gateway es TCP-only — usamos
+# net.connect a 127.0.0.1:5027 para validar que el server escucha. K8s
+# tcpSocket probe en el manifest hace lo mismo a nivel pod (Docker
+# HEALTHCHECK es cosmetic en GKE pero satisface Trivy + util en local).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('net').connect(5027,'127.0.0.1').on('connect',function(){this.end();process.exit(0)}).on('error',()=>process.exit(1))"
+
 CMD ["node", "dist/main.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -88,4 +88,8 @@ USER nginx
 # nginx sirve index.html (200) por SPA fallback. Suficiente para liveness.
 
 EXPOSE 8080
+# Trivy IaC AVD-DS-0026: HEALTHCHECK requerido. wget viene en nginx-alpine
+# por default; spider request a / valida que nginx sirve el index.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1
 CMD ["nginx", "-g", "daemon off;"]

--- a/apps/whatsapp-bot/Dockerfile
+++ b/apps/whatsapp-bot/Dockerfile
@@ -42,4 +42,8 @@ COPY --from=deploy --chown=booster:booster /prod/bot ./
 COPY --from=build --chown=booster:booster /app/apps/whatsapp-bot/dist ./dist
 USER booster
 EXPOSE 8080
+# Trivy IaC AVD-DS-0026: HEALTHCHECK requerido para detectar runtime issues.
+# Node http.get a /health — el container falla si el server no responde 200.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:8080/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 CMD ["node", "dist/main.js"]


### PR DESCRIPTION
## Summary

Mitiga 4 alerts Low: **"No HEALTHCHECK defined"** (AVD-DS-0026).

| Dockerfile | Probe | Port |
|---|---|---|
| `apps/whatsapp-bot` | node http GET /health | 8080 |
| `apps/telemetry-processor` | node http GET /health | 8080 |
| `apps/telemetry-tcp-gateway` | node net.connect | 5027 (TCP-only) |
| `apps/web` | wget --spider / | 8080 (nginx) |

Parámetros consistentes: `--interval=30s --timeout=5s --start-period=10s --retries=3`.

## Notas

- **Cloud Run / GKE**: HEALTHCHECK del Dockerfile es cosmetic (usan sus propios probes). Pero Trivy lo requiere y es útil en local docker testing.
- Para gateway TCP-only, usé `net.connect` en lugar de HTTP porque no expone HTTP.
- Para web, usé `wget` que viene en nginx-alpine.

## Test plan

- [ ] CI verde
- [ ] Cloud Build rebuilds las 4 imágenes con HEALTHCHECK
- [ ] `docker inspect <image> | grep -A5 Healthcheck` muestra el probe
- [ ] Trivy próxima run: 4 alerts Low cierran

🤖 Generated with [Claude Code](https://claude.com/claude-code)