### PR TITLE
fix(iam): github-deployer roles/cloudbuild.workerPoolUser

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -144,6 +144,7 @@ locals {
   github_deployer_roles = [
     "roles/run.admin",                # Deploy a Cloud Run
     "roles/cloudbuild.builds.editor", # Trigger Cloud Build
+    "roles/cloudbuild.workerPoolUser", # Usar el private worker pool (PR #68)
     "roles/artifactregistry.writer",  # Push Docker images
     # roles/iam.serviceAccountUser REMOVIDO del project-level (Trivy IaC
     # AVD-GCP-0008 — too broad; permitia impersonar CUALQUIER SA del proyecto).


### PR DESCRIPTION
## Summary

Tercer fix de la cascada del scope-down de PR #70 combinado con el private worker pool introducido en PR #68. Después de:

1. PR #78 — pasar `--region` a `gcloud builds submit` ✅
2. PR #79 — `github-deployer` self-impersonation (`actAs`) ✅
3. **Este PR** — `github-deployer` con permission de USAR el private pool

El run [25618453954](https://github.com/boosterchile/booster-ai/actions/runs/25618453954) (commit a3b1a17, post-merge de #79) reveló:

```
ERROR: PERMISSION_DENIED: IAM Authority does not have the permission
'cloudbuild.workerpools.use' required for action CreateBuild on resource
"booster-ai-494222"
```

Cuando `cloudbuild.production.yaml` declara `options.pool.name`, el caller necesita `roles/cloudbuild.workerPoolUser` sobre el proyecto. `github-deployer` tenía `roles/cloudbuild.builds.editor` (crear/lanzar builds) pero faltaba permission de USAR worker pools privados.

## Fix

Agregar `roles/cloudbuild.workerPoolUser` a `github_deployer_roles` en `iam.tf`.

```hcl
"roles/cloudbuild.workerPoolUser", # Usar el private worker pool (PR #68)
```

Scope mínimo: `workerPoolUser` permite USE de pools, no admin (crear/borrar/modificar).

## Test plan

- [ ] CI green
- [ ] Post-merge: `terraform apply -target=...` agrega el binding
- [ ] Push a main dispara Release+Deploy y `gcloud builds submit` completa hasta build steps (no más PERMISSION_DENIED)

## Refs

- PR #68 (introducción private worker pool)
- PR #70 (scope-down inicial de github-deployer)
- PR #78 (--region flag)
- PR #79 (self-impersonation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)