### PR TITLE
feat(api): cobertura telemétrica + recálculo de nivel post-entrega (ADR-028 PR-G)

### DIFF
--- a/apps/api/src/services/calcular-cobertura-telemetria.ts
+++ b/apps/api/src/services/calcular-cobertura-telemetria.ts
@@ -1,0 +1,185 @@
+import type { Logger } from '@booster-ai/logger';
+import { and, asc, eq, gte, lte } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { telemetryPoints } from '../db/schema.js';
+
+/**
+ * Cálculo de cobertura telemétrica de un trip (ADR-028 §5).
+ *
+ * Define qué porcentaje del trip estuvo cubierto por pings GPS continuos
+ * del Teltonika. Es la métrica clave para downgrade automático del nivel
+ * de certificación cuando el dispositivo perdió señal mid-trip.
+ *
+ * Algoritmo:
+ *
+ *     coverage_pct =
+ *       (km_cubiertos_por_pings_continuos / km_totales_estimados) × 100
+ *
+ *     km_cubiertos = sumatoria de distancias haversine entre pings
+ *                    consecutivos cuyo gap temporal < CONTINUITY_GAP_S
+ *
+ *     km_totales_estimados = distancia origen→destino (Maps Routes API
+ *                            o tabla pre-computada Chile)
+ *
+ * Decisiones de diseño:
+ *
+ * - **Threshold de continuidad = 60 segundos** entre pings consecutivos.
+ *   Por debajo del gap, el segmento se considera cubierto. Por encima,
+ *   el polyline real en ese tramo es desconocido y NO se cuenta como
+ *   cobertura. 60s es conservador: el FMC150 reporta cada ~30s en
+ *   tracking activo, así que un gap > 60s indica pérdida real de señal.
+ *
+ * - **Si no hay pings → coverage = 0**. El servicio devuelve `0`, no
+ *   `null`, para que la matriz §2 caiga limpia a secundario sin caso
+ *   especial.
+ *
+ * - **Si distanciaEstimadaKm = 0** (caso defensivo, no debería ocurrir)
+ *   → coverage = 0. Evita división por cero.
+ *
+ * - **Cap a 100**. Si por errores de GPS los pings reportan distancias
+ *   superiores a la estimación (ej. ruta más larga que la sugerida),
+ *   capeamos a 100. Reportar > 100% sería contraintuitivo en el cert.
+ *
+ * Función con I/O: hace una query a `telemetria_puntos`. Pero la lógica
+ * del cálculo (haversine + suma) está extraída en `calcularCoberturaPura`
+ * para test independiente del DB.
+ */
+
+/** Gap máximo en segundos entre pings consecutivos para considerarlos
+ *  parte del mismo segmento continuo (ADR-028 §5). */
+export const CONTINUITY_GAP_S = 60;
+
+/** Radio de la Tierra en km, usado en haversine. WGS84 mean radius. */
+const EARTH_RADIUS_KM = 6371;
+
+interface PingPoint {
+  /** Timestamp del ping en epoch ms. */
+  tMs: number;
+  lat: number;
+  lng: number;
+}
+
+/**
+ * Distancia great-circle entre dos puntos GPS via fórmula haversine.
+ * Output en km. Suficientemente precisa (<0.5% error) para distancias
+ * típicas de un trip dentro de Chile (decenas a miles de km).
+ */
+export function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLng = toRad(lng2 - lng1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return EARTH_RADIUS_KM * c;
+}
+
+/**
+ * Calcula cobertura sobre una lista de pings (función pura, sin I/O).
+ *
+ * Recibe pings ordenados ascendentemente por tiempo. Suma distancias
+ * haversine entre pings consecutivos cuando el gap < CONTINUITY_GAP_S.
+ *
+ * @param pings ordenados por tMs ascendente
+ * @param distanciaEstimadaKm distancia origen→destino (denominador)
+ * @returns coverage_pct ∈ [0, 100]
+ */
+export function calcularCoberturaPura(
+  pings: readonly PingPoint[],
+  distanciaEstimadaKm: number,
+): number {
+  if (distanciaEstimadaKm <= 0 || pings.length < 2) {
+    return 0;
+  }
+
+  let kmCubiertos = 0;
+  for (let i = 1; i < pings.length; i++) {
+    const prev = pings[i - 1];
+    const curr = pings[i];
+    if (!prev || !curr) {
+      continue;
+    }
+    const gapS = (curr.tMs - prev.tMs) / 1000;
+    if (gapS < CONTINUITY_GAP_S) {
+      kmCubiertos += haversineKm(prev.lat, prev.lng, curr.lat, curr.lng);
+    }
+  }
+
+  const pct = (kmCubiertos / distanciaEstimadaKm) * 100;
+  return Math.min(Math.max(pct, 0), 100);
+}
+
+/**
+ * Carga los pings del vehículo en la ventana del trip y calcula la
+ * cobertura. Si el vehículo no tiene pings o la distancia estimada es 0,
+ * devuelve 0 sin error.
+ */
+export async function calcularCobertura(opts: {
+  db: Db;
+  logger: Logger;
+  vehicleId: string;
+  /** Inicio del trip — usualmente trips.pickup_window_start. */
+  pickupAt: Date;
+  /** Fin del trip — usualmente assignments.delivered_at. */
+  deliveredAt: Date;
+  /** Distancia origen→destino esperada en km. */
+  distanciaEstimadaKm: number;
+}): Promise<number> {
+  const { db, logger, vehicleId, pickupAt, deliveredAt, distanciaEstimadaKm } = opts;
+
+  if (distanciaEstimadaKm <= 0) {
+    logger.debug({ vehicleId, distanciaEstimadaKm }, 'cobertura=0 (distancia estimada <= 0)');
+    return 0;
+  }
+
+  // Solo necesitamos lat/lng/timestampDevice para el cálculo. Ordenado
+  // ascendente por timestamp para que `calcularCoberturaPura` opere
+  // sobre la secuencia natural de pings.
+  const pings = await db
+    .select({
+      ts: telemetryPoints.timestampDevice,
+      lat: telemetryPoints.latitude,
+      lng: telemetryPoints.longitude,
+    })
+    .from(telemetryPoints)
+    .where(
+      and(
+        eq(telemetryPoints.vehicleId, vehicleId),
+        gte(telemetryPoints.timestampDevice, pickupAt),
+        lte(telemetryPoints.timestampDevice, deliveredAt),
+      ),
+    )
+    .orderBy(asc(telemetryPoints.timestampDevice));
+
+  // Filtramos pings sin lat/lng (defensa contra rows malformados —
+  // schema permite null en latitud/longitud para records sin GPS fix).
+  const validPings: PingPoint[] = [];
+  for (const p of pings) {
+    if (p.lat === null || p.lng === null) {
+      continue;
+    }
+    validPings.push({
+      tMs: p.ts.getTime(),
+      lat: Number(p.lat),
+      lng: Number(p.lng),
+    });
+  }
+
+  const coverage = calcularCoberturaPura(validPings, distanciaEstimadaKm);
+
+  logger.info(
+    {
+      vehicleId,
+      pickupAt,
+      deliveredAt,
+      distanciaEstimadaKm,
+      pingsTotal: pings.length,
+      pingsValidos: validPings.length,
+      coveragePct: coverage,
+    },
+    'cobertura telemétrica calculada',
+  );
+
+  return coverage;
+}

