### PR TITLE
fix(infra): master_global_access en GKE clusters (Cloud Build pool peering)

### DIFF
--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -510,6 +510,14 @@ resource "google_container_cluster" "telemetry" {
     enable_private_nodes    = true
     enable_private_endpoint = false
     master_ipv4_cidr_block  = "172.16.0.0/28"
+
+    # Necesario para que Cloud Build private pool (peering distinto) y operadores
+    # via IAP TCP puedan alcanzar el master interno (172.16.0.2) cross-region.
+    # Sin esto, el VPC peering al master no propaga rutas a la peering del pool.
+    # Ver PR #73 + post-apply manual gcloud update 2026-05-09.
+    master_global_access_config {
+      enabled = true
+    }
   }
 
   release_channel {

--- a/infrastructure/dr-region.tf
+++ b/infrastructure/dr-region.tf
@@ -105,6 +105,12 @@ resource "google_container_cluster" "telemetry_dr" {
     enable_private_nodes    = true
     enable_private_endpoint = false
     master_ipv4_cidr_block  = "172.17.0.0/28"
+
+    # Master global access habilitado para que Cloud Build pool (en south-west)
+    # alcance el master DR cross-region via VPC peering.
+    master_global_access_config {
+      enabled = true
+    }
   }
 
   release_channel {


### PR DESCRIPTION
Necesario para que Cloud Build private pool alcance el GKE master interno (172.16.0.0/28 + 172.17.0.0/28) via VPC peering cross-region.

Sin esto, el peering del Cloud Build pool y el peering del master son independientes — kubectl timeout. Aplicado manualmente con gcloud post-PR #73; este PR refleja el cambio en Terraform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)