### PR TITLE
feat(web): mostrar coaching IA en BehaviorScoreCard (Phase 3 PR-J3)

### DIFF
--- a/apps/api/drizzle/0012_metricas_viaje_coaching.sql
+++ b/apps/api/drizzle/0012_metricas_viaje_coaching.sql
@@ -1,0 +1,28 @@
+-- Migration 0012 — Coaching IA en metricas_viaje (Phase 3 PR-J2)
+--
+-- Agrega 5 columnas para persistir el mensaje de coaching generado
+-- post-entrega por @booster-ai/coaching-generator (PR-J1):
+--
+--   - coaching_mensaje: el texto (≤320 chars, cabe en SMS/WhatsApp)
+--   - coaching_foco: bucket del feedback ('frenado' | 'aceleracion' |
+--     'curvas' | 'velocidad' | 'felicitacion' | 'multiple') para
+--     analytics
+--   - coaching_fuente: 'gemini' | 'plantilla' (para distinguir cobertura
+--     AI vs fallback determinístico)
+--   - coaching_modelo: nombre del modelo (e.g. 'gemini-1.5-flash');
+--     NULL si fuente='plantilla'
+--   - coaching_generado_en: timestamp de generación
+--
+-- Persistir en lugar de recomputar evita re-pagar Gemini cada vez que
+-- el carrier abre el detalle del trip. Re-generación solo en recálculo
+-- explícito (admin o cron de re-emit).
+--
+-- Riesgo deploy: bajo. ADD COLUMN nullable es metadata-only en Postgres
+-- ≥ 11. Reversible vía DROP COLUMN.
+
+ALTER TABLE "metricas_viaje"
+  ADD COLUMN "coaching_mensaje" text,
+  ADD COLUMN "coaching_foco" varchar(20),
+  ADD COLUMN "coaching_fuente" varchar(20),
+  ADD COLUMN "coaching_modelo" varchar(50),
+  ADD COLUMN "coaching_generado_en" timestamptz;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778889600000,
       "tag": "0011_metricas_viaje_behavior_score",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1778976000000,
+      "tag": "0012_metricas_viaje_coaching",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@booster-ai/carbon-calculator": "workspace:*",
     "@booster-ai/certificate-generator": "workspace:*",
+    "@booster-ai/coaching-generator": "workspace:*",
     "@booster-ai/config": "workspace:*",
     "@booster-ai/driver-scoring": "workspace:*",
     "@booster-ai/logger": "workspace:*",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -225,6 +225,23 @@ const apiEnvSchema = commonEnvSchema
      * generan sugerencia de eco-route. Útil en dev sin quota Routes API.
      */
     GOOGLE_ROUTES_API_KEY: z.string().min(1).optional(),
+
+    /**
+     * API key para Google Gemini API (Phase 3 — coaching IA).
+     *
+     * Server-side: la usa apps/api en `generar-coaching-viaje.ts` para
+     * generar el mensaje de coaching personalizado post-entrega.
+     *
+     * Optional: si está ausente, el coaching cae al fallback de plantilla
+     * determinística de @booster-ai/coaching-generator. El carrier
+     * recibe igual feedback útil — la diferencia es solo personalización
+     * por contexto del trip.
+     *
+     * El secret `gemini-api-key` ya existe en Secret Manager (TF
+     * security.tf). Cargar con: gcloud secrets versions add gemini-api-key
+     * --data-file=<(echo -n "AIza...").
+     */
+    GEMINI_API_KEY: z.string().min(1).optional(),
   });
 
 export type ApiEnv = z.infer<typeof apiEnvSchema>;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -776,6 +776,25 @@ export const tripMetrics = pgTable(
      * ResultadoScore.desglose del package driver-scoring.
      */
     behaviorScoreBreakdown: jsonb('puntaje_conduccion_desglose'),
+    /**
+     * Phase 3 PR-J2 — Mensaje de coaching para el conductor, generado
+     * post-entrega. ≤320 chars (cabe en SMS/WhatsApp). Generado por
+     * @booster-ai/coaching-generator con Gemini API o fallback de
+     * plantilla determinística (ver coachingFuente).
+     */
+    coachingMensaje: text('coaching_mensaje'),
+    /**
+     * Foco principal del feedback: 'frenado' | 'aceleracion' | 'curvas' |
+     * 'velocidad' | 'felicitacion' | 'multiple'. Para tagging en analytics
+     * + filtros de UI ("trips con coaching de frenado este mes").
+     */
+    coachingFoco: varchar('coaching_foco', { length: 20 }),
+    /** 'gemini' | 'plantilla' — para distinguir cobertura AI vs fallback. */
+    coachingFuente: varchar('coaching_fuente', { length: 20 }),
+    /** Nombre del modelo Gemini (e.g. 'gemini-1.5-flash'). NULL si fuente='plantilla'. */
+    coachingModelo: varchar('coaching_modelo', { length: 50 }),
+    /** Timestamp de generación. Para SLO + cache invalidation. */
+    coachingGeneradoEn: timestamp('coaching_generado_en', { withTimezone: true }),
     createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -364,5 +364,65 @@ export function createAssignmentsRoutes(opts: {
     });
   });
 
