### PR TITLE
feat(api/db): migración 0009 — fuente_dato_ruta + nivel_certificacion (ADR-028 PR-D)

### DIFF
--- a/apps/api/drizzle/0009_metricas_viaje_dual_source_adr028.sql
+++ b/apps/api/drizzle/0009_metricas_viaje_dual_source_adr028.sql
@@ -1,0 +1,87 @@
+-- Migration 0009 — Modelo dual de fuente de datos (ADR-028)
+--
+-- Implementa el schema de "fuente de datos del viaje" para distinguir
+-- entre clientes con Teltonika (datos primarios verificables) y clientes
+-- sin Teltonika (datos secundarios estimados). Selecciona el template
+-- de certificado: cert-primario.html vs report-secundario.html.
+--
+-- Sin este modelo, el cert generator no puede distinguir niveles de
+-- certificación → riesgo de greenwashing accidental al emitir certs
+-- "verificables" sobre trips sin telemetría real suficiente.
+--
+-- Cambios:
+--   1. Dos enums nuevos: fuente_dato_ruta y nivel_certificacion.
+--   2. Cuatro columnas nuevas en metricas_viaje: route_data_source,
+--      coverage_pct, certification_level, uncertainty_factor.
+--   3. Backfill de filas legacy a partir del campo `fuente_datos`
+--      (legacy text varchar) hacia los nuevos enums.
+--
+-- Riesgo de despliegue: bajo. CREATE TYPE + ADD COLUMN nullable es
+-- metadata-only en Postgres ≥ 11; sin re-write de filas existentes.
+-- El backfill UPDATE toca solo metricas_viaje, tabla con cardinalidad
+-- baja (1:1 con viajes). Reversible vía DROP de columnas + DROP TYPE.
+--
+-- Postergado: drop del campo legacy `fuente_datos` (varchar 20). Queda
+-- nullable para no romper código que aún lo lea durante la transición;
+-- migración posterior lo elimina cuando todo el código consumidor pase
+-- a leer route_data_source. Ver ADR-028 §1.
+
+-- Enums nuevos
+CREATE TYPE "fuente_dato_ruta" AS ENUM (
+  'teltonika_gps',
+  'maps_directions',
+  'manual_declared'
+);
+
+CREATE TYPE "nivel_certificacion" AS ENUM (
+  'primario_verificable',
+  'secundario_modeled',
+  'secundario_default'
+);
+
+-- Columnas nuevas en metricas_viaje (todas nullable inicialmente para
+-- no fallar la migración en filas existentes; se pueblan por backfill
+-- y luego por el flujo normal del carbon-calculator al cierre de cada
+-- trip).
+ALTER TABLE "metricas_viaje"
+  ADD COLUMN "fuente_dato_ruta" "fuente_dato_ruta",
+  ADD COLUMN "cobertura_pct" numeric(5, 2),
+  ADD COLUMN "nivel_certificacion" "nivel_certificacion",
+  ADD COLUMN "factor_incertidumbre" numeric(4, 3);
+
+-- Backfill desde el campo legacy `fuente_datos` (varchar 20).
+--
+-- Mapeo del enum legacy al nuevo enum:
+--   canbus     → teltonika_gps + cobertura 100% (asumimos full coverage
+--                porque históricamente no fue tracked; el cálculo previo
+--                ya usó esos datos como primarios)
+--   modeled    → maps_directions + cobertura 0 (sin telemetría real)
+--   driver_app → manual_declared + cobertura 0 (declaración del cliente)
+--   NULL       → NULL en ambas columnas (sin info, queda para el próximo
+--                cálculo de carbon-calculator)
+--
+-- certification_level y uncertainty_factor NO se backfillean acá. Se
+-- poblarán cuando el cron `recalcular-metricas-viaje` corra sobre cada
+-- viaje (ver apps/api/src/services/calcular-metricas-viaje.ts en el PR-F).
+-- Esto evita tener que replicar la matriz de derivación en SQL puro.
+
+UPDATE "metricas_viaje"
+SET
+  "fuente_dato_ruta" = CASE "fuente_datos"
+    WHEN 'canbus' THEN 'teltonika_gps'::"fuente_dato_ruta"
+    WHEN 'modeled' THEN 'maps_directions'::"fuente_dato_ruta"
+    WHEN 'driver_app' THEN 'manual_declared'::"fuente_dato_ruta"
+    ELSE NULL
+  END,
+  "cobertura_pct" = CASE "fuente_datos"
+    WHEN 'canbus' THEN 100
+    WHEN 'modeled' THEN 0
+    WHEN 'driver_app' THEN 0
+    ELSE NULL
+  END
+WHERE "fuente_datos" IS NOT NULL;
+
+-- Index para queries por nivel de certificación (analytics, dashboard
+-- admin de cuántos certs primarios vs secundarios se han emitido).
+CREATE INDEX "idx_metricas_viaje_nivel_certificacion"
+  ON "metricas_viaje" ("nivel_certificacion");

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777996800005,
       "tag": "0008_metricas_viaje_empty_backhaul",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1778716800000,
