### PR TITLE
feat(api): GET /offers/:id/eco-preview — emisiones pre-accept (Phase 1 PR-H3)

### DIFF
--- a/apps/api/src/routes/offers.ts
+++ b/apps/api/src/routes/offers.ts
@@ -3,8 +3,14 @@ import { zValidator } from '@hono/zod-validator';
 import { and, desc, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { config } from '../config.js';
 import type { Db } from '../db/client.js';
 import { offers, trips } from '../db/schema.js';
+import {
+  OfferForbiddenForPreviewError,
+  OfferNotFoundForPreviewError,
+  generarEcoPreview,
+} from '../services/eco-route-preview.js';
 import {
   OfferExpiredError,
   OfferNotFoundError,
@@ -161,6 +167,59 @@ export function createOfferRoutes(opts: { db: Db; logger: Logger }) {
         return c.json({ error: 'trip_already_assigned', code: 'trip_already_assigned' }, 409);
       }
       opts.logger.error({ err, offerId }, 'unexpected error in /offers/:id/accept');
+      throw err;
+    }
+  });
+
+  // GET /offers/:id/eco-preview — Phase 1 PR-H3
+  // Devuelve la huella de carbono estimada de la oferta (pre-accept).
+  // Usa Routes API si está configurado; si no, fallback a tabla Chile.
+  app.get('/:id/eco-preview', async (c) => {
+    const userContext = c.get('userContext');
+    if (!userContext) {
+      return c.json({ error: 'internal_server_error' }, 500);
+    }
+    const active = userContext.activeMembership;
+    if (!active) {
+      return c.json({ error: 'no_active_empresa', code: 'no_active_empresa' }, 403);
+    }
+    if (!active.empresa.isTransportista) {
+      return c.json({ error: 'not_a_carrier', code: 'not_a_carrier' }, 403);
+    }
+
+    const offerId = c.req.param('id');
+
+    try {
+      const preview = await generarEcoPreview({
+        db: opts.db,
+        logger: opts.logger,
+        offerId,
+        empresaId: active.empresa.id,
+        routesApiKey: config.GOOGLE_ROUTES_API_KEY,
+      });
+      return c.json({
+        trip_request_id: preview.tripId,
+        suggested_vehicle_id: preview.suggestedVehicleId,
+        distance_km: preview.distanceKm,
+        duration_s: preview.durationS,
+        fuel_liters_estimated: preview.fuelLitersEstimated,
+        emisiones_kgco2e_wtw: preview.emisionesKgco2eWtw,
+        emisiones_kgco2e_ttw: preview.emisionesKgco2eTtw,
+        emisiones_kgco2e_wtt: preview.emisionesKgco2eWtt,
+        intensidad_gco2e_por_tonkm: preview.intensidadGco2ePorTonKm,
+        precision_method: preview.precisionMethod,
+        data_source: preview.dataSource,
+        glec_version: preview.glecVersion,
+        generated_at: preview.generatedAt,
+      });
+    } catch (err) {
+      if (err instanceof OfferNotFoundForPreviewError) {
+        return c.json({ error: 'offer_not_found', code: 'offer_not_found' }, 404);
+      }
+      if (err instanceof OfferForbiddenForPreviewError) {
+        return c.json({ error: 'offer_forbidden', code: 'offer_forbidden' }, 403);
+      }
+      opts.logger.error({ err, offerId }, 'unexpected error in /offers/:id/eco-preview');
       throw err;
     }
   });

