### PR TITLE
feat(web): UI behavior score en asignacion-detalle (Phase 2 PR-I5)

### DIFF
--- a/apps/api/drizzle/0011_metricas_viaje_behavior_score.sql
+++ b/apps/api/drizzle/0011_metricas_viaje_behavior_score.sql
@@ -1,0 +1,27 @@
+-- Migration 0011 — Driver behavior score en metricas_viaje (Phase 2 PR-I4)
+--
+-- Agrega 3 columnas al row de metricas existente para persistir el
+-- score de conducción del trip + su breakdown. El cálculo lo hace
+-- @booster-ai/driver-scoring (PR-I3) consumiendo eventos de
+-- eventos_conduccion_verde (PR-I2). Persistir el resultado evita
+-- recomputar en cada GET del dashboard.
+--
+-- Nullables porque:
+--   - Trips sin Teltonika (Basic tier ADR-026) no producen eventos →
+--     no hay score que computar.
+--   - Trips legacy (pre-PR-I4) no tienen score hasta que pase un
+--     recálculo. El recálculo se dispara automáticamente en
+--     confirmar-entrega-viaje (PR-I4 wire).
+--
+-- Riesgo deploy: bajo. ADD COLUMN nullable es metadata-only en
+-- Postgres ≥ 11. Reversible vía DROP COLUMN.
+
+ALTER TABLE "metricas_viaje"
+  ADD COLUMN "puntaje_conduccion" numeric(5, 2),
+  ADD COLUMN "puntaje_conduccion_nivel" varchar(20),
+  ADD COLUMN "puntaje_conduccion_desglose" jsonb;
+
+-- Index para queries del dashboard ("top 10 transportistas por score
+-- este mes" o "todos los trips con score < 50 que requieren coaching").
+CREATE INDEX "idx_metricas_viaje_puntaje_conduccion"
+  ON "metricas_viaje" ("puntaje_conduccion");

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1778803200000,
       "tag": "0010_eventos_conduccion_verde",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1778889600000,
+      "tag": "0011_metricas_viaje_behavior_score",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "@booster-ai/carbon-calculator": "workspace:*",
     "@booster-ai/certificate-generator": "workspace:*",
     "@booster-ai/config": "workspace:*",
+    "@booster-ai/driver-scoring": "workspace:*",
     "@booster-ai/logger": "workspace:*",
     "@booster-ai/matching-algorithm": "workspace:*",
     "@booster-ai/notification-fan-out": "workspace:*",

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -755,12 +755,34 @@ export const tripMetrics = pgTable(
       precision: 10,
       scale: 3,
     }),
+    /**
+     * Phase 2 PR-I4 — Driver behavior score [0, 100]. Computed por
+     * @booster-ai/driver-scoring a partir de `eventos_conduccion_verde`
+     * filtrados por (vehículo, ventana del trip). Nullable: trips sin
+     * Teltonika (Basic tier) no tienen score; trips legacy pre-PR-I4
+     * tampoco hasta el primer recálculo.
+     */
+    behaviorScore: numeric('puntaje_conduccion', { precision: 5, scale: 2 }),
+    /**
+     * Bucket cualitativo del score: 'excelente' | 'bueno' | 'regular' | 'malo'.
+     * Persistido en vez de derivado en query para que la UI pueda hacer
+     * filtros tipo "transportistas con nivel bueno o mejor" sin recomputar.
+     */
+    behaviorScoreNivel: varchar('puntaje_conduccion_nivel', { length: 20 }),
+    /**
+     * Desglose completo del score (counts por tipo, penalizacionTotal,
+     * eventosPorHora) en JSONB. Permite drill-down en el dashboard sin
+     * re-cargar los eventos individuales. Shape espejo de
+     * ResultadoScore.desglose del package driver-scoring.
+     */
+    behaviorScoreBreakdown: jsonb('puntaje_conduccion_desglose'),
     createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
     precisionIdx: index('idx_metricas_viaje_metodo_precision').on(table.precisionMethod),
     calculatedIdx: index('idx_metricas_viaje_calculado').on(table.calculatedAt),
+    behaviorScoreIdx: index('idx_metricas_viaje_puntaje_conduccion').on(table.behaviorScore),
   }),
 );
 

