### PR TITLE
test(web): expandir coverage 87% → 97% (hooks Phase 2/3 + 4 components excluidos)

### DIFF
--- a/apps/web/src/components/CompanySwitcher.test.tsx
+++ b/apps/web/src/components/CompanySwitcher.test.tsx
@@ -7,10 +7,11 @@ function membership(
   id: string,
   name: string,
   status: MembershipPayload['status'] = 'activa',
+  role: MembershipPayload['role'] = 'dueno',
 ): MembershipPayload {
   return {
     id: `m-${id}`,
-    role: 'dueno',
+    role,
     status,
     joined_at: '2026-01-01T00:00:00Z',
     empresa: {
@@ -145,5 +146,89 @@ describe('CompanySwitcher', () => {
     expect(screen.getByRole('menu')).toBeInTheDocument();
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('press tecla cualquiera no cierra el menu', () => {
+    render(
+      <CompanySwitcher
+        memberships={[membership('1', 'Empresa A'), membership('2', 'Empresa B')]}
+        activeEmpresaId="1"
+        onSelect={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    fireEvent.keyDown(document, { key: 'A' });
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('click fuera del container cierra el menu', () => {
+    render(
+      <div>
+        <CompanySwitcher
+          memberships={[membership('1', 'Empresa A'), membership('2', 'Empresa B')]}
+          activeEmpresaId="1"
+          onSelect={vi.fn()}
+        />
+        <button type="button" data-testid="outside">
+          fuera
+        </button>
+      </div>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /Empresa A/ }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('disabled=true → trigger deshabilitado', () => {
+    render(
+      <CompanySwitcher
+        memberships={[membership('1', 'Empresa A'), membership('2', 'Empresa B')]}
+        activeEmpresaId="1"
+        onSelect={vi.fn()}
+        disabled
+      />,
+    );
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('activeEmpresaId no encontrado → fallback al primer activo', () => {
+    render(
+      <CompanySwitcher
+        memberships={[membership('1', 'Empresa A'), membership('2', 'Empresa B')]}
+        activeEmpresaId="zzz-no-existe"
+        onSelect={vi.fn()}
+      />,
+    );
+    // Active es Empresa A (el primero del array filtrado).
+    const trigger = screen.getByRole('button');
+    expect(trigger).toHaveTextContent('Empresa A');
+  });
+
+  describe('roleLabel branches', () => {
+    const cases = [
+      ['admin', 'Administrador'],
+      ['despachador', 'Despachador'],
+      ['conductor', 'Conductor'],
+      ['visualizador', 'Visualizador'],
+      ['stakeholder_sostenibilidad', 'Stakeholder'],
+    ] as const;
+
+    for (const [role, label] of cases) {
+      it(`role=${role} → label "${label}"`, () => {
+        render(
+          <CompanySwitcher
+            memberships={[
+              membership('1', 'Empresa A', 'activa', role),
+              membership('2', 'Empresa B'),
+            ]}
+            activeEmpresaId="1"
+            onSelect={vi.fn()}
+          />,
+        );
+        fireEvent.click(screen.getByRole('button'));
+        expect(screen.getByText(label)).toBeInTheDocument();
+      });
+    }
   });
 });

--- a/apps/web/src/components/Layout.test.tsx
+++ b/apps/web/src/components/Layout.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import type { MeResponse } from '../hooks/use-me.js';
@@ -16,10 +16,13 @@ vi.mock('../hooks/use-switch-company.js', () => ({
 }));
 
 vi.mock('../hooks/use-auth.js', () => ({
-  signOutUser: vi.fn(),
+  signOutUser: vi.fn(async () => undefined),
 }));
 
+import { signOutUser } from '../hooks/use-auth.js';
 import { Layout } from './Layout.js';
+
+const signOutUserMock = vi.mocked(signOutUser);
 
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 
@@ -109,5 +112,100 @@ describe('Layout — integración del CompanySwitcher (FIX-013/§3.1)', () => {
       </Layout>,
     );
     expect(screen.getByText('contenido del main')).toBeInTheDocument();
+  });
+});
+
+describe('Layout — mobile menu + signOut', () => {
+  it('hamburguesa cambia aria-expanded false → true → false', () => {
+    const me = buildMe([membership('e-1', 'Naviera Costera')]);
+    render(
+      <Layout me={me} title="Cargas">
+        <div>x</div>
+      </Layout>,
+    );
+    const trigger = screen.getByRole('button', { name: 'Abrir menú' });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.click(trigger);
+    expect(screen.getByRole('button', { name: 'Cerrar menú' })).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar menú' }));
+    expect(screen.getByRole('button', { name: 'Abrir menú' })).toBeInTheDocument();
+  });
+
+  it('click logo cierra el menú móvil si estaba abierto', () => {
+    const me = buildMe([membership('e-1', 'Naviera Costera')]);
+    render(
+      <Layout me={me} title="Cargas">
+        <div>x</div>
+      </Layout>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú' }));
+    fireEvent.click(screen.getByText('Booster AI'));
+    expect(screen.getByRole('button', { name: 'Abrir menú' })).toBeInTheDocument();
+  });
+
+  it('click "Salir" desktop llama signOutUser', () => {
+    const me = buildMe([membership('e-1', 'Naviera Costera')]);
+    render(
+      <Layout me={me} title="Cargas">
+        <div>x</div>
+      </Layout>,
+    );
+    const buttons = screen.getAllByRole('button', { name: /Salir/ });
+    const first = buttons[0];
+    if (!first) {
+      throw new Error('expected button');
+    }
+    fireEvent.click(first);
+    expect(signOutUserMock).toHaveBeenCalled();
+  });
+
+  it('click "Salir" mobile (dentro del panel desplegable) también llama signOutUser', () => {
+    signOutUserMock.mockClear();
+    const me = buildMe([membership('e-1', 'Naviera Costera')]);
+    render(
+      <Layout me={me} title="Cargas">
+        <div>x</div>
+      </Layout>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú' }));
+    const buttons = screen.getAllByRole('button', { name: /Salir/ });
+    const last = buttons[buttons.length - 1];
+    if (!last) {
+      throw new Error('expected Salir button');
+    }
+    fireEvent.click(last);
+    expect(signOutUserMock).toHaveBeenCalled();
+  });
+
+  it('handleSwitchEmpresa invoca switchTo + cierra menú mobile', () => {
+    switchToMock.mockClear();
+    const me = buildMe([
+      membership('e-1', 'Naviera Costera'),
+      membership('e-2', 'Transportes Andes'),
+    ]);
+    render(
+      <Layout me={me} title="Cargas">
+        <div>x</div>
+      </Layout>,
+    );
+    // Abre el menú móvil para que su switcher esté visible.
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú' }));
+    // El switcher mobile (el último renderizado) tiene los items del dropdown.
+    const switcherButtons = screen.getAllByRole('button', { expanded: false });
+    const lastSwitcher = switcherButtons[switcherButtons.length - 1];
+    if (!lastSwitcher) {
+      throw new Error('expected switcher trigger');
+    }
+    fireEvent.click(lastSwitcher);
+    const items = screen.getAllByRole('menuitem');
+    const target = items.find((el) => !el.hasAttribute('disabled'));
+    if (!target) {
+      throw new Error('expected non-disabled menuitem');
+    }
+    fireEvent.click(target);
+    expect(switchToMock).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/chat/PushSubscribeBanner.test.tsx
+++ b/apps/web/src/components/chat/PushSubscribeBanner.test.tsx
@@ -1,0 +1,146 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PushDisabledError,
+  PushPermissionDeniedError,
+  isWebPushSupported,
+  subscribeToWebPush,
+} from '../../lib/web-push.js';
+import { PushSubscribeBanner } from './PushSubscribeBanner.js';
+
+vi.mock('../../lib/web-push.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../../lib/web-push.js')>('../../lib/web-push.js');
+  return {
+    ...actual,
+    isWebPushSupported: vi.fn(),
+    subscribeToWebPush: vi.fn(),
+  };
+});
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderBanner() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <PushSubscribeBanner />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  sessionStorage.clear();
+  vi.clearAllMocks();
+  // Default: support + permission default.
+  vi.mocked(isWebPushSupported).mockReturnValue(true);
+  (globalThis as any).Notification = { permission: 'default' };
+});
+
+afterEach(() => {
+  Reflect.deleteProperty(globalThis as any, 'Notification');
+  vi.restoreAllMocks();
+});
+
+describe('PushSubscribeBanner — visibilidad', () => {
+  it('no soporta Web Push → no se renderiza', () => {
+    vi.mocked(isWebPushSupported).mockReturnValue(false);
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('permission=granted → no se renderiza', () => {
+    (globalThis as any).Notification = { permission: 'granted' };
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('permission=denied → no se renderiza', () => {
+    (globalThis as any).Notification = { permission: 'denied' };
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('dismissed flag en sessionStorage → no se renderiza', () => {
+    sessionStorage.setItem('booster.pushBanner.dismissed', '1');
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('soporte + permission default + sin flag → se muestra', () => {
+    renderBanner();
+    expect(screen.getByText(/Activa las notificaciones/)).toBeInTheDocument();
+  });
+});
+
+describe('PushSubscribeBanner — acciones', () => {
+  it('click Activar → subscribeToWebPush + se oculta on success', async () => {
+    vi.mocked(subscribeToWebPush).mockResolvedValueOnce({
+      endpoint: 'https://x',
+    } as never);
+    const { container } = renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: 'Activar' }));
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+    expect(subscribeToWebPush).toHaveBeenCalled();
+  });
+
+  it('PushPermissionDeniedError → set dismiss flag + ocultar', async () => {
+    vi.mocked(subscribeToWebPush).mockRejectedValueOnce(new PushPermissionDeniedError());
+    const { container } = renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: 'Activar' }));
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+    expect(sessionStorage.getItem('booster.pushBanner.dismissed')).toBe('1');
+  });
+
+  it('PushDisabledError → set dismiss flag + ocultar', async () => {
+    vi.mocked(subscribeToWebPush).mockRejectedValueOnce(new PushDisabledError());
+    const { container } = renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: 'Activar' }));
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+    expect(sessionStorage.getItem('booster.pushBanner.dismissed')).toBe('1');
+  });
+
+  it('error genérico → log warn + sigue visible', async () => {
+    vi.mocked(subscribeToWebPush).mockRejectedValueOnce(new Error('network'));
+    renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: 'Activar' }));
+    await waitFor(() => {
+      // Sigue visible.
+      expect(screen.getByText(/Activa las notificaciones/)).toBeInTheDocument();
+    });
+    // No flag de dismiss.
+    expect(sessionStorage.getItem('booster.pushBanner.dismissed')).toBeNull();
+  });
+
+  it('click X (Descartar) → flag + ocultar', () => {
+    const { container } = renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: 'Descartar banner' }));
+    expect(container.firstChild).toBeNull();
+    expect(sessionStorage.getItem('booster.pushBanner.dismissed')).toBe('1');
+  });
+
+  it('mientras isPending → botón muestra "Activando…" y disabled', async () => {
+    vi.mocked(subscribeToWebPush).mockImplementation(() => new Promise<never>(() => undefined));
+    renderBanner();
+    fireEvent.click(screen.getByRole('button', { name: 'Activar' }));
+    await waitFor(() => {
+      const btn = screen.getByRole('button', { name: /Activando/ });
+      expect(btn).toBeDisabled();
+    });
+  });
+});

--- a/apps/web/src/components/offers/OfferCard.test.tsx
+++ b/apps/web/src/components/offers/OfferCard.test.tsx
@@ -1,0 +1,309 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { OfferPayload } from '../../hooks/use-offers.js';
+import { ApiError, api } from '../../lib/api-client.js';
+import { OfferCard } from './OfferCard.js';
+
+function makeOffer(over: Partial<OfferPayload> = {}): OfferPayload {
+  return {
+    id: 'o1',
+    status: 'pendiente',
+    score: 0.85,
+    proposed_price_clp: 250_000,
+    suggested_vehicle_id: null,
+    sent_at: '2026-05-10T10:00:00Z',
+    expires_at: new Date(Date.now() + 30 * 60_000).toISOString(),
+    responded_at: null,
+    rejection_reason: null,
+    trip_request: {
+      id: 'tr1',
+      tracking_code: 'BST-001',
+      status: 'pendiente',
+      origin_address_raw: 'Av. Apoquindo 4500',
+      origin_region_code: 'XIII',
+      destination_address_raw: 'Plaza Sotomayor',
+      destination_region_code: 'V',
+      cargo_type: 'carga_seca',
+      cargo_weight_kg: 5000,
+      pickup_window_start: '2026-05-11T08:00:00Z',
+      pickup_window_end: '2026-05-11T18:00:00Z',
+    },
+    ...over,
+  };
+}
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderCard(offer: OfferPayload = makeOffer()) {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <OfferCard offer={offer} />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('OfferCard — render base', () => {
+  it('muestra tracking code, regiones, precio y carga', () => {
+    renderCard();
+    expect(screen.getByText('BST-001')).toBeInTheDocument();
+    expect(screen.getByText(/RM →/)).toBeInTheDocument();
+    expect(screen.getByText(/Valparaíso/)).toBeInTheDocument();
+    expect(screen.getByText(/250\.000/)).toBeInTheDocument();
+    expect(screen.getByText(/Carga seca/)).toBeInTheDocument();
+    expect(screen.getByText(/5\.000 kg/)).toBeInTheDocument();
+  });
+
+  it('cargo_type desconocido → muestra el código raw', () => {
+    renderCard(makeOffer({ trip_request: { ...makeOffer().trip_request, cargo_type: 'mistery' } }));
+    expect(screen.getByText(/mistery/)).toBeInTheDocument();
+  });
+
+  it('region_code desconocido → muestra el código raw', () => {
+    renderCard(
+      makeOffer({
+        trip_request: {
+          ...makeOffer().trip_request,
+          origin_region_code: 'ZZ',
+          destination_region_code: 'YY',
+        },
+      }),
+    );
+    expect(screen.getByText(/ZZ → YY/)).toBeInTheDocument();
+  });
+
+  it('region_code null → muestra "—"', () => {
+    renderCard(
+      makeOffer({
+        trip_request: {
+          ...makeOffer().trip_request,
+          origin_region_code: null,
+          destination_region_code: null,
+        },
+      }),
+    );
+    expect(screen.getByText(/— → —/)).toBeInTheDocument();
+  });
+
+  it('cargo_weight_kg null → no muestra peso', () => {
+    renderCard(makeOffer({ trip_request: { ...makeOffer().trip_request, cargo_weight_kg: null } }));
+    expect(screen.queryByText(/kg/)).not.toBeInTheDocument();
+  });
+
+  it('pickup_window null → muestra "—"', () => {
+    renderCard(
+      makeOffer({
+        trip_request: {
+          ...makeOffer().trip_request,
+          pickup_window_start: null,
+          pickup_window_end: null,
+        },
+      }),
+    );
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('OfferCard — timeRemaining states', () => {
+  it('expirada (expires_at en el pasado) → "Expirada" + urgent', () => {
+    renderCard(makeOffer({ expires_at: new Date(Date.now() - 1000).toISOString() }));
+    expect(screen.getByText('Expirada')).toBeInTheDocument();
+  });
+
+  it('< 15 min → urgent visual', () => {
+    // +5 min y un buffer para evitar que la división redondee a 4 si
+    // pasaron unos ms entre el cálculo del expires_at y el timeRemaining.
+    renderCard(makeOffer({ expires_at: new Date(Date.now() + 5 * 60_000 + 5_000).toISOString() }));
+    expect(screen.getByText(/[45] min/)).toBeInTheDocument();
+  });
+
+  it('45 min → no urgent + label "min"', () => {
+    renderCard(makeOffer({ expires_at: new Date(Date.now() + 45 * 60_000 + 5_000).toISOString() }));
+    expect(screen.getByText(/4[45] min/)).toBeInTheDocument();
+  });
+
+  it('2+ horas → label hh + mm', () => {
+    renderCard(makeOffer({ expires_at: new Date(Date.now() + 125 * 60_000).toISOString() }));
+    expect(screen.getByText(/2 h/)).toBeInTheDocument();
+  });
+});
+
+describe('OfferCard — accept flow', () => {
+  it('happy: click Aceptar invoca POST y queda en pending visible', async () => {
+    const spy = vi.spyOn(api, 'post').mockResolvedValueOnce({
+      offer: { id: 'o1', status: 'aceptada' },
+      assignment: { id: 'a1' },
+      superseded_offer_ids: [],
+    });
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Aceptar oferta/ }));
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('/offers/o1/accept', {}));
+  });
+
+  it('error ApiError offer_expired → mensaje traducido visible', async () => {
+    vi.spyOn(api, 'post').mockRejectedValueOnce(new ApiError(409, 'offer_expired', null));
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Aceptar oferta/ }));
+    expect(await screen.findByText(/expiró/i)).toBeInTheDocument();
+  });
+
+  it('error 5xx → mensaje genérico de servidor', async () => {
+    vi.spyOn(api, 'post').mockRejectedValueOnce(new ApiError(500, 'internal', null));
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Aceptar oferta/ }));
+    expect(await screen.findByText(/Error del servidor/)).toBeInTheDocument();
+  });
+
+  it('error no-ApiError → mensaje "Error inesperado"', async () => {
+    vi.spyOn(api, 'post').mockRejectedValueOnce(new Error('boom'));
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Aceptar oferta/ }));
+    expect(await screen.findByText(/Error inesperado/)).toBeInTheDocument();
+  });
+});
+
+describe('OfferCard — reject flow', () => {
+  it('click Rechazar abre form, click Volver lo cierra', () => {
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Rechazar/ }));
+    expect(screen.getByLabelText(/Razón del rechazo/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Volver/ }));
+    expect(screen.queryByLabelText(/Razón del rechazo/)).not.toBeInTheDocument();
+  });
+
+  it('submit sin reason → POST con body vacío', async () => {
+    const spy = vi.spyOn(api, 'post').mockResolvedValueOnce({ offer: { id: 'o1' } });
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Rechazar/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Confirmar rechazo/ }));
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('/offers/o1/reject', {}));
+  });
+
+  it('submit con reason → POST incluye reason trimmed', async () => {
+    const spy = vi.spyOn(api, 'post').mockResolvedValueOnce({ offer: { id: 'o1' } });
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Rechazar/ }));
+    fireEvent.change(screen.getByLabelText(/Razón del rechazo/), {
+      target: { value: '  fuera de zona  ' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Confirmar rechazo/ }));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith('/offers/o1/reject', { reason: 'fuera de zona' }),
+    );
+  });
+
+  it('error en reject → muestra error y form sigue abierto', async () => {
+    vi.spyOn(api, 'post').mockRejectedValueOnce(new ApiError(403, 'offer_forbidden', null));
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Rechazar/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Confirmar rechazo/ }));
+    expect(await screen.findByText(/No tienes permiso/)).toBeInTheDocument();
+  });
+});
+
+describe('OfferCard — eco preview', () => {
+  it('default oculto, click "Ver impacto ambiental" lo abre y fetcha', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request_id: 'tr1',
+      suggested_vehicle_id: null,
+      distance_km: 130,
+      duration_s: 5400,
+      fuel_liters_estimated: 28,
+      emisiones_kgco2e_wtw: 75,
+      emisiones_kgco2e_ttw: 60,
+      emisiones_kgco2e_wtt: 15,
+      intensidad_gco2e_por_tonkm: 50,
+      precision_method: 'modelado',
+      data_source: 'routes_api',
+      glec_version: 'GLEC v3.0',
+      generated_at: '2026-05-10T00:00:00Z',
+    });
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Ver impacto ambiental/ }));
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('/offers/o1/eco-preview'));
+    expect(await screen.findByText(/130 km/)).toBeInTheDocument();
+    expect(screen.getByText(/75\.0 kg CO₂e/)).toBeInTheDocument();
+    expect(screen.getByText(/Google Routes API/)).toBeInTheDocument();
+  });
+
+  it('eco preview loading → spinner', async () => {
+    vi.spyOn(api, 'get').mockImplementation(() => new Promise<never>(() => undefined));
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Ver impacto ambiental/ }));
+    expect(await screen.findByText(/Calculando impacto ambiental/)).toBeInTheDocument();
+  });
+
+  it('eco preview error → fallback message', async () => {
+    vi.spyOn(api, 'get').mockRejectedValue(new ApiError(401, 'unauthorized', null));
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Ver impacto ambiental/ }));
+    expect(await screen.findByText(/No pudimos calcular el impacto/)).toBeInTheDocument();
+  });
+
+  it('data_source=tabla_chile → label correspondiente', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request_id: 'tr1',
+      suggested_vehicle_id: null,
+      distance_km: 100,
+      duration_s: null,
+      fuel_liters_estimated: null,
+      emisiones_kgco2e_wtw: 50,
+      emisiones_kgco2e_ttw: 40,
+      emisiones_kgco2e_wtt: 10,
+      intensidad_gco2e_por_tonkm: 25,
+      precision_method: 'por_defecto',
+      data_source: 'tabla_chile',
+      glec_version: 'GLEC v3.0',
+      generated_at: '2026-05-10T00:00:00Z',
+    });
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Ver impacto ambiental/ }));
+    expect(await screen.findByText(/Estimación por región/)).toBeInTheDocument();
+  });
+});
+
+describe('OfferCard — translate ApiError code branches', () => {
+  const cases = [
+    ['offer_not_found', /Esta oferta ya no existe/],
+    ['offer_forbidden', /No tienes permiso/],
+    ['offer_not_pending', /ya fue respondida/],
+    ['trip_already_assigned', /Otro carrier aceptó primero/],
+    ['no_active_empresa', /no tiene empresa activa/],
+    ['not_a_carrier', /no opera como carrier/],
+  ] as const;
+
+  for (const [code, regex] of cases) {
+    it(`code ${code} → ${regex}`, async () => {
+      vi.spyOn(api, 'post').mockRejectedValueOnce(new ApiError(403, code, null));
+      renderCard();
+      fireEvent.click(screen.getByRole('button', { name: /Aceptar oferta/ }));
+      expect(await screen.findByText(regex)).toBeInTheDocument();
+    });
+  }
+
+  it('ApiError unknown code 4xx → message del error', async () => {
+    vi.spyOn(api, 'post').mockRejectedValueOnce(
+      new ApiError(400, 'unknown_x', null, 'msg-from-err'),
+    );
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /Aceptar oferta/ }));
+    expect(await screen.findByText(/msg-from-err/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/profile/ProfileForm.test.tsx
+++ b/apps/web/src/components/profile/ProfileForm.test.tsx
@@ -1,0 +1,186 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../../lib/api-client.js';
+import { ProfileForm } from './ProfileForm.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderForm(initial: Parameters<typeof ProfileForm>[0]['initial']) {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <ProfileForm initial={initial} />
+    </Wrapper>,
+  );
+}
+
+const INITIAL_DEFAULT = {
+  full_name: 'Felipe Vicencio',
+  phone: '+56912345678',
+  whatsapp_e164: '+56912345678',
+  rut: '12.345.678-5',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ProfileForm — render', () => {
+  it('precarga valores iniciales en los inputs', () => {
+    renderForm(INITIAL_DEFAULT);
+    expect(screen.getByLabelText(/Nombre completo/)).toHaveValue('Felipe Vicencio');
+    expect(screen.getByLabelText(/Teléfono móvil/)).toHaveValue('+56912345678');
+    expect(screen.getByLabelText(/WhatsApp/)).toHaveValue('+56912345678');
+  });
+
+  it('RUT existente → input deshabilitado y muestra hint de inmutable', () => {
+    renderForm(INITIAL_DEFAULT);
+    expect(screen.getByLabelText(/RUT/)).toBeDisabled();
+    expect(screen.getByText(/no se puede modificar/)).toBeInTheDocument();
+  });
+
+  it('RUT null → input habilitado', () => {
+    renderForm({ ...INITIAL_DEFAULT, rut: null });
+    expect(screen.getByLabelText(/RUT/)).not.toBeDisabled();
+    expect(screen.getByText(/Una vez declarado/)).toBeInTheDocument();
+  });
+});
+
+describe('ProfileForm — validación', () => {
+  it('teléfono inválido → error onBlur', async () => {
+    renderForm(INITIAL_DEFAULT);
+    const input = screen.getByLabelText(/Teléfono móvil/);
+    fireEvent.change(input, { target: { value: 'no-es-tel' } });
+    fireEvent.blur(input);
+    expect(await screen.findByText(/Número de teléfono Chile inválido/)).toBeInTheDocument();
+  });
+
+  it('full_name vacío al blur → error', async () => {
+    renderForm(INITIAL_DEFAULT);
+    const input = screen.getByLabelText(/Nombre completo/);
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+    expect(await screen.findByText(/El nombre debe tener entre 1 y 200/)).toBeInTheDocument();
+  });
+});
+
+describe('ProfileForm — submit', () => {
+  it('sin cambios (no dirty) → no PATCH al API + muestra mensaje guardado', async () => {
+    const spy = vi.spyOn(api, 'patch').mockResolvedValue({});
+    renderForm(INITIAL_DEFAULT);
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    await waitFor(() => expect(screen.getByText(/Cambios guardados/)).toBeInTheDocument());
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('cambia full_name → PATCH solo con full_name', async () => {
+    const spy = vi.spyOn(api, 'patch').mockResolvedValueOnce({});
+    renderForm(INITIAL_DEFAULT);
+    fireEvent.change(screen.getByLabelText(/Nombre completo/), {
+      target: { value: 'Felipe Updated' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith('/me/profile', { full_name: 'Felipe Updated' }),
+    );
+  });
+
+  it('cambia phone (válido) → PATCH solo con phone', async () => {
+    const spy = vi.spyOn(api, 'patch').mockResolvedValueOnce({});
+    renderForm(INITIAL_DEFAULT);
+    fireEvent.change(screen.getByLabelText(/Teléfono móvil/), {
+      target: { value: '+56987654321' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    await waitFor(() => expect(spy).toHaveBeenCalledWith('/me/profile', { phone: '+56987654321' }));
+  });
+
+  it('cambia whatsapp_e164 → PATCH', async () => {
+    const spy = vi.spyOn(api, 'patch').mockResolvedValueOnce({});
+    renderForm({ ...INITIAL_DEFAULT, whatsapp_e164: null });
+    fireEvent.change(screen.getByLabelText(/WhatsApp/), { target: { value: '+56987654321' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith('/me/profile', { whatsapp_e164: '+56987654321' }),
+    );
+  });
+
+  it('completa RUT (cuando estaba null) → PATCH con rut', async () => {
+    const spy = vi.spyOn(api, 'patch').mockResolvedValueOnce({});
+    renderForm({ ...INITIAL_DEFAULT, rut: null });
+    fireEvent.change(screen.getByLabelText(/RUT/), { target: { value: '12.345.678-5' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        '/me/profile',
+        expect.objectContaining({ rut: expect.any(String) }),
+      ),
+    );
+  });
+
+  it('PATCH succeede → mensaje "Cambios guardados"', async () => {
+    vi.spyOn(api, 'patch').mockResolvedValueOnce({});
+    renderForm(INITIAL_DEFAULT);
+    fireEvent.change(screen.getByLabelText(/Nombre completo/), {
+      target: { value: 'Nuevo nombre' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    expect(await screen.findByText(/Cambios guardados/)).toBeInTheDocument();
+  });
+});
+
+describe('ProfileForm — translateApiError', () => {
+  it('rut_immutable → mensaje específico', async () => {
+    vi.spyOn(api, 'patch').mockRejectedValueOnce(new ApiError(409, 'rut_immutable', null));
+    renderForm(INITIAL_DEFAULT);
+    fireEvent.change(screen.getByLabelText(/Nombre completo/), {
+      target: { value: 'Otro nombre' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    expect(await screen.findByText(/No se puede modificar el RUT/)).toBeInTheDocument();
+  });
+
+  it('user_not_found → mensaje vuelve al onboarding', async () => {
+    vi.spyOn(api, 'patch').mockRejectedValueOnce(new ApiError(404, 'user_not_found', null));
+    renderForm(INITIAL_DEFAULT);
+    fireEvent.change(screen.getByLabelText(/Nombre completo/), {
+      target: { value: 'Otro nombre' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    expect(await screen.findByText(/Vuelve al onboarding/)).toBeInTheDocument();
+  });
+
+  it('error 5xx → mensaje genérico de servidor', async () => {
+    vi.spyOn(api, 'patch').mockRejectedValueOnce(new ApiError(500, 'internal', null));
+    renderForm(INITIAL_DEFAULT);
+    fireEvent.change(screen.getByLabelText(/Nombre completo/), {
+      target: { value: 'Otro nombre' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    expect(await screen.findByText(/Error del servidor/)).toBeInTheDocument();
+  });
+
+  it('ApiError 4xx con message → muestra el message', async () => {
+    vi.spyOn(api, 'patch').mockRejectedValueOnce(
+      new ApiError(400, 'unknown_thing', null, 'mensaje del backend'),
+    );
+    renderForm(INITIAL_DEFAULT);
+    fireEvent.change(screen.getByLabelText(/Nombre completo/), {
+      target: { value: 'Otro nombre' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar cambios/ }));
+    expect(await screen.findByText(/mensaje del backend/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/scoring/BehaviorScoreCard.test.tsx
+++ b/apps/web/src/components/scoring/BehaviorScoreCard.test.tsx
@@ -1,0 +1,207 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../../lib/api-client.js';
+import { BehaviorScoreCard } from './BehaviorScoreCard.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderCard(assignmentId = 'a1') {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <BehaviorScoreCard assignmentId={assignmentId} />
+    </Wrapper>,
+  );
+}
+
+const SCORE_OK = {
+  trip_id: 't1',
+  score: 87,
+  nivel: 'bueno' as const,
+  breakdown: {
+    aceleracionesBruscas: 1,
+    frenadosBruscos: 0,
+    curvasBruscas: 1,
+    excesosVelocidad: 0,
+    penalizacionTotal: 13,
+    eventosPorHora: 1.5,
+  },
+  calculated_at: '2026-05-10T00:00:00Z',
+  status: 'disponible' as const,
+};
+
+const SCORE_NO_DISP = {
+  trip_id: 't1',
+  score: null,
+  nivel: null,
+  breakdown: null,
+  status: 'no_disponible' as const,
+  reason: 'sin telemetria',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('BehaviorScoreCard — estados', () => {
+  it('isLoading → muestra skeleton', () => {
+    vi.spyOn(api, 'get').mockImplementation(() => new Promise<never>(() => undefined));
+    renderCard();
+    expect(screen.getByText(/Cargando score de conducción/)).toBeInTheDocument();
+  });
+
+  it('isError → no renderiza nada (silencioso)', async () => {
+    // ApiError 401 short-circuita el retry del hook → falla rápido.
+    vi.spyOn(api, 'get').mockRejectedValue(new ApiError(401, 'unauthorized', null));
+    const { container } = renderCard();
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it('status no_disponible → mensaje educativo Teltonika', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(SCORE_NO_DISP);
+    renderCard();
+    expect(await screen.findByText(/Score de conducción no disponible/)).toBeInTheDocument();
+    expect(screen.getByText(/Activa Teltonika/)).toBeInTheDocument();
+  });
+});
+
+describe('BehaviorScoreCard — disponible', () => {
+  it('muestra score + nivel + eventos/hora colapsado', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(SCORE_OK);
+    renderCard();
+    expect(await screen.findByText(/87\/100/)).toBeInTheDocument();
+    expect(screen.getByText('Bueno')).toBeInTheDocument();
+    expect(screen.getByText(/1\.5 eventos\/hora/)).toBeInTheDocument();
+    expect(screen.getByText(/2 eventos totales/)).toBeInTheDocument();
+  });
+
+  it('eventosPorHora=0 → muestra "Sin eventos"', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      ...SCORE_OK,
+      breakdown: {
+        ...SCORE_OK.breakdown,
+        eventosPorHora: 0,
+        aceleracionesBruscas: 0,
+        curvasBruscas: 0,
+      },
+      score: 100,
+      nivel: 'excelente',
+    });
+    renderCard();
+    expect(await screen.findByText(/Sin eventos en este viaje/)).toBeInTheDocument();
+    expect(screen.getByText('Excelente')).toBeInTheDocument();
+  });
+
+  it('expand reveals breakdown + métricas individuales', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(SCORE_OK);
+    renderCard();
+    const button = await screen.findByRole('button', { expanded: false });
+    fireEvent.click(button);
+    expect(await screen.findByText('Aceleración brusca')).toBeInTheDocument();
+    expect(screen.getByText('Frenado brusco')).toBeInTheDocument();
+    expect(screen.getByText('Curva brusca')).toBeInTheDocument();
+    expect(screen.getByText('Exceso velocidad')).toBeInTheDocument();
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+  });
+
+  it('toggle expand/collapse via aria-expanded', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(SCORE_OK);
+    renderCard();
+    const button = await screen.findByRole('button', { expanded: false });
+    fireEvent.click(button);
+    expect(screen.getByRole('button', { expanded: true })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { expanded: true }));
+    expect(screen.getByRole('button', { expanded: false })).toBeInTheDocument();
+  });
+
+  for (const nivel of ['excelente', 'bueno', 'regular', 'malo'] as const) {
+    it(`nivel=${nivel} → renderiza badge correspondiente`, async () => {
+      vi.spyOn(api, 'get').mockResolvedValue({ ...SCORE_OK, nivel });
+      renderCard();
+      const labels = {
+        excelente: 'Excelente',
+        bueno: 'Bueno',
+        regular: 'Regular',
+        malo: 'Mejorar',
+      };
+      expect(await screen.findByText(labels[nivel])).toBeInTheDocument();
+    });
+  }
+});
+
+describe('BehaviorScoreCard — coaching IA', () => {
+  it('coaching status disponible (gemini) → muestra Sparkles + "Sugerencia personalizada"', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path.includes('/coaching')) {
+        return {
+          trip_id: 't1',
+          message: 'Anticipa los frenados',
+          focus: 'frenado',
+          source: 'gemini',
+          model: 'gemini-pro',
+          generated_at: '2026-05-10T00:00:00Z',
+          status: 'disponible',
+        };
+      }
+      return SCORE_OK;
+    });
+    renderCard();
+    fireEvent.click(await screen.findByRole('button', { expanded: false }));
+    expect(await screen.findByText('Sugerencia personalizada (IA)')).toBeInTheDocument();
+    expect(screen.getByText('Anticipa los frenados')).toBeInTheDocument();
+  });
+
+  it('coaching source=plantilla → muestra "Sugerencia general"', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path.includes('/coaching')) {
+        return {
+          trip_id: 't1',
+          message: 'Buen viaje',
+          focus: 'felicitacion',
+          source: 'plantilla',
+          model: null,
+          generated_at: '2026-05-10T00:00:00Z',
+          status: 'disponible',
+        };
+      }
+      return SCORE_OK;
+    });
+    renderCard();
+    fireEvent.click(await screen.findByRole('button', { expanded: false }));
+    expect(await screen.findByText('Sugerencia general')).toBeInTheDocument();
+  });
+
+  it('coaching no disponible → no se muestra sección', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path.includes('/coaching')) {
+        return {
+          trip_id: 't1',
+          message: null,
+          focus: null,
+          source: null,
+          status: 'no_disponible',
+          reason: 'pending',
+        };
+      }
+      return SCORE_OK;
+    });
+    renderCard();
+    fireEvent.click(await screen.findByRole('button', { expanded: false }));
+    await screen.findByText('Aceleración brusca');
+    expect(screen.queryByText(/Sugerencia/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/hooks/use-behavior-score.test.tsx
+++ b/apps/web/src/hooks/use-behavior-score.test.tsx
@@ -1,0 +1,144 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../lib/api-client.js';
+import { useBehaviorScore, useCoaching } from './use-behavior-score.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useCoaching', () => {
+  it('default enabled=true → fetch /assignments/:id/coaching', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_id: 't1',
+      message: 'Buen trabajo',
+      focus: 'felicitacion',
+      source: 'gemini',
+      model: 'gemini-pro',
+      generated_at: '2026-05-10T00:00:00Z',
+      status: 'disponible',
+    });
+    const { result } = renderHook(() => useCoaching('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('/assignments/a1/coaching');
+  });
+
+  it('enabled=false → no fetch', () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValue({});
+    renderHook(() => useCoaching('a1', { enabled: false }), { wrapper: makeWrapper() });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('ApiError 401 → no retry', async () => {
+    const spy = vi.spyOn(api, 'get').mockRejectedValue(new ApiError(401, 'unauthorized', null));
+    const { result } = renderHook(() => useCoaching('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ApiError 403 → no retry', async () => {
+    const spy = vi.spyOn(api, 'get').mockRejectedValue(new ApiError(403, 'forbidden', null));
+    const { result } = renderHook(() => useCoaching('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ApiError 404 → no retry', async () => {
+    const spy = vi.spyOn(api, 'get').mockRejectedValue(new ApiError(404, 'not_found', null));
+    const { result } = renderHook(() => useCoaching('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('status=no_disponible se devuelve sin error', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_id: 't1',
+      message: null,
+      focus: null,
+      source: null,
+      status: 'no_disponible',
+      reason: 'pending generation',
+    });
+    const { result } = renderHook(() => useCoaching('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.status).toBe('no_disponible');
+  });
+});
+
+describe('useBehaviorScore', () => {
+  it('default enabled=true → fetch /assignments/:id/behavior-score', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_id: 't1',
+      score: 85,
+      nivel: 'bueno',
+      breakdown: {
+        aceleracionesBruscas: 1,
+        frenadosBruscos: 0,
+        curvasBruscas: 1,
+        excesosVelocidad: 0,
+        penalizacionTotal: 15,
+        eventosPorHora: 2,
+      },
+      calculated_at: '2026-05-10T00:00:00Z',
+      status: 'disponible',
+    });
+    const { result } = renderHook(() => useBehaviorScore('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('/assignments/a1/behavior-score');
+  });
+
+  it('enabled=false → no fetch', () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValue({});
+    renderHook(() => useBehaviorScore('a1', { enabled: false }), { wrapper: makeWrapper() });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('ApiError 401 → no retry', async () => {
+    const spy = vi.spyOn(api, 'get').mockRejectedValue(new ApiError(401, 'unauthorized', null));
+    const { result } = renderHook(() => useBehaviorScore('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ApiError 403 → no retry', async () => {
+    const spy = vi.spyOn(api, 'get').mockRejectedValue(new ApiError(403, 'forbidden', null));
+    const { result } = renderHook(() => useBehaviorScore('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ApiError 404 → no retry', async () => {
+    const spy = vi.spyOn(api, 'get').mockRejectedValue(new ApiError(404, 'not_found', null));
+    const { result } = renderHook(() => useBehaviorScore('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('status=no_disponible se devuelve sin error', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_id: 't1',
+      score: null,
+      nivel: null,
+      breakdown: null,
+      status: 'no_disponible',
+      reason: 'sin telemetria',
+    });
+    const { result } = renderHook(() => useBehaviorScore('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.status).toBe('no_disponible');
+  });
+});

--- a/apps/web/src/hooks/use-offers.test.tsx
+++ b/apps/web/src/hooks/use-offers.test.tsx
@@ -3,7 +3,12 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError, api } from '../lib/api-client.js';
-import { useAcceptOfferMutation, useOffersMine, useRejectOfferMutation } from './use-offers.js';
+import {
+  useAcceptOfferMutation,
+  useEcoPreview,
+  useOffersMine,
+  useRejectOfferMutation,
+} from './use-offers.js';
 
 function makeWrapper() {
   const client = new QueryClient({
@@ -91,5 +96,45 @@ describe('useRejectOfferMutation', () => {
       await result.current.mutateAsync({ offerId: 'o1', reason: 'fuera de zona' });
     });
     expect(spy).toHaveBeenCalledWith('/offers/o1/reject', { reason: 'fuera de zona' });
+  });
+});
+
+describe('useEcoPreview', () => {
+  it('default enabled=false → no fetch', () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValue({});
+    renderHook(() => useEcoPreview('o1'), { wrapper: makeWrapper() });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('enabled=true → fetch /offers/:id/eco-preview', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request_id: 'tr1',
+      distance_km: 100,
+      emisiones_kgco2e_wtw: 50,
+      data_source: 'routes_api',
+    });
+    const { result } = renderHook(() => useEcoPreview('o1', { enabled: true }), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('/offers/o1/eco-preview');
+  });
+
+  it('ApiError 401 → no retry', async () => {
+    const spy = vi.spyOn(api, 'get').mockRejectedValue(new ApiError(401, 'unauthorized', null));
+    const { result } = renderHook(() => useEcoPreview('o1', { enabled: true }), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ApiError 403 → no retry', async () => {
+    const spy = vi.spyOn(api, 'get').mockRejectedValue(new ApiError(403, 'forbidden', null));
+    const { result } = renderHook(() => useEcoPreview('o1', { enabled: true }), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -41,13 +41,9 @@ export default defineConfig({
         // — testeables sólo con Playwright e2e contra build real.
         'src/components/map/**',
         'src/components/chat/ChatPanel.tsx',
-        'src/components/chat/PushSubscribeBanner.tsx',
         'src/components/profile/AuthProvidersSection.tsx',
-        'src/components/profile/ProfileForm.tsx',
         'src/components/onboarding/OnboardingForm.tsx',
         'src/components/map/**',
-        'src/components/offers/OfferCard.tsx',
-        'src/components/Layout.tsx', // navbar + dropdowns Tanstack Router; e2e
         // Hooks que sólo tienen sentido in-browser (SSE EventSource, telemetría).
         'src/hooks/use-chat-stream.ts',
         'src/hooks/use-chat-messages.ts',


### PR DESCRIPTION
## Resumen

Web coverage **87% → 97% lines / 77% → 93% branches / 84% → 96% functions** cubriendo:
- Hooks nuevos de Phase 2/3 (use-behavior-score, useEcoPreview)
- 4 components antes excluidos del gate (Layout, PushSubscribeBanner, OfferCard, ProfileForm)
- Gaps de CompanySwitcher (78% → 100%) y BehaviorScoreCard (0% → 100%)

Tests web: **200 → 299 (+99)**.

## Cambios

| Archivo | Tests | Cobertura |
|---------|-------|-----------|
| `use-behavior-score.test.tsx` | 12 nuevos | 0% → 100% |
| `use-offers.test.tsx` | +4 (useEcoPreview) | 68% → 100% |
| `BehaviorScoreCard.test.tsx` | 14 nuevos | 0% → 100% |
| `CompanySwitcher.test.tsx` | +9 (roleLabel + click outside + disabled) | 78% → 100% |
| `Layout.test.tsx` | +5 (mobile menu + signOut + switchEmpresa) | excluido → 100% |
| `PushSubscribeBanner.test.tsx` | 11 nuevos | excluido → 100% |
| `OfferCard.test.tsx` | 29 nuevos | excluido → 100% |
| `ProfileForm.test.tsx` | 15 nuevos | excluido → 100% |

## Excludes removidos en vitest.config.ts
- `src/components/Layout.tsx`
- `src/components/chat/PushSubscribeBanner.tsx`
- `src/components/offers/OfferCard.tsx`
- `src/components/profile/ProfileForm.tsx`

## Excludes restantes (delegados a Playwright e2e)

- `TwoFactorSection`, `two-factor.ts` — Firebase Phone Auth + reCAPTCHA
- `AuthProvidersSection` — Firebase OAuth provider linking
- `OnboardingForm` — 673 líneas, multi-step form complejo
- `ChatPanel`, `use-chat-stream`, `use-chat-messages` — SSE EventSource
- `components/map/**` — Google Maps API
- `routes/**` — TanStack Router con lazy + form complejos
- `firebase.ts` — initializeApp side-effects
- `main.tsx`, `router.tsx`, `sw.ts` — bootstrap

## Test plan

- [x] \`pnpm lint\` verde (0 errores, 0 warnings)
- [x] \`pnpm typecheck\` verde (29/29 paquetes)
- [x] \`pnpm --filter @booster-ai/web test:coverage\` verde con threshold 80%
- [ ] CI: 14 checks SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)