--- a/apps/api/src/services/eco-route-preview.ts
+++ b/apps/api/src/services/eco-route-preview.ts
@@ -1,0 +1,226 @@
+import {
+  type ResultadoEmisiones,
+  type TipoCombustible,
+  calcularEmisionesViaje,
+} from '@booster-ai/carbon-calculator';
+import type { Logger } from '@booster-ai/logger';
+import { eq } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { offers, trips, vehicles } from '../db/schema.js';
+import { estimarDistanciaKm } from './estimar-distancia.js';
+import { type RouteSuggestion, type VehicleEmissionType, computeRoutes } from './routes-api.js';
+
+/**
+ * Eco-route preview (Phase 1 PR-H3) — computa la huella de carbono
+ * estimada de una oferta ANTES de que el transportista la acepte.
+ *
+ * Diseño:
+ *   - Endpoint on-demand. NO persiste nada (no toca metricas_viaje, que
+ *     es exclusivo del flujo post-accept).
+ *   - Dos paths:
+ *     a) Si hay GOOGLE_ROUTES_API_KEY + vehicle.fuelType → Routes API
+ *        con FUEL_CONSUMPTION → datos más precisos para mostrar al
+ *        carrier.
+ *     b) Fallback: estimarDistanciaKm + calcularEmisionesViaje en modo
+ *        modelado/por_defecto.
+ *   - Idempotente: misma input → misma output (modulo cambios de
+ *     tráfico en Routes API).
+ *
+ * Uso desde la UI: cuando el carrier abre el detalle de una oferta
+ * pendiente, el front llama a este endpoint para mostrar:
+ *   - "Si aceptas, generarás ~X kg CO2e en este viaje"
+ *   - Distancia y duración estimadas
+ *   - Diferencial vs flota promedio (cuando agreguemos la comparación
+ *     en una iteración futura)
+ */
+
+export type DataSourcePreview = 'routes_api' | 'tabla_chile';
+
+export interface EcoRoutePreview {
+  tripId: string;
+  suggestedVehicleId: string | null;
+  distanceKm: number;
+  durationS: number | null;
+  fuelLitersEstimated: number | null;
+  emisionesKgco2eWtw: number;
+  emisionesKgco2eTtw: number;
+  emisionesKgco2eWtt: number;
+  intensidadGco2ePorTonKm: number;
+  precisionMethod: ResultadoEmisiones['metodoPrecision'];
+  dataSource: DataSourcePreview;
+  glecVersion: string;
+  generatedAt: Date;
+}
+
+export class OfferNotFoundForPreviewError extends Error {
+  constructor(public readonly offerId: string) {
+    super(`Offer ${offerId} not found`);
+    this.name = 'OfferNotFoundForPreviewError';
+  }
+}
+
+export class OfferForbiddenForPreviewError extends Error {
+  constructor(
+    public readonly offerId: string,
+    public readonly empresaId: string,
+  ) {
+    super(`Offer ${offerId} does not belong to empresa ${empresaId}`);
+    this.name = 'OfferForbiddenForPreviewError';
+  }
+}
+
+/**
+ * Mapeo TipoCombustible → VehicleEmissionType (espejo del que vive en
+ * calcular-metricas-viaje.ts; duplicado a propósito porque ambos
+ * servicios deben funcionar independientes y un helper compartido
+ * agregaría dependency cycle entre dos services del mismo nivel).
+ */
+function mapFuelToEmissionType(combustible: string): VehicleEmissionType | undefined {
+  switch (combustible) {
+    case 'diesel':
+      return 'DIESEL';
+    case 'gasolina':
+    case 'gas_glp':
+    case 'gas_gnc':
+      return 'GASOLINE';
+    case 'electrico':
+    case 'hidrogeno':
+      return 'ELECTRIC';
+    case 'hibrido_diesel':
+    case 'hibrido_gasolina':
+      return 'HYBRID';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Genera el preview de huella de carbono de una oferta.
+ *
+ * Retorna el preview o throwea si la oferta no existe o no pertenece
+ * al carrier. El caller (route handler) mapea a HTTP status apropiado.
+ *
+ * Si Routes API falla, cae al fallback transparente — siempre retorna
+ * un preview válido con dataSource explícito para que la UI sepa qué
+ * está mostrando.
+ */
+export async function generarEcoPreview(opts: {
+  db: Db;
+  logger: Logger;
+  offerId: string;
+  /** Empresa del carrier que está pidiendo el preview (validación de ownership). */
+  empresaId: string;
+  routesApiKey?: string | undefined;
+}): Promise<EcoRoutePreview> {
+  const { db, logger, offerId, empresaId, routesApiKey } = opts;
+
+  // (1) Cargar offer + trip + vehicle en una sola query con joins.
+  const rows = await db
+    .select({
+      offer: offers,
+      trip: trips,
+      vehicle: vehicles,
+    })
+    .from(offers)
+    .innerJoin(trips, eq(offers.tripId, trips.id))
+    .leftJoin(vehicles, eq(offers.suggestedVehicleId, vehicles.id))
+    .where(eq(offers.id, offerId))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    throw new OfferNotFoundForPreviewError(offerId);
+  }
+  if (row.offer.empresaId !== empresaId) {
+    throw new OfferForbiddenForPreviewError(offerId, empresaId);
+  }
+
+  const { trip, vehicle: veh } = row;
+  const cargaKg = trip.cargoWeightKg ?? 0;
+
+  // (2) Resolver distancia + (opcional) fuel via Routes API.
+  let distanceKm = 0;
+  let durationS: number | null = null;
+  let fuelLitersEstimated: number | null = null;
+  let dataSource: DataSourcePreview = 'tabla_chile';
+
+  if (routesApiKey) {
+    try {
+      const emissionType = veh?.fuelType ? mapFuelToEmissionType(veh.fuelType) : undefined;
+      const routes = await computeRoutes({
+        apiKey: routesApiKey,
+        origin: trip.originAddressRaw,
+        destination: trip.destinationAddressRaw,
+        emissionType,
+      });
+      const best: RouteSuggestion | undefined = routes[0];
+      if (best && best.distanceKm > 0) {
+        distanceKm = best.distanceKm;
+        durationS = best.durationS;
+        fuelLitersEstimated = best.fuelL;
+        dataSource = 'routes_api';
+      }
+    } catch (err) {
+      logger.warn(
+        { err, offerId, origenDireccion: trip.originAddressRaw },
+        'Routes API falló en eco-preview, fallback a estimarDistanciaKm',
+      );
+    }
+  }
+
+  if (distanceKm === 0) {
+    distanceKm = estimarDistanciaKm(trip.originRegionCode, trip.destinationRegionCode);
+  }
+
+  // (3) Compute emisiones via carbon-calculator (puro, GLEC v3.0).
+  let emisiones: ResultadoEmisiones;
+  if (veh) {
+    const consumoBase = veh.consumptionLPer100kmBaseline
+      ? Number(veh.consumptionLPer100kmBaseline)
+      : null;
+
+    if (veh.fuelType && consumoBase != null) {
+      emisiones = calcularEmisionesViaje({
+        metodo: 'modelado',
+        distanciaKm: distanceKm,
+        cargaKg,
+        vehiculo: {
+          combustible: veh.fuelType as TipoCombustible,
+          consumoBasePor100km: consumoBase,
+          pesoVacioKg: veh.curbWeightKg,
+          capacidadKg: veh.capacityKg,
+        },
+      });
+    } else {
+      emisiones = calcularEmisionesViaje({
+        metodo: 'por_defecto',
+        distanciaKm: distanceKm,
+        cargaKg,
+        tipoVehiculo: veh.vehicleType,
+      });
+    }
+  } else {
+    emisiones = calcularEmisionesViaje({
+      metodo: 'por_defecto',
+      distanciaKm: distanceKm,
+      cargaKg,
+      tipoVehiculo: 'camion_mediano',
+    });
+  }
+
+  return {
+    tripId: trip.id,
+    suggestedVehicleId: row.offer.suggestedVehicleId ?? null,
+    distanceKm,
+    durationS,
+    fuelLitersEstimated,
+    emisionesKgco2eWtw: emisiones.emisionesKgco2eWtw,
+    emisionesKgco2eTtw: emisiones.emisionesKgco2eTtw,
+    emisionesKgco2eWtt: emisiones.emisionesKgco2eWtt,
+    intensidadGco2ePorTonKm: emisiones.intensidadGco2ePorTonKm,
+    precisionMethod: emisiones.metodoPrecision,
+    dataSource,
+    glecVersion: emisiones.versionGlec,
+    generatedAt: new Date(),
+  };
+}


### PR DESCRIPTION
## Resumen

Tercer PR de **Phase 1**. Surface al transportista la huella de carbono estimada de una oferta **antes de aceptarla**, para que pueda decidir con información completa.

Builds on top of [#97](../pull/97).

## Endpoint nuevo

\`GET /api/v1/offers/:id/eco-preview\`

\`\`\`json
{
  \"trip_request_id\": \"uuid\",
  \"suggested_vehicle_id\": \"uuid|null\",
  \"distance_km\": 142.3,
  \"duration_s\": 5400,
  \"fuel_liters_estimated\": 12.5,
  \"emisiones_kgco2e_wtw\": 38.4,
  \"emisiones_kgco2e_ttw\": 31.9,
  \"emisiones_kgco2e_wtt\": 6.5,
  \"intensidad_gco2e_por_tonkm\": 50.95,
  \"precision_method\": \"modelado\",
  \"data_source\": \"routes_api\" | \"tabla_chile\",
  \"glec_version\": \"v3.0\",
  \"generated_at\": \"...\"
}
\`\`\`

## Cambios

### \`apps/api/src/services/eco-route-preview.ts\` (nuevo)
- \`generarEcoPreview()\`: toma \`offerId\` + \`empresaId\`, valida ownership, computa preview on-demand sin persistir.
- Path A (Routes API + emissionType): distancia precisa + duración traffic-aware + fuel estimado.
- Path B (fallback): \`estimarDistanciaKm\` + carbon-calculator. Routes API falla → log WARN + fallback transparente.
- Errors tipadas para 404/403.

### \`apps/api/src/routes/offers.ts\`
Nuevo handler con guards consistentes (\`no_active_empresa\`, \`not_a_carrier\`), pasa \`config.GOOGLE_ROUTES_API_KEY\`.

## Diseño

- **On-demand, no caché**. UI llama al abrir detalle. Si Routes API quota se vuelve issue, caché por \`(tripId, vehicleId)\` con TTL ~10min en iteración futura.
- **NO persiste en \`metricas_viaje\`**. Esa tabla es exclusiva post-accept; el preview es especulativo.
- **Idempotente** módulo cambios de tráfico.

## Verificación

- [x] \`pnpm --filter @booster-ai/api typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/api test\` — 138/138 passed
- [x] \`biome check\` — 0 errores

## Próximo PR

**PR-H4**: UI en \`apps/web\` consume el endpoint cuando el carrier abre el detalle de una oferta pendiente. Muestra \"Si aceptás, generarás ~X kg CO2e en este viaje\" con tooltip del data source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)