### PR TITLE
chore(security): bastion SSH-block + HEALTHCHECK en api/sms-fallback-gw (3 alerts)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -48,4 +48,7 @@ COPY --from=build --chown=booster:booster /app/apps/api/dist ./dist
 COPY --from=build --chown=booster:booster /app/apps/api/drizzle ./drizzle
 USER booster
 EXPOSE 8080
+# Trivy IaC AVD-DS-0026: HEALTHCHECK requerido (#7).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:8080/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 CMD ["node", "dist/main.js"]

--- a/apps/sms-fallback-gateway/Dockerfile
+++ b/apps/sms-fallback-gateway/Dockerfile
@@ -34,4 +34,7 @@ COPY --from=deploy --chown=booster:booster /prod/svc ./
 COPY --from=build --chown=booster:booster /app/apps/sms-fallback-gateway/dist ./dist
 USER booster
 EXPOSE 8080
+# Trivy IaC AVD-DS-0026: HEALTHCHECK requerido (#8).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD node -e "require('http').get('http://localhost:8080/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 CMD ["node", "dist/main.js"]

--- a/infrastructure/modules/iap-bastion/main.tf
+++ b/infrastructure/modules/iap-bastion/main.tf
@@ -94,8 +94,12 @@ resource "google_compute_instance" "bastion" {
   }
 
   # OS Login para auth via IAM en lugar de SSH keys gestionadas en metadata.
+  # Trivy IaC AVD-GCP-0030: bloquear project-wide SSH keys aplicadas a esta
+  # instancia (#63). El bastion solo acepta IAP tunnel + IAM-OAuth (OS Login),
+  # nunca SSH keys del proyecto. Defense-in-depth si alguien agrega project keys.
   metadata = {
-    enable-oslogin = "TRUE"
+    enable-oslogin         = "TRUE"
+    block-project-ssh-keys = "TRUE"
   }
 
   metadata_startup_script = local.startup_script


### PR DESCRIPTION
## Summary

Mitiga 3 alerts del Trivy IaC scan:

| Alert | Severity | Path | Fix |
|---|---|---|---|
| #63 Disable project-wide SSH keys | Medium | `infrastructure/modules/iap-bastion/main.tf:97` | `block-project-ssh-keys = "TRUE"` |
| #7 No HEALTHCHECK | Low | `apps/api/Dockerfile` | `node http GET /health` probe |
| #8 No HEALTHCHECK | Low | `apps/sms-fallback-gateway/Dockerfile` | `node http GET /health` probe |

## Notas

- **Bastion**: defense-in-depth. Ya teníamos `enable-oslogin=TRUE`; agregar `block-project-ssh-keys` previene que alguien agregue project keys que se aplicarían a esta VM.
- **HEALTHCHECK** completa la cobertura de todos los servicios Node (este round agrega api + sms-fallback-gateway que faltaban en #59).

## Test plan

- [ ] CI verde
- [ ] `terraform plan` muestra `+ block-project-ssh-keys` en bastion metadata
- [ ] Cloud Build rebuilds api + sms-fallback-gateway con HEALTHCHECK
- [ ] Trivy próxima run: 3 alerts cierran (29 → 26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)