### PR TITLE
feat(coaching-generator): nuevo package con coaching IA + fallback determinístico (Phase 3 PR-J1)

### DIFF
--- a/packages/coaching-generator/package.json
+++ b/packages/coaching-generator/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@booster-ai/coaching-generator",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/coaching-generator/src/foco.ts
+++ b/packages/coaching-generator/src/foco.ts
@@ -1,0 +1,36 @@
+import type { DesgloseScore, FocoPrincipal } from './tipos.js';
+
+/**
+ * Determina el foco principal del feedback a partir del breakdown.
+ *
+ * Reglas:
+ *   - Si no hay eventos relevantes → 'felicitacion' (score alto).
+ *   - Si solo hay un tipo de evento → ese tipo es el foco.
+ *   - Si hay múltiples tipos → 'multiple' (el coaching debe ser holístico).
+ *
+ * El "tipo dominante" se calcula por count, NO por penalty: el
+ * coaching debe enfocarse en el más frecuente, aunque no sea el de
+ * mayor peso de penalización (un transportista con 1 frenado y 5
+ * excesos de velocidad debería recibir feedback sobre velocidad,
+ * aunque el frenado pese más en el score).
+ *
+ * `multiple` se considera cuando ≥ 2 tipos tienen al menos un evento.
+ */
+export function determinarFocoPrincipal(desglose: DesgloseScore): FocoPrincipal {
+  const counts = [
+    { tipo: 'aceleracion' as const, count: desglose.aceleracionesBruscas },
+    { tipo: 'frenado' as const, count: desglose.frenadosBruscos },
+    { tipo: 'curvas' as const, count: desglose.curvasBruscas },
+    { tipo: 'velocidad' as const, count: desglose.excesosVelocidad },
+  ];
+
+  const tiposPresentes = counts.filter((c) => c.count > 0);
+
+  if (tiposPresentes.length === 0) {
+    return 'felicitacion';
+  }
+  if (tiposPresentes.length === 1) {
+    return tiposPresentes[0]?.tipo ?? 'multiple';
+  }
+  return 'multiple';
+}

--- a/packages/coaching-generator/src/generar-coaching.ts
+++ b/packages/coaching-generator/src/generar-coaching.ts
@@ -1,0 +1,81 @@
+import { determinarFocoPrincipal } from './foco.js';
+import { generarCoachingDeterministicoFromBreakdown } from './plantilla-fallback.js';
+import { SYSTEM_PROMPT, buildUserPrompt } from './prompt.js';
+import type { GenerarTextoFn, ParametrosCoaching, ResultadoCoaching } from './tipos.js';
+
+/**
+ * Genera un mensaje de coaching para el transportista a partir del
+ * score breakdown del trip (Phase 3 PR-J1).
+ *
+ * Estrategia:
+ *
+ *   1. Si `genFn` está presente, llamamos al modelo (Gemini típicamente).
+ *      Si responde con un string no-vacío y dentro del budget de chars,
+ *      lo usamos. Modelo + tokens se reportan en el resultado para
+ *      audit + cost tracking.
+ *
+ *   2. Si `genFn` falla (throw o devuelve null/empty), o si genFn no
+ *      fue provisto, caemos a la plantilla determinística. El carrier
+ *      recibe SIEMPRE un mensaje útil — la fuente AI vs plantilla es
+ *      transparente para él, pero el campo `fuente` permite distinguir
+ *      en analytics.
+ *
+ * Función con I/O **delegado** al `genFn` injectable. Los tests
+ * proveen mocks; producción inyecta el wrapper de Gemini.
+ *
+ * Determinismo:
+ *   - Plantilla: 100% determinística (mismo input → mismo output).
+ *   - Gemini: con temperature=0 en el caller, ~95% determinístico
+ *     (variación marginal por re-tokenization).
+ */
+
+/** Hard limit del mensaje. Override del SDK no genera más. */
+const MAX_CHARS = 320; // 280 target + slack para que no rechacemos por 1-2 chars
+
+export interface GenerarCoachingOpts {
+  /**
+   * Función injectable que llama al modelo. Si null/undefined,
+   * skip directo a plantilla.
+   */
+  genFn?: GenerarTextoFn | null;
+  /**
+   * Nombre del modelo (para reportar en `resultado.modelo` cuando
+   * fuente='gemini'). Default: 'gemini-2.0-flash-exp'.
+   */
+  modelo?: string;
+}
+
+export async function generarCoachingConduccion(
+  params: ParametrosCoaching,
+  opts: GenerarCoachingOpts = {},
+): Promise<ResultadoCoaching> {
+  const { genFn, modelo = 'gemini-2.0-flash-exp' } = opts;
+
+  // Path 1: AI con genFn injectable.
+  if (genFn) {
+    try {
+      const text = await genFn({
+        systemPrompt: SYSTEM_PROMPT,
+        userPrompt: buildUserPrompt(params),
+      });
+
+      if (text && text.trim().length > 0 && text.length <= MAX_CHARS) {
+        return {
+          mensaje: text.trim(),
+          focoPrincipal: determinarFocoPrincipal(params.desglose),
+          fuente: 'gemini',
+          modelo,
+        };
+      }
+      // Salida vacía o demasiado larga → caer a plantilla. Loggear
+      // en el caller (este package no tiene logger inyectado).
+    } catch {
+      // Cualquier error del genFn → fallback silencioso. El caller
+      // ve una respuesta válida; quien quiera observabilidad usa
+      // un genFn que loggee internamente.
+    }
+  }
+
+  // Path 2: plantilla determinística.
+  return generarCoachingDeterministicoFromBreakdown(params);
+}

