### PR TITLE
feat(driver-scoring): nuevo package con cálculo de score por viaje (Phase 2 PR-I3)

### DIFF
--- a/packages/driver-scoring/package.json
+++ b/packages/driver-scoring/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@booster-ai/driver-scoring",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/driver-scoring/src/calcular-score.ts
+++ b/packages/driver-scoring/src/calcular-score.ts
@@ -1,0 +1,137 @@
+import type { EventoConduccion, NivelScore, ParametrosScore, ResultadoScore } from './tipos.js';
+
+/**
+ * Cálculo del score de conducción por viaje (Phase 2 PR-I3).
+ *
+ * v1 — fórmula simple, transparente, defendible ante un transportista
+ * que cuestione su score:
+ *
+ *     score = max(0, 100 − Σ penalty(evento))
+ *
+ *     penalty(aceleracion_brusca) = 5
+ *     penalty(frenado_brusco)     = 5
+ *     penalty(curva_brusca)       = 5
+ *     penalty(exceso_velocidad)   = 2
+ *
+ * **Por qué estos pesos**:
+ *
+ *   - **Harsh accel/brake/cornering = 5 cada uno**. Estudios SAE
+ *     eco-driving muestran que evitar arrancadas/frenadas bruscas
+ *     reduce 5–15% el consumo. Cada evento es proxy directo del
+ *     impacto en huella de carbono — el feature original que motivó
+ *     Phase 2 ("comportamiento en ruta para reducir huella").
+ *
+ *   - **Exceso velocidad = 2** (peso menor). Sobre el límite no
+ *     consume MUCHO más combustible (curva consumo vs velocidad es
+ *     plana entre 80-110 km/h). El peso menor refleja que es
+ *     primariamente un riesgo de seguridad (multas, accidentes), no
+ *     de eficiencia. Los carriers Verified pueden tener su propio
+ *     incentivo de seguridad encima del de carbono.
+ *
+ *   - **Cap a 100 puntos de penalty**: un trip horrible no puede
+ *     bajar el score bajo 0 (sería confuso al cliente). Si se
+ *     acumulan >100 puntos, el score llega a 0 igual.
+ *
+ * **Ponderación por severidad — out of scope v1**:
+ *
+ * El campo `severity` (mG para harsh, km/h sobre límite para over)
+ * NO afecta el score en v1. Justificación:
+ *
+ *   - El device aplica un threshold a nivel hardware antes de emitir
+ *     el evento. Por construcción ya pasó el filtro "severity > X".
+ *   - La distribución de severities post-threshold es aproximadamente
+ *     log-normal con media cercana al threshold. Ponderar agrega
+ *     complejidad sin ganancia clara para v1.
+ *   - Un transportista que conteste "ese frenado fue suave" tiene
+ *     argumento débil — el FMC150 ya filtró los suaves.
+ *
+ * Si en v2 se añade ponderación por severity, será aditivo (no rompe
+ * v1): los carriers existentes verán sus scores moverse, lo cual
+ * requiere comunicación pero es justificable.
+ *
+ * Función PURA. Sin I/O. Determinística para un input dado. Si el
+ * caller quiere persistir el resultado, se hace fuera.
+ */
+
+/** Pesos por tipo de evento (puntos restados al baseline 100). */
+const PESO_POR_TIPO: Readonly<Record<EventoConduccion['type'], number>> = {
+  aceleracion_brusca: 5,
+  frenado_brusco: 5,
+  curva_brusca: 5,
+  exceso_velocidad: 2,
+};
+
+/** Score baseline antes de penalizaciones. */
+const SCORE_BASELINE = 100;
+
+/** Score mínimo (cap inferior). */
+const SCORE_MIN = 0;
+
+/** Thresholds de los buckets cualitativos (UI). */
+const THRESHOLD_EXCELENTE = 90;
+const THRESHOLD_BUENO = 70;
+const THRESHOLD_REGULAR = 50;
+
+export function calcularScoreConduccion(input: ParametrosScore): ResultadoScore {
+  const { events, tripDurationMinutes } = input;
+
+  // Contadores por tipo. Inicializamos en 0 para garantizar shape
+  // estable del desglose aunque no haya eventos de algún tipo.
+  const counts = {
+    aceleracionesBruscas: 0,
+    frenadosBruscos: 0,
+    curvasBruscas: 0,
+    excesosVelocidad: 0,
+  };
+
+  let penalty = 0;
+  for (const event of events) {
+    penalty += PESO_POR_TIPO[event.type];
+    switch (event.type) {
+      case 'aceleracion_brusca':
+        counts.aceleracionesBruscas += 1;
+        break;
+      case 'frenado_brusco':
+        counts.frenadosBruscos += 1;
+        break;
+      case 'curva_brusca':
+        counts.curvasBruscas += 1;
+        break;
+      case 'exceso_velocidad':
+        counts.excesosVelocidad += 1;
+        break;
+    }
+  }
+
+  const score = Math.max(SCORE_MIN, SCORE_BASELINE - penalty);
+  const nivel = bucketScore(score);
+
+  // Eventos por hora — métrica para UI/dashboard, no para scoring.
+  // Si tripDurationMinutes ≤ 0, retornamos NaN para que el caller
+  // sepa "no aplica" vs un valor numérico engañoso.
+  const eventosPorHora =
+    tripDurationMinutes > 0 ? (events.length / tripDurationMinutes) * 60 : Number.NaN;
+
+  return {
+    score,
+    nivel,
+    desglose: {
+      ...counts,
+      penalizacionTotal: penalty,
+      eventosPorHora,
+    },
+  };
+}
+
+function bucketScore(score: number): NivelScore {
+  if (score >= THRESHOLD_EXCELENTE) {
+    return 'excelente';
+  }
+  if (score >= THRESHOLD_BUENO) {
+    return 'bueno';
+  }
+  if (score >= THRESHOLD_REGULAR) {
+    return 'regular';
+  }
+  return 'malo';
+}

