### PR TITLE
feat(api): integrar Routes API en calcularMetricasEstimadas (Phase 1 PR-H2)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -210,6 +210,21 @@ const apiEnvSchema = commonEnvSchema
       .string()
       .regex(/^[a-z0-9-]+@[a-z0-9-]+\.iam\.gserviceaccount\.com$/, 'SA email inválido')
       .optional(),
+
+    /**
+     * API key para Google Routes API (Phase 1 — eco route suggestion).
+     *
+     * IMPORTANTE: esta key DEBE estar restringida a los servidores de
+     * Cloud Run del backend, NO al dominio app.boosterchile.com — Routes
+     * API se llama server-to-server, no desde el browser. La restricción
+     * en GCP Console → APIs → Credentials → "Booster Routes - API
+     * Backend" debe ser por IP o por SA, nunca HTTP referrer.
+     *
+     * Optional: si está ausente, los servicios que la usan caen al
+     * fallback de estimarDistanciaKm (tabla pre-computada Chile) y NO
+     * generan sugerencia de eco-route. Útil en dev sin quota Routes API.
+     */
+    GOOGLE_ROUTES_API_KEY: z.string().min(1).optional(),
   });
 
 export type ApiEnv = z.infer<typeof apiEnvSchema>;

--- a/apps/api/src/services/calcular-metricas-viaje.ts
+++ b/apps/api/src/services/calcular-metricas-viaje.ts
@@ -12,6 +12,7 @@ import type { Db } from '../db/client.js';
 import { assignments, tripMetrics, trips, vehicles } from '../db/schema.js';
 import { calcularCobertura } from './calcular-cobertura-telemetria.js';
 import { estimarDistanciaKm } from './estimar-distancia.js';