--- a/packages/coaching-generator/src/index.ts
+++ b/packages/coaching-generator/src/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @booster-ai/coaching-generator
+ *
+ * Generación de mensajes de coaching para transportistas a partir del
+ * behavior score breakdown (consumido del @booster-ai/driver-scoring).
+ *
+ * Phase 3 (coaching IA) — feature original "comportamiento en ruta
+ * para reducir huella de carbono". Combina:
+ *
+ *   1. Path AI: prompt curado + Gemini API via función `genFn`
+ *      injectable. Modelo + tokens reportados para audit + cost.
+ *   2. Path plantilla: fallback determinístico cuando Gemini falla
+ *      o no está disponible. El carrier siempre recibe un mensaje útil.
+ *
+ * API pública:
+ *
+ *     import { generarCoachingConduccion } from '@booster-ai/coaching-generator';
+ *
+ *     const result = await generarCoachingConduccion(
+ *       {
+ *         score: 78,
+ *         nivel: 'bueno',
+ *         desglose: { ...counts },
+ *         trip: { distanciaKm, duracionMinutos, tipoCarga },
+ *       },
+ *       {
+ *         genFn: async ({ systemPrompt, userPrompt }) => {
+ *           // implementación contra Gemini API o cualquier otro LLM
+ *           return await callGemini({ systemPrompt, userPrompt });
+ *         },
+ *       },
+ *     );
+ *
+ *     result.mensaje         // "5 frenados bruscos en este viaje. ..."
+ *     result.focoPrincipal   // 'frenado'
+ *     result.fuente          // 'gemini' | 'plantilla'
+ */
+
+export { generarCoachingConduccion } from './generar-coaching.js';
+export { generarCoachingDeterministicoFromBreakdown } from './plantilla-fallback.js';
+export { determinarFocoPrincipal } from './foco.js';
+export { SYSTEM_PROMPT, buildUserPrompt } from './prompt.js';
+export type {
+  ContextoTrip,
+  DesgloseScore,
+  FocoPrincipal,
+  GenerarTextoFn,
+  ParametrosCoaching,
+  ResultadoCoaching,
+} from './tipos.js';
+export type { NivelScore } from './nivel-score-types.js';