--- a/packages/driver-scoring/src/index.ts
+++ b/packages/driver-scoring/src/index.ts
@@ -1,0 +1,41 @@
+/**
+ * @booster-ai/driver-scoring
+ *
+ * Cálculo del score de conducción por viaje, basado en eventos
+ * green-driving + over-speeding capturados por Teltonika FMC150
+ * (codec8-parser IO 253/254/255).
+ *
+ * Phase 2 (driver behavior scoring) — feature original "comportamiento
+ * en ruta para reducir huella de carbono".
+ *
+ * API pública:
+ *
+ *     import { calcularScoreConduccion } from '@booster-ai/driver-scoring';
+ *
+ *     const result = calcularScoreConduccion({
+ *       events: [
+ *         { type: 'frenado_brusco', severity: 1900, timestampMs: 1_777_000_000_000 },
+ *         { type: 'exceso_velocidad', severity: 110, timestampMs: 1_777_000_300_000 },
+ *       ],
+ *       tripDurationMinutes: 90,
+ *     });
+ *
+ *     result.score                          // 93
+ *     result.nivel                          // 'excelente'
+ *     result.desglose.frenadosBruscos       // 1
+ *     result.desglose.excesosVelocidad      // 1
+ *     result.desglose.penalizacionTotal     // 7 (5 + 2)
+ *     result.desglose.eventosPorHora        // 1.33
+ *
+ * Función PURA: sin I/O, determinística. Si el caller (apps/api o
+ * dashboard) quiere persistir el resultado, lo hace fuera.
+ */
+
+export { calcularScoreConduccion } from './calcular-score.js';
+export type {
+  EventoConduccion,
+  NivelScore,
+  ParametrosScore,
+  ResultadoScore,
+  TipoEvento,
+} from './tipos.js';

