### PR TITLE
fix(cloudbuild): kubectl --internal-ip + bastion CMEK syntax fix

### DIFF
--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -230,9 +230,14 @@ steps:
       - -c
       - |
         set -eu
+        # --internal-ip: Cloud Build private pool sale por NAT egress (no por
+        # VPC peering). El master_authorized_networks_config whitelistea el
+        # peering range, no las IPs NAT de Google. Usar el endpoint interno
+        # del control plane (accesible via VPC peering) evita ese problema.
         gcloud container clusters get-credentials booster-ai-telemetry \
           --region=${_REGION} \
-          --project=${PROJECT_ID}
+          --project=${PROJECT_ID} \
+          --internal-ip
 
         # Si la primera vez, apply manifests; sino, set image del deployment.
         if ! kubectl get deployment telemetry-tcp-gateway -n telemetry > /dev/null 2>&1; then

--- a/infrastructure/modules/iap-bastion/main.tf
+++ b/infrastructure/modules/iap-bastion/main.tf
@@ -92,16 +92,11 @@ resource "google_compute_instance" "bastion" {
       type  = "pd-standard"
     }
 
-    # Trivy IaC AVD-GCP-0040: CMEK para boot disk si se pasa la key. Usar
-    # disk_encryption_key (Customer-Managed via KMS) en lugar de
-    # disk_encryption_key_raw (Customer-Supplied que requiere manejar la
-    # key material en el cliente — operacionalmente caro).
-    dynamic "disk_encryption_key" {
-      for_each = var.disk_encryption_kms_key_self_link != null ? [var.disk_encryption_kms_key_self_link] : []
-      content {
-        kms_key_self_link = disk_encryption_key.value
-      }
-    }
+    # Trivy IaC GCP-0033: CMEK para boot disk via KMS. La syntax google
+    # provider expone kms_key_self_link como atributo directo del boot_disk
+    # block (NO un bloque anidado disk_encryption_key). null si var es null
+    # = default Google-managed encryption.
+    kms_key_self_link = var.disk_encryption_kms_key_self_link
   }
 
   # OS Login para auth via IAM en lugar de SSH keys gestionadas en metadata.


### PR DESCRIPTION
Fixes encontrados durante terraform apply del sprint IaC.

## Cambios

1. **`cloudbuild.production.yaml`**: `gcloud container clusters get-credentials --internal-ip`
   El private pool sale por NAT (PUBLIC_EGRESS) para internet — esas IPs NAT de Google no están en `master_authorized_networks_config`. Solución: usar el endpoint INTERNO del control plane GKE, accesible vía VPC peering desde el pool peering range (10.104.24.0/24).

2. **`infrastructure/modules/iap-bastion/main.tf`**: corregir sintaxis CMEK boot disk
   El bloque `dynamic "disk_encryption_key"` anidado no es válido en `google_compute_instance.boot_disk`. La sintaxis correcta es atributo directo `kms_key_self_link`. `terraform plan` lo detectó.

## Test plan

- [ ] CI verde
- [ ] Cloud Build via private pool completa el deploy del gateway sin timeout
- [ ] Smoke test `app.boosterchile.com/health` post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)