+  // ---------------------------------------------------------------------
+  // GET /:id/coaching — Phase 3 PR-J2
+  //
+  // Devuelve el mensaje de coaching IA persistido en metricas_viaje
+  // del trip. Generado post-entrega por generar-coaching-viaje.ts a
+  // partir del behavior score breakdown (PR-I4) usando Gemini API o
+  // fallback de plantilla determinística.
+  // ---------------------------------------------------------------------
+  app.get('/:id/coaching', async (c) => {
+    const auth = requireCarrierAuth(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const assignmentId = c.req.param('id');
+    const empresaId = auth.activeMembership.empresa.id;
+
+    const [row] = await opts.db
+      .select({
+        assignmentEmpresaId: assignments.empresaId,
+        tripId: assignments.tripId,
+        mensaje: tripMetrics.coachingMensaje,
+        foco: tripMetrics.coachingFoco,
+        fuente: tripMetrics.coachingFuente,
+        modelo: tripMetrics.coachingModelo,
+        generadoEn: tripMetrics.coachingGeneradoEn,
+      })
+      .from(assignments)
+      .leftJoin(tripMetrics, eq(tripMetrics.tripId, assignments.tripId))
+      .where(eq(assignments.id, assignmentId))
+      .limit(1);
+
+    if (!row) {
+      return c.json({ error: 'assignment_not_found', code: 'assignment_not_found' }, 404);
+    }
+    if (row.assignmentEmpresaId !== empresaId) {
+      return c.json({ error: 'forbidden', code: 'assignment_forbidden' }, 403);
+    }
+
+    if (!row.mensaje) {
+      return c.json({
+        trip_id: row.tripId,
+        message: null,
+        focus: null,
+        source: null,
+        status: 'no_disponible',
+        reason: 'sin_score_o_no_entregado',
+      });
+    }
+
+    return c.json({
+      trip_id: row.tripId,
+      message: row.mensaje,
+      focus: row.foco,
+      source: row.fuente, // 'gemini' | 'plantilla'
+      model: row.modelo,
+      generated_at: row.generadoEn,
+      status: 'disponible',
+    });
+  });
+
   return app;
 }

--- a/apps/api/src/services/confirmar-entrega-viaje.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.ts
@@ -30,6 +30,9 @@
 
 import type { Logger } from '@booster-ai/logger';
 import { and, eq } from 'drizzle-orm';
+// `appConfig` (no `config`) para no chocar con el `config` de cert que
+// recibe la función como opt parameter (`opts.config: Partial<EmitirCertificadoConfig>`).
+import { config as appConfig } from '../config.js';
 import type { Db } from '../db/client.js';
 import { assignments, tripEvents, trips } from '../db/schema.js';
 import { recalcularNivelPostEntrega } from './calcular-metricas-viaje.js';
@@ -38,6 +41,7 @@ import {
   type EmitirCertificadoConfig,
   emitirCertificadoViaje,
 } from './emitir-certificado-viaje.js';
