### PR TITLE
fix(cloudbuild): skip GKE deploy + manual script (transitive peering issue)

### DIFF
--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -222,35 +222,35 @@ steps:
     waitFor: [push-sms-fallback-gateway]
 
   # apps/telemetry-tcp-gateway — GKE Autopilot. NO va a Cloud Run.
-  # Update via kubectl set image al deployment del cluster.
-  - id: deploy-telemetry-tcp-gateway
-    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+  #
+  # NOTA OPERACIONAL (2026-05-09): el deploy a GKE NO se hace desde Cloud
+  # Build private pool. El pool y el GKE control plane usan service
+  # networking peerings independientes que no propagan rutas entre si
+  # (limitacion VPC peering no-transitivo). kubectl desde el pool al
+  # master interno (172.16.0.2) hace timeout.
+  #
+  # Cloud Build SOLO buildea + pushea la imagen :${_COMMIT_SHA} a
+  # Artifact Registry. El operador deploya manualmente desde su laptop
+  # (autorizado en master_authorized_networks_config) o via IAP TCP:
+  #
+  #   ./scripts/deploy-telemetry-gateway.sh ${_COMMIT_SHA}
+  #
+  # El script hace `kubectl set image` al SHA buildeado. Output del
+  # build incluye el SHA para facilitar copy-paste.
+  - id: gke-deploy-instructions
+    name: gcr.io/cloud-builders/curl
     entrypoint: bash
     args:
       - -c
       - |
-        set -eu
-        # --internal-ip: Cloud Build private pool sale por NAT egress (no por
-        # VPC peering). El master_authorized_networks_config whitelistea el
-        # peering range, no las IPs NAT de Google. Usar el endpoint interno
-        # del control plane (accesible via VPC peering) evita ese problema.
-        gcloud container clusters get-credentials booster-ai-telemetry \
-          --region=${_REGION} \
-          --project=${PROJECT_ID} \
-          --internal-ip
-
-        # Si la primera vez, apply manifests; sino, set image del deployment.
-        if ! kubectl get deployment telemetry-tcp-gateway -n telemetry > /dev/null 2>&1; then
-          echo "Primer deploy — apply manifests completos"
-          kubectl apply -f infrastructure/k8s/telemetry-tcp-gateway.yaml
-        fi
-
-        kubectl set image deployment/telemetry-tcp-gateway \
-          gateway=${_REGISTRY}/telemetry-tcp-gateway:${_COMMIT_SHA} \
-          -n telemetry
-
-        kubectl rollout status deployment/telemetry-tcp-gateway \
-          -n telemetry --timeout=5m
+        echo "=========================================="
+        echo "  GKE deploy MANUAL pendiente"
+        echo "=========================================="
+        echo "  Imagen lista: ${_REGISTRY}/telemetry-tcp-gateway:${_COMMIT_SHA}"
+        echo ""
+        echo "  Para deployar al gateway, ejecutar desde laptop autorizado:"
+        echo "    ./scripts/deploy-telemetry-gateway.sh ${_COMMIT_SHA}"
+        echo "=========================================="
     waitFor: [push-telemetry-tcp-gateway]
 
   # =========================================================================

