### PR TITLE
chore(security): override http-proxy-agent>=7 (cierra Trivy #3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "onlyBuiltDependencies": ["@biomejs/biome", "esbuild"],
     "overrides": {
       "crypto-js@<4.2.0": ">=4.2.0",
-      "fast-xml-builder@<1.1.7": ">=1.1.7"
+      "fast-xml-builder@<1.1.7": ">=1.1.7",
+      "http-proxy-agent@<7.0.0": ">=7.0.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   crypto-js@<4.2.0: '>=4.2.0'
   fast-xml-builder@<1.1.7: '>=1.1.7'
+  http-proxy-agent@<7.0.0: '>=7.0.0'
 
 importers:
 
@@ -3391,10 +3392,6 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
-  '@tootallnate/once@2.0.0':
-    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
-    engines: {node: '>= 10'}
-
   '@turbo/darwin-64@2.9.8':
     resolution: {integrity: sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA==}
     cpu: [x64]
@@ -4687,10 +4684,6 @@ packages:
 
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
-
-  http-proxy-agent@5.0.0:
-    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
-    engines: {node: '>= 6'}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -9792,8 +9785,6 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
-  '@tootallnate/once@2.0.0': {}
-
   '@turbo/darwin-64@2.9.8':
     optional: true
 
@@ -11250,14 +11241,6 @@ snapshots:
   html-entities@2.6.0: {}
 
   http-parser-js@0.5.10: {}
-
-  http-proxy-agent@5.0.0:
-    dependencies:
-      '@tootallnate/once': 2.0.0
-      agent-base: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -12773,7 +12756,7 @@ snapshots:
 
   teeny-request@9.0.0:
     dependencies:
-      http-proxy-agent: 5.0.0
+      http-proxy-agent: 7.0.2
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       stream-events: 1.0.5


### PR DESCRIPTION
## Summary

Mitiga **1 alert Low** del Trivy: `@tootallnate/once` DoS (#3).

Cadena vulnerable:
\`\`\`
@google-cloud/* → google-gax → retry-request → teeny-request → http-proxy-agent@5 → @tootallnate/once
\`\`\`

`http-proxy-agent@7.x` eliminó `@tootallnate/once`. Override en `package.json`:

\`\`\`json
"pnpm.overrides": {
  "http-proxy-agent@<7.0.0": ">=7.0.0"
}
\`\`\`

## Verificación local

- `pnpm-lock.yaml`: `@tootallnate/once` **removido** (0 occurrences)
- `pnpm --filter @booster-ai/api typecheck`: ✅ pass
- `pnpm audit --audit-level=high --prod`: 2 → 1 vuln (1 moderate residual)
- API compat: `http-proxy-agent@7.x` mantiene `HttpProxyAgent` constructor que `teeny-request@9` usa

## Test plan

- [ ] CI verde (lint, typecheck, test, build)
- [ ] Smoke staging post-merge: api conecta a Cloud Storage / KMS / PubSub OK
- [ ] Trivy próxima run: 1 alert Low cierra

🤖 Generated with [Claude Code](https://claude.com/claude-code)