--- a/apps/api/src/services/calcular-metricas-viaje.ts
+++ b/apps/api/src/services/calcular-metricas-viaje.ts
@@ -9,7 +9,8 @@ import {
 import type { Logger } from '@booster-ai/logger';
 import { eq, sql } from 'drizzle-orm';
 import type { Db } from '../db/client.js';
-import { tripMetrics, trips, vehicles } from '../db/schema.js';
+import { assignments, tripMetrics, trips, vehicles } from '../db/schema.js';
+import { calcularCobertura } from './calcular-cobertura-telemetria.js';
 import { estimarDistanciaKm } from './estimar-distancia.js';
 
 /**
@@ -191,4 +192,165 @@ export async function calcularMetricasEstimadas(opts: {
 
     return { tripId, isInitialCalculation, emisiones };
   });
+}
+
+/**
+ * Re-deriva el nivel de certificación post-entrega usando la cobertura
+ * telemétrica real (ADR-028 §5).
+ *
+ * Disparo: al confirmar entrega, ANTES de emitir el certificado. Tiene
+ * que correr en este orden porque emitirCertificadoViaje lee
+ * `certification_level` y `uncertainty_factor` del row de
+ * `metricas_viaje` para elegir el template del PDF (primario vs
+ * secundario) y el ± impreso.
+ *
+ * Lógica:
+ *   1. Cargar trip + assignment + métricas existentes.
+ *   2. Si el vehículo NO tiene Teltonika asociado, no hay forma de
+ *      mejorar la cobertura — skip silencioso (el cert sale con los
+ *      valores estimados pre-entrega: maps_directions + 0%).
+ *   3. Si el vehículo tiene Teltonika, calcular cobertura entre
+ *      pickupAt y deliveredAt; promover routeDataSource a teltonika_gps.
+ *   4. Re-derivar nivel + uncertainty con los nuevos valores.
+ *   5. UPDATE selectivo de los 4 campos (no toca emisiones, factor, etc.
+ *      — esos se mantienen del cálculo estimado, salvo que en una
+ *      revisión futura agreguemos modo `exacto_canbus` con consumo real
+ *      del CAN bus).
+ *
+ * Idempotente: si la cobertura nueva da el mismo nivel, el UPDATE es
+ * no-op (drizzle igual hace el round-trip — opt: chequeo de igualdad
+ * antes de update si esto se vuelve hot path).
+ */
+export async function recalcularNivelPostEntrega(opts: {
+  db: Db;
+  logger: Logger;
+  tripId: string;
+}): Promise<{
+  recomputed: boolean;
+  /** Nivel resultante (puede ser igual al previo). */
+  certificationLevel?: 'primario_verificable' | 'secundario_modeled' | 'secundario_default';
+  /** Cobertura calculada (0..100). */
+  coveragePct?: number;
+}> {
+  const { db, logger, tripId } = opts;
+
+  const tripRows = await db.select().from(trips).where(eq(trips.id, tripId)).limit(1);
+  const trip = tripRows[0];
+  if (!trip) {
+    throw new TripNotFoundError(tripId);
+  }
+
+  const metricsRows = await db
+    .select()
+    .from(tripMetrics)
+    .where(eq(tripMetrics.tripId, tripId))
+    .limit(1);
+  const existing = metricsRows[0];
+  if (!existing) {
+    // No hay métricas previas — no hay nada que recalcular. Esto
+    // normalmente no debería ocurrir en producción (calcularMetricasEstimadas
+    // corre al asignar), pero defensivo: log + skip.
+    logger.warn({ tripId }, 'recalcularNivelPostEntrega: trip sin metricas_viaje');
+    return { recomputed: false };
+  }
+
+  // Necesitamos vehicleId + deliveredAt del assignment. Si no hay
+  // assignment cerrado, no se debería estar llamando esta función todavía.
+  const assignmentRows = await db
+    .select({
+      vehicleId: assignments.vehicleId,
+      deliveredAt: assignments.deliveredAt,
+    })
+    .from(assignments)
+    .where(eq(assignments.tripId, tripId))
+    .limit(1);
+  const assignment = assignmentRows[0];
+
+  if (!assignment?.vehicleId || !assignment.deliveredAt) {
+    logger.info(
+      { tripId, hasAssignment: !!assignment, hasVehicle: !!assignment?.vehicleId },
+      'recalcularNivelPostEntrega: skip (sin assignment con vehicle + deliveredAt)',
+    );
+    return { recomputed: false };
+  }
+
+  // Si el vehículo no tiene Teltonika, no hay telemetría — el nivel se
+  // queda como secundario_modeled con maps_directions y coverage 0.
+  // Skip silencioso para no escribir un UPDATE no-op.
+  const vehRows = await db
+    .select({ teltonikaImei: vehicles.teltonikaImei })
+    .from(vehicles)
+    .where(eq(vehicles.id, assignment.vehicleId))
+    .limit(1);
+  const vehiculo = vehRows[0];
+  if (!vehiculo?.teltonikaImei) {
+    logger.info(
+      { tripId, vehicleId: assignment.vehicleId },
+      'recalcularNivelPostEntrega: vehicle sin Teltonika — sin upgrade del nivel',
+    );
+    return { recomputed: false };
+  }
+
+  // Usar pickupWindowStart como inicio del trip si no hay pickup_at real.
+  // Es conservador: si el pickup real fue después, ampliamos la ventana
+  // de búsqueda y dejamos al cálculo el filtrado por gaps de continuidad.
+  const pickupAt = trip.pickupWindowStart ?? trip.createdAt;
+
+  const distanciaEstimadaKm = existing.distanceKmEstimated
+    ? Number(existing.distanceKmEstimated)
+    : 0;
+
+  const coveragePct = await calcularCobertura({
+    db,
+    logger,
+    vehicleId: assignment.vehicleId,
+    pickupAt,
+    deliveredAt: assignment.deliveredAt,
+    distanciaEstimadaKm,
+  });
+
+  const precisionMethod =
+    (existing.precisionMethod as 'exacto_canbus' | 'modelado' | 'por_defecto' | null) ??
+    'por_defecto';
+
+  // routeDataSource sube a 'teltonika_gps' porque el vehículo tiene
+  // device asociado y SI calculamos cobertura (puede ser 0 si no llegó
+  // ningún ping, pero la fuente conceptual es Teltonika).
+  const routeDataSource: RouteDataSource = 'teltonika_gps';
+
+  const certificationLevel = derivarNivelCertificacion({
+    precisionMethod,
+    routeDataSource,
+    coveragePct,
+  });
+  const uncertaintyFactor = calcularFactorIncertidumbre({
+    nivelCertificacion: certificationLevel,
+    coveragePct,
+    vehicleTypeMatchesRoutesApi: true,
+  });
+
+  await db
+    .update(tripMetrics)
+    .set({
+      routeDataSource,
+      coveragePct: coveragePct.toString(),
+      certificationLevel,
+      uncertaintyFactor: uncertaintyFactor.toString(),
+      updatedAt: sql`now()`,
+    })
+    .where(eq(tripMetrics.tripId, tripId));
+
+  logger.info(
+    {
+      tripId,
+      vehicleId: assignment.vehicleId,
+      coveragePct,
+      certificationLevel,
+      uncertaintyFactor,
+      precisionMethod,
+    },
+    'nivel de certificación recalculado post-entrega',
+  );
+
+  return { recomputed: true, certificationLevel, coveragePct };
 }

--- a/apps/api/src/services/confirmar-entrega-viaje.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.ts
@@ -32,6 +32,7 @@ import type { Logger } from '@booster-ai/logger';
 import { and, eq } from 'drizzle-orm';
 import type { Db } from '../db/client.js';
 import { assignments, tripEvents, trips } from '../db/schema.js';
+import { recalcularNivelPostEntrega } from './calcular-metricas-viaje.js';
 import {
   type EmitirCertificadoConfig,
   emitirCertificadoViaje,
@@ -184,6 +185,22 @@ export async function confirmarEntregaViaje(opts: {
   // re-disparamos (el cert ya debería existir; si no, un job de backfill
   // lo retoma).
   if (txResult.ok && !txResult.alreadyDelivered) {
+    // ADR-028 §5 — re-derivar nivel de certificación con telemetría real
+    // ANTES de emitir el cert. Esto convierte un trip que se persistió
+    // como secundario_modeled (al asignar) en primario_verificable o
+    // sigue como secundario con incertidumbre menor, según la cobertura
+    // GPS efectiva del viaje. Si falla, loggeamos pero seguimos con la
+    // emisión del cert con los valores estimados (no bloqueamos al
+    // cliente).
+    try {
+      await recalcularNivelPostEntrega({ db, logger, tripId });
+    } catch (err) {
+      logger.error(
+        { err, tripId },
+        'recalcularNivelPostEntrega fallo — emitiendo cert con valores estimados',
+      );
+    }
+
     emitirCertificadoViaje({ db, logger, tripId, config })
       .then((res) => {
         if (res.skipped) {

--- a/apps/api/test/unit/calcular-cobertura-telemetria.test.ts
+++ b/apps/api/test/unit/calcular-cobertura-telemetria.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CONTINUITY_GAP_S,
+  calcularCoberturaPura,
+  haversineKm,
+} from '../../src/services/calcular-cobertura-telemetria.js';
+
+/**
+ * Tests del cálculo puro de cobertura telemétrica (ADR-028 §5).
+ *
+ * El servicio que toca DB (`calcularCobertura`) es difícil de testear
+ * sin un Postgres real (Drizzle no tiene mock built-in fácil). La lógica
+ * crítica está extraída en funciones puras (`haversineKm`,
+ * `calcularCoberturaPura`) que se testean acá exhaustivamente.
+ *
+ * Casos cubiertos:
+ *   - haversine: pares conocidos con distancia documentada
+ *   - cobertura: 0 pings, 1 ping, 2+ pings con/sin gaps de continuidad
+ *   - boundary del threshold de gap (60s)
+ *   - cap a 100 cuando los pings reportan más distancia que la estimada
+ *   - sin distancia estimada → 0
+ */
+
+describe('haversineKm', () => {
+  it('Santiago (Plaza de Armas) → Valparaíso (centro) ≈ 100 km', () => {
+    // Plaza de Armas Santiago: -33.4378, -70.6504
+    // Plaza Sotomayor Valparaíso: -33.0367, -71.6262
+    // Distancia great-circle ≈ 100 km (vuelo directo, no ruta de
+    // carretera).
+    const km = haversineKm(-33.4378, -70.6504, -33.0367, -71.6262);
+    expect(km).toBeGreaterThan(95);
+    expect(km).toBeLessThan(105);
+  });
+
+  it('mismo punto → 0 km', () => {
+    expect(haversineKm(-33.4, -70.6, -33.4, -70.6)).toBe(0);
+  });
+
+  it('1° de latitud (en ecuador) ≈ 111.2 km', () => {
+    const km = haversineKm(0, 0, 1, 0);
+    expect(km).toBeGreaterThan(110);
+    expect(km).toBeLessThan(112);
+  });
+
+  it('simetría: haversine(A,B) = haversine(B,A)', () => {
+    const ab = haversineKm(-33.4, -70.6, -33.05, -71.6);
+    const ba = haversineKm(-33.05, -71.6, -33.4, -70.6);
+    expect(ab).toBeCloseTo(ba, 6);
+  });
+});
+
+describe('calcularCoberturaPura — casos vacíos / triviales', () => {
+  it('0 pings → cobertura 0', () => {
+    expect(calcularCoberturaPura([], 100)).toBe(0);
+  });
+
+  it('1 ping (no hay pares) → cobertura 0', () => {
+    expect(calcularCoberturaPura([{ tMs: 0, lat: -33.4, lng: -70.6 }], 100)).toBe(0);
+  });
+
+  it('distanciaEstimadaKm = 0 → cobertura 0 (evita división por cero)', () => {
+    const pings = [
+      { tMs: 0, lat: -33.4, lng: -70.6 },
+      { tMs: 30_000, lat: -33.4, lng: -70.65 },
+    ];
+    expect(calcularCoberturaPura(pings, 0)).toBe(0);
+  });
+
+  it('distanciaEstimadaKm negativa (defensivo) → cobertura 0', () => {
+    expect(calcularCoberturaPura([], -10)).toBe(0);
+  });
+});
+
+describe('calcularCoberturaPura — pings continuos', () => {
+  it('dos pings con gap < 60s → cobertura es proporcional a la distancia entre ellos', () => {
+    // Dos pings separados 30s en tiempo y ~5.5km en espacio (1° de
+    // longitud en latitud -33° ≈ 92km × 0.06° ≈ 5.5km).
+    // Si la distancia estimada del trip total es 50km → cobertura ≈ 11%.
+    const pings = [
+      { tMs: 0, lat: -33.4, lng: -70.6 },
+      { tMs: 30_000, lat: -33.4, lng: -70.66 },
+    ];
+    const cov = calcularCoberturaPura(pings, 50);
+    expect(cov).toBeGreaterThan(10);
+    expect(cov).toBeLessThan(13);
+  });
+
+  it('serie de 5 pings continuos → suma todas las distancias intermedias', () => {
+    // Cada ping a 30s, separados 1km uno del otro (~0.009° de longitud
+    // a -33° de latitud ≈ 1km). Total acumulado = 4km en 4 pares.
+    const pings = [
+      { tMs: 0, lat: -33.4, lng: -70.6 },
+      { tMs: 30_000, lat: -33.4, lng: -70.6108 },
+      { tMs: 60_000, lat: -33.4, lng: -70.6216 },
+      { tMs: 90_000, lat: -33.4, lng: -70.6324 },
+      { tMs: 120_000, lat: -33.4, lng: -70.6432 },
+    ];
+    const cov = calcularCoberturaPura(pings, 10);
+    // Con cada ping 30s después y < 60s gap, todos cuentan.
+    // 4 segmentos × ~1km = ~4km. 4/10 = 40%.
+    expect(cov).toBeGreaterThan(35);
+    expect(cov).toBeLessThan(45);
+  });
+});
+
+describe('calcularCoberturaPura — gaps de discontinuidad', () => {
+  it('gap > 60s entre pings NO suma al km cubierto', () => {
+    // Dos pings separados 120s (gap > 60s) y 5km en espacio. NO debe
+    // contar al km cubierto. Cobertura = 0.
+    const pings = [
+      { tMs: 0, lat: -33.4, lng: -70.6 },
+      { tMs: 120_000, lat: -33.4, lng: -70.66 },
+    ];
+    const cov = calcularCoberturaPura(pings, 50);
+    expect(cov).toBe(0);
+  });
+
+  it('mezcla continuo + gap → solo cuenta el continuo', () => {
+    // Pings 1-2: continuos (30s gap, ~1km).
+    // Pings 2-3: gap 120s (NO cuenta).
+    // Pings 3-4: continuos (30s gap, ~1km).
+    // Total km cubiertos: ~2km de los 10 estimados → ~20%.
+    const pings = [
+      { tMs: 0, lat: -33.4, lng: -70.6 },
+      { tMs: 30_000, lat: -33.4, lng: -70.6108 }, // continuo
+      { tMs: 150_000, lat: -33.4, lng: -70.7 }, // gap 120s — descarta
+      { tMs: 180_000, lat: -33.4, lng: -70.7108 }, // continuo
+    ];
+    const cov = calcularCoberturaPura(pings, 10);
+    expect(cov).toBeGreaterThan(15);
+    expect(cov).toBeLessThan(25);
+  });
+
+  it('gap exactamente CONTINUITY_GAP_S es discontinuidad (no cuenta)', () => {
+    // El threshold es < 60s (estricto). gap = 60s exacto NO cuenta
+    // porque la condición es `gapS < CONTINUITY_GAP_S`.
+    expect(CONTINUITY_GAP_S).toBe(60);
+    const pings = [
+      { tMs: 0, lat: -33.4, lng: -70.6 },
+      { tMs: 60_000, lat: -33.4, lng: -70.66 }, // gap = 60s → NO cuenta
+    ];
+    expect(calcularCoberturaPura(pings, 50)).toBe(0);
+  });
+
+  it('gap 59.9s SI cuenta (boundary)', () => {
+    const pings = [
+      { tMs: 0, lat: -33.4, lng: -70.6 },
+      { tMs: 59_900, lat: -33.4, lng: -70.6108 },
+    ];
+    const cov = calcularCoberturaPura(pings, 10);
+    expect(cov).toBeGreaterThan(0);
+  });
+});
+
+describe('calcularCoberturaPura — cap', () => {
+  it('si los pings reportan más distancia que la estimada, cap a 100', () => {
+    // Caso: el conductor tomó una ruta más larga que la estimada
+    // (por ejemplo, desvíos). Los pings suman 60km cuando la estimada
+    // era 50km → 120% sin cap → 100% con cap.
+    const pings = [
+      { tMs: 0, lat: -33, lng: -70 },
+      { tMs: 30_000, lat: -33.5, lng: -70.5 }, // ~70km
+    ];
+    const cov = calcularCoberturaPura(pings, 50);
+    expect(cov).toBe(100);
+  });
+});


### PR DESCRIPTION
## Resumen

PR-G de la implementación de [ADR-028](../blob/main/docs/adr/028-dual-source-data-model-teltonika-vs-maps.md). **Cierra el upgrade path** secundario→primario (cuando hay datos para hacerlo).

Builds on top of [#94](../pull/94). **Cierra Phase 0**.

Flow end-to-end después de este merge:

\`\`\`
Asignación creada
  → calcularMetricasEstimadas()
    → persiste secundario_modeled (Maps-only, cobertura 0)

Entrega confirmada
  → recalcularNivelPostEntrega()  [NUEVO en este PR]
    → si vehicle tiene Teltonika: calcular cobertura GPS real,
      promover routeDataSource a 'teltonika_gps', re-derivar
      certification_level + uncertainty_factor
    → si no: skip silencioso (cert sale con valores estimados)
  → emitirCertificadoViaje()
    → cert-generator (PR-E) usa los valores recalculados para
      elegir template y publicar el ± de incertidumbre
\`\`\`

## Cambios

### \`apps/api/src/services/calcular-cobertura-telemetria.ts\` (nuevo)
- \`haversineKm()\`: distancia great-circle (función pura, WGS84 6371km)
- \`calcularCoberturaPura()\`: función pura que computa \`coverage_pct\` desde una lista de pings ordenados por tiempo + distancia esperada. Suma haversine entre pares consecutivos cuando gap < 60s. Cap a 100. Defensiva ante divisor 0.
- \`calcularCobertura()\`: wrapper con I/O para query de \`telemetria_puntos\`.
- \`CONTINUITY_GAP_S = 60\` exportado.

### \`apps/api/src/services/calcular-metricas-viaje.ts\`
Nueva función \`recalcularNivelPostEntrega()\`:
- Si vehicle no tiene Teltonika → skip silencioso
- Si tiene: cobertura → \`teltonika_gps\` + cobertura real → re-derivar nivel + uncertainty
- UPDATE selectivo de los 4 campos ADR-028, sin tocar emisiones/factor existentes.

### \`apps/api/src/services/confirmar-entrega-viaje.ts\`
Hook al recálculo ANTES de \`emitirCertificadoViaje\`. Try/catch defensivo para no bloquear emisión del cert si recálculo falla.

## Tests

15 casos nuevos en \`calcular-cobertura-telemetria.test.ts\`:
- **haversineKm**: pares conocidos (Santiago-Valparaíso ~100km, 1° lat ecuador ~111km), simetría, mismo punto = 0.
- **calcularCoberturaPura**: empty/trivial, distancias pequeñas reales, serie de pings continuos, gaps de discontinuidad, mezcla continuo+gap, **boundary del threshold** (60s exacto = NO cuenta porque condición es \`< 60\`), cap a 100% cuando pings reportan más km que la estimada.

## Verificación

- [x] \`pnpm --filter @booster-ai/api typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/api test\` — 123/123 passed (108 existentes + 15 nuevos)
- [x] \`biome check\` — 0 errores

## Trade-off importante

\`recalcularNivelPostEntrega\` NO actualiza \`precisionMethod\` — promover a \`exacto_canbus\` requiere consumo real del CAN bus, que es integración separada (futura). Sin CAN, el techo es \`modelado + teltonika_gps\`, que en la matriz §2 cae a \`secundario_modeled\` aún con cobertura 100%.

**Los certs \`primario_verificable\` solo se emitirán cuando agreguemos \`precisionMethod='exacto_canbus'\` en una iteración posterior** (consistente con ADR-017 §4).

Sin embargo, el \`uncertainty_factor\` SI mejora con telemetría: \`secundario_modeled\` con cobertura 100% → uncertainty 0.15. Cobertura 0% (Maps-only) → uncertainty 0.35. El cliente Verified gana ~0.20 menos de incertidumbre publicada en el cert vs Basic. **Diferencial concreto post-merge**.

## Cierre de Phase 0

Tras este merge, Phase 0 está completa:

| | Estado |
|---|---|
| ADR-028 | ✅ #89 |
| Domain types | ✅ #90 |
| Carbon-calculator | ✅ #91 |
| DB schema + migration | ✅ #92 |
| Cert templates | ✅ #93 |
| API integration | ✅ #94 |
| Cobertura telemétrica + post-delivery upgrade | 🟡 este PR |

**Greenwashing imposible por construcción**: el nivel deriva de datos persistidos por funciones puras, no de input del cliente. Los certs en producción distinguen primario vs secundario y el ± de incertidumbre se publica en el PDF.

## Después: Phase 1 (eco-route suggestion)

Routes API integration con \`extraComputations: ['FUEL_CONSUMPTION']\` + \`vehicleInfo.emissionType\`. Funciona para AMBOS tiers de cliente — la diferencia ya no está en si reciben sugerencia (ambos), está en cómo verifican lo que efectivamente recorrieron (Teltonika vs Maps), que es lo que ADR-028 ya resuelve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)