### PR TITLE
feat(web): UI eco-preview pre-accept en OfferCard (Phase 1 PR-H4)

### DIFF
--- a/apps/api/src/routes/offers.ts
+++ b/apps/api/src/routes/offers.ts
@@ -3,8 +3,14 @@ import { zValidator } from '@hono/zod-validator';
 import { and, desc, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
+import { config } from '../config.js';
 import type { Db } from '../db/client.js';
 import { offers, trips } from '../db/schema.js';
+import {
+  OfferForbiddenForPreviewError,
+  OfferNotFoundForPreviewError,
+  generarEcoPreview,
+} from '../services/eco-route-preview.js';
 import {
   OfferExpiredError,
   OfferNotFoundError,
@@ -161,6 +167,59 @@ export function createOfferRoutes(opts: { db: Db; logger: Logger }) {
         return c.json({ error: 'trip_already_assigned', code: 'trip_already_assigned' }, 409);
       }
       opts.logger.error({ err, offerId }, 'unexpected error in /offers/:id/accept');
+      throw err;
+    }
+  });
+
+  // GET /offers/:id/eco-preview — Phase 1 PR-H3
+  // Devuelve la huella de carbono estimada de la oferta (pre-accept).
+  // Usa Routes API si está configurado; si no, fallback a tabla Chile.
+  app.get('/:id/eco-preview', async (c) => {
+    const userContext = c.get('userContext');
+    if (!userContext) {
+      return c.json({ error: 'internal_server_error' }, 500);
+    }
+    const active = userContext.activeMembership;
+    if (!active) {
+      return c.json({ error: 'no_active_empresa', code: 'no_active_empresa' }, 403);
+    }
+    if (!active.empresa.isTransportista) {
+      return c.json({ error: 'not_a_carrier', code: 'not_a_carrier' }, 403);
+    }
+
+    const offerId = c.req.param('id');
+
+    try {
+      const preview = await generarEcoPreview({
+        db: opts.db,
+        logger: opts.logger,
+        offerId,
+        empresaId: active.empresa.id,
+        routesApiKey: config.GOOGLE_ROUTES_API_KEY,
+      });
+      return c.json({
+        trip_request_id: preview.tripId,
+        suggested_vehicle_id: preview.suggestedVehicleId,
+        distance_km: preview.distanceKm,
+        duration_s: preview.durationS,
+        fuel_liters_estimated: preview.fuelLitersEstimated,
+        emisiones_kgco2e_wtw: preview.emisionesKgco2eWtw,
+        emisiones_kgco2e_ttw: preview.emisionesKgco2eTtw,
+        emisiones_kgco2e_wtt: preview.emisionesKgco2eWtt,
+        intensidad_gco2e_por_tonkm: preview.intensidadGco2ePorTonKm,
+        precision_method: preview.precisionMethod,
+        data_source: preview.dataSource,
+        glec_version: preview.glecVersion,
+        generated_at: preview.generatedAt,
+      });
+    } catch (err) {
+      if (err instanceof OfferNotFoundForPreviewError) {
+        return c.json({ error: 'offer_not_found', code: 'offer_not_found' }, 404);
+      }
+      if (err instanceof OfferForbiddenForPreviewError) {
+        return c.json({ error: 'offer_forbidden', code: 'offer_forbidden' }, 403);
+      }
+      opts.logger.error({ err, offerId }, 'unexpected error in /offers/:id/eco-preview');
       throw err;
     }
   });