--- a/scripts/deploy-telemetry-gateway.sh
+++ b/scripts/deploy-telemetry-gateway.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Deploy manual del telemetry-tcp-gateway al GKE Autopilot.
+#
+# Por que manual y no automatico via Cloud Build:
+#
+# Cloud Build private pool (PR #68) y GKE control plane usan service
+# networking peerings independientes al booster-ai-vpc. VPC peering NO es
+# transitivo por default — el pool no aprende rutas al master CIDR
+# (172.16.0.0/28) desde el peering del master, ni viceversa.
+#
+# Solucion oficial GCP requiere setear `import-custom-routes`/`export-custom-routes`
+# en peerings managed (no se puede via Terraform — son creadas por
+# servicenetworking automaticamente). Decision: mantener Cloud Build
+# pool para builds + push, y deployar GKE manualmente desde laptop
+# operador (autorizado en master_authorized_networks via IP whitelist en
+# terraform.tfvars.local) o via IAP TCP tunnel.
+#
+# Usage:
+#   ./scripts/deploy-telemetry-gateway.sh <COMMIT_SHA>
+#   ./scripts/deploy-telemetry-gateway.sh latest      # tag :latest
+#   ./scripts/deploy-telemetry-gateway.sh             # auto-detecta HEAD
+#
+# Pre-requisitos:
+#   - gcloud auth login (con dev@boosterchile.com o miembro engineers@)
+#   - IP del laptop en gke_operator_authorized_cidrs O conexion via IAP
+#   - kubectl instalado
+#
+# Idempotente: detecta primer deploy (apply manifests) vs update (set image).
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-booster-ai-494222}"
+REGION="${REGION:-southamerica-west1}"
+CLUSTER="${CLUSTER:-booster-ai-telemetry}"
+NAMESPACE="${NAMESPACE:-telemetry}"
+DEPLOYMENT="${DEPLOYMENT:-telemetry-tcp-gateway}"
+REGISTRY="${REGISTRY:-${REGION}-docker.pkg.dev/${PROJECT_ID}/containers}"
+
+# Argumento opcional: SHA o tag. Default: HEAD del repo.
+TAG="${1:-$(git rev-parse HEAD 2>/dev/null || echo 'latest')}"
+IMAGE="${REGISTRY}/${DEPLOYMENT}:${TAG}"
+
+echo "=========================================="
+echo "  Deploy telemetry-tcp-gateway"
+echo "=========================================="
+echo "  Cluster:     ${CLUSTER} (${REGION})"
+echo "  Image:       ${IMAGE}"
+echo "  Namespace:   ${NAMESPACE}"
+echo "  Deployment:  ${DEPLOYMENT}"
+echo ""
+
+# Get credentials para el cluster privado.
+echo "--- Fetching cluster credentials ---"
+gcloud container clusters get-credentials "${CLUSTER}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}"
+
+echo ""
+echo "--- Checking deployment state ---"
+if ! kubectl get deployment "${DEPLOYMENT}" -n "${NAMESPACE}" > /dev/null 2>&1; then
+  echo "Primer deploy — apply manifests completos"
+  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || dirname "$(realpath "$0")")/.."
+  kubectl apply -f "${REPO_ROOT}/infrastructure/k8s/telemetry-tcp-gateway.yaml"
+fi
+
+echo ""
+echo "--- Setting image ---"
+kubectl set image "deployment/${DEPLOYMENT}" \
+  "gateway=${IMAGE}" \
+  -n "${NAMESPACE}"
+
+echo ""
+echo "--- Rolling out ---"
+kubectl rollout status "deployment/${DEPLOYMENT}" \
+  -n "${NAMESPACE}" --timeout=5m
+
+echo ""
+echo "=========================================="
+echo "  ✓ Deploy completado"
+echo "=========================================="
+kubectl get pods -n "${NAMESPACE}" -l app="${DEPLOYMENT}" -o wide


### PR DESCRIPTION
Cloud Build private pool no puede llegar al GKE master via VPC peering por la limitacion de transitive peering en service networking. 3 builds fallaron en el step deploy-telemetry-tcp-gateway. Decision pragmatica: deploy manual del gateway desde operador autorizado.

## Cambios

- `cloudbuild.production.yaml`: step `deploy-telemetry-tcp-gateway` reemplazado por mensaje informativo. Cloud Build sigue building+pushing la imagen.
- `scripts/deploy-telemetry-gateway.sh`: script idempotente para deploy manual.

## Para deployar el gateway

```bash
# Despues de Cloud Build, desde tu laptop (con IP en master_authorized_networks):
./scripts/deploy-telemetry-gateway.sh $_COMMIT_SHA
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)