### PR TITLE
chore(infra): wire gemini-api-key al api Cloud Run (Phase 3 ops)

### DIFF
--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -157,6 +157,15 @@ module "service_api" {
     # ROTATE_ME_GOOGLE_ROUTES_API_KEY, el servicio cae al fallback de
     # estimarDistanciaKm (tabla pre-computada Chile) sin romper nada.
     GOOGLE_ROUTES_API_KEY = google_secret_manager_secret.secrets["google-routes-api-key"].secret_id
+
+    # Phase 3 PR-J2 — Gemini API key para coaching IA post-entrega.
+    # Server-side; el api la usa en generar-coaching-viaje.ts para
+    # llamar a Gemini REST API. Si la key está con placeholder o
+    # ausente, generarCoachingConduccion cae al fallback de plantilla
+    # determinística — el carrier sigue recibiendo coaching útil.
+    # El secret ya existe en security.tf; este binding lo expone como
+    # env var GEMINI_API_KEY al api Cloud Run (apps/api lee via config.ts).
+    GEMINI_API_KEY = google_secret_manager_secret.secrets["gemini-api-key"].secret_id
   })
 
   vpc_connector = google_vpc_access_connector.serverless.id


### PR DESCRIPTION
## Resumen

Cierra el cableado para que el api en producción consuma \`GEMINI_API_KEY\` desde Secret Manager. El secret ya existe en \`security.tf\`; este PR solo añade el binding al módulo \`service_api\` en \`compute.tf\`, espejo del wiring que ya existía en \`service_whatsapp_bot\`.

Sin esto, \`generarCoachingViaje\` en producción siempre cae a la plantilla determinística — el carrier ve coaching útil pero NO personalizado por contexto del trip via Gemini.

## Cambio

Una línea en el \`secrets\` block de \`service_api\`:

\`\`\`hcl
GEMINI_API_KEY = google_secret_manager_secret.secrets[\"gemini-api-key\"].secret_id
\`\`\`

## Pasos manuales post-merge

\`\`\`bash
# 1. Apply Terraform
cd infrastructure
terraform plan -out=gemini-api.tfplan -target=module.service_api
terraform apply gemini-api.tfplan

# 2. Verificar binding
gcloud run services describe booster-ai-api \\
  --region=southamerica-west1 --project=booster-ai-494222 \\
  --format=\"value(spec.template.spec.containers[0].env)\" | grep GEMINI

# 3. (Si la key todavía es placeholder) cargar la real
gcloud secrets versions add gemini-api-key \\
  --data-file=<(echo -n \"AIza...\") --project=booster-ai-494222
\`\`\`

**Estado actual del secret**: la versión 3 (real) ya está cargada via \`gcloud services api-keys create\` con restricción a \`generativelanguage.googleapis.com\`. Solo falta el binding TF.

## Greenwashing safety

Sin Gemini válido, \`generarCoachingConduccion\` cae a plantilla determinística — coaching útil curado en español. La fuente es transparente al carrier en la UI vía \`coaching_fuente\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)