### PR TITLE
chore(security): IAM user: -> group: migration (4 alerts AVD-GCP-0008)

### DIFF
--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -244,20 +244,30 @@ resource "google_sql_user" "iam_operators" {
   instance = google_sql_database_instance.main.name
   project  = google_project.booster_ai.project_id
   # Sin password: autenticación via IAM token.
+  #
+  # Trivy AVD-GCP-0008: este resource crea Postgres roles individuales que
+  # mapean a la identidad del operador (cloud-sql-proxy --auto-iam-authn
+  # autentica con OAuth token del user). API GCP NO acepta grupos aqui —
+  # cada miembro del engineers_group que necesite acceso DB se agrega
+  # manualmente a local.db_iam_operators. .trivyignore documenta que esta
+  # regla en este archivo es false-positive (Cloud SQL IAM API limit).
 }
 
-resource "google_project_iam_member" "db_iam_operators_client" {
-  for_each = toset(local.db_iam_operators)
-  project  = google_project.booster_ai.project_id
-  role     = "roles/cloudsql.client"
-  member   = "user:${each.value}"
+# Trivy AVD-GCP-0008: bindings a nivel proyecto migrados a engineers_group.
+# El cloud-sql-proxy de cada operador autentica con su OAuth token; la
+# membresia del grupo determina si el token es aceptado. Onboarding =
+# agregar miembro al grupo + 1 entry en local.db_iam_operators (sin
+# terraform apply). Offboarding inverso.
+resource "google_project_iam_member" "engineers_cloudsql_client" {
+  project = google_project.booster_ai.project_id
+  role    = "roles/cloudsql.client"
+  member  = "group:${var.engineers_group}"
 }
 
-resource "google_project_iam_member" "db_iam_operators_instanceuser" {
-  for_each = toset(local.db_iam_operators)
-  project  = google_project.booster_ai.project_id
-  role     = "roles/cloudsql.instanceUser"
-  member   = "user:${each.value}"
+resource "google_project_iam_member" "engineers_cloudsql_instanceuser" {
+  project = google_project.booster_ai.project_id
+  role    = "roles/cloudsql.instanceUser"
+  member  = "group:${var.engineers_group}"
 }
 
 # Guardar password en Secret Manager (rotación posterior vía otro flujo).
@@ -428,7 +438,9 @@ module "db_bastion" {
 
   cloudsql_instance_connection_name = google_sql_database_instance.main.connection_name
 
-  iap_users = local.db_iam_operators
+  # Trivy AVD-GCP-0008: bastion IAP + osLogin via grupo engineers@.
+  # Onboarding/offboarding sin terraform apply (se gestiona en Workspace).
+  iap_principals = ["group:${var.engineers_group}"]
 
   labels = {
     env = var.environment

--- a/infrastructure/modules/iap-bastion/main.tf
+++ b/infrastructure/modules/iap-bastion/main.tf
@@ -186,26 +186,29 @@ resource "google_compute_firewall" "iap_postgres" {
 # bastion necesita ver Cloud SQL en su rango de VPC peering.
 # (No se crea regla — la default cubre.)
 
-# IAM: cada operador puede tunelar via IAP a este bastion.
+# IAM: principals (users/groups) pueden tunelar via IAP a este bastion.
+# Trivy AVD-GCP-0008: var.iap_principals acepta full IAM members con
+# prefijo (user:..., group:..., serviceAccount:...) — caller en data.tf
+# pasa group:engineers@boosterchile.com en lugar de user emails sueltos.
 resource "google_iap_tunnel_instance_iam_member" "operators" {
-  for_each = toset(var.iap_users)
+  for_each = toset(var.iap_principals)
 
   project  = var.project_id
   zone     = var.zone
   instance = google_compute_instance.bastion.name
 
   role   = "roles/iap.tunnelResourceAccessor"
-  member = "user:${each.value}"
+  member = each.value
 }
 
-# OS Login: cada operador puede iniciar sesion SSH (necesario aunque solo
-# tunelemos TCP — IAP usa el canal SSH como transporte).
+# OS Login: principals (users/groups) pueden iniciar sesion SSH (necesario
+# aunque solo tunelemos TCP — IAP usa el canal SSH como transporte).
 resource "google_project_iam_member" "os_login_users" {
-  for_each = toset(var.iap_users)
+  for_each = toset(var.iap_principals)
 
   project = var.project_id
   role    = "roles/compute.osLogin"
-  member  = "user:${each.value}"
+  member  = each.value
 }
 
 output "name" {

--- a/infrastructure/modules/iap-bastion/variables.tf
+++ b/infrastructure/modules/iap-bastion/variables.tf
@@ -69,12 +69,20 @@ variable "cloudsql_instance_connection_name" {
   EOT
 }
 
-variable "iap_users" {
+variable "iap_principals" {
   type        = list(string)
   description = <<-EOT
-    Lista de emails (sin prefijo "user:") con permiso de tunelar via IAP.
-    Cada uno necesita: roles/iap.tunnelResourceAccessor sobre el proyecto y
-    roles/compute.instanceAdmin.v1 (o más restrictivo: osLogin) sobre la VM.
+    Lista de IAM members (con prefijo) con permiso de tunelar via IAP.
+    Acepta:
+      - "user:operator@example.com"
+      - "group:engineers@example.com"   (preferido — Trivy AVD-GCP-0008)
+      - "serviceAccount:sa@project.iam.gserviceaccount.com"
+
+    Cada principal recibe: roles/iap.tunnelResourceAccessor sobre la VM y
+    roles/compute.osLogin sobre el proyecto.
+
+    Migracion 2026-05-09: variable renombrada de `iap_users` (que asumia
+    prefijo user:) a `iap_principals` para soportar grupos.
   EOT
   default     = []
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -69,13 +69,60 @@ variable "domain" {
 }
 
 # -----------------------------------------------------------------------------
-# Identidad humana — owners del proyecto (ADR-010 Booster 2.0: IAM via IaC)
+# Identidad humana — Workspace groups (ADR-010 + Trivy IaC AVD-GCP-0008)
 # -----------------------------------------------------------------------------
+# Migracion 2026-05-09: bindings IAM a nivel proyecto se asignan a grupos
+# Workspace en lugar de users individuales. Beneficios:
+# - Trivy "IAM granted directly to user" cierra (best practice de scaling)
+# - Onboarding/offboarding de un dev = agregar/quitar miembro del grupo,
+#   sin terraform apply
+# - Audit trail de membresia centralizado en Workspace Admin
+#
+# CREATE-FIRST: los grupos deben existir en Workspace ANTES del terraform
+# apply (sino apply falla con "principalNotFound"). Crearlos con:
+#
+#   gcloud identity groups create admins@boosterchile.com \
+#     --organization=$ORG_ID \
+#     --display-name="Booster AI - Admins"
+#
+#   gcloud identity groups create engineers@boosterchile.com \
+#     --organization=$ORG_ID \
+#     --display-name="Booster AI - Engineers"
+#
+# Luego agregar miembros via Workspace Admin UI o:
+#   gcloud identity groups memberships add \
+#     --group-email=admins@boosterchile.com \
+#     --member-email=dev@boosterchile.com
+
+variable "admins_group" {
+  description = <<-EOT
+    Workspace group con rol Owner del proyecto.
+    Miembros tipicos: founders / org admins / business owners.
+    Default: admins@boosterchile.com (incluye dev@ + contacto@).
+  EOT
+  type        = string
+  default     = "admins@boosterchile.com"
+}
+
+variable "engineers_group" {
+  description = <<-EOT
+    Workspace group con acceso operacional: Cloud SQL (cloudsql.client +
+    instanceUser) y bastion IAP (iap.tunnelResourceAccessor + osLogin).
+    Miembros tipicos: developers, SREs, on-call.
+    Default: engineers@boosterchile.com (inicialmente solo dev@).
+  EOT
+  type        = string
+  default     = "engineers@boosterchile.com"
+}
+
+# Mantenido como variable por compatibilidad — pero el default ahora apunta
+# al grupo. Si se quiere bindings extra (ej. user:freelance@... temporal)
+# se puede agregar en tfvars.local sin tocar este default.
 variable "human_owners" {
-  description = "Cuentas humanas con rol Owner. Cambios requieren PR."
+  description = "IAM members con rol Owner. Default usa group:admins@... (Trivy AVD-GCP-0008)."
   type        = set(string)
   default = [
-    "user:dev@boosterchile.com",
+    "group:admins@boosterchile.com",
   ]
 }
 


### PR DESCRIPTION
## Summary

Migra 4 IAM bindings de `user:dev@...` a `group:admins@...` / `group:engineers@...` para cerrar alerts Trivy AVD-GCP-0008.

## Estructura de grupos (escala con el equipo)

| Grupo | Rol | Miembros iniciales |
|---|---|---|
| `admins@boosterchile.com` | Project Owner | `dev@` + `contacto@` |
| `engineers@boosterchile.com` | Cloud SQL + bastion IAP | `dev@` |

## Cambios

| Archivo | Cambio |
|---|---|
| `variables.tf` | + `admins_group`, `engineers_group`. `human_owners` default → `group:admins@...` |
| `data.tf` Cloud SQL | per-user bindings → un binding al grupo `engineers@` |
| `modules/iap-bastion` | `iap_users` (emails) → `iap_principals` (full IAM members) |
| `data.tf` (caller) | `iap_principals = ["group:engineers@..."]` |

## ⚠️ CREATE-FIRST: crear grupos antes del apply

```bash
ORG_ID=$(gcloud organizations list --format='value(ID)' --limit=1)

gcloud identity groups create admins@boosterchile.com \
  --organization=$ORG_ID \
  --display-name="Booster AI - Admins"

gcloud identity groups create engineers@boosterchile.com \
  --organization=$ORG_ID \
  --display-name="Booster AI - Engineers"

# Agregar miembros (Workspace Admin UI o):
gcloud identity groups memberships add \
  --group-email=admins@boosterchile.com \
  --member-email=dev@boosterchile.com
gcloud identity groups memberships add \
  --group-email=admins@boosterchile.com \
  --member-email=contacto@boosterchile.com
gcloud identity groups memberships add \
  --group-email=engineers@boosterchile.com \
  --member-email=dev@boosterchile.com
```

## Caveat: Cloud SQL IAM users (NO afectado)

`google_sql_user.iam_operators` con `type=CLOUD_IAM_USER` requiere email individual (limitación API GCP — no acepta `group:`). Cada miembro de `engineers_group` que necesite acceso DB se agrega manualmente a `local.db_iam_operators`. Esto NO está flagged por Trivy (resource type distinto al `google_project_iam_member`).

## Test plan

- [ ] CI verde (terraform validate, no apply)
- [ ] **MANUAL**: crear grupos en Workspace antes de apply
- [ ] `terraform plan`: muestra `~ update` en bindings, ningún error de "principal not found"
- [ ] `terraform apply`: bindings cambian sin downtime (el SA Cloud Run de runtime no se ve afectado, solo IAM humano)
- [ ] Verificación: `gcloud projects get-iam-policy ... | grep -E "admins@|engineers@"` muestra los grupos
- [ ] `cloud-sql-proxy --auto-iam-authn` desde laptop sigue conectando OK (después de agregarse al grupo `engineers@`)
- [ ] Trivy próxima run: 4 alerts cierran (10 → 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)