--- a/apps/api/src/services/eco-route-preview.ts
+++ b/apps/api/src/services/eco-route-preview.ts
@@ -1,0 +1,226 @@
+import {
+  type ResultadoEmisiones,
+  type TipoCombustible,
+  calcularEmisionesViaje,
+} from '@booster-ai/carbon-calculator';
+import type { Logger } from '@booster-ai/logger';
+import { eq } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { offers, trips, vehicles } from '../db/schema.js';
+import { estimarDistanciaKm } from './estimar-distancia.js';
+import { type RouteSuggestion, type VehicleEmissionType, computeRoutes } from './routes-api.js';
+
+/**
+ * Eco-route preview (Phase 1 PR-H3) — computa la huella de carbono
+ * estimada de una oferta ANTES de que el transportista la acepte.
+ *
+ * Diseño:
+ *   - Endpoint on-demand. NO persiste nada (no toca metricas_viaje, que
+ *     es exclusivo del flujo post-accept).
+ *   - Dos paths:
+ *     a) Si hay GOOGLE_ROUTES_API_KEY + vehicle.fuelType → Routes API
+ *        con FUEL_CONSUMPTION → datos más precisos para mostrar al
+ *        carrier.
+ *     b) Fallback: estimarDistanciaKm + calcularEmisionesViaje en modo
+ *        modelado/por_defecto.
+ *   - Idempotente: misma input → misma output (modulo cambios de
+ *     tráfico en Routes API).
+ *
+ * Uso desde la UI: cuando el carrier abre el detalle de una oferta
+ * pendiente, el front llama a este endpoint para mostrar:
+ *   - "Si aceptas, generarás ~X kg CO2e en este viaje"
+ *   - Distancia y duración estimadas
+ *   - Diferencial vs flota promedio (cuando agreguemos la comparación
+ *     en una iteración futura)
+ */
+
+export type DataSourcePreview = 'routes_api' | 'tabla_chile';
+
+export interface EcoRoutePreview {
+  tripId: string;
+  suggestedVehicleId: string | null;
+  distanceKm: number;
+  durationS: number | null;
+  fuelLitersEstimated: number | null;
+  emisionesKgco2eWtw: number;
+  emisionesKgco2eTtw: number;
+  emisionesKgco2eWtt: number;
+  intensidadGco2ePorTonKm: number;
+  precisionMethod: ResultadoEmisiones['metodoPrecision'];
+  dataSource: DataSourcePreview;
+  glecVersion: string;
+  generatedAt: Date;
+}
+
+export class OfferNotFoundForPreviewError extends Error {
+  constructor(public readonly offerId: string) {
+    super(`Offer ${offerId} not found`);
+    this.name = 'OfferNotFoundForPreviewError';
+  }
+}
+
+export class OfferForbiddenForPreviewError extends Error {
+  constructor(
+    public readonly offerId: string,
+    public readonly empresaId: string,
+  ) {
+    super(`Offer ${offerId} does not belong to empresa ${empresaId}`);
+    this.name = 'OfferForbiddenForPreviewError';
+  }
+}
+
+/**
+ * Mapeo TipoCombustible → VehicleEmissionType (espejo del que vive en
+ * calcular-metricas-viaje.ts; duplicado a propósito porque ambos
+ * servicios deben funcionar independientes y un helper compartido
+ * agregaría dependency cycle entre dos services del mismo nivel).
+ */
+function mapFuelToEmissionType(combustible: string): VehicleEmissionType | undefined {
+  switch (combustible) {
+    case 'diesel':
+      return 'DIESEL';
+    case 'gasolina':
+    case 'gas_glp':
+    case 'gas_gnc':
+      return 'GASOLINE';
+    case 'electrico':
+    case 'hidrogeno':
+      return 'ELECTRIC';
+    case 'hibrido_diesel':
+    case 'hibrido_gasolina':
+      return 'HYBRID';
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Genera el preview de huella de carbono de una oferta.
+ *
+ * Retorna el preview o throwea si la oferta no existe o no pertenece
+ * al carrier. El caller (route handler) mapea a HTTP status apropiado.
+ *
+ * Si Routes API falla, cae al fallback transparente — siempre retorna
+ * un preview válido con dataSource explícito para que la UI sepa qué
+ * está mostrando.
+ */
+export async function generarEcoPreview(opts: {
+  db: Db;
+  logger: Logger;
+  offerId: string;
+  /** Empresa del carrier que está pidiendo el preview (validación de ownership). */
+  empresaId: string;
+  routesApiKey?: string | undefined;
+}): Promise<EcoRoutePreview> {
+  const { db, logger, offerId, empresaId, routesApiKey } = opts;
+
+  // (1) Cargar offer + trip + vehicle en una sola query con joins.
+  const rows = await db
+    .select({
+      offer: offers,
+      trip: trips,
+      vehicle: vehicles,
+    })
+    .from(offers)
+    .innerJoin(trips, eq(offers.tripId, trips.id))
+    .leftJoin(vehicles, eq(offers.suggestedVehicleId, vehicles.id))
+    .where(eq(offers.id, offerId))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    throw new OfferNotFoundForPreviewError(offerId);
+  }
+  if (row.offer.empresaId !== empresaId) {
+    throw new OfferForbiddenForPreviewError(offerId, empresaId);
+  }
+
+  const { trip, vehicle: veh } = row;
+  const cargaKg = trip.cargoWeightKg ?? 0;
+
+  // (2) Resolver distancia + (opcional) fuel via Routes API.
+  let distanceKm = 0;
+  let durationS: number | null = null;
+  let fuelLitersEstimated: number | null = null;
+  let dataSource: DataSourcePreview = 'tabla_chile';
+
+  if (routesApiKey) {
+    try {
+      const emissionType = veh?.fuelType ? mapFuelToEmissionType(veh.fuelType) : undefined;
+      const routes = await computeRoutes({
+        apiKey: routesApiKey,
+        origin: trip.originAddressRaw,
+        destination: trip.destinationAddressRaw,
+        emissionType,
+      });
+      const best: RouteSuggestion | undefined = routes[0];
+      if (best && best.distanceKm > 0) {
+        distanceKm = best.distanceKm;
+        durationS = best.durationS;
+        fuelLitersEstimated = best.fuelL;
+        dataSource = 'routes_api';
+      }
+    } catch (err) {
+      logger.warn(
+        { err, offerId, origenDireccion: trip.originAddressRaw },
+        'Routes API falló en eco-preview, fallback a estimarDistanciaKm',
+      );
+    }
+  }
+
+  if (distanceKm === 0) {
+    distanceKm = estimarDistanciaKm(trip.originRegionCode, trip.destinationRegionCode);
+  }
+
+  // (3) Compute emisiones via carbon-calculator (puro, GLEC v3.0).
+  let emisiones: ResultadoEmisiones;
+  if (veh) {
+    const consumoBase = veh.consumptionLPer100kmBaseline
+      ? Number(veh.consumptionLPer100kmBaseline)
+      : null;
+
+    if (veh.fuelType && consumoBase != null) {
+      emisiones = calcularEmisionesViaje({
+        metodo: 'modelado',
+        distanciaKm: distanceKm,
+        cargaKg,
+        vehiculo: {
+          combustible: veh.fuelType as TipoCombustible,
+          consumoBasePor100km: consumoBase,
+          pesoVacioKg: veh.curbWeightKg,
+          capacidadKg: veh.capacityKg,
+        },
+      });
+    } else {
+      emisiones = calcularEmisionesViaje({
+        metodo: 'por_defecto',
+        distanciaKm: distanceKm,
+        cargaKg,
+        tipoVehiculo: veh.vehicleType,
+      });
+    }
+  } else {
+    emisiones = calcularEmisionesViaje({
+      metodo: 'por_defecto',
+      distanciaKm: distanceKm,
+      cargaKg,
+      tipoVehiculo: 'camion_mediano',
+    });
+  }
+
+  return {
+    tripId: trip.id,
+    suggestedVehicleId: row.offer.suggestedVehicleId ?? null,
+    distanceKm,
+    durationS,
+    fuelLitersEstimated,
+    emisionesKgco2eWtw: emisiones.emisionesKgco2eWtw,
+    emisionesKgco2eTtw: emisiones.emisionesKgco2eTtw,
+    emisionesKgco2eWtt: emisiones.emisionesKgco2eWtt,
+    intensidadGco2ePorTonKm: emisiones.intensidadGco2ePorTonKm,
+    precisionMethod: emisiones.metodoPrecision,
+    dataSource,
+    glecVersion: emisiones.versionGlec,
+    generatedAt: new Date(),
+  };
+}

--- a/apps/web/src/components/offers/OfferCard.tsx
+++ b/apps/web/src/components/offers/OfferCard.tsx
@@ -1,8 +1,10 @@
-import { Check, Clock, MapPin, Package, X } from 'lucide-react';
+import { Check, Clock, Leaf, Loader2, MapPin, Package, X } from 'lucide-react';
 import { type FormEvent, useId, useState } from 'react';
 import {
+  type EcoPreviewResponse,
   type OfferPayload,
   useAcceptOfferMutation,
+  useEcoPreview,
   useRejectOfferMutation,
 } from '../../hooks/use-offers.js';
 import { ApiError } from '../../lib/api-client.js';
@@ -79,9 +81,15 @@ export function OfferCard({ offer }: OfferCardProps) {
   const [showRejectForm, setShowRejectForm] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [showEcoPreview, setShowEcoPreview] = useState(false);
   const reasonId = useId();
   const acceptMutation = useAcceptOfferMutation();
   const rejectMutation = useRejectOfferMutation();
+  // Eco preview lazy — solo se fetcha cuando el carrier hace click. La
+  // razón es costo: cada preview gatilla una llamada Routes API
+  // ($0.01/req con FUEL_CONSUMPTION). Si lo fetchearamos por cada card
+  // del list, 10 cards × 30s polling = 1200 req/h por carrier activo.
+  const ecoPreview = useEcoPreview(offer.id, { enabled: showEcoPreview });
 
   const remaining = timeRemaining(offer.expires_at);
   const cargoLabel = CARGO_LABELS[offer.trip_request.cargo_type] ?? offer.trip_request.cargo_type;
@@ -184,6 +192,22 @@ export function OfferCard({ offer }: OfferCardProps) {
         </div>
       </dl>
 
+      {/* Eco preview — Phase 1 PR-H4. Lazy fetch on user click. */}
+      <div className="mt-4">
+        {showEcoPreview ? (
+          <EcoPreviewBlock query={ecoPreview} />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setShowEcoPreview(true)}
+            className="flex items-center gap-1.5 text-success-700 text-xs underline-offset-2 transition hover:text-success-700 hover:underline"
+          >
+            <Leaf className="h-3.5 w-3.5" aria-hidden />
+            Ver impacto ambiental estimado
+          </button>
+        )}
+      </div>
+
       {error && (
         <output className="mt-4 block rounded-md border border-danger-500/30 bg-danger-50 p-3 text-danger-700 text-sm">
           {error}
@@ -251,6 +275,81 @@ export function OfferCard({ offer }: OfferCardProps) {
         </div>
       )}
     </article>
+  );
+}
+
+/**
+ * Bloque de eco-preview que se renderiza cuando el carrier hizo click
+ * en "Ver impacto ambiental". Maneja los tres estados de la query:
+ *   - loading: spinner + texto
+ *   - error: mensaje genérico (no expone detalle)
+ *   - success: distancia, kg CO2e, intensidad + nota del data source
+ */
+function EcoPreviewBlock(props: {
+  query: ReturnType<typeof useEcoPreview>;
+}) {
+  const { query } = props;
+  if (query.isLoading) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-success-700/20 bg-success-50/50 p-3 text-success-700 text-xs">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+        Calculando impacto ambiental con Google Routes…
+      </div>
+    );
+  }
+  if (query.isError || !query.data) {
+    return (
+      <div className="rounded-md border border-neutral-200 bg-neutral-50 p-3 text-neutral-600 text-xs">
+        No pudimos calcular el impacto ambiental ahora. Intenta de nuevo en unos segundos.
+      </div>
+    );
+  }
+  const p: EcoPreviewResponse = query.data;
+  const sourceLabel =
+    p.data_source === 'routes_api'
+      ? 'Google Routes API + perfil del vehículo'
+      : 'Estimación por región (sin Routes API en este viaje)';
+  return (
+    <section
+      aria-label="Impacto ambiental estimado de la oferta"
+      className="rounded-md border border-success-700/20 bg-success-50/40 p-3"
+    >
+      <header className="flex items-center gap-1.5 text-success-700 text-xs">
+        <Leaf className="h-3.5 w-3.5" aria-hidden />
+        <span className="font-semibold">Impacto ambiental estimado</span>
+      </header>
+      <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-3">
+        <div>
+          <dt className="text-neutral-600">Distancia</dt>
+          <dd className="font-medium text-neutral-900">{p.distance_km.toFixed(0)} km</dd>
+        </div>
+        <div>
+          <dt className="text-neutral-600">Emisiones (WTW)</dt>
+          <dd className="font-semibold text-success-700">
+            {p.emisiones_kgco2e_wtw.toFixed(1)} kg CO₂e
+          </dd>
+        </div>
+        <div>
+          <dt className="text-neutral-600">Intensidad</dt>
+          <dd className="text-neutral-900">{p.intensidad_gco2e_por_tonkm.toFixed(0)} g/t·km</dd>
+        </div>
+        {p.fuel_liters_estimated != null && (
+          <div>
+            <dt className="text-neutral-600">Combustible est.</dt>
+            <dd className="text-neutral-900">{p.fuel_liters_estimated.toFixed(1)} L</dd>
+          </div>
+        )}
+        {p.duration_s != null && (
+          <div>
+            <dt className="text-neutral-600">Duración est.</dt>
+            <dd className="text-neutral-900">{Math.round(p.duration_s / 60)} min</dd>
+          </div>
+        )}
+      </dl>
+      <p className="mt-2 text-[11px] text-neutral-500">
+        Cálculo {p.glec_version} · {sourceLabel}
+      </p>
+    </section>
   );
 }
 