--- a/packages/driver-scoring/src/tipos.ts
+++ b/packages/driver-scoring/src/tipos.ts
@@ -1,0 +1,95 @@
+/**
+ * Tipos compartidos del package @booster-ai/driver-scoring.
+ *
+ * Naming espejo de la tabla DB `eventos_conduccion_verde`
+ * (apps/api/src/db/schema.ts) — los string literals son el enum SQL
+ * `tipo_evento_conduccion`. Si cambia un lado, actualizar el otro.
+ */
+
+/**
+ * Tipo de evento de conducción capturado por el FMC150 vía IO 253/255.
+ *
+ *   - aceleracion_brusca: harsh acceleration (IO 253 value=1)
+ *   - frenado_brusco: harsh braking (IO 253 value=2)
+ *   - curva_brusca: harsh cornering (IO 253 value=3)
+ *   - exceso_velocidad: over-speeding (IO 255)
+ */
+export type TipoEvento =
+  | 'aceleracion_brusca'
+  | 'frenado_brusco'
+  | 'curva_brusca'
+  | 'exceso_velocidad';
+
+/**
+ * Un evento individual ya cargado de la DB (o passed in para test).
+ *
+ * `severity` está en su unidad nativa (mG para harsh, km/h para over).
+ * En esta versión del scoring v1 no se usa para ponderar — todos los
+ * eventos del mismo tipo cuentan igual. Se persiste de todas formas
+ * para análisis post-hoc + futuras versiones que ponderen por
+ * intensidad.
+ */
+export interface EventoConduccion {
+  type: TipoEvento;
+  /** mG (harsh) o km/h (exceso). */
+  severity: number;
+  /** Timestamp del evento, epoch ms. Para ordering + análisis temporal. */
+  timestampMs: number;
+}
+
+/**
+ * Nivel cualitativo del score, derivado del número:
+ *   - excelente: ≥ 90
+ *   - bueno: 70–89
+ *   - regular: 50–69
+ *   - malo: < 50
+ *
+ * Útil para badges de UI sin que el dashboard tenga que duplicar la
+ * lógica de bucketización.
+ */
+export type NivelScore = 'excelente' | 'bueno' | 'regular' | 'malo';
+
+/**
+ * Resultado del cálculo de score. Score normalizado a [0, 100], con
+ * desglose para auditoría + UI.
+ */
+export interface ResultadoScore {
+  /** Score 0–100. 100 = sin eventos, sin penalización. */
+  score: number;
+
+  nivel: NivelScore;
+
+  /**
+   * Desglose detallado para la UI y para auditoría del cálculo.
+   * El cliente puede mostrar "12 frenados bruscos · 3 excesos de
+   * velocidad" sin re-procesar la lista de eventos.
+   */
+  desglose: {
+    aceleracionesBruscas: number;
+    frenadosBruscos: number;
+    curvasBruscas: number;
+    excesosVelocidad: number;
+    /** Suma de penalizaciones aplicadas (antes del cap a 100). */
+    penalizacionTotal: number;
+    /**
+     * Eventos por hora del trip — métrica normalizada para comparar
+     * trips de duraciones distintas. NaN si tripDurationMinutes ≤ 0.
+     */
+    eventosPorHora: number;
+  };
+}
+
+/**
+ * Parámetros de entrada del scoring.
+ */
+export interface ParametrosScore {
+  /** Lista de eventos extraídos para el viaje (cualquier orden). */
+  events: readonly EventoConduccion[];
+  /**
+   * Duración del viaje en minutos. Solo se usa para calcular
+   * `eventosPorHora` (métrica de la UI, no afecta el score). Si es 0
+   * o negativo, eventosPorHora = NaN para que el caller lo trate como
+   * "no aplica".
+   */
+  tripDurationMinutes: number;
+}