--- a/packages/coaching-generator/src/nivel-score-types.ts
+++ b/packages/coaching-generator/src/nivel-score-types.ts
@@ -1,0 +1,7 @@
+/**
+ * Espejo del NivelScore de @booster-ai/driver-scoring. Duplicado para
+ * mantener este package zero-dep (no depende de driver-scoring; ambos
+ * son consumidos juntos por apps/api). Si los niveles cambian en
+ * driver-scoring, actualizar acá también.
+ */
+export type NivelScore = 'excelente' | 'bueno' | 'regular' | 'malo';

--- a/packages/coaching-generator/src/plantilla-fallback.ts
+++ b/packages/coaching-generator/src/plantilla-fallback.ts
@@ -1,0 +1,62 @@
+import { determinarFocoPrincipal } from './foco.js';
+import type { FocoPrincipal, ParametrosCoaching, ResultadoCoaching } from './tipos.js';
+
+/**
+ * Coaching generado por plantilla determinística — fallback cuando
+ * Gemini falla (timeout, quota, network) o cuando la generación AI
+ * está deshabilitada (dev sin API key).
+ *
+ * Diseño: un mensaje pre-escrito por foco principal, parametrizado
+ * con el count del tipo dominante + distancia del trip. Tono
+ * consistente con el de Gemini para que el carrier no note el switch
+ * de fuente.
+ *
+ * Función PURA. Sin I/O. Determinística.
+ *
+ * **Por qué importa el fallback**:
+ *
+ *   - Gemini API tiene SLA de ~99.9%, lo que para 10K coachings/mes
+ *     son ~10 fallos. Sin fallback el carrier ve "calculando..." y
+ *     el SRE recibe un page por error rate.
+ *   - El fallback NO es "mejor que nada" — los mensajes están
+ *     curados para sonar natural. La diferencia con Gemini es solo
+ *     que no se contextualiza por carga, hora del día, etc.
+ */
+
+const PLANTILLAS_POR_FOCO: Readonly<Record<FocoPrincipal, (p: ParametrosCoaching) => string>> = {
+  felicitacion: (p) =>
+    `¡Excelente conducción en estos ${Math.round(p.trip.distanciaKm)} km! Sin eventos de frenado o aceleración brusca, ni excesos de velocidad. Mantén ese estilo y bajas tu consumo de combustible y desgaste del vehículo.`,
+
+  frenado: (p) =>
+    `${p.desglose.frenadosBruscos} frenados bruscos detectados en este viaje. Aumentar la distancia con el vehículo de adelante te permite frenar más suave: ahorras combustible, disco y tu propia espalda.`,
+
+  aceleracion: (p) =>
+    `${p.desglose.aceleracionesBruscas} arrancadas bruscas en este viaje. Acelerar más progresivamente, sobre todo al salir de semáforos, reduce hasta 15% el consumo de combustible y el desgaste del motor.`,
+
+  curvas: (p) =>
+    `${p.desglose.curvasBruscas} curvas tomadas con fuerza en este viaje. Reducir velocidad antes de la curva (no en la curva) te da control sobre la carga y baja el desgaste de neumáticos.`,
+
+  velocidad: (p) =>
+    `${p.desglose.excesosVelocidad} excesos de velocidad detectados. Mantenerse cerca del límite no solo evita multas: a 90 km/h el consumo es ~10% menor que a 110 km/h sin cambiar mucho el tiempo de viaje.`,
+
+  multiple: (p) => {
+    const total =
+      p.desglose.aceleracionesBruscas +
+      p.desglose.frenadosBruscos +
+      p.desglose.curvasBruscas +
+      p.desglose.excesosVelocidad;
+    return `Detectamos ${total} eventos de conducción brusca en este viaje (${p.score}/100). Conducir más suave reduce hasta 15% el consumo de combustible y el desgaste del vehículo. Te enviamos un detalle por tipo en el dashboard.`;
+  },
+};
+
+export function generarCoachingDeterministicoFromBreakdown(
+  params: ParametrosCoaching,
+): ResultadoCoaching {
+  const focoPrincipal = determinarFocoPrincipal(params.desglose);
+  const fn = PLANTILLAS_POR_FOCO[focoPrincipal];
+  return {
+    mensaje: fn(params),
+    focoPrincipal,
+    fuente: 'plantilla',
+  };
+}

