### PR TITLE
feat(api): integrar derivación de nivel + factor incertidumbre (ADR-028 PR-F)

### DIFF
--- a/apps/api/src/services/calcular-metricas-viaje.ts
+++ b/apps/api/src/services/calcular-metricas-viaje.ts
@@ -1,7 +1,10 @@
 import {
   type ResultadoEmisiones,
+  type RouteDataSource,
   type TipoCombustible,
   calcularEmisionesViaje,
+  calcularFactorIncertidumbre,
+  derivarNivelCertificacion,
 } from '@booster-ai/carbon-calculator';
 import type { Logger } from '@booster-ai/logger';
 import { eq, sql } from 'drizzle-orm';
@@ -120,6 +123,32 @@ export async function calcularMetricasEstimadas(opts: {
       .limit(1);
     const isInitialCalculation = existing.length === 0;
 
+    // ADR-028 — derivar fuente de datos y nivel de certificación.
+    //
+    // En esta fase pre-entrega no hay telemetría real disponible — la
+    // distancia viene de `estimarDistanciaKm` (tabla Chile) y se trata
+    // conceptualmente como ruta modelada Maps-style. Si en Phase 1 se
+    // reemplaza por Routes API, la fuente sigue siendo `maps_directions`.
+    //
+    // `coveragePct = 0` porque no hay pings GPS aún; cuando se cierre el
+    // trip y telemetry-processor calcule la cobertura real, este servicio
+    // se llamará de nuevo (post-entrega) y los valores se actualizarán.
+    const routeDataSource: RouteDataSource = 'maps_directions';
+    const coveragePct = 0;
+    const certificationLevel = derivarNivelCertificacion({
+      precisionMethod: emisiones.metodoPrecision,
+      routeDataSource,
+      coveragePct,
+    });
+    const uncertaintyFactor = calcularFactorIncertidumbre({
+      nivelCertificacion: certificationLevel,
+      coveragePct,
+      // En modo estimado pre-entrega no comparamos contra Routes API, así
+      // que asumimos que el tipo declarado matchea (no penalizamos sin
+      // evidencia). La verificación real ocurre post-entrega.
+      vehicleTypeMatchesRoutesApi: true,
+    });
+
     const valuesToWrite = {
       distanceKmEstimated: emisiones.distanciaKm.toString(),
       carbonEmissionsKgco2eEstimated: emisiones.emisionesKgco2eWtw.toString(),
@@ -129,6 +158,11 @@ export async function calcularMetricasEstimadas(opts: {
       glecVersion: emisiones.versionGlec,
       emissionFactorUsed: emisiones.factorEmisionUsado.toString(),
       source: 'modelado',
+      // ADR-028 — campos nuevos del modelo dual.
+      routeDataSource,
+      coveragePct: coveragePct.toString(),
+      certificationLevel,
+      uncertaintyFactor: uncertaintyFactor.toString(),
       calculatedAt: new Date(),
     };
 

--- a/apps/api/src/services/emitir-certificado-viaje.ts
+++ b/apps/api/src/services/emitir-certificado-viaje.ts
@@ -228,6 +228,16 @@ export async function emitirCertificadoViaje(opts: {
       emissionFactorUsado: numOrNull(metrics.emissionFactorUsed) ?? 0,
       fuenteFactores: 'SEC Chile 2024 + GLEC v3.0',
       calculatedAt: metrics.calculatedAt ?? new Date(),
+      // ADR-028 — dual-source data fields. Si están NULL (trips legacy
+      // pre-migración 0009 que no fueron recalculados), el cert-generator
+      // cae al path legacy sin disclaimer. Una vez que el cron de recálculo
+      // pase sobre todos los trips, estos campos siempre estarán presentes.
+      ...(metrics.routeDataSource ? { routeDataSource: metrics.routeDataSource } : {}),
+      ...(metrics.coveragePct !== null ? { coveragePct: numOrNull(metrics.coveragePct) ?? 0 } : {}),
+      ...(metrics.certificationLevel ? { certificationLevel: metrics.certificationLevel } : {}),
+      ...(metrics.uncertaintyFactor !== null
+        ? { uncertaintyFactor: numOrNull(metrics.uncertaintyFactor) ?? 0 }
+        : {}),
     },
     empresaShipper: {
       id: shipper.id,


### PR DESCRIPTION
## Resumen

PR-F de la implementación de [ADR-028](../blob/main/docs/adr/028-dual-source-data-model-teltonika-vs-maps.md). **Cierra el loop end-to-end** para los certs nuevos:

\`calcularMetricasEstimadas\` → deriva \`nivel_certificacion\` + \`uncertainty_factor\` → persiste en \`metricas_viaje\` → \`emitirCertificadoViaje\` los lee → \`@booster-ai/certificate-generator\` (PR-E) elige template (primario vs secundario).

Builds on top of [#90](../pull/90), [#91](../pull/91), [#92](../pull/92), [#93](../pull/93). **Esto cierra Fase 0**.

## Cambios

### \`apps/api/src/services/calcular-metricas-viaje.ts\`

Después de computar emisiones, deriva el nivel:
- \`route_data_source = 'maps_directions'\` (la distancia actual viene de \`estimarDistanciaKm\`, conceptualmente Maps-style; cuando Phase 1 lo reemplace por Routes API, sigue siendo este source).
- \`coverage_pct = 0\` (sin telemetría pre-entrega).
- \`vehicleTypeMatchesRoutesApi = true\` asumido (sin verificación todavía).

Persiste 4 campos nuevos: \`routeDataSource\`, \`coveragePct\`, \`certificationLevel\`, \`uncertaintyFactor\`.

### \`apps/api/src/services/emitir-certificado-viaje.ts\`

Lee los 4 campos del row de \`metricas_viaje\` y los pasa al cert-generator. Spread condicional para no romper trips legacy: si los campos están NULL (trip pre-migración 0009 sin recálculo), el cert-generator cae al path legacy.

## Trade-offs explícitos (documentados en commit message)

- En esta fase el \`route_data_source\` siempre es \`'maps_directions'\` porque no hay path post-entrega con telemetría todavía. **Los certs que emitimos hoy son TODOS secundarios** (consistente con la matriz ADR-028 §2 cuando \`coverage < 95%\`).
- El upgrade a \`primario_verificable\` llega con PR-G (telemetry-processor calcula \`coverage_pct\` post-entrega).

## Verificación

- [x] \`pnpm --filter @booster-ai/api typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/api test\` — 108/108 passed (sin nuevos tests; lógica testeada en PR-C, persistencia tipo-segura por PR-D)
- [x] \`biome check\` — 0 errores

## Resultado de Fase 0 con este merge

| Componente | Estado |
|---|---|
| ADR-028 (decisión) | ✅ #89 merged |
| Domain types (shared-schemas) | ✅ #90 merged |
| Carbon-calculator (derivar + uncertainty) | ✅ #91 merged |
| DB schema + migration 0009 | ✅ #92 merged |
| Cert-generator dual templates | ✅ #93 merged |
| API integration | 🟡 este PR |

Una vez mergeado, **Fase 0 cierra** y los certs en producción ya distinguen primario vs secundario por construcción. **Greenwashing imposible** porque el nivel deriva de datos persistidos, no de input del cliente.

## Próximo PR (Phase 0.6 / PR-G)

\`apps/telemetry-processor\`: al cierre del trip, calcular \`coverage_pct\` basado en GPS pings + disparar re-cálculo de \`metricas_viaje\` para upgrade del nivel cuando el dato primario está disponible. Eso completa el path de Verified/Enterprise tier emitiendo certs primarios.

## Después (Fases 1-4)

Eco-route suggestion (Routes API), driver behavior scoring (IO 253/254/255), coaching IA (Vertex Gemini), network optimization (OR-Tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)