+import { type VehicleEmissionType, computeRoutes } from './routes-api.js';
 
 /**
  * Calcular y persistir métricas ESG de un viaje, usando el carbon-calculator
@@ -52,6 +53,109 @@ export interface CalcularMetricasResult {
 }
 
 /**
+ * Mapeo de tipo_combustible interno (TipoCombustible) al enum de Routes
+ * API (VehicleEmissionType). Routes API solo acepta 4 valores; los
+ * combustibles más específicos del schema interno (GLP, GNC, hidrógeno)
+ * se mapean al más cercano:
+ *
+ *   - diesel              → DIESEL
+ *   - gasolina            → GASOLINE
+ *   - gas_glp / gas_gnc   → GASOLINE (closest behavioral analog)
+ *   - electrico           → ELECTRIC
+ *   - hibrido_*           → HYBRID
+ *   - hidrogeno           → ELECTRIC (closest hop, no H2 enum aún)
+ *
+ * Si el tipo no es uno de los del schema, devolvemos undefined → Routes
+ * API no calcula FUEL_CONSUMPTION para esa request (ahorra costo).
+ */
+function mapFuelToEmissionType(combustible: string): VehicleEmissionType | undefined {
+  switch (combustible) {
+    case 'diesel':
+      return 'DIESEL';
+    case 'gasolina':
+    case 'gas_glp':
+    case 'gas_gnc':
+      return 'GASOLINE';
+    case 'electrico':
+    case 'hidrogeno':
+      return 'ELECTRIC';
+    case 'hibrido_diesel':
+    case 'hibrido_gasolina':
+      return 'HYBRID';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Obtiene la distancia origen→destino del trip en km.
+ *
+ * Prioridad:
+ *   1. Si hay GOOGLE_ROUTES_API_KEY configurada Y el vehículo tiene
+ *      fuelType conocido → llamar Routes API. Usa la distancia de la
+ *      mejor ruta (TRAFFIC_AWARE_OPTIMAL).
+ *   2. Si Routes API falla (timeout, quota exceeded, etc.) o no hay
+ *      key → fallback a estimarDistanciaKm (tabla pre-computada Chile).
+ *
+ * Fallback explícito: cualquier error del Routes API se loggea WARN y
+ * caemos al fallback. NO bloquea el cálculo de métricas — el carrier
+ * recibe igual su confirmación de asignación.
+ *
+ * Función con I/O — no debe correrse dentro de una transacción de DB
+ * para no extender el lock por la duración del HTTP call (~500ms-1s).
+ */
+async function obtenerDistanciaKm(opts: {
+  origenDireccion: string;
+  destinoDireccion: string;
+  origenRegionCode: string | null;
+  destinoRegionCode: string | null;
+  fuelType: string | null;
+  routesApiKey: string | undefined;
+  logger: Logger;
+}): Promise<number> {
+  const {
+    origenDireccion,
+    destinoDireccion,
+    origenRegionCode,
+    destinoRegionCode,
+    fuelType,
+    routesApiKey,
+    logger,
+  } = opts;
+
+  if (routesApiKey) {
+    try {
+      const emissionType = fuelType ? mapFuelToEmissionType(fuelType) : undefined;
+      const routes = await computeRoutes({
+        apiKey: routesApiKey,
+        origin: origenDireccion,
+        destination: destinoDireccion,
+        emissionType,
+      });
+      const best = routes[0];
+      if (best && best.distanceKm > 0) {
+        logger.info(
+          { distanciaKm: best.distanceKm, durationS: best.durationS, source: 'routes_api' },
+          'distancia obtenida via Routes API',
+        );
+        return best.distanceKm;
+      }
+      logger.warn(
+        { origenDireccion, destinoDireccion },
+        'Routes API devolvió 0 rutas, fallback a estimarDistanciaKm',
+      );
+    } catch (err) {
+      logger.warn(
+        { err, origenDireccion, destinoDireccion },
+        'Routes API falló, fallback a estimarDistanciaKm',
+      );
+    }
+  }
+
+  return estimarDistanciaKm(origenRegionCode, destinoRegionCode);
+}
+
+/**
  * Calcular métricas estimadas (al asignar viaje, antes de la entrega).
  */
 export async function calcularMetricasEstimadas(opts: {
@@ -59,64 +163,85 @@ export async function calcularMetricasEstimadas(opts: {
   logger: Logger;
   tripId: string;
   vehicleId: string | null;
+  /**
+   * GOOGLE_ROUTES_API_KEY del config. Si está presente, se usa Routes API
+   * para distancia precisa. Si no, se cae al fallback de estimarDistanciaKm.
+   * Optional: el caller decide si la pasa o no (en dev sin quota la omite).
+   */
+  routesApiKey?: string | undefined;
 }): Promise<CalcularMetricasResult> {
-  const { db, logger, tripId, vehicleId } = opts;
+  const { db, logger, tripId, vehicleId, routesApiKey } = opts;
 
-  return await db.transaction(async (tx) => {
-    const tripRows = await tx.select().from(trips).where(eq(trips.id, tripId)).limit(1);
-    const trip = tripRows[0];
-    if (!trip) {
-      throw new TripNotFoundError(tripId);
-    }
+  // (1) Lectura de trip + vehicle FUERA de la transacción. Esto permite
+  // hacer el HTTP a Routes API sin extender el lock de la tx (que sería
+  // anti-patrón: un HTTP de ~500ms-1s holding row lock genera contención
+  // en re-cálculos concurrentes del mismo trip). Postgres MVCC garantiza
+  // que las lecturas son consistentes punto-en-tiempo aunque sean fuera
+  // del begin/commit del UPDATE final.
+  const tripRows = await db.select().from(trips).where(eq(trips.id, tripId)).limit(1);
+  const trip = tripRows[0];
+  if (!trip) {
+    throw new TripNotFoundError(tripId);
+  }
 
-    const cargaKg = trip.cargoWeightKg ?? 0;
-    const distanciaKm = estimarDistanciaKm(trip.originRegionCode, trip.destinationRegionCode);
+  const veh = vehicleId
+    ? (await db.select().from(vehicles).where(eq(vehicles.id, vehicleId)).limit(1))[0]
+    : undefined;
 
-    // Resolver perfil del vehículo. Si no hay vehicleId aún, o no se
-    // encuentra, o no tiene perfil completo → modo por_defecto.
-    let emisiones: ResultadoEmisiones | null = null;
-    if (vehicleId) {
-      const vehs = await tx.select().from(vehicles).where(eq(vehicles.id, vehicleId)).limit(1);
-      const veh = vehs[0];
-      if (veh) {
-        const consumoBase = veh.consumptionLPer100kmBaseline
-          ? Number(veh.consumptionLPer100kmBaseline)
-          : null;
+  // (2) HTTP out-of-tx — Routes API o fallback a tabla.
+  const distanciaKm = await obtenerDistanciaKm({
+    origenDireccion: trip.originAddressRaw,
+    destinoDireccion: trip.destinationAddressRaw,
+    origenRegionCode: trip.originRegionCode,
+    destinoRegionCode: trip.destinationRegionCode,
+    fuelType: veh?.fuelType ?? null,
+    routesApiKey,
+    logger,
+  });
 
-        if (veh.fuelType && consumoBase != null) {
-          // Modo modelado — perfil completo declarado.
-          emisiones = calcularEmisionesViaje({
-            metodo: 'modelado',
-            distanciaKm,
-            cargaKg,
-            vehiculo: {
-              combustible: veh.fuelType as TipoCombustible,
-              consumoBasePor100km: consumoBase,
-              pesoVacioKg: veh.curbWeightKg,
-              capacidadKg: veh.capacityKg,
-            },
-          });
-        } else {
-          // Modo por_defecto — usamos tipo de vehículo como proxy.
-          emisiones = calcularEmisionesViaje({
-            metodo: 'por_defecto',
-            distanciaKm,
-            cargaKg,
-            tipoVehiculo: veh.vehicleType,
-          });
-        }
-      }
-    }
-    if (emisiones == null) {
-      // Fallback: por_defecto con camion_mediano (proxy genérico).
+  // (3) Compute emisiones (puro, GLEC v3.0).
+  const cargaKg = trip.cargoWeightKg ?? 0;
+  let emisiones: ResultadoEmisiones | null = null;
+  if (veh) {
+    const consumoBase = veh.consumptionLPer100kmBaseline
+      ? Number(veh.consumptionLPer100kmBaseline)
+      : null;
+
+    if (veh.fuelType && consumoBase != null) {
+      // Modo modelado — perfil completo declarado.
+      emisiones = calcularEmisionesViaje({
+        metodo: 'modelado',
+        distanciaKm,
+        cargaKg,
+        vehiculo: {
+          combustible: veh.fuelType as TipoCombustible,
+          consumoBasePor100km: consumoBase,
+          pesoVacioKg: veh.curbWeightKg,
+          capacidadKg: veh.capacityKg,
+        },
+      });
+    } else {
+      // Modo por_defecto — usamos tipo de vehículo como proxy.
       emisiones = calcularEmisionesViaje({
         metodo: 'por_defecto',
         distanciaKm,
         cargaKg,
-        tipoVehiculo: 'camion_mediano',
+        tipoVehiculo: veh.vehicleType,
       });
     }
+  }
+  if (emisiones == null) {
+    // Fallback: por_defecto con camion_mediano (proxy genérico).
+    emisiones = calcularEmisionesViaje({
+      metodo: 'por_defecto',
+      distanciaKm,
+      cargaKg,
+      tipoVehiculo: 'camion_mediano',
+    });
+  }
 
+  // (4) Persistencia — tx corta con todo pre-computado.
+  return await db.transaction(async (tx) => {
     const existing = await tx
       .select()
       .from(tripMetrics)

--- a/apps/api/src/services/offer-actions.ts
+++ b/apps/api/src/services/offer-actions.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@booster-ai/logger';
 import { and, eq, ne } from 'drizzle-orm';
+import { config } from '../config.js';
 import type { Db } from '../db/client.js';
 import {
   type AssignmentRow,
@@ -203,6 +204,11 @@ export async function acceptOffer(opts: {
           logger,
           tripId: result.assignment.tripId,
           vehicleId: result.assignment.vehicleId || null,
+          // ADR-028 PR-H2: si hay GOOGLE_ROUTES_API_KEY, calcularMetricas
+          // usa Routes API para distancia (más precisa, traffic-aware) en
+          // vez de la tabla pre-computada Chile. Si no hay key (dev sin
+          // quota), cae al fallback automáticamente.
+          routesApiKey: config.GOOGLE_ROUTES_API_KEY,
         });
         logger.info(
           {

--- a/apps/api/src/services/routes-api.ts
+++ b/apps/api/src/services/routes-api.ts
@@ -1,0 +1,229 @@
+import type { Logger } from '@booster-ai/logger';
+
+/**
+ * Cliente del Google Routes API (Phase 1 — eco route suggestion).
+ *
+ * Endpoint: POST https://routes.googleapis.com/directions/v2:computeRoutes
+ * Docs: https://developers.google.com/maps/documentation/routes/compute_route_directions
+ *
+ * Diseño:
+ *   - Función pura (toma `fetch` inyectable para tests).
+ *   - Devuelve estructura normalizada que oculta detalles del wire
+ *     protocol de Google (microliters → liters, distanceMeters → km).
+ *   - Acepta direcciones como strings (Routes API geocodifica internamente).
+ *     Cuando agreguemos lat/lng a `viajes`, se podrá pasar coordenadas
+ *     directamente sin geocoding extra (más barato).
+ *
+ * Costo: ~$5 USD por 1000 requests con extras computations habilitados.
+ *
+ * Restricción de la API key (configurada en GCP Console):
+ *   - Por IP del egress de Cloud Run (preferido) o por SA token.
+ *   - NUNCA por HTTP referrer (Routes API es server-side).
+ */
+
+/** Tipos de combustible aceptados por Routes API. Espejo de
+ *  google.routes.v2.VehicleEmissionType. */
+export type VehicleEmissionType = 'GASOLINE' | 'ELECTRIC' | 'HYBRID' | 'DIESEL';
+
+/** Una ruta alternativa devuelta por Routes API, normalizada a unidades SI. */
+export interface RouteSuggestion {
+  /** Distancia total en km. */
+  distanceKm: number;
+  /** Duración estimada en segundos (con tráfico si TRAFFIC_AWARE). */
+  durationS: number;
+  /**
+   * Combustible estimado en litros. Solo presente si la API computó
+   * FUEL_CONSUMPTION (depende de emissionType + región). Null indica
+   * que el cálculo no fue posible (ej: ELECTRIC).
+   */
+  fuelL: number | null;
+  /**
+   * Polyline encoded (Google's Encoded Polyline format) de la geometría
+   * de la ruta. Para mostrar en el mapa cliente.
+   */
+  polylineEncoded: string;
+}
+
+export interface ComputeRoutesParams {
+  /** API key con restricción server-side (no HTTP referrer). */
+  apiKey: string;
+  /** Origen — dirección textual (Routes API la geocodifica). */
+  origin: string;
+  /** Destino — dirección textual. */
+  destination: string;
+  /**
+   * Tipo de motor del vehículo, para que Routes API estime
+   * `fuelConsumptionMicroliters`. Si se omite, no se solicita
+   * FUEL_CONSUMPTION extra computation.
+   */
+  emissionType?: VehicleEmissionType | undefined;
+  /**
+   * Si true, computa rutas alternativas (hasta 3). Default false.
+   * El primer elemento siempre es la "principal" (TRAFFIC_AWARE_OPTIMAL).
+   */
+  computeAlternatives?: boolean | undefined;
+  /** Opcional: fetch inyectable (para tests). Default global fetch. */
+  fetchImpl?: typeof fetch | undefined;
+  /** Opcional: logger para debug. */
+  logger?: Logger | undefined;
+}
+
+/**
+ * Errores tipados para el caller distinguir tipo de fallo y decidir
+ * fallback (ej: si es transient → reintento; si es API key inválida →
+ * fallback a estimarDistanciaKm).
+ */
+export class RoutesApiError extends Error {
+  constructor(
+    message: string,
+    public readonly code:
+      | 'invalid_request'
+      | 'auth_error'
+      | 'quota_exceeded'
+      | 'network_error'
+      | 'unknown',
+    public readonly httpStatus: number | null,
+  ) {
+    super(message);
+    this.name = 'RoutesApiError';
+  }
+}
+
+const ROUTES_API_URL = 'https://routes.googleapis.com/directions/v2:computeRoutes';
+
+/**
+ * Llama al Routes API y devuelve las rutas normalizadas.
+ *
+ * @throws RoutesApiError si la API rechaza el request (4xx) o falla la red.
+ * El caller debe decidir si hacer fallback o propagar.
+ */
+export async function computeRoutes(params: ComputeRoutesParams): Promise<RouteSuggestion[]> {
+  const {
+    apiKey,
+    origin,
+    destination,
+    emissionType,
+    computeAlternatives = false,
+    fetchImpl = fetch,
+    logger,
+  } = params;
+
+  const body: Record<string, unknown> = {
+    origin: { address: origin },
+    destination: { address: destination },
+    travelMode: 'DRIVE',
+    routingPreference: 'TRAFFIC_AWARE_OPTIMAL',
+    computeAlternativeRoutes: computeAlternatives,
+  };
+
+  // Solo agregamos vehicleInfo + extraComputations si tenemos emission
+  // type — sin esto Routes API no calcula fuelConsumption (cobra menos).
+  if (emissionType) {
+    body.vehicleInfo = { emissionType };
+    body.extraComputations = ['FUEL_CONSUMPTION'];
+  }
+
+  // Field mask reducido para minimizar response size (Routes API factura
+  // por field-mask; pedir solo lo que usamos).
+  const fieldMask = [
+    'routes.distanceMeters',
+    'routes.duration',
+    'routes.polyline.encodedPolyline',
+    emissionType ? 'routes.travelAdvisory.fuelConsumptionMicroliters' : null,
+  ]
+    .filter(Boolean)
+    .join(',');
+
+  let response: Response;
+  try {
+    response = await fetchImpl(ROUTES_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Goog-Api-Key': apiKey,
+        'X-Goog-FieldMask': fieldMask,
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    logger?.error({ err, origin, destination }, 'Routes API network error');
+    throw new RoutesApiError(
+      `Network error calling Routes API: ${err instanceof Error ? err.message : 'unknown'}`,
+      'network_error',
+      null,
+    );
+  }
+
+  if (!response.ok) {
+    let errBody = '';
+    try {
+      errBody = await response.text();
+    } catch {
+      // ignore
+    }
+    const code = mapHttpStatusToCode(response.status);
+    logger?.warn(
+      { httpStatus: response.status, code, errBody, origin, destination },
+      'Routes API non-2xx response',
+    );
+    throw new RoutesApiError(
+      `Routes API returned ${response.status}: ${errBody.slice(0, 200)}`,
+      code,
+      response.status,
+    );
+  }
+
+  // Parse + normalización defensiva. Routes API puede devolver `{}` si
+  // no encontró rutas (ej. origen sin grafo de calles).
+  const json = (await response.json()) as {
+    routes?: Array<{
+      distanceMeters?: number;
+      duration?: string; // formato "1234s"
+      polyline?: { encodedPolyline?: string };
+      travelAdvisory?: {
+        fuelConsumptionMicroliters?: string; // BigInt serializado
+      };
+    }>;
+  };
+
+  if (!json.routes || json.routes.length === 0) {
+    return [];
+  }
+
+  return json.routes.map((r): RouteSuggestion => {
+    const distanceM = r.distanceMeters ?? 0;
+    const durationS = parseDurationS(r.duration);
+    const fuelMicroL = r.travelAdvisory?.fuelConsumptionMicroliters;
+    return {
+      distanceKm: distanceM / 1000,
+      durationS,
+      fuelL: fuelMicroL != null ? Number(fuelMicroL) / 1_000_000 : null,
+      polylineEncoded: r.polyline?.encodedPolyline ?? '',
+    };
+  });
+}
+
+/**
+ * Routes API serializa duration como `"1234s"` (Google's Duration
+ * format de protobuf). Parseamos a número de segundos.
+ */
+function parseDurationS(s: string | undefined): number {
+  if (!s) {
+    return 0;
+  }
+  const m = s.match(/^(\d+)s$/);
+  return m?.[1] ? Number(m[1]) : 0;
+}
+
+function mapHttpStatusToCode(status: number): RoutesApiError['code'] {
+  if (status === 400) {
+    return 'invalid_request';
+  }
+  if (status === 401 || status === 403) {
+    return 'auth_error';
+  }
+  if (status === 429) {
+    return 'quota_exceeded';
+  }
+  return 'unknown';
+}

--- a/apps/api/test/unit/routes-api.test.ts
+++ b/apps/api/test/unit/routes-api.test.ts
@@ -1,0 +1,309 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type RouteSuggestion,
+  RoutesApiError,
+  computeRoutes,
+} from '../../src/services/routes-api.js';
+
+/**
+ * Tests del cliente Routes API (Phase 1 — eco route suggestion).
+ *
+ * Mockean `fetch` directamente con `vi.fn()` — el contrato del Routes
+ * API es simple (POST + JSON in/out), no hay valor en usar msw.
+ *
+ * Cobertura:
+ *   - Request body bien formado (origen, destino, vehicle info, field mask)
+ *   - Field mask cambia según haya emissionType (con/sin FUEL_CONSUMPTION)
+ *   - Parse de response: distanceMeters → km, microliters → liters,
+ *     duration "1234s" → 1234
+ *   - Errores HTTP: 400/401/403/429 mapean a RoutesApiError con code
+ *     correcto
+ *   - Errores de red (fetch throws) → RoutesApiError network_error
+ *   - Response sin rutas → [] (no throw)
+ */
+
+function makeFetchOk(body: unknown): typeof fetch {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  })) as unknown as typeof fetch;
+}
+
+function makeFetchError(status: number, body = '{"error":"..."}'): typeof fetch {
+  return vi.fn(async () => ({
+    ok: false,
+    status,
+    json: async () => ({}),
+    text: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+describe('computeRoutes — request body', () => {
+  it('arma origin + destination como address strings', async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ routes: [] }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    await computeRoutes({
+      apiKey: 'AIzaTest',
+      origin: 'Av. Apoquindo 5400, Las Condes',
+      destination: 'Calle 1 Norte 123, Concepción',
+      fetchImpl: fetchSpy,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const callArgs = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(callArgs?.[0]).toBe('https://routes.googleapis.com/directions/v2:computeRoutes');
+    const init = callArgs?.[1] as RequestInit;
+    const parsed = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(parsed.origin).toEqual({ address: 'Av. Apoquindo 5400, Las Condes' });
+    expect(parsed.destination).toEqual({ address: 'Calle 1 Norte 123, Concepción' });
+    expect(parsed.travelMode).toBe('DRIVE');
+    expect(parsed.routingPreference).toBe('TRAFFIC_AWARE_OPTIMAL');
+  });
+
+  it('incluye vehicleInfo + extraComputations cuando hay emissionType', async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ routes: [] }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    await computeRoutes({
+      apiKey: 'AIzaTest',
+      origin: 'A',
+      destination: 'B',
+      emissionType: 'DIESEL',
+      fetchImpl: fetchSpy,
+    });
+
+    const init = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as RequestInit;
+    const parsed = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(parsed.vehicleInfo).toEqual({ emissionType: 'DIESEL' });
+    expect(parsed.extraComputations).toEqual(['FUEL_CONSUMPTION']);
+
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Goog-FieldMask']).toContain(
+      'routes.travelAdvisory.fuelConsumptionMicroliters',
+    );
+  });
+
+  it('omite vehicleInfo + FUEL_CONSUMPTION cuando NO hay emissionType (cobra menos)', async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ routes: [] }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    await computeRoutes({
+      apiKey: 'AIzaTest',
+      origin: 'A',
+      destination: 'B',
+      fetchImpl: fetchSpy,
+    });
+
+    const init = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as RequestInit;
+    const parsed = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(parsed.vehicleInfo).toBeUndefined();
+    expect(parsed.extraComputations).toBeUndefined();
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Goog-FieldMask']).not.toContain('fuelConsumption');
+  });
+
+  it('computeAlternatives=true se propaga a la request', async () => {
+    const fetchSpy = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ routes: [] }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+
+    await computeRoutes({
+      apiKey: 'k',
+      origin: 'A',
+      destination: 'B',
+      computeAlternatives: true,
+      fetchImpl: fetchSpy,
+    });
+
+    const init = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as RequestInit;
+    const parsed = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(parsed.computeAlternativeRoutes).toBe(true);
+  });
+});
+
+describe('computeRoutes — response parsing', () => {
+  it('normaliza distanceMeters → km y duration "1234s" → 1234', async () => {
+    const fetchImpl = makeFetchOk({
+      routes: [
+        {
+          distanceMeters: 142000,
+          duration: '5400s',
+          polyline: { encodedPolyline: 'abc123' },
+        },
+      ],
+    });
+
+    const routes = await computeRoutes({
+      apiKey: 'k',
+      origin: 'A',
+      destination: 'B',
+      fetchImpl,
+    });
+
+    expect(routes).toEqual<RouteSuggestion[]>([
+      {
+        distanceKm: 142,
+        durationS: 5400,
+        fuelL: null,
+        polylineEncoded: 'abc123',
+      },
+    ]);
+  });
+
+  it('convierte fuelConsumptionMicroliters → litros', async () => {
+    const fetchImpl = makeFetchOk({
+      routes: [
+        {
+          distanceMeters: 100000,
+          duration: '3600s',
+          polyline: { encodedPolyline: 'xyz' },
+          travelAdvisory: { fuelConsumptionMicroliters: '12000000' }, // 12 L
+        },
+      ],
+    });
+
+    const [r] = await computeRoutes({
+      apiKey: 'k',
+      origin: 'A',
+      destination: 'B',
+      emissionType: 'DIESEL',
+      fetchImpl,
+    });
+
+    expect(r?.fuelL).toBe(12);
+  });
+
+  it('response con múltiples rutas → array completo', async () => {
+    const fetchImpl = makeFetchOk({
+      routes: [
+        { distanceMeters: 100000, duration: '3600s', polyline: { encodedPolyline: 'p1' } },
+        { distanceMeters: 110000, duration: '4000s', polyline: { encodedPolyline: 'p2' } },
+        { distanceMeters: 95000, duration: '5400s', polyline: { encodedPolyline: 'p3' } },
+      ],
+    });
+
+    const routes = await computeRoutes({
+      apiKey: 'k',
+      origin: 'A',
+      destination: 'B',
+      computeAlternatives: true,
+      fetchImpl,
+    });
+
+    expect(routes).toHaveLength(3);
+    expect(routes[0]?.distanceKm).toBe(100);
+    expect(routes[1]?.distanceKm).toBe(110);
+    expect(routes[2]?.distanceKm).toBe(95);
+  });
+
+  it('response sin rutas → [] (no throw)', async () => {
+    const fetchImpl = makeFetchOk({}); // sin field "routes"
+    const routes = await computeRoutes({
+      apiKey: 'k',
+      origin: 'A',
+      destination: 'B',
+      fetchImpl,
+    });
+    expect(routes).toEqual([]);
+  });
+
+  it('response con campos faltantes → defaults defensivos', async () => {
+    const fetchImpl = makeFetchOk({
+      routes: [{}], // ruta sin nada
+    });
+    const [r] = await computeRoutes({
+      apiKey: 'k',
+      origin: 'A',
+      destination: 'B',
+      fetchImpl,
+    });
+    expect(r).toEqual<RouteSuggestion>({
+      distanceKm: 0,
+      durationS: 0,
+      fuelL: null,
+      polylineEncoded: '',
+    });
+  });
+});
+
+describe('computeRoutes — errores HTTP', () => {
+  it('400 → invalid_request', async () => {
+    const fetchImpl = makeFetchError(400, 'Origin not parseable');
+    await expect(
+      computeRoutes({
+        apiKey: 'k',
+        origin: 'invalid',
+        destination: 'B',
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      name: 'RoutesApiError',
+      code: 'invalid_request',
+      httpStatus: 400,
+    });
+  });
+
+  it('401 y 403 → auth_error', async () => {
+    for (const status of [401, 403]) {
+      const fetchImpl = makeFetchError(status);
+      await expect(
+        computeRoutes({ apiKey: 'wrong', origin: 'A', destination: 'B', fetchImpl }),
+      ).rejects.toMatchObject({ code: 'auth_error', httpStatus: status });
+    }
+  });
+
+  it('429 → quota_exceeded', async () => {
+    const fetchImpl = makeFetchError(429);
+    await expect(
+      computeRoutes({ apiKey: 'k', origin: 'A', destination: 'B', fetchImpl }),
+    ).rejects.toMatchObject({ code: 'quota_exceeded', httpStatus: 429 });
+  });
+
+  it('500 → unknown', async () => {
+    const fetchImpl = makeFetchError(500);
+    await expect(
+      computeRoutes({ apiKey: 'k', origin: 'A', destination: 'B', fetchImpl }),
+    ).rejects.toMatchObject({ code: 'unknown', httpStatus: 500 });
+  });
+
+  it('fetch throws (network error) → RoutesApiError network_error', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('connection reset by peer');
+    }) as unknown as typeof fetch;
+
+    await expect(
+      computeRoutes({ apiKey: 'k', origin: 'A', destination: 'B', fetchImpl }),
+    ).rejects.toMatchObject({
+      code: 'network_error',
+      httpStatus: null,
+    });
+  });
+});
+
+describe('RoutesApiError', () => {
+  it('es Error y captura código + status', () => {
+    const e = new RoutesApiError('msg', 'auth_error', 403);
+    expect(e).toBeInstanceOf(Error);
+    expect(e.name).toBe('RoutesApiError');
+    expect(e.code).toBe('auth_error');
+    expect(e.httpStatus).toBe(403);
+  });
+});


### PR DESCRIPTION
## Resumen

Segundo PR de **Phase 1**. Conecta el cliente Routes API (PR-H1) al flujo de asignación: al confirmar oferta, calcular distancia origen→destino con Routes API en vez de la tabla pre-computada Chile. Incluye refactor para sacar el HTTP fuera de la transacción de DB.

Builds on top of [#96](../pull/96).

## Cambios

### \`apps/api/src/services/calcular-metricas-viaje.ts\`

**Helpers nuevos**:
- \`mapFuelToEmissionType\`: mapea \`TipoCombustible\` interno al enum de Routes API.
- \`obtenerDistanciaKm\`: prioriza Routes API (si hay key) con fallback a \`estimarDistanciaKm\`. Loggea WARN en cualquier fallo, NUNCA throwea.

**Refactor de \`calcularMetricasEstimadas\`**:
- Lecturas de trip + vehicle **movidas FUERA** de la transacción (Postgres MVCC permite reads consistentes sin lock).
- HTTP a Routes API ocurre fuera de tx — evita extender el lock por la duración del HTTP (~500ms-1s).
- Solo el INSERT/UPDATE final + concurrency check van dentro de tx corta.
- Nueva opt \`routesApiKey?: string | undefined\` (default undefined → fallback).

### \`apps/api/src/services/offer-actions.ts\`
Pasa \`config.GOOGLE_ROUTES_API_KEY\` a \`calcularMetricasEstimadas\`.

## Verificación

- [x] \`pnpm --filter @booster-ai/api typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/api test\` — 138/138 passed
- [x] \`biome check\` — 0 errores

## Trade-offs

- En modo Routes API el \`routeDataSource\` sigue siendo \`'maps_directions'\` (Routes API es modelado, no medición real). Solo \`recalcularNivelPostEntrega\` (PR-G) lo promueve a \`teltonika_gps\` cuando hay telemetría post-entrega.
- Costo: ~\$10/1K requests con FUEL_CONSUMPTION. 1000 viajes/día → ~\$300/mes. Monitorear billing en GCP.

## Próximos PRs

- **PR-H3**: surface \"ruta sugerida\" + \"emisiones evitadas vs ruta más corta\" en respuestas API
- **PR-H4**: UI en apps/web — mostrar sugerencia pre-aceptación

🤖 Generated with [Claude Code](https://claude.com/claude-code)