### PR TITLE
chore(security): CMEK en 3 buckets GCS + bastion boot disk (Trivy IaC)

### DIFF
--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -405,6 +405,9 @@ module "db_bastion" {
   subnet                = google_compute_subnetwork.private.self_link
   service_account_email = google_service_account.db_bastion.email
 
+  # Trivy IaC AVD-GCP-0040: CMEK para boot disk del bastion.
+  disk_encryption_kms_key_self_link = google_kms_crypto_key.compute_disk.id
+
   cloudsql_instance_connection_name = google_sql_database_instance.main.connection_name
 
   iap_users = local.db_iam_operators
@@ -412,4 +415,6 @@ module "db_bastion" {
   labels = {
     env = var.environment
   }
+
+  depends_on = [google_kms_crypto_key_iam_member.gce_disk_encrypter]
 }

--- a/infrastructure/modules/iap-bastion/main.tf
+++ b/infrastructure/modules/iap-bastion/main.tf
@@ -91,6 +91,17 @@ resource "google_compute_instance" "bastion" {
       size  = 10
       type  = "pd-standard"
     }
+
+    # Trivy IaC AVD-GCP-0040: CMEK para boot disk si se pasa la key. Usar
+    # disk_encryption_key (Customer-Managed via KMS) en lugar de
+    # disk_encryption_key_raw (Customer-Supplied que requiere manejar la
+    # key material en el cliente — operacionalmente caro).
+    dynamic "disk_encryption_key" {
+      for_each = var.disk_encryption_kms_key_self_link != null ? [var.disk_encryption_kms_key_self_link] : []
+      content {
+        kms_key_self_link = disk_encryption_key.value
+      }
+    }
   }
 
   # OS Login para auth via IAM en lugar de SSH keys gestionadas en metadata.

--- a/infrastructure/modules/iap-bastion/variables.tf
+++ b/infrastructure/modules/iap-bastion/variables.tf
@@ -33,6 +33,18 @@ variable "machine_type" {
   default     = "e2-micro"
 }
 
