### PR TITLE
chore(infra): wire google-routes-api-key secret al api Cloud Run (Phase 1 ops)

### DIFF
--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -150,6 +150,13 @@ module "service_api" {
     # `npx web-push generate-vapid-keys`.
     WEBPUSH_VAPID_PUBLIC_KEY  = google_secret_manager_secret.secrets["webpush-vapid-public-key"].secret_id
     WEBPUSH_VAPID_PRIVATE_KEY = google_secret_manager_secret.secrets["webpush-vapid-private-key"].secret_id
+
+    # Phase 1 (ADR-028) — Google Routes API key para eco-route suggestion.
+    # Server-side; el api la usa al confirmar oferta y al consultar
+    # GET /offers/:id/eco-preview. Si está con placeholder
+    # ROTATE_ME_GOOGLE_ROUTES_API_KEY, el servicio cae al fallback de
+    # estimarDistanciaKm (tabla pre-computada Chile) sin romper nada.
+    GOOGLE_ROUTES_API_KEY = google_secret_manager_secret.secrets["google-routes-api-key"].secret_id
   })
 
   vpc_connector = google_vpc_access_connector.serverless.id

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -233,6 +233,28 @@ locals {
     # browser); la privada SOLO al api.
     "webpush-vapid-public-key",
     "webpush-vapid-private-key",
+
+    # Google Routes API key (Phase 1 — eco route suggestion).
+    # Server-side ONLY: el api la usa para llamar
+    # https://routes.googleapis.com/directions/v2:computeRoutes desde
+    # Cloud Run. NO va al bundle del cliente (a diferencia de
+    # frontend-maps-key que es pública por diseño).
+    #
+    # Restricciones obligatorias en GCP Console al crear la key:
+    #   - API restriction: ONLY "Routes API" (limita blast radius)
+    #   - Application restriction: NONE inicialmente (Cloud Run egress IP
+    #     no es estática sin Cloud NAT). Si se conecta VPC connector con
+    #     egress estático, restringir por IP.
+    #   - Quota: cap a $X/mes en GCP Billing budgets para evitar abuso.
+    #
+    # Cargar el valor real con:
+    #   gcloud secrets versions add google-routes-api-key \
+    #     --data-file=<(echo -n "AIza...")
+    #
+    # El api lee config.GOOGLE_ROUTES_API_KEY; si vale el placeholder
+    # ROTATE_ME_..., el calculator cae al fallback estimarDistanciaKm
+    # automáticamente (no rompe el flujo de asignación).
+    "google-routes-api-key",
   ]
 }
 


### PR DESCRIPTION
## Resumen

Cableado de infraestructura para que el api en producción consuma \`GOOGLE_ROUTES_API_KEY\` desde Secret Manager. Cierra la pieza de **operations** que faltaba para activar Phase 1 end-to-end (PRs #96-#99 ya mergeados).

## Cambios

### \`infrastructure/security.tf\`
Nuevo entry \`\"google-routes-api-key\"\` en \`local.secret_names\`. Dispara creación del secret + placeholder version cuando se corra \`terraform apply\`.

### \`infrastructure/compute.tf\`
Nueva entry \`GOOGLE_ROUTES_API_KEY\` en el \`secrets\` block del módulo \`service_api\`. El api ya lo lee vía \`config.ts\` (PR-H1) y lo pasa a \`calcularMetricasEstimadas\` (PR-H2) + \`generarEcoPreview\` (PR-H3).

## Pasos manuales post-merge

```bash
# 1. Apply Terraform → crea el secret + placeholder
cd infrastructure
terraform plan -out=routes-api-key.tfplan
terraform apply routes-api-key.tfplan

# 2. Crear API key en GCP (restricted a Routes API only)
gcloud services api-keys create \\
  --display-name=\"Booster Routes - API Backend\" \\
  --api-target=service=routes.googleapis.com \\
  --project=booster-ai-494222

# 3. Capturar keyString del paso 2 y cargar como secret version
echo -n \"AIza...\" | gcloud secrets versions add google-routes-api-key \\
  --data-file=- --project=booster-ai-494222

# 4. Redeploy del api para tomar el nuevo valor del secret
gcloud run services update booster-ai-api \\
  --region=southamerica-west1 --project=booster-ai-494222 \\
  --update-labels=routes-api-rotated=true

# 5. Verificar: GET /offers/:id/eco-preview con offer real debe
#    devolver data_source: \"routes_api\" (no \"tabla_chile\")
```

## Costo + alertas

- ~\$10/1K requests con FUEL_CONSUMPTION
- Estimado a 1000 viajes/día → ~\$300/mes
- **Recomendado**: billing budget en GCP con alerta a 80% del cap mensual.

## Greenwashing safety

Independiente del valor de la key, el sistema sigue siendo seguro. Sin Routes API válido, el cert se emite como \`secundario_modeled\` (ADR-028 §2). La key solo mejora la precisión del cálculo, no cambia el nivel de certificación.

🤖 Generated with [Claude Code](https://claude.com/claude-code)