### PR TITLE
fix(iam): github-deployer self-impersonation para Cloud Build

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -172,6 +172,24 @@ resource "google_service_account_iam_member" "github_can_impersonate_runtime" {
   member             = "serviceAccount:${google_service_account.github_deployer.email}"
 }
 
+# github-deployer puede actuar como SI MISMO. Necesario porque
+# cloudbuild.production.yaml declara `serviceAccount: .../github-deployer@...`
+# (Cloud Build corre el build "como github-deployer"), y actAs de uno mismo
+# requiere binding explicito de roles/iam.serviceAccountUser desde que se
+# scopeo el rol project-wide en PR #70.
+#
+# Sin este binding, gcloud builds submit falla con:
+#   ERROR: PERMISSION_DENIED: caller does not have permission to act as
+#   service account .../github-deployer@...
+#
+# Mantiene el aislamiento de PR #70 (no abre actAs sobre otros SAs del
+# proyecto), solo permite la self-impersonation que el build necesita.
+resource "google_service_account_iam_member" "github_deployer_self_impersonate" {
+  service_account_id = google_service_account.github_deployer.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
 # =============================================================================
 # GKE Autopilot Default Compute SA — necesita pull de Artifact Registry
 # =============================================================================


### PR DESCRIPTION
## Summary

Fix cascada del scope-down de IAM en PR #70 (sprint IaC hardening).

PR #70 removió `roles/iam.serviceAccountUser` project-wide de `github-deployer` (correcto para evitar lateral movement, Trivy AVD-GCP-0008). Pero `cloudbuild.production.yaml` declara:

```yaml
serviceAccount: projects/booster-ai-494222/serviceAccounts/github-deployer@...
```

Es decir, Cloud Build corre el build "como `github-deployer`". `actAs` de uno mismo requiere binding explícito de `iam.serviceAccountUser` desde que se scopeó el rol.

Sin este fix, `gcloud builds submit` falla en cada deploy:

```
ERROR: PERMISSION_DENIED: caller does not have permission to act as
service account projects/.../github-deployer@booster-ai-494222.iam.gserviceaccount.com
```

Comprobado en run [25618280066](https://github.com/boosterchile/booster-ai/actions/runs/25618280066) (commit e571036, post merge de PR #78 que arregló el `--region` flag).

## Fix

Agregar `google_service_account_iam_member` para self-impersonation:

```hcl
resource "google_service_account_iam_member" "github_deployer_self_impersonate" {
  service_account_id = google_service_account.github_deployer.name
  role               = "roles/iam.serviceAccountUser"
  member             = "serviceAccount:${google_service_account.github_deployer.email}"
}
```

Mantiene el aislamiento de PR #70 (no abre `actAs` sobre otros SAs), solo permite la self-impersonation que el build genuinamente necesita.

## Test plan

- [x] `terraform plan -target=google_service_account_iam_member.github_deployer_self_impersonate` → `1 to add, 0 to change, 0 to destroy`
- [ ] CI green (este PR)
- [ ] Post-merge: `terraform apply -target=...` → binding creado
- [ ] Post-apply: verificar que el próximo push a main dispara `Deploy to production` y `gcloud builds submit` completa sin PERMISSION_DENIED

## Refs

- PR #70 (scope-down inicial)
- PR #78 (fix anterior `--region` flag)
- Sprint handoff: `docs/handoff/2026-05-09-iac-hardening-sprint.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)