+variable "disk_encryption_kms_key_self_link" {
+  type        = string
+  description = <<-EOT
+    Self-link de la KMS crypto key para CMEK del boot disk del bastion.
+    Trivy IaC AVD-GCP-0040 ("VM disks should be encrypted with CMEK").
+    El SA de servicio de Compute Engine (service-PROJECT_NUMBER@compute-system.iam)
+    debe tener roles/cloudkms.cryptoKeyEncrypterDecrypter sobre esta key.
+    Pasar null para usar default Google-managed encryption.
+  EOT
+  default     = null
+}
+
 variable "service_account_email" {
   type        = string
   description = <<-EOT

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -110,6 +110,57 @@ resource "google_kms_crypto_key_iam_member" "gcs_encrypter" {
   member        = "serviceAccount:${data.google_storage_project_service_account.gcs.email_address}"
 }
 
+# Trivy IaC AVD-GCP-0066: CMEK para los buckets operacionales (uploads_raw,
+# public_assets, chat_attachments) que NO son de retencion legal como
+# documents. Una sola key compartida porque el caso de uso es el mismo
+# (cifrado en reposo de blobs operacionales) y simplifica IAM.
+# Si en el futuro algun bucket necesita audit isolation, separar.
+resource "google_kms_crypto_key" "storage_operational" {
+  name            = "storage-operational-cmek"
+  key_ring        = google_kms_key_ring.main.id
+  rotation_period = "7776000s" # 90 dias
+
+  version_template {
+    algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"
+    protection_level = "SOFTWARE"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_kms_crypto_key_iam_member" "gcs_encrypter_operational" {
+  crypto_key_id = google_kms_crypto_key.storage_operational.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${data.google_storage_project_service_account.gcs.email_address}"
+}
+
+# Trivy IaC AVD-GCP-0040: CMEK para boot disks de VMs (bastion). Compute
+# Engine usa el SA de servicio per-project para encryption.
+resource "google_kms_crypto_key" "compute_disk" {
+  name            = "compute-disk-cmek"
+  key_ring        = google_kms_key_ring.main.id
+  rotation_period = "7776000s" # 90 dias
+
+  version_template {
+    algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"
+    protection_level = "SOFTWARE"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+# Compute Engine system SA — necesario para que GCE pueda cifrar/descifrar
+# boot disks con la key (cuando bastion arranca o re-encrypts post-rotation).
+resource "google_kms_crypto_key_iam_member" "gce_disk_encrypter" {
+  crypto_key_id = google_kms_crypto_key.compute_disk.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${google_project.booster_ai.number}@compute-system.iam.gserviceaccount.com"
+}
+
 # =============================================================================
 # SECRET MANAGER — shells vacíos. Los valores se setean con gcloud:
 #   echo -n "value" | gcloud secrets versions add <name> --data-file=-

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -109,6 +109,11 @@ resource "google_storage_bucket" "uploads_raw" {
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
 
+  # Trivy IaC AVD-GCP-0066: CMEK con key operacional compartida.
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.storage_operational.id
+  }
+
   # Trivy IaC: versioning habilitado para recovery de delete accidental.
   # Lifecycle inmediato debajo limita costo extra de versiones archivadas.
   versioning {
@@ -150,6 +155,14 @@ resource "google_storage_bucket" "public_assets" {
   storage_class = "STANDARD"
 
   uniform_bucket_level_access = true
+
+  # Trivy IaC AVD-GCP-0066: CMEK con key operacional compartida.
+  # Aunque los assets son publicos (servidos al PWA), el cifrado en reposo
+  # con CMEK satisface compliance estandar y permite revocacion rapida via
+  # disable-key si se detecta exfiltracion.
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.storage_operational.id
+  }
 
   # Trivy IaC: versioning habilitado. Assets estáticos del sitio marketing
   # — versionado permite rollback rápido si subimos un asset roto.
@@ -222,6 +235,13 @@ resource "google_storage_bucket" "chat_attachments" {
 
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
+
+  # Trivy IaC AVD-GCP-0066: CMEK con key operacional compartida. Importante
+  # para chat attachments porque contiene PII (fotos del chat shipper-carrier).
+  # Disable-key en KMS revoca acceso instantaneo en caso de breach.
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.storage_operational.id
+  }
 
   # Trivy IaC: versioning habilitado para recovery de delete accidental
   # de fotos del chat. Versiones archivadas se purgan a los 7 días para


### PR DESCRIPTION
## Summary

Mitiga 4 alerts del Trivy IaC scan via 2 nuevas KMS crypto keys:

| Key | Cifra | Closes |
|---|---|---|
| `storage-operational-cmek` | uploads_raw + public_assets + chat_attachments | #69, #68, #67 |
| `compute-disk-cmek` | bastion boot disk | #64 |

Ambas con rotación 90 días. IAM grants:
- GCS service SA → encrypter/decrypter en `storage-operational-cmek`
- GCE compute-system SA → encrypter/decrypter en `compute-disk-cmek`

## ⚠️ Notas para `terraform apply`

1. **Buckets**: `encryption.default_kms_key_name` solo afecta **nuevos objects**. Los existentes siguen con default Google-managed key. Si compliance requiere re-encrypt completo: `gsutil rewrite`.

2. **Bastion boot disk**: SI requiere recreate (VM se reaprovisiona con CMEK desde cero). Downtime ~30s durante apply. Aceptable porque solo se usa on-demand.

## Test plan

- [ ] CI verde
- [ ] `terraform plan` muestra `+ kms_crypto_key`, `+ encryption` blocks, `+ disk_encryption_key`
- [ ] `terraform apply` crea las 2 keys + IAM bindings sin errores
- [ ] Trivy próxima run: 4 alerts cierran (26 → 22)
- [ ] Bastion arranca post-apply (test SSH via IAP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)