### PR TITLE
chore(security): KSV-0125 + access_logs versioning + crash_traces logs (4 alerts)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -5,7 +5,7 @@
 # silenciosos. Revisar trimestralmente para validar que la razon sigue
 # vigente.
 
-# AVD-KSV-0019: "Restrict container images to trusted registries"
+# KSV-0125: "Restrict container images to trusted registries"
 #
 # Las imagenes de los manifests K8s vienen de Artifact Registry de GCP
 # (*.docker.pkg.dev). Trivy default policy no incluye AR en la allowlist,
@@ -18,4 +18,4 @@
 # Reabrir esta regla si:
 #   - Se introduce un registry externo (dockerhub, ghcr, etc.)
 #   - Se mueven a un AR cross-project
-AVD-KSV-0019
+KSV-0125

--- a/infrastructure/crash-traces.tf
+++ b/infrastructure/crash-traces.tf
@@ -73,6 +73,13 @@ resource "google_storage_bucket" "crash_traces" {
     default_kms_key_name = google_kms_crypto_key.crash_traces.id
   }
 
+  # Trivy IaC AVD-GCP-0002: access logs delivered al bucket dedicado.
+  # Critico para crash traces porque son evidencia legal (insurance claims).
+  logging {
+    log_bucket        = google_storage_bucket.access_logs.name
+    log_object_prefix = "crash-traces/"
+  }
+
   # Retention 7 años — requisito aseguradora + compliance forense.
   retention_policy {
     retention_period = 220752000 # 7 años en segundos = 7 * 365.25 * 24 * 3600

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -59,9 +59,29 @@ resource "google_storage_bucket" "access_logs" {
   uniform_bucket_level_access = true
   public_access_prevention    = "enforced"
 
+  # Trivy IaC AVD-GCP-0066: versioning para recovery de logs accidentalmente
+  # borrados. Critico porque los logs son evidencia forense — un atacante
+  # con write podria intentar borrar trazas (aunque las IAM bindings ya lo
+  # bloquean, defense-in-depth).
+  versioning {
+    enabled = true
+  }
+
   lifecycle_rule {
     condition {
       age = 90
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # Versiones archivadas (post-delete) -> 7 dias extra y borran. Suficiente
+  # para detectar y recuperar deletions accidentales sin acumular costo.
+  lifecycle_rule {
+    condition {
+      age        = 7
+      with_state = "ARCHIVED"
     }
     action {
       type = "Delete"


### PR DESCRIPTION
## Summary

Tres fixes Trivy IaC en una pasada:

| Fix | Cierra |
|---|---|
| `.trivyignore`: `AVD-KSV-0019` → `KSV-0125` (rule ID correcto) | #80, #84 (ignore) |
| `access_logs` bucket: versioning + ARCHIVED lifecycle 7d | #87 |
| `crash_traces` bucket: logging block → access_logs | #18 |

## ¿Por qué se reabrió KSV-0125?

PR #64 usé `AVD-KSV-0019` en `.trivyignore` pero al chequear el alert #84 en UI confirmé que el rule ID real es `KSV-0125`. La línea ignored estaba muerta. Esto lo arregla.

## Test plan

- [ ] CI verde
- [ ] Trivy próxima run: 4 alerts cierran (16 → 12)
- [ ] `terraform plan` muestra `+ versioning` en access_logs y `+ logging` en crash_traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)