--- a/packages/driver-scoring/test/calcular-score.test.ts
+++ b/packages/driver-scoring/test/calcular-score.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import { calcularScoreConduccion } from '../src/calcular-score.js';
+import type { EventoConduccion, TipoEvento } from '../src/tipos.js';
+
+/**
+ * Tests del scoring v1 (Phase 2 PR-I3).
+ *
+ * El score afecta directamente la UX del transportista (dashboard) y
+ * potencialmente decisiones del shipper (preferir carriers con score
+ * alto). Tests exhaustivos por construcción.
+ */
+
+function makeEvent(type: TipoEvento, overrides: Partial<EventoConduccion> = {}): EventoConduccion {
+  return {
+    type,
+    severity: type === 'exceso_velocidad' ? 110 : 1850,
+    timestampMs: 1_777_000_000_000,
+    ...overrides,
+  };
+}
+
+describe('calcularScoreConduccion — score baseline', () => {
+  it('sin eventos → 100 (excelente)', () => {
+    const r = calcularScoreConduccion({ events: [], tripDurationMinutes: 60 });
+    expect(r.score).toBe(100);
+    expect(r.nivel).toBe('excelente');
+    expect(r.desglose.penalizacionTotal).toBe(0);
+    expect(r.desglose.eventosPorHora).toBe(0);
+  });
+
+  it('1 frenado → 95 (excelente)', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('frenado_brusco')],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(95);
+    expect(r.nivel).toBe('excelente');
+    expect(r.desglose.penalizacionTotal).toBe(5);
+  });
+
+  it('1 exceso velocidad → 98 (excelente)', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('exceso_velocidad')],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(98);
+    expect(r.nivel).toBe('excelente');
+    expect(r.desglose.penalizacionTotal).toBe(2);
+  });
+});
+
+describe('calcularScoreConduccion — pesos por tipo', () => {
+  it('aceleración brusca pesa 5', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('aceleracion_brusca')],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(95);
+  });
+
+  it('frenado brusco pesa 5', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('frenado_brusco')],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(95);
+  });
+
+  it('curva brusca pesa 5', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('curva_brusca')],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(95);
+  });
+
+  it('exceso velocidad pesa 2 (peso menor: seguridad, no eficiencia)', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('exceso_velocidad')],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(98);
+  });
+});
+
+describe('calcularScoreConduccion — bucketización (niveles)', () => {
+  // Helper: crea N eventos de exceso_velocidad para alcanzar exactamente
+  // el penalty target (cada uno suma 2).
+  const eventosParaPenalty = (target: number): EventoConduccion[] =>
+    Array.from({ length: target / 2 }, () => makeEvent('exceso_velocidad'));
+
+  it('score 100 → excelente', () => {
+    expect(calcularScoreConduccion({ events: [], tripDurationMinutes: 60 }).nivel).toBe(
+      'excelente',
+    );
+  });
+
+  it('score 90 → excelente (boundary)', () => {
+    const r = calcularScoreConduccion({
+      events: eventosParaPenalty(10),
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(90);
+    expect(r.nivel).toBe('excelente');
+  });
+
+  it('score 89 → bueno (cae bajo threshold de excelente)', () => {
+    // 11 puntos de penalty: 1 harsh (5) + 3 exceso (6) = 11
+    const r = calcularScoreConduccion({
+      events: [makeEvent('frenado_brusco'), ...eventosParaPenalty(6)],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(89);
+    expect(r.nivel).toBe('bueno');
+  });
+
+  it('score 70 → bueno (boundary)', () => {
+    const r = calcularScoreConduccion({
+      events: eventosParaPenalty(30),
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(70);
+    expect(r.nivel).toBe('bueno');
+  });
+
+  it('score 69 → regular', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('frenado_brusco'), ...eventosParaPenalty(26)],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(69);
+    expect(r.nivel).toBe('regular');
+  });
+
+  it('score 50 → regular (boundary)', () => {
+    const r = calcularScoreConduccion({
+      events: eventosParaPenalty(50),
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(50);
+    expect(r.nivel).toBe('regular');
+  });
+
+  it('score 49 → malo', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('frenado_brusco'), ...eventosParaPenalty(46)],
+      tripDurationMinutes: 60,
+    });
+    expect(r.score).toBe(49);
+    expect(r.nivel).toBe('malo');
+  });
+});
+
+describe('calcularScoreConduccion — cap inferior', () => {
+  it('penalty > 100 → score = 0 (no negativo)', () => {
+    // 25 frenados × 5 = 125 puntos de penalty.
+    const events = Array.from({ length: 25 }, () => makeEvent('frenado_brusco'));
+    const r = calcularScoreConduccion({ events, tripDurationMinutes: 60 });
+    expect(r.score).toBe(0);
+    expect(r.nivel).toBe('malo');
+    expect(r.desglose.penalizacionTotal).toBe(125); // valor real (sin cap), para auditoría
+  });
+
+  it('penalty exactamente 100 → score = 0', () => {
+    const events = Array.from({ length: 20 }, () => makeEvent('frenado_brusco'));
+    const r = calcularScoreConduccion({ events, tripDurationMinutes: 60 });
+    expect(r.score).toBe(0);
+    expect(r.desglose.penalizacionTotal).toBe(100);
+  });
+});
+
+describe('calcularScoreConduccion — desglose contadores', () => {
+  it('cuenta cada tipo por separado', () => {
+    const events = [
+      makeEvent('aceleracion_brusca'),
+      makeEvent('aceleracion_brusca'),
+      makeEvent('frenado_brusco'),
+      makeEvent('curva_brusca'),
+      makeEvent('curva_brusca'),
+      makeEvent('curva_brusca'),
+      makeEvent('exceso_velocidad'),
+    ];
+    const r = calcularScoreConduccion({ events, tripDurationMinutes: 60 });
+    expect(r.desglose.aceleracionesBruscas).toBe(2);
+    expect(r.desglose.frenadosBruscos).toBe(1);
+    expect(r.desglose.curvasBruscas).toBe(3);
+    expect(r.desglose.excesosVelocidad).toBe(1);
+    // Penalty: (2+1+3) × 5 + 1 × 2 = 30 + 2 = 32 → score 68
+    expect(r.score).toBe(68);
+    expect(r.desglose.penalizacionTotal).toBe(32);
+  });
+
+  it('shape del desglose es estable aunque algún tipo no aparezca', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('frenado_brusco')],
+      tripDurationMinutes: 60,
+    });
+    // Garantizamos shape para que el front no tenga que checkear undefined.
+    expect(r.desglose.aceleracionesBruscas).toBe(0);
+    expect(r.desglose.curvasBruscas).toBe(0);
+    expect(r.desglose.excesosVelocidad).toBe(0);
+    expect(r.desglose.frenadosBruscos).toBe(1);
+  });
+});
+
+describe('calcularScoreConduccion — eventosPorHora', () => {
+  it('60 min con 6 eventos → 6 eventos/hora', () => {
+    const events = Array.from({ length: 6 }, () => makeEvent('exceso_velocidad'));
+    const r = calcularScoreConduccion({ events, tripDurationMinutes: 60 });
+    expect(r.desglose.eventosPorHora).toBe(6);
+  });
+
+  it('30 min con 6 eventos → 12 eventos/hora', () => {
+    const events = Array.from({ length: 6 }, () => makeEvent('exceso_velocidad'));
+    const r = calcularScoreConduccion({ events, tripDurationMinutes: 30 });
+    expect(r.desglose.eventosPorHora).toBe(12);
+  });
+
+  it('tripDurationMinutes = 0 → eventosPorHora = NaN (no aplica)', () => {
+    const r = calcularScoreConduccion({
+      events: [makeEvent('frenado_brusco')],
+      tripDurationMinutes: 0,
+    });
+    expect(Number.isNaN(r.desglose.eventosPorHora)).toBe(true);
+  });
+
+  it('tripDurationMinutes negativo → NaN', () => {
+    const r = calcularScoreConduccion({ events: [], tripDurationMinutes: -5 });
+    expect(Number.isNaN(r.desglose.eventosPorHora)).toBe(true);
+  });
+});
+
+describe('calcularScoreConduccion — determinismo', () => {
+  it('mismo input → mismo output (función pura)', () => {
+    const events = [
+      makeEvent('frenado_brusco', { timestampMs: 100, severity: 2400 }),
+      makeEvent('exceso_velocidad', { timestampMs: 200, severity: 115 }),
+      makeEvent('aceleracion_brusca', { timestampMs: 300, severity: 1900 }),
+    ];
+    const r1 = calcularScoreConduccion({ events, tripDurationMinutes: 90 });
+    const r2 = calcularScoreConduccion({ events, tripDurationMinutes: 90 });
+    expect(r1).toEqual(r2);
+  });
+
+  it('orden de eventos NO afecta el resultado', () => {
+    const events = [
+      makeEvent('frenado_brusco'),
+      makeEvent('aceleracion_brusca'),
+      makeEvent('exceso_velocidad'),
+    ];
+    const reversed = [...events].reverse();
+    const r1 = calcularScoreConduccion({ events, tripDurationMinutes: 60 });
+    const r2 = calcularScoreConduccion({ events: reversed, tripDurationMinutes: 60 });
+    expect(r1.score).toBe(r2.score);
+    expect(r1.desglose).toEqual(r2.desglose);
+  });
+});

