### PR TITLE
feat(telemetry): persistir eventos de conducción verde (Phase 2 PR-I2)

### DIFF
--- a/apps/api/drizzle/0010_eventos_conduccion_verde.sql
+++ b/apps/api/drizzle/0010_eventos_conduccion_verde.sql
@@ -1,0 +1,62 @@
+-- Migration 0010 — Eventos de conducción verde (Phase 2 PR-I2)
+--
+-- Tabla nueva para persistir los eventos green-driving + over-speeding
+-- que el FMC150 emite vía IO 253/254/255. El telemetry-processor (PR-I2
+-- siguiente, en apps/telemetry-processor) los extrae con
+-- @booster-ai/codec8-parser/extractGreenDrivingEvents y los inserta
+-- acá uno por uno (un AVL packet puede traer múltiples).
+--
+-- Por qué tabla aparte de telemetria_puntos:
+--   - Cardinalidad muy distinta: puntos = ~1 ping cada 30s (millones
+--     por mes); eventos = 5-50 por trip (~miles por mes). Mezclar rompe
+--     planes de query.
+--   - Semántica distinta: puntos son state-of-world (posición, velocidad);
+--     eventos son transiciones discretas (frenazo, exceso). Indexes
+--     diferentes.
+--   - Driver scoring (PR-I3 siguiente) agrega solo desde acá; no quiere
+--     ruido de los puntos periódicos.
+--
+-- Dedup: UNIQUE (vehiculo_id, timestamp_device, tipo). El reloj del FMC150
+-- tiene resolución 1s, así que dos eventos del mismo tipo en el mismo
+-- timestamp solo pueden venir de un retry del processor — el ON CONFLICT
+-- DO NOTHING en el caller los descarta.
+--
+-- Riesgo deploy: bajo. CREATE TYPE + CREATE TABLE son metadata-only en
+-- Postgres; no afectan tablas existentes. Reversible vía DROP TABLE +
+-- DROP TYPE.
+
+-- Enum nuevo
+CREATE TYPE "tipo_evento_conduccion" AS ENUM (
+  'aceleracion_brusca',
+  'frenado_brusco',
+  'curva_brusca',
+  'exceso_velocidad'
+);
+
+-- Tabla nueva
+CREATE TABLE "eventos_conduccion_verde" (
+  "id" bigserial PRIMARY KEY,
+  "vehiculo_id" uuid NOT NULL,
+  "imei" varchar(20) NOT NULL,
+  "timestamp_device" timestamptz NOT NULL,
+  "timestamp_recibido_en" timestamptz NOT NULL DEFAULT now(),
+  "tipo" tipo_evento_conduccion NOT NULL,
+  "severidad" numeric(8, 2) NOT NULL,
+  "unidad" varchar(8) NOT NULL,
+  "latitud" numeric(10, 7),
+  "longitud" numeric(10, 7),
+  "velocidad_kmh" smallint,
+  CONSTRAINT "fk_eventos_conduccion_vehiculo"
+    FOREIGN KEY ("vehiculo_id") REFERENCES "vehiculos"("id") ON DELETE RESTRICT,
+  CONSTRAINT "uq_eventos_conduccion_vehiculo_ts_tipo"
+    UNIQUE ("vehiculo_id", "timestamp_device", "tipo")
+);
+
+-- Index para queries de scoring por (vehículo, ventana de trip).
+CREATE INDEX "idx_eventos_conduccion_vehiculo_ts"
+  ON "eventos_conduccion_verde" ("vehiculo_id", "timestamp_device");
+
+-- Index para analytics por tipo de evento (ej. "cuántos exceso_velocidad
+-- este mes a nivel de flota").
+CREATE INDEX "idx_eventos_conduccion_tipo_ts"
+  ON "eventos_conduccion_verde" ("tipo", "timestamp_device");

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1778716800000,
       "tag": "0009_metricas_viaje_dual_source_adr028",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1778803200000,
+      "tag": "0010_eventos_conduccion_verde",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -240,6 +240,23 @@ export const reportingStandardEnum = pgEnum('estandar_reporte', [
   'CDP',
 ]);
 
+/**
+ * Tipo de evento de conducción capturado por el FMC150 vía IO 253/255
+ * (Phase 2 PR-I2). Usado en `eventos_conduccion_verde`.
+ *
+ * Mapeo desde el codec8-parser (inglés) al DB (español sin tildes):
+ *   harsh_acceleration → aceleracion_brusca
+ *   harsh_braking      → frenado_brusco
+ *   harsh_cornering    → curva_brusca
+ *   over_speed         → exceso_velocidad
+ */
+export const tipoEventoConduccionEnum = pgEnum('tipo_evento_conduccion', [
+  'aceleracion_brusca',
+  'frenado_brusco',
+  'curva_brusca',
+  'exceso_velocidad',
+]);
+
 export const stakeholderTypeEnum = pgEnum('tipo_stakeholder', [
   'mandante_corporativo',
   'sostenibilidad_interna',
@@ -924,6 +941,71 @@ export const telemetryPoints = pgTable(
       table.timestampReceivedAt,
     ),
     priorityCheck: check('prioridad_check', sql`${table.priority} IN (0, 1, 2)`),
+  }),
+);
+
+/**
+ * Eventos de conducción captados por el FMC150 (Phase 2 PR-I2).
+ *
+ * El device emite vía IO 253 (harsh accel/brake/cornering) e IO 255
+ * (over-speeding). El telemetry-processor extrae esos eventos del
+ * AvlRecord usando @booster-ai/codec8-parser/extractGreenDrivingEvents
+ * y los persiste acá. Tabla aparte de `telemetria_puntos` porque:
+ *
+ *   - Cardinalidad muy distinta: telemetría = ~1 ping/30s; eventos =
+ *     5-50 por trip típico. Mezclarlos rompe planes de query.
+ *   - Semántica distinta: puntos son state-of-world; eventos son
+ *     transiciones discretas. Indexes y queries son diferentes.
+ *   - Driver scoring (PR-I3) agrega solo desde acá; no quiere ruido
+ *     de los puntos periódicos.
+ *
+ * Dedup: UNIQUE (vehiculo_id, timestamp_device, tipo). Si por algún
+ * retry el processor procesa dos veces el mismo packet, el INSERT
+ * cae en ON CONFLICT DO NOTHING en el caller.
+ */
+export const greenDrivingEvents = pgTable(
+  'eventos_conduccion_verde',
+  {
+    id: bigserial('id', { mode: 'bigint' }).primaryKey(),
+    vehicleId: uuid('vehiculo_id')
+      .notNull()
+      .references(() => vehicles.id, { onDelete: 'restrict' }),
+    imei: varchar('imei', { length: 20 }).notNull(),
+    /** Timestamp del evento según el reloj del device (autoritativo). */
+    timestampDevice: timestamp('timestamp_device', { withTimezone: true }).notNull(),
+    /** Timestamp de recepción server-side (para SLO de pipeline). */
+    timestampReceivedAt: timestamp('timestamp_recibido_en', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    type: tipoEventoConduccionEnum('tipo').notNull(),
+    /**
+     * Magnitud del evento en su unidad nativa:
+     *   - aceleracion/frenado/curva: pico en mG (positivo)
+     *   - exceso_velocidad: km/h del momento
+     */
+    severity: numeric('severidad', { precision: 8, scale: 2 }).notNull(),
+    /** 'mG' para harsh; 'km/h' para over_speed. Explícito para evitar confusión. */
+    unit: varchar('unidad', { length: 8 }).notNull(),
+    /** GPS en el momento del evento (opcional — defensivo si pasa fix=0). */
+    latitude: numeric('latitud', { precision: 10, scale: 7 }),
+    longitude: numeric('longitud', { precision: 10, scale: 7 }),
+    speedKmh: smallint('velocidad_kmh'),
+  },
+  (table) => ({
+    // Dedup natural — un device físicamente no puede emitir dos eventos
+    // del mismo tipo en el mismo timestamp_device (el reloj del device
+    // tiene resolución 1s). Si llega duplicado vía retry, ON CONFLICT.
+    vehicleTsTypeUnique: unique('uq_eventos_conduccion_vehiculo_ts_tipo').on(
+      table.vehicleId,
+      table.timestampDevice,
+      table.type,
+    ),
+    // Index para queries de scoring por (vehículo, ventana de trip).
+    vehicleTsIdx: index('idx_eventos_conduccion_vehiculo_ts').on(
+      table.vehicleId,
+      table.timestampDevice,
+    ),
+    typeTsIdx: index('idx_eventos_conduccion_tipo_ts').on(table.type, table.timestampDevice),
   }),
 );
 

--- a/apps/telemetry-processor/src/main.ts
+++ b/apps/telemetry-processor/src/main.ts
@@ -12,6 +12,7 @@ import {
   createGcsCrashTraceUploader,
 } from './crash-trace-adapters.js';
 import { crashTraceMessageSchema, persistCrashTrace } from './persist-crash-trace.js';
+import { persistGreenDrivingFromRecord } from './persist-green-driving.js';
 import { persistRecord, recordMessageSchema } from './persist.js';
 
 /**
@@ -89,6 +90,34 @@ async function main(): Promise<void> {
       }
 
       const result = await persistRecord({ db, logger, msg: parsed.data });
+
+      // Phase 2 PR-I2 — extraer y persistir eventos green-driving del
+      // mismo record. Solo aplica si el record tiene IO 253 o IO 255
+      // (caso minoritario: 5-50 eventos por trip vs ~100 puntos por
+      // trip). El extractor es side-effect-free; persistencia falla
+      // silenciosa (loggea + sigue) para no bloquear el ack del punto
+      // principal — los eventos no son críticos para el lifecycle del
+      // viaje, son solo input al scoring.
+      let greenDrivingInserted = 0;
+      try {
+        const gdResult = await persistGreenDrivingFromRecord({
+          db,
+          logger,
+          msg: parsed.data,
+        });
+        greenDrivingInserted = gdResult.insertedCount;
+      } catch (err) {
+        logger.error(
+          {
+            err,
+            messageId: message.id,
+            imei: parsed.data.imei,
+            vehicleId: parsed.data.vehicleId,
+          },
+          'green-driving persist falló, ack del record igual (no bloquea)',
+        );
+      }
+
       message.ack();
 
       logger.info(
@@ -98,6 +127,7 @@ async function main(): Promise<void> {
           vehicleId: parsed.data.vehicleId,
           inserted: result.inserted,
           isFirstPointForVehicle: result.isFirstPointForVehicle,
+          greenDrivingInserted,
           latencyMs: Date.now() - start,
         },
         result.inserted ? 'record persistido' : 'record duplicado (skip)',

--- a/apps/telemetry-processor/src/persist-green-driving.ts
+++ b/apps/telemetry-processor/src/persist-green-driving.ts
@@ -1,0 +1,145 @@
+import {
+  type GreenDrivingEvent,
+  type GreenDrivingEventType,
+  extractGreenDrivingEvents,
+} from '@booster-ai/codec8-parser';
+import type { Logger } from '@booster-ai/logger';
+import { sql } from 'drizzle-orm';
+import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { RecordMessage } from './persist.js';
+
+/**
+ * Persistencia de eventos de conducción (Phase 2 PR-I2).
+ *
+ * El processor recibe records uno-a-uno via PubSub. Para cada record:
+ *   1. extractGreenDrivingEvents lo escanea y extrae 0..2 eventos
+ *      (harsh accel/brake/cornering + over_speed pueden coexistir).
+ *   2. Cada evento se inserta en `eventos_conduccion_verde` con
+ *      ON CONFLICT DO NOTHING — dedup natural por
+ *      (vehiculo_id, timestamp_device, tipo).
+ *
+ * Por qué inserción individual (no bulk):
+ *   - Eventos por record son 0-2 en el caso normal. Bulk con
+ *     jsonb_to_recordset agrega complejidad sin ganancia perceptible.
+ *   - Falla parcial (un evento OK, otro corrupto) no bloquea al otro:
+ *     cada INSERT es independiente.
+ *
+ * Idempotencia: si un AVL packet llega dos veces (retry de Pub/Sub),
+ * los eventos son los mismos por (vehículo, timestamp_device, tipo) →
+ * el ON CONFLICT los descarta. result.rowCount cuenta cuántos
+ * efectivamente entraron por primera vez.
+ */
+
+/**
+ * Mapeo del tipo del codec8-parser (inglés) al enum de DB (español).
+ * Espejo de `tipoEventoConduccionEnum` en apps/api/src/db/schema.ts
+ * (PR-I2). Si cambia un lado, actualizar el otro.
+ */
+const TYPE_TO_DB: Record<GreenDrivingEventType, string> = {
+  harsh_acceleration: 'aceleracion_brusca',
+  harsh_braking: 'frenado_brusco',
+  harsh_cornering: 'curva_brusca',
+  over_speed: 'exceso_velocidad',
+};
+
+export interface PersistGreenDrivingResult {
+  /** Total de eventos extraídos del record (0..2 típico). */
+  extractedCount: number;
+  /** Cuántos efectivamente entraron por primera vez (dedup ON CONFLICT). */
+  insertedCount: number;
+}
+
+/**
+ * Extrae y persiste eventos de green-driving del record. Si el record
+ * no tiene los IO IDs relevantes (253/255), retorna 0/0 sin tocar la DB.
+ *
+ * Si `vehicleId === null` (device pendiente de aprobación), retorna 0/0
+ * silently — sin vehicleId la FK no es válida y persistir es imposible.
+ *
+ * Errores de DB se propagan al caller (handler de PubSub) que decide
+ * ack/nack. Eventos corruptos individuales no bloquean al record
+ * completo: cada INSERT es independiente; si uno falla, el siguiente
+ * sigue.
+ */
+export async function persistGreenDrivingFromRecord(opts: {
+  db: NodePgDatabase<Record<string, unknown>>;
+  logger: Logger;
+  msg: RecordMessage;
+}): Promise<PersistGreenDrivingResult> {
+  const { db, logger, msg } = opts;
+
+  if (!msg.vehicleId) {
+    return { extractedCount: 0, insertedCount: 0 };
+  }
+
+  // Convertir RecordMessage (wire format) → AvlRecord (codec8-parser
+  // shape). La diferencia clave es `value`: en el wire es number|string,
+  // en AvlRecord es number|bigint|Buffer. Para los IDs de green-driving
+  // (253/254/255) los values son siempre uint8/uint16 → number plain,
+  // así que la conversión es trivial. Defensivamente convertimos string
+  // a number por si llegan IDs grandes (no debería para estos IDs, pero
+  // protege ante futuros cambios del wire format).
+  const ioEntries = msg.record.io.entries.map((e) => ({
+    id: e.id,
+    value: typeof e.value === 'string' ? Number(e.value) : e.value,
+    byteSize: e.byteSize,
+  }));
+
+  const events: GreenDrivingEvent[] = extractGreenDrivingEvents({
+    timestampMs: BigInt(msg.record.timestampMs),
+    priority: msg.record.priority,
+    gps: msg.record.gps,
+    io: {
+      eventIoId: msg.record.io.eventIoId,
+      totalIo: msg.record.io.totalIo,
+      entries: ioEntries,
+    },
+  });
+
+  if (events.length === 0) {
+    return { extractedCount: 0, insertedCount: 0 };
+  }
+
+  let insertedCount = 0;
+  for (const event of events) {
+    const tsDate = new Date(Number(event.timestampMs));
+    const result = await db.execute<{ id: string }>(sql`
+      INSERT INTO eventos_conduccion_verde (
+        vehiculo_id, imei, timestamp_device, tipo, severidad, unidad,
+        latitud, longitud, velocidad_kmh
+      ) VALUES (
+        ${msg.vehicleId}::uuid,
+        ${msg.imei},
+        ${tsDate.toISOString()}::timestamptz,
+        ${TYPE_TO_DB[event.type]}::tipo_evento_conduccion,
+        ${event.severity.toFixed(2)},
+        ${event.unit},
+        ${event.gps.latitude},
+        ${event.gps.longitude},
+        ${event.gps.speedKmh}
+      )
+      ON CONFLICT ON CONSTRAINT uq_eventos_conduccion_vehiculo_ts_tipo
+      DO NOTHING
+      RETURNING id
+    `);
+    if ((result.rows?.length ?? 0) > 0) {
+      insertedCount += 1;
+    }
+  }
+
+  if (insertedCount > 0) {
+    logger.info(
+      {
+        vehicleId: msg.vehicleId,
+        imei: msg.imei,
+        timestampMs: msg.record.timestampMs,
+        extractedCount: events.length,
+        insertedCount,
+        types: events.map((e) => e.type),
+      },
+      'green-driving events persistidos',
+    );
+  }
+
+  return { extractedCount: events.length, insertedCount };
+}


### PR DESCRIPTION
## Resumen

Segundo PR de **Phase 2**. Conecta el extractor de [#101](../pull/101) al pipeline de producción: por cada AVL record que entra al telemetry-processor, extrae eventos green-driving + over-speed y los persiste en una tabla nueva.

## Cambios

### \`apps/api/src/db/schema.ts\`
- Enum nuevo \`tipoEventoConduccionEnum\` (4 valores en español).
- Tabla \`eventos_conduccion_verde\` con FK a \`vehiculos\`, dedup natural \`(vehiculo_id, timestamp_device, tipo)\`, índices por trip y por tipo.

### \`apps/api/drizzle/0010_eventos_conduccion_verde.sql\`
Migración con CREATE TYPE + CREATE TABLE + 2 CREATE INDEX. Riesgo deploy bajo (tabla nueva, sin alter de existentes). Reversible.

### \`apps/telemetry-processor/src/persist-green-driving.ts\` (nuevo)
- \`persistGreenDrivingFromRecord(opts)\`: convierte \`RecordMessage\` (wire) → \`AvlRecord\` (codec8-parser shape), extrae eventos, INSERT con \`ON CONFLICT DO NOTHING\`.
- Mapeo de enum inglés (codec8) a español (DB).
- Si \`vehicleId === null\` → skip silencioso.

### \`apps/telemetry-processor/src/main.ts\`
- Llama \`persistGreenDrivingFromRecord\` DESPUÉS de \`persistRecord\` exitoso.
- try/catch defensivo: fallo de eventos no bloquea ack del record (eventos son input al scoring, no críticos para lifecycle del viaje).
- Log incluye \`greenDrivingInserted\` para SLO.

## Verificación

- [x] \`pnpm --filter @booster-ai/api typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/telemetry-processor typecheck\` — 0 errores
- [x] \`biome check\` — 0 errores
- [x] Tests del codec8-parser (PR-I1, [#101](../pull/101)) cubren extracción; persistencia es wrapper trivial.

## Próximos PRs

- **PR-I3**: agregación por trip → score (base 100 menos penalizaciones).
- **PR-I4**: endpoint API para scores.
- **PR-I5**: UI dashboard transportista.

🤖 Generated with [Claude Code](https://claude.com/claude-code)