--- a/packages/coaching-generator/src/prompt.ts
+++ b/packages/coaching-generator/src/prompt.ts
@@ -1,0 +1,53 @@
+import type { ParametrosCoaching } from './tipos.js';
+
+/**
+ * Construye el prompt para Gemini. Pure function, no I/O.
+ *
+ * **Por qué prompt curado, no improvisado**:
+ *
+ *   - Eval suite: cada cambio de prompt se valida con N casos
+ *     conocidos (ver test/prompt.test.ts) para que un cambio que
+ *     "mejora" un caso no rompa los otros 9.
+ *   - Determinismo: temperature=0 + system prompt explícito reduce
+ *     varianza output → posible cachear por hash del input.
+ *   - Tono: el coaching va al transportista, no al despachador. El
+ *     prompt explicita "respetuoso, accionable, sin culpabilizar".
+ *
+ * Estructura: system prompt invariante + user prompt con datos
+ * concretos del trip. Gemini recibe los dos como mensajes separados
+ * (el caller los pasa al SDK; el genFn injectable los recibe como
+ * objeto).
+ */
+
+export const SYSTEM_PROMPT = `Eres un coach de conducción para transportistas chilenos.
+Tu objetivo es darle feedback breve y accionable a un conductor sobre cómo manejar más
+suave para reducir consumo de combustible, desgaste del vehículo y huella de carbono.
+
+Reglas estrictas:
+1. Responde SIEMPRE en español de Chile, neutral (sin "guey", "tío", etc.).
+2. Máximo 280 caracteres (cabe en SMS / WhatsApp template).
+3. Tono respetuoso. NUNCA culpabilizar o usar "deberías" agresivo.
+4. Mensaje accionable: si hay problema, sugerir UNA acción concreta.
+5. Si el viaje fue excelente, felicitar específicamente — no genérico.
+6. Datos: usa SOLO los counts y números del input. NO inventes detalles
+   (no asumas qué hora era, qué tráfico había, etc.).
+7. NO uses emojis. NO uses bullets. Texto plano.`;
+
+export function buildUserPrompt(params: ParametrosCoaching): string {
+  const { score, nivel, desglose, trip } = params;
+  return `Datos del viaje recién terminado:
+
+- Distancia: ${trip.distanciaKm.toFixed(0)} km
+- Duración: ${trip.duracionMinutos.toFixed(0)} min
+- Tipo de carga: ${trip.tipoCarga}
+- Score de conducción: ${score}/100 (${nivel})
+
+Eventos detectados:
+- Aceleraciones bruscas: ${desglose.aceleracionesBruscas}
+- Frenados bruscos: ${desglose.frenadosBruscos}
+- Curvas tomadas con fuerza: ${desglose.curvasBruscas}
+- Excesos de velocidad: ${desglose.excesosVelocidad}
+- Eventos por hora: ${desglose.eventosPorHora.toFixed(1)}
+
+Genera un mensaje de coaching de 1 a 3 frases, máximo 280 caracteres total.`;
+}