--- a/packages/driver-scoring/tsconfig.json
+++ b/packages/driver-scoring/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,15 @@ importers:
         specifier: ^4.0.18
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/driver-scoring:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/dte-provider:
     devDependencies:
       typescript:
@@ -10771,7 +10780,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 


### PR DESCRIPTION
## Resumen

Tercer PR de **Phase 2**. Pure function package — calcula el score de conducción de un viaje a partir de la lista de eventos green-driving + over-speeding. Sin I/O, determinístico.

Builds on top of [#102](../pull/102) (que persiste los eventos consumidos por este package).

## Fórmula

\`\`\`
score = max(0, 100 − Σ penalty(evento))
  penalty(aceleracion_brusca) = 5
  penalty(frenado_brusco)     = 5
  penalty(curva_brusca)       = 5
  penalty(exceso_velocidad)   = 2
\`\`\`

**Justificación de pesos**:
- Harsh accel/brake/cornering = 5: estudios SAE eco-driving muestran 5–15% de exceso de combustible. Proxy directo de huella de carbono — alineado con feature original "comportamiento en ruta".
- Exceso velocidad = 2: peso menor porque sobre el límite NO consume MUCHO más combustible (curva consumo plana 80-110 km/h). Refleja riesgo de seguridad, no eficiencia.

**Niveles** (UI):
- excelente ≥ 90
- bueno 70–89
- regular 50–69
- malo < 50

## API

\`\`\`ts
import { calcularScoreConduccion } from '@booster-ai/driver-scoring';

const r = calcularScoreConduccion({
  events: [
    { type: 'frenado_brusco', severity: 1900, timestampMs: ... },
    { type: 'exceso_velocidad', severity: 110, timestampMs: ... },
  ],
  tripDurationMinutes: 90,
});

// r.score = 93, r.nivel = 'excelente'
// r.desglose = { frenadosBruscos: 1, excesosVelocidad: 1, ..., penalizacionTotal: 7, eventosPorHora: 1.33 }
\`\`\`

## Out of scope v1

Ponderación por severity. El device aplica threshold hardware antes de emitir; values post-threshold tienen distribución log-normal con media cerca del threshold. Ponderar agrega complejidad sin ganancia clara.

## Tests (24 casos)

- Score baseline (sin eventos = 100)
- Pesos por tipo (5/5/5/2)
- Bucketización: cada threshold (90, 70, 50) con boundary
- Cap inferior (penalty > 100 → score = 0)
- Desglose contadores (shape estable)
- eventosPorHora (con/sin trip duration)
- Determinismo (orden no afecta resultado)

## Verificación

- [x] \`pnpm --filter @booster-ai/driver-scoring typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/driver-scoring test\` — 24/24 passed
- [x] \`biome check\` — 0 errores

## Próximo PR

**PR-I4**: Service en \`apps/api\` que carga eventos de \`eventos_conduccion_verde\` por (vehículo, ventana del trip), llama a \`calcularScoreConduccion\`, persiste y expone vía endpoint para el dashboard del transportista.

🤖 Generated with [Claude Code](https://claude.com/claude-code)