+import { generarCoachingViaje } from './generar-coaching-viaje.js';
 
 /**
  * Status del trip en los que es válido confirmar entrega. Si está
@@ -213,6 +217,24 @@ export async function confirmarEntregaViaje(opts: {
       logger.error(
         { err, tripId },
         'calcularScoreConduccionViaje fallo — sin score persistido para este trip',
+      );
+    }
+
+    // Phase 3 PR-J2 — generar coaching IA después del score. Depende
+    // de que el behaviorScore + breakdown estén persistidos. Si falla,
+    // log + sigue: el coaching es información complementaria; el
+    // dashboard lo muestra como "no disponible" sin error visible.
+    try {
+      await generarCoachingViaje({
+        db,
+        logger,
+        tripId,
+        geminiApiKey: appConfig.GEMINI_API_KEY,
+      });
+    } catch (err) {
+      logger.error(
+        { err, tripId },
+        'generarCoachingViaje fallo — sin coaching persistido para este trip',
       );
     }
 

--- a/apps/api/src/services/gemini-client.ts
+++ b/apps/api/src/services/gemini-client.ts
@@ -1,0 +1,151 @@
+import type { Logger } from '@booster-ai/logger';
+
+/**
+ * Cliente HTTP del Gemini API (Phase 3 PR-J2).
+ *
+ * Usamos la REST API directamente en vez del SDK @google/generative-ai
+ * por:
+ *   - Cero deps adicionales (apps/api ya tiene fetch nativo).
+ *   - Control fino del timeout (~10s) — el SDK no lo expone fácilmente.
+ *   - Test pattern consistente con routes-api.ts (fetch mockeable).
+ *
+ * Endpoint:
+ *   POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
+ *   ?key=API_KEY
+ *
+ * Diseño: este módulo expone una factoría que crea un `GenerarTextoFn`
+ * compatible con la interfaz de @booster-ai/coaching-generator. El
+ * caller (generar-coaching-viaje.ts) inyecta el resultado al package.
+ *
+ * Errores: cualquier fallo (timeout, 4xx, 5xx, parse error) loggea WARN
+ * y retorna `null`. El package coaching-generator interpreta null como
+ * señal de "fallback a plantilla", que es el comportamiento deseado.
+ */
+
+import type { GenerarTextoFn } from '@booster-ai/coaching-generator';
+
+const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
+
+/** Timeout total del HTTP call (ms). Si Gemini tarda más, fallback. */
+const TIMEOUT_MS = 10_000;
+
+/** Modelo default. Override via opts del crear cliente. */
+const DEFAULT_MODEL = 'gemini-1.5-flash';
+
+export interface CreateGeminiGenFnOpts {
+  apiKey: string;
+  /** Modelo Gemini. Default: gemini-1.5-flash (cheap, rápido). */
+  model?: string;
+  /**
+   * Inyectable para tests. Default: global fetch.
+   */
+  fetchImpl?: typeof fetch;
+  logger?: Logger;
+}
+
+/**
+ * Crea una `GenerarTextoFn` que llama a Gemini API. El package
+ * coaching-generator la consume sin saber del HTTP underlying.
+ */
+export function createGeminiGenFn(opts: CreateGeminiGenFnOpts): GenerarTextoFn {
+  const { apiKey, model = DEFAULT_MODEL, fetchImpl = fetch, logger } = opts;
+
+  return async ({ systemPrompt, userPrompt }) => {
+    const url = `${GEMINI_API_BASE}/${model}:generateContent?key=${encodeURIComponent(apiKey)}`;
+
+    const body = {
+      systemInstruction: {
+        parts: [{ text: systemPrompt }],
+      },
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: userPrompt }],
+        },
+      ],
+      generationConfig: {
+        // Temperature 0.2 para casi-determinismo manteniendo variedad
+        // mínima en wording (0 estricto a veces da output muy seco).
+        temperature: 0.2,
+        maxOutputTokens: 200, // ~280 chars target + slack
+        topK: 40,
+        topP: 0.95,
+      },
+      // Safety: bloquear solo high-severity. Coaching tiene tono
+      // neutral; no necesitamos bloqueo médico/sexual paranoico.
+      safetySettings: [
+        { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
+        { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH' },
+        { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
+        { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
+      ],
+    };
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    try {
+      const response = await fetchImpl(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errBody = await response.text().catch(() => '');
+        logger?.warn(
+          {
+            httpStatus: response.status,
+            errBody: errBody.slice(0, 300),
+            model,
+          },
+          'Gemini API non-2xx, fallback a plantilla',
+        );
+        return null;
+      }
+
+      const json = (await response.json()) as {
+        candidates?: Array<{
+          content?: { parts?: Array<{ text?: string }> };
+          finishReason?: string;
+        }>;
+      };
+
+      const candidate = json.candidates?.[0];
+      if (!candidate) {
+        logger?.warn({ model }, 'Gemini API sin candidates, fallback a plantilla');
+        return null;
+      }
+
+      // finishReason ≠ 'STOP' indica que Gemini fue truncado o bloqueado
+      // por safety. En esos casos no usamos el output parcial.
+      if (candidate.finishReason && candidate.finishReason !== 'STOP') {
+        logger?.warn(
+          { finishReason: candidate.finishReason, model },
+          'Gemini API finish reason inesperado, fallback a plantilla',
+        );
+        return null;
+      }
+
+      const text = candidate.content?.parts?.[0]?.text?.trim();
+      if (!text || text.length === 0) {
+        logger?.warn({ model }, 'Gemini API devolvió texto vacío, fallback a plantilla');
+        return null;
+      }
+
+      return text;
+    } catch (err) {
+      logger?.warn(
+        {
+          err: err instanceof Error ? err.message : String(err),
+          model,
+        },
+        'Gemini API fetch error, fallback a plantilla',
+      );
+      return null;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  };
+}

--- a/apps/api/src/services/generar-coaching-viaje.ts
+++ b/apps/api/src/services/generar-coaching-viaje.ts
@@ -1,0 +1,164 @@
+import {
+  type ParametrosCoaching,
+  type ResultadoCoaching,
+  generarCoachingConduccion,
+} from '@booster-ai/coaching-generator';
+import type { Logger } from '@booster-ai/logger';
+import { eq, sql } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { assignments, tripMetrics, trips } from '../db/schema.js';
+import { createGeminiGenFn } from './gemini-client.js';
+
+/**
+ * Genera y persiste el coaching post-entrega de un trip (Phase 3 PR-J2).
+ *
+ * Flow:
+ *   1. Cargar metricas_viaje del trip — necesitamos behavior_score y
+ *      breakdown ya computados (PR-I4) como input al coaching.
+ *   2. Construir ParametrosCoaching con los datos del trip + breakdown.
+ *   3. Llamar a generarCoachingConduccion con Gemini wrapper (si hay
+ *      GEMINI_API_KEY) o sin él (fallback plantilla).
+ *   4. Persistir coaching en metricas_viaje (mensaje + foco + fuente +
+ *      modelo + timestamp).
+ *
+ * Disparo: post-cálculo de score (calcularScoreConduccionViaje en
+ * confirmar-entrega-viaje.ts) y ANTES de emitir cert.
+ *
+ * **Idempotente**: re-ejecuciones sobrescriben con nuevo cálculo. Si
+ * el carrier abre el detalle del trip y la query ve el mensaje
+ * persistido, no se re-paga Gemini.
+ *
+ * Si no hay score persistido (trip sin Teltonika), skip silencioso —
+ * sin breakdown no hay coaching.
+ */
+
+export class TripNotFoundForCoachingError extends Error {
+  constructor(public readonly tripId: string) {
+    super(`Trip ${tripId} not found`);
+    this.name = 'TripNotFoundForCoachingError';
+  }
+}
+
+export interface GenerarCoachingResult {
+  /** True si se generó y persistió. False si no había score (skip). */
+  computed: boolean;
+  fuente?: 'gemini' | 'plantilla';
+  focoPrincipal?: string;
+}
+
+export async function generarCoachingViaje(opts: {
+  db: Db;
+  logger: Logger;
+  tripId: string;
+  /**
+   * GEMINI_API_KEY del config. Si está presente, se usa Gemini API.
+   * Si no, fallback a plantilla determinística (sin AI). Optional —
+   * el caller decide si la pasa según config.
+   */
+  geminiApiKey?: string | undefined;
+}): Promise<GenerarCoachingResult> {
+  const { db, logger, tripId, geminiApiKey } = opts;
+
+  // Cargar trip + metricas + assignment para construir el contexto.
+  const tripRows = await db.select().from(trips).where(eq(trips.id, tripId)).limit(1);
+  const trip = tripRows[0];
+  if (!trip) {
+    throw new TripNotFoundForCoachingError(tripId);
+  }
+
+  const metricsRows = await db
+    .select({
+      score: tripMetrics.behaviorScore,
+      nivel: tripMetrics.behaviorScoreNivel,
+      breakdown: tripMetrics.behaviorScoreBreakdown,
+      distanceKm: tripMetrics.distanceKmActual,
+      distanceKmEst: tripMetrics.distanceKmEstimated,
+    })
+    .from(tripMetrics)
+    .where(eq(tripMetrics.tripId, tripId))
+    .limit(1);
+  const metrics = metricsRows[0];
+
+  if (!metrics?.score || !metrics.nivel || !metrics.breakdown) {
+    logger.info(
+      { tripId, hasMetrics: !!metrics },
+      'generarCoachingViaje: skip (sin behavior score persistido)',
+    );
+    return { computed: false };
+  }
+
+  const assignmentRows = await db
+    .select({ deliveredAt: assignments.deliveredAt })
+    .from(assignments)
+    .where(eq(assignments.tripId, tripId))
+    .limit(1);
+  const assignment = assignmentRows[0];
+
+  // Duración: deliveredAt − pickupWindowStart. Si falta uno, asumimos
+  // 0 (la plantilla lo maneja como NaN en eventosPorHora — el
+  // package validó esto).
+  const pickupAt = trip.pickupWindowStart ?? trip.createdAt;
+  const tripDurationMinutes =
+    assignment?.deliveredAt && pickupAt
+      ? Math.max(0, (assignment.deliveredAt.getTime() - pickupAt.getTime()) / 60_000)
+      : 0;
+
+  const distanciaKm = Number(metrics.distanceKm ?? metrics.distanceKmEst ?? 0);
+
+  // El breakdown viene como JSONB (any). Cast defensivo + lectura
+  // explícita de campos esperados.
+  const breakdown = metrics.breakdown as Record<string, unknown>;
+  const params: ParametrosCoaching = {
+    score: Number(metrics.score),
+    nivel: metrics.nivel as ParametrosCoaching['nivel'],
+    desglose: {
+      aceleracionesBruscas: Number(breakdown.aceleracionesBruscas ?? 0),
+      frenadosBruscos: Number(breakdown.frenadosBruscos ?? 0),
+      curvasBruscas: Number(breakdown.curvasBruscas ?? 0),
+      excesosVelocidad: Number(breakdown.excesosVelocidad ?? 0),
+      eventosPorHora: Number(breakdown.eventosPorHora ?? 0),
+    },
+    trip: {
+      distanciaKm,
+      duracionMinutos: tripDurationMinutes,
+      tipoCarga: trip.cargoType,
+    },
+  };
+
+  // Construir genFn solo si hay API key. Sin key → undefined → el
+  // package va directo a plantilla.
+  const genFn = geminiApiKey ? createGeminiGenFn({ apiKey: geminiApiKey, logger }) : undefined;
+
+  const result: ResultadoCoaching = await generarCoachingConduccion(params, {
+    ...(genFn ? { genFn } : {}),
+  });
+
+  await db
+    .update(tripMetrics)
+    .set({
+      coachingMensaje: result.mensaje,
+      coachingFoco: result.focoPrincipal,
+      coachingFuente: result.fuente,
+      coachingModelo: result.modelo ?? null,
+      coachingGeneradoEn: new Date(),
+      updatedAt: sql`now()`,
+    })
+    .where(eq(tripMetrics.tripId, tripId));
+
+  logger.info(
+    {
+      tripId,
+      foco: result.focoPrincipal,
+      fuente: result.fuente,
+      modelo: result.modelo,
+      mensajeChars: result.mensaje.length,
+    },
+    'coaching persistido',
+  );
+
+  return {
+    computed: true,
+    fuente: result.fuente,
+    focoPrincipal: result.focoPrincipal,
+  };
+}

--- a/apps/web/src/components/scoring/BehaviorScoreCard.tsx
+++ b/apps/web/src/components/scoring/BehaviorScoreCard.tsx
@@ -1,9 +1,11 @@
-import { ChevronDown, ChevronUp, Gauge, Info } from 'lucide-react';
+import { ChevronDown, ChevronUp, Gauge, Info, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 import {
   type BehaviorScoreResponse,
+  type CoachingResponse,
   type NivelScore,
   useBehaviorScore,
+  useCoaching,
 } from '../../hooks/use-behavior-score.js';
 
 /**
@@ -54,6 +56,10 @@ export interface BehaviorScoreCardProps {
 
 export function BehaviorScoreCard({ assignmentId }: BehaviorScoreCardProps) {
   const query = useBehaviorScore(assignmentId);
+  // Coaching IA — fetch en paralelo. Solo se muestra si está disponible.
+  // Si Gemini está caído y cae a plantilla, igual se muestra (la fuente
+  // se indica con icono pero el contenido es accionable de cualquier forma).
+  const coachingQuery = useCoaching(assignmentId);
   const [expanded, setExpanded] = useState(false);
 
   if (query.isLoading) {
@@ -148,6 +154,12 @@ export function BehaviorScoreCard({ assignmentId }: BehaviorScoreCardProps) {
             <BreakdownItem label="Curva brusca" value={breakdown.curvasBruscas} />
             <BreakdownItem label="Exceso velocidad" value={breakdown.excesosVelocidad} />
           </dl>
+          {/* Phase 3 PR-J3 — coaching IA. Se muestra dentro del drill-down
+              (no en el header colapsado) para que el usuario tenga foco
+              en el score primero, luego lee el feedback. */}
+          {coachingQuery.data && coachingQuery.data.status === 'disponible' && (
+            <CoachingMessage data={coachingQuery.data} />
+          )}
           <p className="mt-3 text-[11px] text-neutral-500">
             Score basado en metodología GLEC + estudios SAE eco-driving. Reducir frenadas y
             arrancadas bruscas baja el consumo de combustible 5–15%.
@@ -155,6 +167,37 @@ export function BehaviorScoreCard({ assignmentId }: BehaviorScoreCardProps) {
         </div>
       )}
     </div>
+  );
+}
+
+/**
+ * Mensaje de coaching IA (Phase 3 PR-J3). Distingue visualmente si vino
+ * de Gemini (✨ Sparkles) o de plantilla determinística (icono Info más
+ * sobrio). Tono visual consistente: borde primary, fondo neutro claro,
+ * mensaje en negro neutral.
+ */
+function CoachingMessage({
+  data,
+}: {
+  data: Extract<CoachingResponse, { status: 'disponible' }>;
+}) {
+  const sourceLabel =
+    data.source === 'gemini' ? 'Sugerencia personalizada (IA)' : 'Sugerencia general';
+  return (
+    <section
+      aria-label="Coaching de conducción"
+      className="mt-3 rounded-md border border-primary-200 bg-white p-3"
+    >
+      <header className="mb-1.5 flex items-center gap-1.5 text-primary-700 text-xs">
+        {data.source === 'gemini' ? (
+          <Sparkles className="h-3.5 w-3.5" aria-hidden />
+        ) : (
+          <Info className="h-3.5 w-3.5" aria-hidden />
+        )}
+        <span className="font-semibold">{sourceLabel}</span>
+      </header>
+      <p className="text-neutral-800 text-sm leading-snug">{data.message}</p>
+    </section>
   );
 }
 

