### PR TITLE
fix(web/map): restaurar Pegman en VehicleMap y LiveTrackingScreen

### DIFF
--- a/apps/web/src/components/map/LiveTrackingScreen.tsx
+++ b/apps/web/src/components/map/LiveTrackingScreen.tsx
@@ -1,6 +1,6 @@
 import { Link } from '@tanstack/react-router';
 // biome-ignore lint/suspicious/noShadowRestrictedNames: `Map` es el componente exportado por la lib de Google Maps; renombrarlo localmente confunde más que ayuda.
-import { APIProvider, AdvancedMarker, Map, Pin } from '@vis.gl/react-google-maps';
+import { APIProvider, AdvancedMarker, ControlPosition, Map, Pin } from '@vis.gl/react-google-maps';
 import { ArrowLeft, Gauge, LocateFixed, MapPin, Navigation, RefreshCw, Truck } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { env } from '../../lib/env.js';
@@ -80,7 +80,14 @@ export function LiveTrackingScreen({
             disableDefaultUI={false}
             mapTypeControl={false}
             fullscreenControl={false}
-            streetViewControl={false}
+            // Pegman habilitado: el operador puede arrastrarlo sobre el
+            // vehículo para ver contexto street view. Lo movemos a RIGHT_TOP
+            // (en vez del default RIGHT_BOTTOM) porque la bottom card de
+            // stats tapa el corner inferior derecho. RIGHT_TOP queda libre
+            // — el header flotante usa max-w-6xl centrado, así que en mobile
+            // queda pegado al borde derecho debajo del refresh button (40x40)
+            // y en desktop queda en el espacio vacío a la derecha del card.
+            streetViewControlOptions={{ position: ControlPosition.RIGHT_TOP }}
             mapId="booster-live-map"
           >
             <FollowVehicle

--- a/apps/web/src/components/map/VehicleMap.tsx
+++ b/apps/web/src/components/map/VehicleMap.tsx
@@ -121,14 +121,13 @@ function VehicleMapInner({
           defaultZoom={zoom}
           gestureHandling="cooperative"
           disableDefaultUI={false}
-          // Quitamos los controles que no aportan en un mapa embebido y que
-          // ocupan la esquina inferior derecha (donde va nuestro botón de
-          // Recentrar). En mobile, el Pegman de Street View se queda en
-          // bottom-right por default y se solapa con cualquier botón flotante
-          // que pongamos ahí; deshabilitarlo es la única forma limpia de
-          // evitar el overlap. Fullscreen tampoco tiene sentido en una vista
-          // embebida (rompería el layout de la página).
-          streetViewControl={false}
+          // Pegman (street view) sí lo queremos: el operador puede arrastrarlo
+          // sobre la posición del vehículo para ver contexto urbano. Como el
+          // botón de Recentrar va dentro de <MapControl RIGHT_BOTTOM>, Google
+          // lo apila con los demás controles del mismo cluster sin solapar.
+          // Fullscreen sí lo dejamos fuera: en una vista embebida (h=320)
+          // expandirlo rompería el layout de la página y no aporta valor
+          // distinto al botón "Ver en vivo" que lleva al modo Uber.
           fullscreenControl={false}
           mapId="booster-vehicle-map"
         >


### PR DESCRIPTION
## Resumen

Reporte: el Pegman (street view) debería seguir disponible en la vista detalle de vehículo y también en \"Ver en vivo\" — el operador lo arrastra sobre la posición del vehículo para ver contexto urbano. El PR anterior ([#81](https://github.com/boosterchile/booster-ai/pull/81)) lo deshabilitó como atajo para evitar el overlap con el botón Recentrar; ahora que el botón vive en \`<MapControl>\` (que sí integra con el sistema de controles de Google Maps) ya no hay overlap y Pegman puede volver.

## Cambios

### \`VehicleMap.tsx\` — vista embedded
- Quitar \`streetViewControl={false}\` → Pegman vuelve al default \`RIGHT_BOTTOM\`
- Mantener \`fullscreenControl={false}\` (no aporta en h=320, rompería el layout; para fullscreen ya está el botón \"Ver en vivo\" que abre \`LiveTrackingScreen\`)
- El botón Recentrar sigue en \`<MapControl RIGHT_BOTTOM>\`: Google apila zoom + Pegman + Recentrar verticalmente en el mismo cluster, sin overlap

### \`LiveTrackingScreen.tsx\` — vista fullscreen
- Quitar \`streetViewControl={false}\` → Pegman se habilita
- Reposicionar a \`RIGHT_TOP\` via \`streetViewControlOptions\`: el default \`RIGHT_BOTTOM\` lo dejaría tapado por la bottom card (stats panel). \`RIGHT_TOP\` lo deja accesible debajo del header flotante
- El botón Recentrar sigue en \`bottom-44 right-4\` (separado del cluster del mapa porque tiene que coexistir con la bottom card del page layout, no con los controles del mapa)

## Verificación

- [x] \`pnpm typecheck\` — 0 errores
- [x] \`biome check apps/web/src/components/map/\` — 0 errores
- [x] \`pnpm test\` — 59/59 (los tests mockean \`useMap\` y son robustos a cambios de props del Map)

## Test plan post-deploy

- [ ] \`/app/vehiculos/<id>\` desktop y mobile: Pegman visible en bottom-right, junto al botón Recentrar (cuando aparece) sin overlap entre ellos
- [ ] Drag del Pegman sobre la posición del vehículo abre street view normalmente
- [ ] \`/app/vehiculos/<id>/live\` (fullscreen): Pegman visible en top-right (debajo del header)
- [ ] Drag del Pegman funcional en fullscreen también
- [ ] Sin regresiones del fix anterior: pan/zoom + auto-center + recentrar siguen funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)