+      "tag": "0009_metricas_viaje_dual_source_adr028",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -203,6 +203,34 @@ export const precisionMethodEnum = pgEnum('metodo_precision', [
   'por_defecto',
 ]);
 
+/**
+ * Origen del polyline real recorrido por el viaje (ADR-028 §1).
+ * Es la segunda dimensión ortogonal a `metodo_precision`. Junto con
+ * `coverage_pct` determina si el viaje califica para certificado primario.
+ *
+ *   - teltonika_gps: pings GPS del dispositivo Teltonika (única fuente
+ *     que califica para nivel primario verificable).
+ *   - maps_directions: ruta sintetizada por Google Routes API.
+ *   - manual_declared: declaración del cliente sin telemetría ni simulación.
+ */
+export const routeDataSourceEnum = pgEnum('fuente_dato_ruta', [
+  'teltonika_gps',
+  'maps_directions',
+  'manual_declared',
+]);
+
+/**
+ * Nivel de certificación derivado al cierre del trip (ADR-028 §2).
+ * NO es self-declared — lo computa `derivarNivelCertificacion()` del
+ * package @booster-ai/carbon-calculator. Selecciona el template del
+ * cert-generator (primario verificable vs secundario estimativo).
+ */
+export const certificationLevelEnum = pgEnum('nivel_certificacion', [
+  'primario_verificable',
+  'secundario_modeled',
+  'secundario_default',
+]);
+
 export const reportingStandardEnum = pgEnum('estandar_reporte', [
   'GLEC_V3',
   'GHG_PROTOCOL',
@@ -664,7 +692,35 @@ export const tripMetrics = pgTable(
     precisionMethod: precisionMethodEnum('metodo_precision'),
     glecVersion: varchar('version_glec', { length: 10 }),
     emissionFactorUsed: numeric('factor_emision_usado', { precision: 8, scale: 5 }),
+    /** @deprecated Reemplazado por `route_data_source` (ADR-028). Mantenido
+     *  por backwards-compat hasta que el backfill complete y se ejecute la
+     *  drop column en una migración posterior. */
     source: varchar('fuente_datos', { length: 20 }),
+    /**
+     * ADR-028 §1: origen del polyline real recorrido. Independiente de
+     * `precision_method` (que captura calidad de medición de combustible).
+     */
+    routeDataSource: routeDataSourceEnum('fuente_dato_ruta'),
+    /**
+     * ADR-028 §2: fracción del viaje cubierta por la fuente principal,
+     * en porcentaje [0..100]. Para trips sin telemetría se setea a 0.
+     * Junto con `precision_method` y `route_data_source` determina el
+     * nivel de certificación.
+     */
+    coveragePct: numeric('cobertura_pct', { precision: 5, scale: 2 }),
+    /**
+     * ADR-028 §2: nivel de certificación derivado al cierre del trip.
+     * Computed por carbon-calculator.derivarNivelCertificacion(); no debe
+     * setearse manualmente por el cliente (greenwashing prevention).
+     * Alimenta el selector de template en cert-generator.
+     */
+    certificationLevel: certificationLevelEnum('nivel_certificacion'),
+    /**
+     * ADR-028 §3: factor de incertidumbre publicado en el cert.
+     * Decimal en [0, 1]. Ej: 0.05 = ±5%. Calculado por
+     * carbon-calculator.calcularFactorIncertidumbre().
+     */
+    uncertaintyFactor: numeric('factor_incertidumbre', { precision: 4, scale: 3 }),
     calculatedAt: timestamp('calculado_en', { withTimezone: true }),
     certificatePdfUrl: text('certificado_pdf_url'),
     certificateSha256: char('certificado_sha256', { length: 64 }),


### PR DESCRIPTION
## Resumen

PR-D de la implementación de [ADR-028](../blob/main/docs/adr/028-dual-source-data-model-teltonika-vs-maps.md). Añade los campos de modelo dual de fuente de datos a \`metricas_viaje\` + backfill desde el campo legacy.

Builds on top of [#90](../pull/90) y [#91](../pull/91).

## Cambios

### \`apps/api/src/db/schema.ts\`

Dos enums nuevos + 4 columnas nuevas en \`tripMetrics\`:
- \`routeDataSource\` (\`fuente_dato_ruta\`): \`teltonika_gps | maps_directions | manual_declared\`
- \`coveragePct\` (\`cobertura_pct\`): \`numeric(5, 2)\` — % del trip cubierto por la fuente principal
- \`certificationLevel\` (\`nivel_certificacion\`): \`primario_verificable | secundario_modeled | secundario_default\`
- \`uncertaintyFactor\` (\`factor_incertidumbre\`): \`numeric(4, 3)\` — ± publicado en el cert

Campo legacy \`source\` (\`fuente_datos\`) marcado \`@deprecated\` en JSDoc.

### \`apps/api/drizzle/0009_metricas_viaje_dual_source_adr028.sql\`

- \`CREATE TYPE\` para los dos enums.
- \`ALTER TABLE ADD COLUMN\` nullable para las 4 columnas (metadata-only en Postgres ≥ 11, deploy seguro sin downtime).
- **Backfill** desde \`fuente_datos\` legacy:
  - \`canbus\` → \`teltonika_gps\` + cobertura 100%
  - \`modeled\` → \`maps_directions\` + cobertura 0
  - \`driver_app\` → \`manual_declared\` + cobertura 0
  - \`NULL\` → \`NULL\` en ambas
- \`certification_level\` y \`uncertainty_factor\` NO se backfillean en SQL (replicar la matriz §2 en SQL puro es frágil); se poblarán cuando el cron de recálculo corra sobre cada viaje (PR-F).
- Index nuevo \`idx_metricas_viaje_nivel_certificacion\` para queries de analytics.

### \`apps/api/drizzle/meta/_journal.json\`

Entry \`idx=9\` agregada.

## Verificación

- [x] \`pnpm --filter @booster-ai/api typecheck\` — 0 errores
- [x] \`biome check\` — 0 errores
- [x] Rebased onto main (post PR-B y PR-C)

## Riesgo de despliegue

**Bajo**. \`CREATE TYPE\` + \`ADD COLUMN\` nullable es metadata-only en Postgres ≥ 11. Sin re-write de filas existentes. Reversible vía \`DROP COLUMN\` + \`DROP TYPE\`. El backfill UPDATE solo toca \`metricas_viaje\` (cardinalidad baja, 1:1 con viajes).

## Próximos PRs

- **PR-E**: split de templates en \`packages/certificate-generator\` (cert-primario vs report-secundario)
- **PR-F**: integración en \`apps/api/src/services/calcular-metricas-viaje.ts\` + \`apps/telemetry-processor\` para calcular \`coverage_pct\`
- **PR-G+**: Fases 1-4 (eco-route, scoring, coaching, network opt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)