--- a/apps/web/src/hooks/use-behavior-score.ts
+++ b/apps/web/src/hooks/use-behavior-score.ts
@@ -2,6 +2,61 @@ import { useQuery } from '@tanstack/react-query';
 import { ApiError, api } from '../lib/api-client.js';
 
 /**
+ * Coaching IA — Phase 3 PR-J3.
+ * Consume GET /assignments/:id/coaching (PR-J2). Generado post-entrega
+ * por @booster-ai/coaching-generator usando Gemini API o fallback de
+ * plantilla determinística.
+ */
+export type CoachingFoco =
+  | 'felicitacion'
+  | 'frenado'
+  | 'aceleracion'
+  | 'curvas'
+  | 'velocidad'
+  | 'multiple';
+
+export type CoachingFuente = 'gemini' | 'plantilla';
+
+export type CoachingResponse =
+  | {
+      trip_id: string;
+      message: string;
+      focus: CoachingFoco;
+      source: CoachingFuente;
+      model: string | null;
+      generated_at: string;
+      status: 'disponible';
+    }
+  | {
+      trip_id: string;
+      message: null;
+      focus: null;
+      source: null;
+      status: 'no_disponible';
+      reason: string;
+    };
+
+export function useCoaching(assignmentId: string, opts: { enabled?: boolean } = {}) {
+  return useQuery<CoachingResponse>({
+    queryKey: ['assignment', 'coaching', assignmentId],
+    queryFn: () => api.get<CoachingResponse>(`/assignments/${assignmentId}/coaching`),
+    enabled: opts.enabled ?? true,
+    // Coaching post-entrega es inmutable salvo regeneración manual.
+    // Cache largo para no re-pegar al endpoint en cada navegación.
+    staleTime: 30 * 60 * 1000,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {
+        return false;
+      }
+      if (error instanceof ApiError && error.status === 404) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+}
+
+/**
  * Behavior score de un trip — Phase 2 PR-I5.
  * Consume GET /assignments/:id/behavior-score (Phase 2 PR-I4).
  *

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@booster-ai/certificate-generator':
         specifier: workspace:*
         version: link:../../packages/certificate-generator
+      '@booster-ai/coaching-generator':
+        specifier: workspace:*
+        version: link:../../packages/coaching-generator
       '@booster-ai/config':
         specifier: workspace:*
         version: link:../../packages/config


### PR DESCRIPTION
## Resumen

Tercer y **último PR de Phase 3** (coaching IA). Surface el mensaje de coaching personalizado al transportista directamente en el drill-down de la \`BehaviorScoreCard\`.

Builds on top of [#107](../pull/107). **Cierra Phase 3 end-to-end**.

## Cambios

### \`apps/web/src/hooks/use-behavior-score.ts\`
- Type \`CoachingResponse\`: discriminated union por \`status\`
- Hook \`useCoaching(assignmentId)\` consume \`GET /assignments/:id/coaching\` (PR-J2)
- \`staleTime: 30min\` (coaching post-entrega es inmutable salvo regen manual)

### \`apps/web/src/components/scoring/BehaviorScoreCard.tsx\`
- Subcomponente \`CoachingMessage\` que se muestra DENTRO del drill-down expandido
- Distingue visualmente fuente:
  - \`gemini\` → ✨ Sparkles + \"Sugerencia personalizada (IA)\"
  - \`plantilla\` → Info + \"Sugerencia general\"
- Si \`no_disponible\` o falla → no renderiza (silencioso)

## Verificación

- [x] \`pnpm --filter @booster-ai/web typecheck\` — 0 errores
- [x] \`pnpm --filter @booster-ai/web test\` — 59/59 passed
- [x] \`biome check\` — 0 errores

## Phase 3 cerrada

| PR | Componente |
|---|---|
| [#106](../pull/106) | \`@booster-ai/coaching-generator\` package: prompt + Gemini abstracción + plantilla fallback (22 tests) |
| [#107](../pull/107) | api: \`gemini-client.ts\` (REST wrapper) + \`generar-coaching-viaje.ts\` + endpoint \`GET /:id/coaching\` (migración 0012) |
| Este | UI con \`CoachingMessage\` discriminado por fuente |

**Flow end-to-end**:
\`\`\`
Trip entregado
  → calcular-score-conduccion-viaje persiste behavior score (PR-I4)
  → generar-coaching-viaje:
      - construye ParametrosCoaching desde el breakdown
      - si GEMINI_API_KEY: llama a Gemini API (gemini-1.5-flash)
      - si Gemini falla / no key: fallback a plantilla determinística
      - persiste mensaje + foco + fuente + modelo en metricas_viaje
  → UI dashboard muestra score + breakdown + CoachingMessage
    con icono de fuente (✨ AI vs 📋 plantilla)
\`\`\`

## Pendiente operacional

Para activar Gemini en producción:
\`\`\`bash
gcloud secrets versions add gemini-api-key \\
  --data-file=<(echo -n "AIza...") --project=booster-ai-494222

gcloud run services update booster-ai-api \\
  --region=southamerica-west1 --project=booster-ai-494222 \\
  --update-secrets=GEMINI_API_KEY=gemini-api-key:latest
\`\`\`

Sin esto, todos los coachings caen a plantilla — UI igual los muestra con icono Info.

## Próximas iteraciones (out of scope)

- WhatsApp template para entregar coaching al driver por mensaje
- Eval suite del prompt (regresión de calidad output Gemini)
- Phase 4: optimización de red (multi-stop, OR-Tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)