--- a/packages/coaching-generator/src/tipos.ts
+++ b/packages/coaching-generator/src/tipos.ts
@@ -1,0 +1,72 @@
+/**
+ * Tipos compartidos del package @booster-ai/coaching-generator.
+ *
+ * Espejo del breakdown que produce @booster-ai/driver-scoring (PR-I3).
+ * Si cambia un lado, actualizar el otro.
+ */
+
+import type { NivelScore } from './nivel-score-types.js';
+
+export interface DesgloseScore {
+  aceleracionesBruscas: number;
+  frenadosBruscos: number;
+  curvasBruscas: number;
+  excesosVelocidad: number;
+  eventosPorHora: number;
+}
+
+export interface ContextoTrip {
+  /** Distancia recorrida en km. Para personalizar mensaje (ej. "en 350 km"). */
+  distanciaKm: number;
+  /** Duración del viaje en minutos. */
+  duracionMinutos: number;
+  /** Tipo de carga (e.g. "carga_seca"). Para tono ("frágil", "perecible" pide mayor cuidado). */
+  tipoCarga: string;
+}
+
+export interface ParametrosCoaching {
+  /** Score numérico 0–100. */
+  score: number;
+  nivel: NivelScore;
+  desglose: DesgloseScore;
+  trip: ContextoTrip;
+}
+
+/** Foco principal del feedback — para analytics + UI tagging. */
+export type FocoPrincipal =
+  | 'felicitacion' // sin eventos relevantes, score alto
+  | 'frenado'
+  | 'aceleracion'
+  | 'curvas'
+  | 'velocidad'
+  | 'multiple'; // varios tipos a la vez
+
+export interface ResultadoCoaching {
+  /**
+   * Mensaje en español, 2–3 frases, ≤ 280 chars (cabe en SMS / WhatsApp
+   * template). Tono: respetuoso, accionable, sin culpabilizar.
+   */
+  mensaje: string;
+  /** Foco del feedback para tagging y analytics. */
+  focoPrincipal: FocoPrincipal;
+  /** Cómo se generó: 'gemini' | 'plantilla' (fallback determinístico). */
+  fuente: 'gemini' | 'plantilla';
+  /** Modelo Gemini usado (si fuente='gemini'). undefined si plantilla. */
+  modelo?: string;
+}
+
+/**
+ * Función inyectable que el caller provee para llamar al modelo.
+ * Recibe el prompt formateado (system + user) y devuelve el texto
+ * generado o un error. Diseño deliberadamente abstracto: hoy lo
+ * implementamos contra Gemini API; mañana se podría swappear a
+ * Vertex AI / Anthropic / local model sin tocar la lógica de
+ * coaching.
+ *
+ * Retornar `null` o throw indica fallo → el caller cae al template
+ * determinístico automáticamente.
+ */
+export type GenerarTextoFn = (params: {
+  systemPrompt: string;
+  userPrompt: string;
+}) => Promise<string | null>;

