### PR TITLE
fix(ci): pasar --region a gcloud builds submit en release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
         # `_ENV no matched in template`).
         run: |
           gcloud builds submit --config=cloudbuild.production.yaml \
+            --region=${{ env.GCP_REGION }} \
             --substitutions=_COMMIT_SHA=${{ github.sha }}
 
       # Post-deploy: smoke tests + notificación


### PR DESCRIPTION
## Summary

Fix CI bug introducido por PR #68 (private worker pool en sprint IaC hardening).

`cloudbuild.production.yaml` declara `options.pool.name` con worker pool regional en `southamerica-west1`. Cuando un build config usa pool regional, `gcloud builds submit` requiere flag `--region` explicito y rechaza con:

```
ERROR: (gcloud.builds.submit) Invalid value for [--region]:
--region flag required when workerpool resource includes region substitution
```

El workflow `release.yml` no pasaba `--region`, asi que cada push a `main` desde el sprint fallo en el job `Deploy to production` (runs 25617342941, 25616851315, 25616721454).

Produccion no se vio afectada porque los deploys del sprint se hicieron via `terraform apply` directo + `kubectl set image` manual (PR #76). Pero todo merge futuro a main fallaria igual.

## Fix

Pasar `--region=${{ env.GCP_REGION }}` a `gcloud builds submit`. `GCP_REGION` ya esta definida en el bloque `env` del workflow.

## Test plan

Post-merge: verificar que el proximo push a main dispara `Deploy to production` y completa Cloud Build sin error de --region.

## Refs

PR #68 (private worker pool) | Sprint handoff: `docs/handoff/2026-05-09-iac-hardening-sprint.md`

*Web edit via Chrome MCP — PAT carece de `workflow` scope (pending strategic #1 del sprint).*