--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -24,6 +24,7 @@ import {
   assignments,
   empresas as empresasTable,
   telemetryPoints,
+  tripMetrics,
   trips,
   users as usersTable,
   vehicles,
@@ -292,6 +293,74 @@ export function createAssignmentsRoutes(opts: {
       ok: true,
       already_delivered: result.alreadyDelivered,
       delivered_at: result.deliveredAt.toISOString(),
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // GET /:id/behavior-score — Phase 2 PR-I4
+  //
+  // Devuelve el behavior score persistido en metricas_viaje del trip
+  // asociado al assignment. El score se calcula post-entrega
+  // (calcular-score-conduccion-viaje.ts) consumiendo eventos de
+  // eventos_conduccion_verde.
+  //
+  // Estados:
+  //   - score persistido (numérico) → 200 con shape completo
+  //   - score NULL (trip sin Teltonika o no entregado todavía) → 200
+  //     con score: null + status: 'no_disponible' para que la UI
+  //     muestre estado apropiado sin tirar 404
+  //   - assignment no existe / no es del carrier → 404 / 403
+  // ---------------------------------------------------------------------
+  app.get('/:id/behavior-score', async (c) => {
+    const auth = requireCarrierAuth(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const assignmentId = c.req.param('id');
+    const empresaId = auth.activeMembership.empresa.id;
+
+    const [row] = await opts.db
+      .select({
+        assignmentEmpresaId: assignments.empresaId,
+        tripId: assignments.tripId,
+        score: tripMetrics.behaviorScore,
+        nivel: tripMetrics.behaviorScoreNivel,
+        breakdown: tripMetrics.behaviorScoreBreakdown,
+        calculatedAt: tripMetrics.calculatedAt,
+      })
+      .from(assignments)
+      .leftJoin(tripMetrics, eq(tripMetrics.tripId, assignments.tripId))
+      .where(eq(assignments.id, assignmentId))
+      .limit(1);
+
+    if (!row) {
+      return c.json({ error: 'assignment_not_found', code: 'assignment_not_found' }, 404);
+    }
+    if (row.assignmentEmpresaId !== empresaId) {
+      return c.json({ error: 'forbidden', code: 'assignment_forbidden' }, 403);
+    }
+
+    if (row.score === null || row.score === undefined) {
+      return c.json({
+        trip_id: row.tripId,
+        score: null,
+        nivel: null,
+        breakdown: null,
+        status: 'no_disponible',
+        // Razón probable para la UI: cliente sin Teltonika activo, o
+        // trip todavía no entregado. La UI muestra "Activa Teltonika
+        // para ver behavior score" según el tier del transportista.
+        reason: 'sin_eventos_o_sin_telemetria',
+      });
+    }
+
+    return c.json({
+      trip_id: row.tripId,
+      score: Number(row.score),
+      nivel: row.nivel,
+      breakdown: row.breakdown,
+      calculated_at: row.calculatedAt,
+      status: 'disponible',
     });
   });
 

--- a/apps/api/src/services/calcular-score-conduccion-viaje.ts
+++ b/apps/api/src/services/calcular-score-conduccion-viaje.ts
@@ -1,0 +1,141 @@
+import {
+  type EventoConduccion,
+  type TipoEvento,
+  calcularScoreConduccion,
+} from '@booster-ai/driver-scoring';
+import type { Logger } from '@booster-ai/logger';
+import { and, eq, gte, lte, sql } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { assignments, greenDrivingEvents, tripMetrics, trips } from '../db/schema.js';
+
+/**
+ * Calcular y persistir el behavior score de un trip (Phase 2 PR-I4).
+ *
+ * Flow:
+ *   1. Cargar eventos de `eventos_conduccion_verde` filtrados por
+ *      vehículo + ventana del trip (pickupAt → deliveredAt).
+ *   2. Calcular score puro vía @booster-ai/driver-scoring.
+ *   3. Persistir score + nivel + breakdown en `metricas_viaje`.
+ *
+ * Disparo: post-entrega, llamado por confirmar-entrega-viaje.ts
+ * (mismo flujo que recalcularNivelPostEntrega de ADR-028 PR-G).
+ *
+ * Si el trip no tiene Teltonika asociado, no hay eventos → score
+ * sigue NULL en BD. La UI del transportista debe distinguir
+ * "sin score = no aplica" vs "score 0 = malo extremo".
+ *
+ * Idempotente: si ya hay un score persistido, este se sobrescribe
+ * con el cálculo nuevo (cuya entrada de eventos no debería cambiar
+ * post-entrega salvo retries del processor).
+ */
+
+export class TripNotFoundForScoreError extends Error {
+  constructor(public readonly tripId: string) {
+    super(`Trip ${tripId} not found`);
+    this.name = 'TripNotFoundForScoreError';
+  }
+}
+
+export interface CalcularScoreResult {
+  /** True si hay eventos y se persistió score; false si no había eventos. */
+  computed: boolean;
+  score?: number;
+  nivel?: 'excelente' | 'bueno' | 'regular' | 'malo';
+  eventCount?: number;
+}
+
+export async function calcularScoreConduccionViaje(opts: {
+  db: Db;
+  logger: Logger;
+  tripId: string;
+}): Promise<CalcularScoreResult> {
+  const { db, logger, tripId } = opts;
+
+  // Cargar trip + assignment para obtener vehículo + ventana del trip.
+  const tripRows = await db.select().from(trips).where(eq(trips.id, tripId)).limit(1);
+  const trip = tripRows[0];
+  if (!trip) {
+    throw new TripNotFoundForScoreError(tripId);
+  }
+
+  const assignmentRows = await db
+    .select({
+      vehicleId: assignments.vehicleId,
+      deliveredAt: assignments.deliveredAt,
+    })
+    .from(assignments)
+    .where(eq(assignments.tripId, tripId))
+    .limit(1);
+  const assignment = assignmentRows[0];
+
+  if (!assignment?.vehicleId || !assignment.deliveredAt) {
+    logger.info(
+      { tripId, hasAssignment: !!assignment },
+      'calcularScoreConduccionViaje: skip (sin assignment con vehicle + deliveredAt)',
+    );
+    return { computed: false };
+  }
+
+  // Ventana del trip: desde pickup_window_start (o created_at como
+  // fallback conservador) hasta deliveredAt. Cualquier evento del
+  // vehículo en esa ventana se considera de este trip.
+  const pickupAt = trip.pickupWindowStart ?? trip.createdAt;
+  const deliveredAt = assignment.deliveredAt;
+
+  const eventRows = await db
+    .select({
+      type: greenDrivingEvents.type,
+      severity: greenDrivingEvents.severity,
+      timestampDevice: greenDrivingEvents.timestampDevice,
+    })
+    .from(greenDrivingEvents)
+    .where(
+      and(
+        eq(greenDrivingEvents.vehicleId, assignment.vehicleId),
+        gte(greenDrivingEvents.timestampDevice, pickupAt),
+        lte(greenDrivingEvents.timestampDevice, deliveredAt),
+      ),
+    );
+
+  const events: EventoConduccion[] = eventRows.map((row) => ({
+    type: row.type as TipoEvento,
+    severity: Number(row.severity),
+    timestampMs: row.timestampDevice.getTime(),
+  }));
+
+  // Duración del trip en minutos (para eventos/hora del breakdown).
+  const tripDurationMinutes = Math.max(0, (deliveredAt.getTime() - pickupAt.getTime()) / 60_000);
+
+  const result = calcularScoreConduccion({ events, tripDurationMinutes });
+
+  // Persistir incluso si events.length === 0: en ese caso el score
+  // = 100 (excelente, sin eventos). El transportista lo merece.
+  await db
+    .update(tripMetrics)
+    .set({
+      behaviorScore: result.score.toFixed(2),
+      behaviorScoreNivel: result.nivel,
+      behaviorScoreBreakdown: result.desglose,
+      updatedAt: sql`now()`,
+    })
+    .where(eq(tripMetrics.tripId, tripId));
+
+  logger.info(
+    {
+      tripId,
+      vehicleId: assignment.vehicleId,
+      eventCount: events.length,
+      score: result.score,
+      nivel: result.nivel,
+      tripDurationMinutes,
+    },
+    'behavior score persistido',
+  );
+
+  return {
+    computed: true,
+    score: result.score,
+    nivel: result.nivel,
+    eventCount: events.length,
+  };
+}

--- a/apps/api/src/services/confirmar-entrega-viaje.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.ts
@@ -33,6 +33,7 @@ import { and, eq } from 'drizzle-orm';
 import type { Db } from '../db/client.js';
 import { assignments, tripEvents, trips } from '../db/schema.js';
 import { recalcularNivelPostEntrega } from './calcular-metricas-viaje.js';
+import { calcularScoreConduccionViaje } from './calcular-score-conduccion-viaje.js';
 import {
   type EmitirCertificadoConfig,
   emitirCertificadoViaje,
@@ -198,6 +199,20 @@ export async function confirmarEntregaViaje(opts: {
       logger.error(
         { err, tripId },
         'recalcularNivelPostEntrega fallo — emitiendo cert con valores estimados',
+      );
+    }
+
+    // Phase 2 PR-I4 — calcular behavior score post-entrega. Depende de
+    // que la metricas_viaje row exista (creada en calcularMetricasEstimadas
+    // al asignar) — el UPDATE de score se hace sobre la row existente.
+    // Si falla, log + sigue: el score es información complementaria, no
+    // bloquea el cert.
+    try {
+      await calcularScoreConduccionViaje({ db, logger, tripId });
+    } catch (err) {
+      logger.error(
+        { err, tripId },
+        'calcularScoreConduccionViaje fallo — sin score persistido para este trip',
       );
     }
 

--- a/apps/web/src/components/scoring/BehaviorScoreCard.tsx
+++ b/apps/web/src/components/scoring/BehaviorScoreCard.tsx
@@ -1,0 +1,174 @@
+import { ChevronDown, ChevronUp, Gauge, Info } from 'lucide-react';
+import { useState } from 'react';
+import {
+  type BehaviorScoreResponse,
+  type NivelScore,
+  useBehaviorScore,
+} from '../../hooks/use-behavior-score.js';
+
+/**
+ * Card que muestra el behavior score del trip (Phase 2 PR-I5).
+ *
+ * Estados:
+ *   - Cargando: skeleton compacto
+ *   - status: 'no_disponible': mensaje educativo según reason — el carrier
+ *     entiende qué hacer para tener score
+ *   - status: 'disponible': score grande con badge cualitativo + drill-down
+ *     colapsable de los counts por tipo de evento
+ *
+ * Diseñado para ir encima de la ChatPanel en asignacion-detalle. Compacta
+ * por default (~80px), expansible a ~200px con detalles.
+ */
+
+const NIVEL_STYLES: Record<NivelScore, { label: string; bg: string; text: string; ring: string }> =
+  {
+    excelente: {
+      label: 'Excelente',
+      bg: 'bg-success-50',
+      text: 'text-success-700',
+      ring: 'ring-success-700/20',
+    },
+    bueno: {
+      label: 'Bueno',
+      bg: 'bg-primary-50',
+      text: 'text-primary-700',
+      ring: 'ring-primary-700/20',
+    },
+    regular: {
+      label: 'Regular',
+      bg: 'bg-amber-50',
+      text: 'text-amber-700',
+      ring: 'ring-amber-700/20',
+    },
+    malo: {
+      label: 'Mejorar',
+      bg: 'bg-danger-50',
+      text: 'text-danger-700',
+      ring: 'ring-danger-700/20',
+    },
+  };
+
+export interface BehaviorScoreCardProps {
+  assignmentId: string;
+}
+
+export function BehaviorScoreCard({ assignmentId }: BehaviorScoreCardProps) {
+  const query = useBehaviorScore(assignmentId);
+  const [expanded, setExpanded] = useState(false);
+
+  if (query.isLoading) {
+    return (
+      <div className="border-neutral-200 border-b bg-white px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Gauge className="h-5 w-5 animate-pulse text-neutral-400" aria-hidden />
+          <div className="text-neutral-500 text-sm">Cargando score de conducción…</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (query.isError || !query.data) {
+    // Silencioso. No queremos meter ruido si la query falla — el chat es
+    // lo importante en esta surface.
+    return null;
+  }
+
+  const data: BehaviorScoreResponse = query.data;
+
+  if (data.status === 'no_disponible') {
+    return (
+      <div className="border-neutral-200 border-b bg-neutral-50 px-4 py-3">
+        <div className="flex items-start gap-3">
+          <Info className="h-5 w-5 shrink-0 text-neutral-500" aria-hidden />
+          <div className="flex-1">
+            <p className="font-medium text-neutral-900 text-sm">
+              Score de conducción no disponible
+            </p>
+            <p className="mt-0.5 text-neutral-600 text-xs">
+              Activa Teltonika en este vehículo para recibir feedback automático sobre estilo de
+              conducción tras cada entrega.
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // status === 'disponible'
+  const styles = NIVEL_STYLES[data.nivel];
+  const breakdown = data.breakdown;
+
+  return (
+    <div className="border-neutral-200 border-b bg-white">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center gap-3 px-4 py-3 transition hover:bg-neutral-50"
+        aria-expanded={expanded}
+        aria-controls="behavior-score-details"
+      >
+        <Gauge className={`h-5 w-5 ${styles.text}`} aria-hidden />
+        <div className="flex-1 text-left">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-neutral-900 text-sm">
+              Score de conducción · {data.score.toFixed(0)}/100
+            </span>
+            <span
+              className={`rounded-full px-2 py-0.5 font-medium text-xs ring-1 ${styles.bg} ${styles.text} ${styles.ring}`}
+            >
+              {styles.label}
+            </span>
+          </div>
+          <p className="mt-0.5 text-neutral-500 text-xs">
+            {breakdown.eventosPorHora > 0
+              ? `${breakdown.eventosPorHora.toFixed(1)} eventos/hora · ${
+                  breakdown.aceleracionesBruscas +
+                  breakdown.frenadosBruscos +
+                  breakdown.curvasBruscas +
+                  breakdown.excesosVelocidad
+                } eventos totales`
+              : 'Sin eventos en este viaje'}
+          </p>
+        </div>
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 text-neutral-400" aria-hidden />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-neutral-400" aria-hidden />
+        )}
+      </button>
+
+      {expanded && (
+        <div
+          id="behavior-score-details"
+          className="border-neutral-100 border-t bg-neutral-50 px-4 py-3"
+        >
+          <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs sm:grid-cols-4">
+            <BreakdownItem label="Aceleración brusca" value={breakdown.aceleracionesBruscas} />
+            <BreakdownItem label="Frenado brusco" value={breakdown.frenadosBruscos} />
+            <BreakdownItem label="Curva brusca" value={breakdown.curvasBruscas} />
+            <BreakdownItem label="Exceso velocidad" value={breakdown.excesosVelocidad} />
+          </dl>
+          <p className="mt-3 text-[11px] text-neutral-500">
+            Score basado en metodología GLEC + estudios SAE eco-driving. Reducir frenadas y
+            arrancadas bruscas baja el consumo de combustible 5–15%.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BreakdownItem({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <dt className="text-neutral-500">{label}</dt>
+      <dd
+        className={`font-semibold ${
+          value === 0 ? 'text-success-700' : value <= 2 ? 'text-amber-700' : 'text-danger-700'
+        }`}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-behavior-score.ts
+++ b/apps/web/src/hooks/use-behavior-score.ts
@@ -1,0 +1,59 @@
+import { useQuery } from '@tanstack/react-query';
+import { ApiError, api } from '../lib/api-client.js';
+
+/**
+ * Behavior score de un trip — Phase 2 PR-I5.
+ * Consume GET /assignments/:id/behavior-score (Phase 2 PR-I4).
+ *
+ * Espejo del shape del response del api. Si en una iteración futura
+ * agregamos campos al endpoint, actualizar acá también o (mejor)
+ * mover a shared-schemas.
+ */
+export type NivelScore = 'excelente' | 'bueno' | 'regular' | 'malo';
+
+export interface BehaviorScoreBreakdown {
+  aceleracionesBruscas: number;
+  frenadosBruscos: number;
+  curvasBruscas: number;
+  excesosVelocidad: number;
+  penalizacionTotal: number;
+  eventosPorHora: number;
+}
+
+export type BehaviorScoreResponse =
+  | {
+      trip_id: string;
+      score: number;
+      nivel: NivelScore;
+      breakdown: BehaviorScoreBreakdown;
+      calculated_at: string;
+      status: 'disponible';
+    }
+  | {
+      trip_id: string;
+      score: null;
+      nivel: null;
+      breakdown: null;
+      status: 'no_disponible';
+      reason: string;
+    };
+
+export function useBehaviorScore(assignmentId: string, opts: { enabled?: boolean } = {}) {
+  return useQuery<BehaviorScoreResponse>({
+    queryKey: ['assignment', 'behavior-score', assignmentId],
+    queryFn: () => api.get<BehaviorScoreResponse>(`/assignments/${assignmentId}/behavior-score`),
+    enabled: opts.enabled ?? true,
+    // El score post-entrega NO cambia salvo recálculo manual. Cache largo.
+    staleTime: 10 * 60 * 1000,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+        return false;
+      }
+      // 404 → assignment no existe; no reintentar.
+      if (error instanceof ApiError && error.status === 404) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+}

--- a/apps/web/src/routes/asignacion-detalle.tsx
+++ b/apps/web/src/routes/asignacion-detalle.tsx
@@ -20,6 +20,7 @@ import { ArrowLeft } from 'lucide-react';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { ChatPanel } from '../components/chat/ChatPanel.js';
 import { PushSubscribeBanner } from '../components/chat/PushSubscribeBanner.js';
+import { BehaviorScoreCard } from '../components/scoring/BehaviorScoreCard.js';
 import { api } from '../lib/api-client.js';
 
 interface AssignmentDetail {
@@ -110,6 +111,13 @@ function AsignacionDetallePage() {
           </div>
         </div>
       </div>
+
+      {/* Behavior score card — Phase 2 PR-I5. Solo se muestra cuando
+          el trip está cerrado, porque el score se calcula post-entrega.
+          Para trips en curso, el componente igual maneja el estado
+          "no disponible" pero lo escondemos para no agregar ruido a
+          la surface activa. */}
+      {isClosed && <BehaviorScoreCard assignmentId={assignmentId} />}
 
       {/* ChatPanel fullscreen (sin onClose porque acá es la surface dedicada) */}
       <div className="flex-1 overflow-hidden">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@booster-ai/config':
         specifier: workspace:*
         version: link:../../packages/config
+      '@booster-ai/driver-scoring':
+        specifier: workspace:*
+        version: link:../../packages/driver-scoring
       '@booster-ai/logger':
         specifier: workspace:*
         version: link:../../packages/logger


### PR DESCRIPTION
## Resumen

Quinto y **último PR de Phase 2**. Surface al transportista el score de conducción del trip cerrado, en \`/app/asignaciones/:id\`.

Builds on top of [#104](../pull/104). Cierra Phase 2 end-to-end.

## Cambios

### \`apps/web/src/hooks/use-behavior-score.ts\` (nuevo)
- Hook que consume \`GET /assignments/:id/behavior-score\` (PR-I4).
- Type \`BehaviorScoreResponse\` discriminated union por \`status\`.
- staleTime 10min (score post-entrega es inmutable salvo recálculo).
- Skip retry en 401/403/404.

### \`apps/web/src/components/scoring/BehaviorScoreCard.tsx\` (nuevo)
Card colapsable con 3 estados:
- **Cargando**: skeleton compacto
- **\`no_disponible\`**: mensaje educativo \"Activa Teltonika para recibir feedback\" — sin score badge
- **\`disponible\`**: score numérico (0–100) + badge cualitativo color-coded (excelente/bueno/regular/malo) + drill-down expandible con counts por tipo de evento

Drill-down: color coding por count (0=verde, 1-2=ámbar, 3+=rojo) + nota metodológica GLEC + SAE eco-driving.

### \`apps/web/src/routes/asignacion-detalle.tsx\`
Renderiza el card SOLO cuando \`trip.status === 'entregado' | 'cancelado'\`. Para trips en curso, oculta — el score es post-entrega.

## Verificación

- [x] \`pnpm --filter @booster-ai/web typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/web test\` — 59/59 passed
- [x] \`biome check\` — 0 errores

## Phase 2 cerrada

| PR | Componente |
|---|---|
| [#101](../pull/101) | codec8-parser extractor (IO 253/254/255) |
| [#102](../pull/102) | telemetry-processor persiste eventos |
| [#103](../pull/103) | driver-scoring package (cálculo puro) |
| [#104](../pull/104) | api: persistencia + endpoint |
| Este | UI dashboard transportista |

**Flow end-to-end**:
\`\`\`
Wave 1 cfg → FMC150 emite IO 253/254/255
  → gateway → PubSub → processor extrae + persiste
  → confirmar-entrega → score se calcula y persiste
  → UI muestra score con drill-down
\`\`\`

## Próximas Phases (out of scope)

- **Phase 3**: coaching IA con Vertex Gemini consumiendo el breakdown para sugerencias personalizadas vía push/WhatsApp.
- **Phase 4**: optimización de red (multi-stop, OR-Tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)