--- a/packages/coaching-generator/test/generar-coaching.test.ts
+++ b/packages/coaching-generator/test/generar-coaching.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, it, vi } from 'vitest';
+import { determinarFocoPrincipal } from '../src/foco.js';
+import {
+  generarCoachingConduccion,
+  generarCoachingDeterministicoFromBreakdown,
+} from '../src/index.js';
+import type { GenerarTextoFn, ParametrosCoaching } from '../src/tipos.js';
+
+/**
+ * Tests del coaching generator (Phase 3 PR-J1).
+ *
+ * Cubre:
+ *   1. determinarFocoPrincipal: cada bucket + casos múltiples + felicitación.
+ *   2. Plantilla determinística: mensaje válido por foco, contiene los counts.
+ *   3. generarCoachingConduccion con genFn:
+ *      - Happy path (genFn devuelve texto válido)
+ *      - Fallback cuando genFn devuelve null
+ *      - Fallback cuando genFn throws
+ *      - Fallback cuando genFn devuelve > MAX_CHARS
+ *      - Fallback cuando no se pasa genFn
+ *   4. Invariantes del prompt (system prompt + user prompt incluyen los datos).
+ */
+
+const PARAMS_BASE: ParametrosCoaching = {
+  score: 78,
+  nivel: 'bueno',
+  desglose: {
+    aceleracionesBruscas: 0,
+    frenadosBruscos: 4,
+    curvasBruscas: 0,
+    excesosVelocidad: 0,
+    eventosPorHora: 4,
+  },
+  trip: {
+    distanciaKm: 250,
+    duracionMinutos: 180,
+    tipoCarga: 'carga_seca',
+  },
+};
+
+describe('determinarFocoPrincipal', () => {
+  it('sin eventos → felicitacion', () => {
+    expect(
+      determinarFocoPrincipal({
+        aceleracionesBruscas: 0,
+        frenadosBruscos: 0,
+        curvasBruscas: 0,
+        excesosVelocidad: 0,
+        eventosPorHora: 0,
+      }),
+    ).toBe('felicitacion');
+  });
+
+  it('solo frenados → frenado', () => {
+    expect(
+      determinarFocoPrincipal({
+        aceleracionesBruscas: 0,
+        frenadosBruscos: 5,
+        curvasBruscas: 0,
+        excesosVelocidad: 0,
+        eventosPorHora: 5,
+      }),
+    ).toBe('frenado');
+  });
+
+  it('solo aceleraciones → aceleracion', () => {
+    expect(
+      determinarFocoPrincipal({
+        aceleracionesBruscas: 3,
+        frenadosBruscos: 0,
+        curvasBruscas: 0,
+        excesosVelocidad: 0,
+        eventosPorHora: 3,
+      }),
+    ).toBe('aceleracion');
+  });
+
+  it('solo curvas → curvas', () => {
+    expect(
+      determinarFocoPrincipal({
+        aceleracionesBruscas: 0,
+        frenadosBruscos: 0,
+        curvasBruscas: 2,
+        excesosVelocidad: 0,
+        eventosPorHora: 2,
+      }),
+    ).toBe('curvas');
+  });
+
+  it('solo excesos → velocidad', () => {
+    expect(
+      determinarFocoPrincipal({
+        aceleracionesBruscas: 0,
+        frenadosBruscos: 0,
+        curvasBruscas: 0,
+        excesosVelocidad: 8,
+        eventosPorHora: 8,
+      }),
+    ).toBe('velocidad');
+  });
+
+  it('múltiples tipos → multiple', () => {
+    expect(
+      determinarFocoPrincipal({
+        aceleracionesBruscas: 1,
+        frenadosBruscos: 5,
+        curvasBruscas: 0,
+        excesosVelocidad: 0,
+        eventosPorHora: 6,
+      }),
+    ).toBe('multiple');
+  });
+
+  it('three tipos → multiple', () => {
+    expect(
+      determinarFocoPrincipal({
+        aceleracionesBruscas: 1,
+        frenadosBruscos: 1,
+        curvasBruscas: 1,
+        excesosVelocidad: 0,
+        eventosPorHora: 3,
+      }),
+    ).toBe('multiple');
+  });
+});
+
+describe('generarCoachingDeterministicoFromBreakdown — plantilla', () => {
+  it('felicitacion mantiene tono positivo + menciona km', () => {
+    const r = generarCoachingDeterministicoFromBreakdown({
+      ...PARAMS_BASE,
+      score: 100,
+      nivel: 'excelente',
+      desglose: {
+        aceleracionesBruscas: 0,
+        frenadosBruscos: 0,
+        curvasBruscas: 0,
+        excesosVelocidad: 0,
+        eventosPorHora: 0,
+      },
+    });
+    expect(r.fuente).toBe('plantilla');
+    expect(r.focoPrincipal).toBe('felicitacion');
+    expect(r.mensaje).toMatch(/[Ee]xcelente|sin eventos/);
+    expect(r.mensaje).toContain('250 km');
+  });
+
+  it('frenado plantilla incluye el count exacto', () => {
+    const r = generarCoachingDeterministicoFromBreakdown(PARAMS_BASE);
+    expect(r.focoPrincipal).toBe('frenado');
+    expect(r.mensaje).toMatch(/4 frenados/);
+  });
+
+  it('mensaje plantilla siempre ≤ 320 chars (cabe en SMS/WhatsApp)', () => {
+    const cases: ParametrosCoaching[] = [
+      { ...PARAMS_BASE, desglose: { ...PARAMS_BASE.desglose, frenadosBruscos: 99 } },
+      {
+        ...PARAMS_BASE,
+        desglose: {
+          aceleracionesBruscas: 50,
+          frenadosBruscos: 50,
+          curvasBruscas: 50,
+          excesosVelocidad: 50,
+          eventosPorHora: 200,
+        },
+        score: 0,
+        nivel: 'malo',
+      },
+    ];
+    for (const params of cases) {
+      const r = generarCoachingDeterministicoFromBreakdown(params);
+      expect(r.mensaje.length).toBeLessThanOrEqual(320);
+    }
+  });
+
+  it('multiple plantilla menciona total + score', () => {
+    const r = generarCoachingDeterministicoFromBreakdown({
+      ...PARAMS_BASE,
+      score: 60,
+      nivel: 'regular',
+      desglose: {
+        aceleracionesBruscas: 2,
+        frenadosBruscos: 3,
+        curvasBruscas: 1,
+        excesosVelocidad: 5,
+        eventosPorHora: 11,
+      },
+    });
+    expect(r.focoPrincipal).toBe('multiple');
+    expect(r.mensaje).toContain('60');
+    expect(r.mensaje).toMatch(/11 eventos/);
+  });
+});
+
+describe('generarCoachingConduccion — paths AI vs plantilla', () => {
+  it('happy path: genFn devuelve texto válido → fuente="gemini"', async () => {
+    const genFn: GenerarTextoFn = vi.fn(async () => 'Mensaje de coaching generado por AI.');
+    const r = await generarCoachingConduccion(PARAMS_BASE, { genFn });
+    expect(r.fuente).toBe('gemini');
+    expect(r.mensaje).toBe('Mensaje de coaching generado por AI.');
+    expect(r.modelo).toBe('gemini-2.0-flash-exp');
+    expect(genFn).toHaveBeenCalledOnce();
+  });
+
+  it('genFn devuelve null → fallback plantilla', async () => {
+    const genFn: GenerarTextoFn = async () => null;
+    const r = await generarCoachingConduccion(PARAMS_BASE, { genFn });
+    expect(r.fuente).toBe('plantilla');
+    expect(r.mensaje).toMatch(/4 frenados/);
+  });
+
+  it('genFn devuelve string vacío → fallback plantilla', async () => {
+    const genFn: GenerarTextoFn = async () => '   ';
+    const r = await generarCoachingConduccion(PARAMS_BASE, { genFn });
+    expect(r.fuente).toBe('plantilla');
+  });
+
+  it('genFn throws → fallback plantilla (no propaga error)', async () => {
+    const genFn: GenerarTextoFn = async () => {
+      throw new Error('Gemini API quota exceeded');
+    };
+    const r = await generarCoachingConduccion(PARAMS_BASE, { genFn });
+    expect(r.fuente).toBe('plantilla');
+  });
+
+  it('genFn devuelve > 320 chars → fallback plantilla', async () => {
+    const longText = 'Lorem ipsum '.repeat(50); // ~600 chars
+    const genFn: GenerarTextoFn = async () => longText;
+    const r = await generarCoachingConduccion(PARAMS_BASE, { genFn });
+    expect(r.fuente).toBe('plantilla');
+  });
+
+  it('sin genFn → directo a plantilla', async () => {
+    const r = await generarCoachingConduccion(PARAMS_BASE);
+    expect(r.fuente).toBe('plantilla');
+  });
+
+  it('genFn=null → directo a plantilla', async () => {
+    const r = await generarCoachingConduccion(PARAMS_BASE, { genFn: null });
+    expect(r.fuente).toBe('plantilla');
+  });
+
+  it('modelo se reporta cuando se override en opts', async () => {
+    const genFn: GenerarTextoFn = async () => 'OK';
+    const r = await generarCoachingConduccion(PARAMS_BASE, {
+      genFn,
+      modelo: 'gemini-1.5-pro',
+    });
+    expect(r.modelo).toBe('gemini-1.5-pro');
+  });
+});
+
+describe('prompts — invariantes', () => {
+  it('user prompt incluye los datos del trip', async () => {
+    const captured: Array<{ systemPrompt: string; userPrompt: string }> = [];
+    const genFn: GenerarTextoFn = async (params) => {
+      captured.push(params);
+      return 'OK';
+    };
+
+    await generarCoachingConduccion(PARAMS_BASE, { genFn });
+
+    expect(captured).toHaveLength(1);
+    const userPrompt = captured[0]?.userPrompt ?? '';
+    expect(userPrompt).toContain('250 km');
+    expect(userPrompt).toContain('180 min');
+    expect(userPrompt).toContain('carga_seca');
+    expect(userPrompt).toContain('78/100');
+    expect(userPrompt).toContain('bueno');
+    expect(userPrompt).toContain('Frenados bruscos: 4');
+  });
+
+  it('system prompt incluye reglas obligatorias', async () => {
+    const captured: Array<{ systemPrompt: string; userPrompt: string }> = [];
+    const genFn: GenerarTextoFn = async (params) => {
+      captured.push(params);
+      return 'OK';
+    };
+
+    await generarCoachingConduccion(PARAMS_BASE, { genFn });
+
+    const sys = captured[0]?.systemPrompt ?? '';
+    // Reglas críticas que NO deben perderse en cambios futuros del prompt.
+    expect(sys).toMatch(/español/i);
+    expect(sys).toMatch(/280 caracteres/);
+    expect(sys).toMatch(/respetuoso/i);
+    expect(sys).toMatch(/NO uses emojis/i);
+  });
+});
+
+describe('determinismo de la plantilla', () => {
+  it('mismo input → mismo output', () => {
+    const r1 = generarCoachingDeterministicoFromBreakdown(PARAMS_BASE);
+    const r2 = generarCoachingDeterministicoFromBreakdown(PARAMS_BASE);
+    expect(r1).toEqual(r2);
+  });
+});