--- a/apps/web/src/hooks/use-offers.ts
+++ b/apps/web/src/hooks/use-offers.ts
@@ -82,6 +82,48 @@ export function useOffersMine(
   });
 }
 
+/**
+ * Eco preview de una oferta — emisiones estimadas pre-accept.
+ * Consume GET /offers/:id/eco-preview (Phase 1 PR-H3).
+ *
+ * Se fetcha LAZY (enabled debe ser true) para evitar disparar una
+ * llamada Routes API por cada offer en el list. La OfferCard la
+ * habilita cuando el carrier hace click en "Ver impacto ambiental".
+ */
+export interface EcoPreviewResponse {
+  trip_request_id: string;
+  suggested_vehicle_id: string | null;
+  distance_km: number;
+  duration_s: number | null;
+  fuel_liters_estimated: number | null;
+  emisiones_kgco2e_wtw: number;
+  emisiones_kgco2e_ttw: number;
+  emisiones_kgco2e_wtt: number;
+  intensidad_gco2e_por_tonkm: number;
+  precision_method: 'exacto_canbus' | 'modelado' | 'por_defecto';
+  data_source: 'routes_api' | 'tabla_chile';
+  glec_version: string;
+  generated_at: string;
+}
+
+export function useEcoPreview(offerId: string, opts: { enabled?: boolean } = {}) {
+  return useQuery<EcoPreviewResponse>({
+    queryKey: ['offers', 'eco-preview', offerId],
+    queryFn: () => api.get<EcoPreviewResponse>(`/offers/${offerId}/eco-preview`),
+    enabled: opts.enabled ?? false,
+    // 5 min de cache — el preview es deterministic salvo cambios de
+    // tráfico en Routes API. Si el carrier revisita la misma oferta no
+    // re-paga la llamada.
+    staleTime: 5 * 60 * 1000,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+}
+
 export function useAcceptOfferMutation() {
   const queryClient = useQueryClient();
   return useMutation<AcceptResponse, ApiError, { offerId: string }>({


### PR DESCRIPTION
## Resumen

Cuarto y último PR de **Phase 1**. Surface al transportista la huella de carbono estimada de la oferta directamente en la \`OfferCard\`, antes de aceptar.

Builds on top of [#98](../pull/98). **Cierra Phase 1 end-to-end** para el flujo del carrier.

## UX

Lazy-load por default. La card muestra un link discreto:

> 🌿 Ver impacto ambiental estimado

Al click, dispara \`GET /offers/:id/eco-preview\` (PR-H3) y reemplaza el link con un bloque que muestra:

- **Distancia** (km)
- **Emisiones WTW** (kg CO₂e) — número destacado en verde
- **Intensidad** (g CO₂e / t·km)
- **Combustible estimado** (L) — solo si Routes API computó FUEL_CONSUMPTION
- **Duración estimada** (min) — solo si vino del Routes API
- **Footer**: versión GLEC + data source

## Por qué lazy-load

Cada preview gatilla 1 llamada Routes API (~\$0.01 con FUEL_CONSUMPTION). Si fetcháramos por cada card con polling 30s: 10 cards × 120 polls/h = **1200 req/h por carrier activo**. Con click explícito, solo se fetchea cuando hay intención real.

React Query \`staleTime: 5min\` — re-abrir la misma card no re-paga.

## Cambios

### \`apps/web/src/hooks/use-offers.ts\`
- Type \`EcoPreviewResponse\` (espejo del endpoint).
- Hook \`useEcoPreview(offerId, { enabled })\` con \`enabled: false\` por default.

### \`apps/web/src/components/offers/OfferCard.tsx\`
- State \`showEcoPreview\` + toggle.
- Helper \`EcoPreviewBlock\` que renderea los 3 estados de la query (loading/error/success).
- Iconografía: \`Leaf\` para el affordance verde, \`Loader2\` para loading.
- Color tema \`success-700\` consistente con cert-generator.

## Verificación

- [x] \`pnpm --filter @booster-ai/web typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/web test\` — 59/59 passed (sin regresiones)
- [x] \`biome check\` — 0 errores

## Phase 1 cerrada

| PR | Descripción | Estado |
|---|---|---|
| [#96](../pull/96) | Cliente Routes API | ✅ Merged |
| [#97](../pull/97) | Integración en metricas | ✅ Merged |
| [#98](../pull/98) | Endpoint eco-preview | 🟡 CI corriendo |
| Este | UI eco-preview en OfferCard | 🟡 |

Después de mergear estos dos, el feature de eco-route suggestion está completo end-to-end. Los siguientes pasos son las Phases 2-4 (driver behavior scoring + coaching IA + network optimization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)