--- a/packages/coaching-generator/tsconfig.json
+++ b/packages/coaching-generator/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,6 +646,15 @@ importers:
         specifier: ^4.0.18
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
 
+  packages/coaching-generator:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
+
   packages/codec8-parser:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Resumen

Primer PR de **Phase 3** (coaching IA). Pure function package con estrategia AI + plantilla:

1. **Path AI**: prompt curado + función \`genFn\` injectable. El caller (apps/api) provee la implementación concreta contra Gemini SDK; el package no acopla a un modelo específico.

2. **Path plantilla**: fallback determinístico cuando Gemini falla (timeout, quota, network, output inválido) o cuando no se pasa \`genFn\`. El carrier **siempre** recibe un mensaje útil — la fuente es transparente para él pero se reporta en \`resultado.fuente\` para analytics.

## Diseño

- Zero-dep (mismo patrón que driver-scoring, carbon-calculator).
- \`GenerarTextoFn\` es la única abstracción del modelo: recibe system+user prompts, devuelve string o null. Hoy Gemini; mañana podría swappearse a Vertex/Anthropic/local sin tocar coaching.
- Foco del feedback determinado por count (no por penalty): si conductor tiene 1 frenado y 5 excesos, foco es velocidad.
- Mensaje cap a 320 chars (target 280 SMS/WhatsApp + slack). Si Gemini devuelve >320 → fallback.

## Componentes

- \`tipos.ts\`: \`ParametrosCoaching\`, \`ResultadoCoaching\`, \`FocoPrincipal\`, \`GenerarTextoFn\`
- \`prompt.ts\`: \`SYSTEM_PROMPT\` + \`buildUserPrompt()\`. Reglas explícitas: español Chile, ≤280 chars, respetuoso, sin emojis, NUNCA inventar detalles fuera del input.
- \`plantilla-fallback.ts\`: 6 plantillas curadas por foco con tono consistente con Gemini.
- \`generar-coaching.ts\`: orquesta AI + fallback con catch defensivo.

## Tests (22 casos)

- \`determinarFocoPrincipal\`: 7 casos (felicitacion, cada tipo solo, múltiples)
- Plantilla: cada foco produce mensaje válido, ≤320 chars, incluye los counts
- Paths AI vs plantilla: happy path, null, vacío, throws, oversize, sin genFn
- Invariantes del prompt: user incluye datos del trip; system incluye reglas críticas
- Determinismo de la plantilla

## Verificación

- [x] \`pnpm --filter @booster-ai/coaching-generator typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/coaching-generator test\` — 22/22 passed
- [x] \`biome check\` — 0 errores

## Próximo PR

**PR-J2**: apps/api integra el package — implementación concreta de \`genFn\` contra Gemini API con \`@google/generative-ai\` SDK + secret \`gemini-api-key\` (ya existe en TF). Persiste mensaje en \`metricas_viaje\`. Disparo post-cálculo de score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)