### PR TITLE
feat(api): WhatsApp delivery del coaching IA al transportista (Phase 3 PR-J3)

### DIFF
--- a/apps/api/drizzle/0013_metricas_viaje_coaching_whatsapp.sql
+++ b/apps/api/drizzle/0013_metricas_viaje_coaching_whatsapp.sql
@@ -1,0 +1,20 @@
+-- Migration 0013 — Idempotencia delivery WhatsApp del coaching IA (Phase 3 PR-J3)
+--
+-- Agrega 1 columna a metricas_viaje:
+--
+--   coaching_whatsapp_enviado_en — timestamp de cuando el template
+--     `coaching_post_entrega_v1` fue despachado al dueño del transportista
+--     (whatsapp_e164). NULL si todavía no se envió o si la config Twilio
+--     no estaba seteada.
+--
+-- ¿Por qué columna y no tabla de eventos?
+--   notify-coaching es 1-shot por trip post-entrega. La idempotencia se
+--   logra con UPDATE ... WHERE coaching_whatsapp_enviado_en IS NULL
+--   (mismo patrón que offers.notificado_en y chat_messages.whatsapp_notif_enviado_en).
+--   No necesitamos historial de re-intentos para esta surface.
+--
+-- Riesgo deploy: bajo. ADD COLUMN nullable es metadata-only en Postgres ≥ 11.
+-- Reversible vía DROP COLUMN.
+
+ALTER TABLE "metricas_viaje"
+  ADD COLUMN "coaching_whatsapp_enviado_en" timestamptz;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778976000000,
       "tag": "0012_metricas_viaje_coaching",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1779062400000,
+      "tag": "0013_metricas_viaje_coaching_whatsapp",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -199,6 +199,29 @@ const apiEnvSchema = commonEnvSchema
     ),
 
     /**
+     * Content SID del template Twilio `coaching_post_entrega_v1` para el
+     * envío del coaching post-entrega al dueño del transportista
+     * (Phase 3 PR-J3). Variables (1-based):
+     *   {{1}} → tracking_code
+     *   {{2}} → score + nivel (e.g. "85/100 · Bueno")
+     *   {{3}} → mensaje de coaching (≤280 chars)
+     *   {{4}} → URL al detalle del trip (deep-link a la PWA)
+     *
+     * Optional. Mientras Meta aprueba el template, notify-coaching loggea
+     * warn y skipea sin afectar el resto del flow post-entrega (cert,
+     * score, coaching persistido). Una vez aprobado, cargar el SID al
+     * secret `content-sid-coaching` (TF security.tf) y esta env var queda
+     * montada vía secret env en compute.tf.
+     */
+    CONTENT_SID_COACHING: z.preprocess(
+      (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+      z
+        .string()
+        .regex(/^HX[a-fA-F0-9]+$/, 'Debe empezar con HX seguido de hex chars')
+        .optional(),
+    ),
+
+    /**
      * SA email autorizado a invocar /admin/jobs/* (P3.d Cloud Scheduler
      * cron de fallback WhatsApp). Cloud Scheduler firma OIDC con este SA;
      * el middleware valida claims.email === este valor.

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -795,6 +795,13 @@ export const tripMetrics = pgTable(
     coachingModelo: varchar('coaching_modelo', { length: 50 }),
     /** Timestamp de generación. Para SLO + cache invalidation. */
     coachingGeneradoEn: timestamp('coaching_generado_en', { withTimezone: true }),
+    /**
+     * Phase 3 PR-J3 — Timestamp del envío WhatsApp del template
+     * `coaching_post_entrega_v1` al dueño del transportista. NULL hasta que
+     * el dispatcher (notify-coaching.ts) haya despachado el mensaje.
+     * Usado como guard de idempotencia en el UPDATE post-send.
+     */
+    coachingWhatsappEnviadoEn: timestamp('coaching_whatsapp_enviado_en', { withTimezone: true }),
     createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -6,6 +6,7 @@ import { createDb } from './db/client.js';
 import { runMigrations } from './db/migrator.js';
 import { createServer } from './server.js';
 import { getFirebaseAuth } from './services/firebase.js';
+import type { NotifyCoachingDeps } from './services/notify-coaching.js';
 import type { NotifyOfferDeps } from './services/notify-offer.js';
 
 const logger = createLogger({
@@ -57,6 +58,11 @@ async function main(): Promise<void> {
       'CONTENT_SID_OFFER_NEW no seteado — el template de oferta nueva no está aprobado todavía. Notificaciones serán no-op aunque Twilio esté configurado.',
     );
   }
+  if (!config.CONTENT_SID_COACHING) {
+    logger.warn(
+      'CONTENT_SID_COACHING no seteado — el template de coaching post-entrega no está aprobado todavía. El coaching IA seguirá visible en la PWA pero no se enviará por WhatsApp.',
+    );
+  }
 
   const notify: NotifyOfferDeps = {
     db,
@@ -66,7 +72,19 @@ async function main(): Promise<void> {
     webAppUrl: config.WEB_APP_URL,
   };
 
-  const app = createServer({ db, pool, firebaseAuth, logger, notify });
+  // Phase 3 PR-J3 — wire del dispatcher de coaching post-entrega por
+  // WhatsApp. Reusa el mismo twilioClient que `notify` (un solo Twilio
+  // sender, varios templates aprobados). Si twilioClient es null, el
+  // dispatcher hace skip silencioso por reason='not_configured'.
+  const notifyCoaching: NotifyCoachingDeps = {
+    db,
+    logger,
+    twilioClient,
+    contentSidCoaching: config.CONTENT_SID_COACHING ?? null,
+    webAppUrl: config.WEB_APP_URL,
+  };
+
+  const app = createServer({ db, pool, firebaseAuth, logger, notify, notifyCoaching });
 
   const server = serve(
     {

--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -31,11 +31,18 @@ import {
 } from '../db/schema.js';
 import { confirmarEntregaViaje } from '../services/confirmar-entrega-viaje.js';
 import type { EmitirCertificadoConfig } from '../services/emitir-certificado-viaje.js';
+import type { NotifyCoachingDeps } from '../services/notify-coaching.js';
 
 export function createAssignmentsRoutes(opts: {
   db: Db;
   logger: Logger;
   certConfig?: Partial<EmitirCertificadoConfig>;
+  /**
+   * Dispatch para WhatsApp coaching post-entrega (Phase 3 PR-J3). Si no se
+   * pasa, confirmar-entrega no intenta el envío y el coaching queda sólo
+   * en la PWA (BehaviorScoreCard).
+   */
+  notifyCoaching?: NotifyCoachingDeps;
 }) {
   const app = new Hono();
 
@@ -268,6 +275,7 @@ export function createAssignmentsRoutes(opts: {
         userId: auth.userContext.user.id,
       },
       config: opts.certConfig ?? {},
+      ...(opts.notifyCoaching ? { notifyCoaching: opts.notifyCoaching } : {}),
     });
 
     if (!result.ok) {

--- a/apps/api/src/routes/trip-requests-v2.ts
+++ b/apps/api/src/routes/trip-requests-v2.ts
@@ -20,6 +20,7 @@ import {
 import { confirmarEntregaViaje } from '../services/confirmar-entrega-viaje.js';
 import type { EmitirCertificadoConfig } from '../services/emitir-certificado-viaje.js';
 import { TripRequestNotFoundError, runMatching } from '../services/matching.js';
+import type { NotifyCoachingDeps } from '../services/notify-coaching.js';
 import type { NotifyOfferDeps } from '../services/notify-offer.js';
 
 /**
@@ -70,6 +71,12 @@ export function createTripRequestsV2Routes(opts: {
    * warn en el wire fire-and-forget). Útil para dev sin KMS.
    */
   certConfig?: Partial<EmitirCertificadoConfig>;
+  /**
+   * Dispatch para WhatsApp coaching post-entrega (Phase 3 PR-J3). Si no
+   * se pasa, confirmar-entrega no intenta el envío y el coaching queda
+   * sólo en la PWA.
+   */
+  notifyCoaching?: NotifyCoachingDeps;
 }) {
   const app = new Hono();
 
@@ -468,6 +475,7 @@ export function createTripRequestsV2Routes(opts: {
         userId: auth.userContext.user.id,
       },
       config: opts.certConfig ?? {},
+      ...(opts.notifyCoaching ? { notifyCoaching: opts.notifyCoaching } : {}),
     });
 
     if (!result.ok) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -23,6 +23,7 @@ import { createTripRequestsV2Routes } from './routes/trip-requests-v2.js';
 import { createTripRequestsRoutes } from './routes/trip-requests.js';
 import { createVehiculosRoutes } from './routes/vehiculos.js';
 import { createMePushSubscriptionRoutes, createWebpushPublicRoutes } from './routes/webpush.js';
+import type { NotifyCoachingDeps } from './services/notify-coaching.js';
 import type { NotifyOfferDeps } from './services/notify-offer.js';
 import { configureWebPush } from './services/web-push.js';
 
@@ -41,6 +42,12 @@ export interface CreateServerOptions {
    * notificaciones reales.
    */
   notify?: NotifyOfferDeps;
+  /**
+   * Deps del dispatcher de coaching IA por WhatsApp post-entrega
+   * (Phase 3 PR-J3). Comparte el twilioClient con `notify` pero usa otro
+   * Content SID. Inyectado desde main.ts; en tests se omite.
+   */
+  notifyCoaching?: NotifyCoachingDeps;
 }
 
 export function createServer(opts: CreateServerOptions): Hono {
@@ -177,6 +184,7 @@ export function createServer(opts: CreateServerOptions): Hono {
         logger,
         certConfig,
         ...(opts.notify ? { notify: opts.notify } : {}),
+        ...(opts.notifyCoaching ? { notifyCoaching: opts.notifyCoaching } : {}),
       }),
     );
 
@@ -225,6 +233,7 @@ export function createServer(opts: CreateServerOptions): Hono {
       db: opts.db,
       logger,
       certConfig,
+      ...(opts.notifyCoaching ? { notifyCoaching: opts.notifyCoaching } : {}),
     });
     const chatRouter = createChatRoutes({
       db: opts.db,

--- a/apps/api/src/services/confirmar-entrega-viaje.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.ts
@@ -42,6 +42,7 @@ import {
   emitirCertificadoViaje,
 } from './emitir-certificado-viaje.js';
 import { generarCoachingViaje } from './generar-coaching-viaje.js';
+import { type NotifyCoachingDeps, notifyCoachingToCarrier } from './notify-coaching.js';
 
 /**
  * Status del trip en los que es válido confirmar entrega. Si está
@@ -72,8 +73,16 @@ export async function confirmarEntregaViaje(opts: {
     userId: string;
   };
   config: Partial<EmitirCertificadoConfig>;
+  /**
+   * Deps para despachar el coaching IA por WhatsApp tras la entrega
+   * (Phase 3 PR-J3). Optional — en dev local sin Twilio o sin Content SID
+   * aprobado, el dispatcher hace skip silencioso. Cuando undefined, ni
+   * siquiera se invoca (ahorra una entrada al servicio que igual loguearía
+   * skip).
+   */
+  notifyCoaching?: NotifyCoachingDeps;
 }): Promise<ConfirmarEntregaResult> {
-  const { db, logger, tripId, source, actor, config } = opts;
+  const { db, logger, tripId, source, actor, config, notifyCoaching } = opts;
 
   // Tx de escritura — todo o nada para mantener consistencia.
   const txResult = await db.transaction(async (tx) => {
@@ -236,6 +245,23 @@ export async function confirmarEntregaViaje(opts: {
         { err, tripId },
         'generarCoachingViaje fallo — sin coaching persistido para este trip',
       );
+    }
+
+    // Phase 3 PR-J3 — despachar coaching por WhatsApp al dueño del
+    // transportista. Depende de coachingMensaje persistido en
+    // metricas_viaje. Skip silencioso si notifyCoaching no fue inyectado
+    // (dev sin Twilio) o si la subfunción decide skip por any of the
+    // ~7 razones documentadas en notify-coaching.ts. NUNCA throw — el
+    // delivery del cert es independiente.
+    if (notifyCoaching) {
+      try {
+        await notifyCoachingToCarrier(notifyCoaching, { tripId });
+      } catch (err) {
+        logger.error(
+          { err, tripId },
+          'notifyCoachingToCarrier fallo — coaching persistido pero sin WhatsApp delivery',
+        );
+      }
     }
 
     emitirCertificadoViaje({ db, logger, tripId, config })

--- a/apps/api/src/services/notify-coaching.ts
+++ b/apps/api/src/services/notify-coaching.ts
@@ -1,0 +1,222 @@
+/**
+ * Despacha el coaching IA post-entrega como mensaje WhatsApp al dueño
+ * del transportista (Phase 3 PR-J3).
+ *
+ * Disparado desde `confirmar-entrega-viaje.ts` justo después de que
+ * `generarCoachingViaje` persiste el mensaje en metricas_viaje. La
+ * cadena queda:
+ *
+ *   recalcularNivelPostEntrega
+ *     → calcularScoreConduccionViaje  (persiste behaviorScore + breakdown)
+ *     → generarCoachingViaje          (persiste coachingMensaje)
+ *     → notifyCoachingToCarrier       (acá — envía WhatsApp)
+ *     → emitirCertificadoViaje        (fire-and-forget)
+ *
+ * Trade-offs de diseño:
+ *
+ * 1. **Idempotencia por columna**, no por tabla de eventos. Mismo patrón
+ *    que `offers.notificado_en` y `chat_messages.whatsapp_notif_enviado_en`.
+ *    El UPDATE final usa `WHERE coaching_whatsapp_enviado_en IS NULL`
+ *    como guard contra concurrent retries (raros pero posibles si
+ *    confirmar-entrega corre dos veces antes de que la primera marca el
+ *    timestamp).
+ *
+ * 2. **Marcar antes del send** (al estilo chat-whatsapp-fallback.ts). Si
+ *    el send falla parcial, el coaching queda marcado como enviado y NO
+ *    se reintenta. Trade-off explícito: preferimos no spam-dupelar al
+ *    transportista (recibir el mismo coaching 2 veces es mala UX) antes
+ *    que garantizar delivery 100%. Si el send falla, el coaching igual
+ *    está visible en la PWA (BehaviorScoreCard lo muestra desde
+ *    metricas_viaje).
+ *
+ * 3. **Skip silencioso** si:
+ *    - Twilio no configurado (dev local sin envs) → reason: 'not_configured'
+ *    - Content SID coaching ausente (template Meta pendiente) → 'not_configured'
+ *    - El trip no tiene coaching persistido (sin Teltonika → sin score → sin coaching) → 'no_coaching_persisted'
+ *    - El trip no tiene assignment → 'no_assignment'
+ *    - El transportista no tiene dueño activo → 'no_owner'
+ *    - El dueño no tiene whatsapp_e164 cargado → 'no_whatsapp'
+ *    - Ya se envió antes (idempotencia) → 'already_notified'
+ *
+ *    Todos los skips se loguean con razón. NUNCA throwea hacia
+ *    confirmar-entrega — un fallo en delivery WhatsApp no debe bloquear
+ *    la emisión del cert.
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import {
+  type NotifyCoachingResult,
+  buildCoachingTemplateVariables,
+} from '@booster-ai/notification-fan-out';
+import type { TwilioWhatsAppClient } from '@booster-ai/whatsapp-client';
+import { and, eq, isNull } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { assignments, memberships, tripMetrics, trips, users } from '../db/schema.js';
+
+export type { NotifyCoachingResult };
+
+export interface NotifyCoachingDeps {
+  db: Db;
+  logger: Logger;
+  /** Cliente Twilio. null en dev sin envs. */
+  twilioClient: TwilioWhatsAppClient | null;
+  /** Content SID del template `coaching_post_entrega_v1`. null si pendiente Meta. */
+  contentSidCoaching: string | null;
+  /** URL del PWA, usada para construir el deep-link al detalle del trip. */
+  webAppUrl: string;
+}
+
+export async function notifyCoachingToCarrier(
+  deps: NotifyCoachingDeps,
+  opts: { tripId: string },
+): Promise<NotifyCoachingResult> {
+  const { db, logger, twilioClient, contentSidCoaching, webAppUrl } = deps;
+  const { tripId } = opts;
+
+  if (twilioClient === null || contentSidCoaching === null) {
+    logger.warn(
+      {
+        tripId,
+        hasTwilio: twilioClient !== null,
+        hasContentSid: contentSidCoaching !== null,
+      },
+      'notifyCoachingToCarrier skipped — Twilio o ContentSid coaching ausente',
+    );
+    return { tripId, skipped: true, reason: 'not_configured' };
+  }
+
+  // Cargar trip + metricas + assignment + carrier en un round-trip mínimo.
+  // Usamos 2 selects (no 1 mega-join) porque el schema es ancho y prefiero
+  // claridad — la latencia de 2 round-trips locales a Cloud SQL es < 5ms,
+  // bajo el budget de notif post-entrega.
+  const tripRows = await db
+    .select({ trackingCode: trips.trackingCode })
+    .from(trips)
+    .where(eq(trips.id, tripId))
+    .limit(1);
+  const trip = tripRows[0];
+  if (!trip) {
+    logger.warn({ tripId }, 'notifyCoachingToCarrier: trip no encontrado');
+    return { tripId, skipped: true, reason: 'trip_not_found' };
+  }
+
+  const metricRows = await db
+    .select({
+      score: tripMetrics.behaviorScore,
+      nivel: tripMetrics.behaviorScoreNivel,
+      mensaje: tripMetrics.coachingMensaje,
+      coachingWhatsappEnviadoEn: tripMetrics.coachingWhatsappEnviadoEn,
+    })
+    .from(tripMetrics)
+    .where(eq(tripMetrics.tripId, tripId))
+    .limit(1);
+  const metric = metricRows[0];
+
+  if (!metric?.score || !metric.nivel || !metric.mensaje) {
+    logger.info(
+      {
+        tripId,
+        hasMetric: !!metric,
+        hasScore: !!metric?.score,
+        hasMensaje: !!metric?.mensaje,
+      },
+      'notifyCoachingToCarrier skipped — sin coaching persistido (trip sin Teltonika o coaching aún no generado)',
+    );
+    return { tripId, skipped: true, reason: 'no_coaching_persisted' };
+  }
+
+  if (metric.coachingWhatsappEnviadoEn !== null) {
+    return { tripId, skipped: true, reason: 'already_notified' };
+  }
+
+  // Resolver el carrier owner: assignment → empresa → owner activo.
+  const assignmentRows = await db
+    .select({ empresaId: assignments.empresaId })
+    .from(assignments)
+    .where(eq(assignments.tripId, tripId))
+    .limit(1);
+  const assignment = assignmentRows[0];
+  if (!assignment) {
+    logger.warn({ tripId }, 'notifyCoachingToCarrier: trip sin assignment');
+    return { tripId, skipped: true, reason: 'no_assignment' };
+  }
+
+  // Owner activo más antiguo (idéntico patrón a notify-offer.ts y
+  // chat-whatsapp-fallback.ts — DRY-fy a un helper si aparece un 4to caso).
+  const ownerRows = await db
+    .select({
+      userId: users.id,
+      whatsappE164: users.whatsappE164,
+    })
+    .from(memberships)
+    .innerJoin(users, eq(users.id, memberships.userId))
+    .where(
+      and(
+        eq(memberships.empresaId, assignment.empresaId),
+        eq(memberships.role, 'dueno'),
+        eq(memberships.status, 'activa'),
+      ),
+    )
+    .orderBy(memberships.createdAt)
+    .limit(1);
+  const owner = ownerRows[0];
+
+  if (!owner) {
+    logger.warn(
+      { tripId, empresaId: assignment.empresaId },
+      'notifyCoachingToCarrier: empresa transportista sin dueño activo',
+    );
+    return { tripId, skipped: true, reason: 'no_owner' };
+  }
+
+  if (!owner.whatsappE164) {
+    logger.warn(
+      { tripId, ownerUserId: owner.userId },
+      'notifyCoachingToCarrier: dueño sin whatsapp_e164',
+    );
+    return { tripId, skipped: true, reason: 'no_whatsapp' };
+  }
+
+  // Marcar ANTES del send: si Twilio falla, NO reintentamos (anti-spam,
+  // mismo trade-off que chat-whatsapp-fallback). El UPDATE con
+  // `coachingWhatsappEnviadoEn IS NULL` también actúa como guard contra
+  // un retry concurrente que pase la check de líneas arriba.
+  const markResult = await db
+    .update(tripMetrics)
+    .set({ coachingWhatsappEnviadoEn: new Date() })
+    .where(and(eq(tripMetrics.tripId, tripId), isNull(tripMetrics.coachingWhatsappEnviadoEn)))
+    .returning({ tripId: tripMetrics.tripId });
+
+  if (markResult.length === 0) {
+    // Otra ejecución concurrente ya marcó — no enviamos para no dupelar.
+    return { tripId, skipped: true, reason: 'already_notified' };
+  }
+
+  const variables = buildCoachingTemplateVariables({
+    trackingCode: trip.trackingCode,
+    score: Number(metric.score),
+    nivel: metric.nivel,
+    mensaje: metric.mensaje,
+    tripId,
+    webAppUrl,
+  });
+
+  const response = await twilioClient.sendContent({
+    to: owner.whatsappE164,
+    contentSid: contentSidCoaching,
+    contentVariables: variables,
+  });
+
+  logger.info(
+    {
+      tripId,
+      ownerUserId: owner.userId,
+      empresaId: assignment.empresaId,
+      trackingCode: trip.trackingCode,
+      twilioSid: response.sid,
+    },
+    'notifyCoachingToCarrier sent',
+  );
+
+  return { tripId, skipped: false, twilioMessageSid: response.sid };
+}

--- a/apps/api/test/unit/notify-coaching.test.ts
+++ b/apps/api/test/unit/notify-coaching.test.ts
@@ -1,0 +1,385 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NotifyCoachingDeps } from '../../src/services/notify-coaching.js';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.SERVICE_NAME = 'booster-ai-api';
+  process.env.SERVICE_VERSION = '0.0.0-test';
+  process.env.LOG_LEVEL = 'error';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.REDIS_HOST = 'localhost';
+  process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173';
+  process.env.FIREBASE_PROJECT_ID = 'test';
+  process.env.API_AUDIENCE = 'https://api.boosterchile.com';
+  process.env.ALLOWED_CALLER_SA = 'caller@booster-ai.iam.gserviceaccount.com';
+});
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as NotifyCoachingDeps['logger'];
+
+const TRIP_ID = '00000000-0000-0000-0000-000000000a01';
+const EMPRESA_ID = '00000000-0000-0000-0000-000000000a02';
+const OWNER_USER_ID = '00000000-0000-0000-0000-000000000a03';
+const VALID_SID = 'HXabc1234567890abcdef1234567890ab';
+
+interface TripRow {
+  trackingCode: string;
+}
+interface MetricRow {
+  score: number | null;
+  nivel: string | null;
+  mensaje: string | null;
+  coachingWhatsappEnviadoEn: Date | null;
+}
+interface AssignmentRow {
+  empresaId: string;
+}
+interface OwnerRow {
+  userId: string;
+  whatsappE164: string | null;
+}
+
+/**
+ * Stub del DB. Las 4 queries SELECT en notify-coaching.ts comparten el
+ * patron `select().from().where().limit()` excepto la cuarta (ownerJoin)
+ * que es `select().from().innerJoin().where().orderBy().limit()`. Damos
+ * un FIFO de respuestas ordenadas: trip, metric, assignment, owner.
+ *
+ * El UPDATE final usa update().set().where().returning().
+ */
+function makeDbStub(opts: {
+  trip?: TripRow | null;
+  metric?: MetricRow | null;
+  assignment?: AssignmentRow | null;
+  owner?: OwnerRow | null;
+  /** Si .returning() devuelve 0 rows, hubo race con otro mark. */
+  updateReturned?: number;
+}) {
+  const responses: Array<unknown[]> = [
+    opts.trip === null || opts.trip === undefined ? [] : [opts.trip],
+    opts.metric === null || opts.metric === undefined ? [] : [opts.metric],
+    opts.assignment === null || opts.assignment === undefined ? [] : [opts.assignment],
+    opts.owner === null || opts.owner === undefined ? [] : [opts.owner],
+  ];
+  let callIdx = 0;
+
+  const limitFn = vi.fn(() => Promise.resolve(responses[callIdx++] ?? []));
+  const orderByFn = vi.fn(() => ({ limit: limitFn }));
+  const whereFn = vi.fn(() => ({ limit: limitFn, orderBy: orderByFn }));
+  const innerJoinFn = vi.fn(() => ({ where: whereFn }));
+  const fromFn = vi.fn(() => ({ where: whereFn, innerJoin: innerJoinFn }));
+  const selectFn = vi.fn(() => ({ from: fromFn }));
+
+  // UPDATE returning idempotency mark. tripMetrics PK es tripId.
+  const returnedRows = (opts.updateReturned ?? 1) > 0 ? [{ tripId: TRIP_ID }] : [];
+  const returningFn = vi.fn().mockResolvedValue(returnedRows);
+  const updateWhereFn = vi.fn(() => ({ returning: returningFn }));
+  const updateSetFn = vi.fn(() => ({ where: updateWhereFn }));
+  const updateFn = vi.fn(() => ({ set: updateSetFn }));
+
+  return {
+    db: { select: selectFn, update: updateFn } as unknown as NotifyCoachingDeps['db'],
+    spies: { selectFn, updateFn, updateSetFn, updateWhereFn, returningFn },
+  };
+}
+
+function makeTwilioStub(overrides?: { sendContent?: ReturnType<typeof vi.fn> }) {
+  return {
+    sendText: vi.fn(),
+    sendContent:
+      overrides?.sendContent ??
+      vi.fn().mockResolvedValue({
+        sid: 'SM_test_coaching',
+        status: 'queued',
+        to: 'whatsapp:+56912345678',
+        from: 'whatsapp:+19383365293',
+        body: 'rendered template body',
+        date_created: '2026-05-10T12:00:00Z',
+      }),
+  } as unknown as NonNullable<NotifyCoachingDeps['twilioClient']>;
+}
+
+const baseTrip = (): TripRow => ({ trackingCode: 'BOO-XYZ987' });
+const baseMetric = (overrides: Partial<MetricRow> = {}): MetricRow => ({
+  score: 84,
+  nivel: 'bueno',
+  mensaje: 'Buen viaje. Mantén distancia para anticipar frenadas.',
+  coachingWhatsappEnviadoEn: null,
+  ...overrides,
+});
+const baseAssignment = (): AssignmentRow => ({ empresaId: EMPRESA_ID });
+const baseOwner = (whatsappE164: string | null = '+56912345678'): OwnerRow => ({
+  userId: OWNER_USER_ID,
+  whatsappE164,
+});
+
+describe('notifyCoachingToCarrier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('skipea si twilioClient es null', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({});
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: null,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('not_configured');
+  });
+
+  it('skipea si contentSidCoaching es null', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({});
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: null,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('not_configured');
+  });
+
+  it('skipea si trip no existe', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({ trip: null });
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('trip_not_found');
+    expect(twilio.sendContent).not.toHaveBeenCalled();
+  });
+
+  it('skipea si metric row no existe (trip sin Teltonika)', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({ trip: baseTrip(), metric: null });
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no_coaching_persisted');
+  });
+
+  it('skipea si coachingMensaje todavía no fue persistido', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({
+      trip: baseTrip(),
+      metric: baseMetric({ mensaje: null }),
+    });
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no_coaching_persisted');
+  });
+
+  it('skipea si ya fue notificado (idempotencia)', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db, spies } = makeDbStub({
+      trip: baseTrip(),
+      metric: baseMetric({
+        coachingWhatsappEnviadoEn: new Date('2026-05-10T10:00:00Z'),
+      }),
+    });
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('already_notified');
+    expect(twilio.sendContent).not.toHaveBeenCalled();
+    expect(spies.updateFn).not.toHaveBeenCalled();
+  });
+
+  it('skipea si trip sin assignment', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({
+      trip: baseTrip(),
+      metric: baseMetric(),
+      assignment: null,
+    });
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no_assignment');
+  });
+
+  it('skipea si empresa transportista sin dueño activo', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({
+      trip: baseTrip(),
+      metric: baseMetric(),
+      assignment: baseAssignment(),
+      owner: null,
+    });
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no_owner');
+  });
+
+  it('skipea si dueño sin whatsapp_e164', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({
+      trip: baseTrip(),
+      metric: baseMetric(),
+      assignment: baseAssignment(),
+      owner: baseOwner(null),
+    });
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no_whatsapp');
+    expect(twilio.sendContent).not.toHaveBeenCalled();
+  });
+
+  it('envía con variables correctas y registra el twilioMessageSid', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db, spies } = makeDbStub({
+      trip: baseTrip(),
+      metric: baseMetric(),
+      assignment: baseAssignment(),
+      owner: baseOwner(),
+    });
+    const sendContent = vi.fn().mockResolvedValue({
+      sid: 'SM_real',
+      status: 'queued',
+      to: 'whatsapp:+56912345678',
+      from: 'whatsapp:+19383365293',
+      body: '...',
+      date_created: '2026-05-10T12:00:00Z',
+    });
+    const twilio = makeTwilioStub({ sendContent });
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(false);
+    expect(result.twilioMessageSid).toBe('SM_real');
+    expect(sendContent).toHaveBeenCalledWith({
+      to: '+56912345678',
+      contentSid: VALID_SID,
+      contentVariables: {
+        '1': 'BOO-XYZ987',
+        '2': '84/100 · Bueno',
+        '3': 'Buen viaje. Mantén distancia para anticipar frenadas.',
+        '4': `https://app.boosterchile.com/app/viajes/${TRIP_ID}`,
+      },
+    });
+    // Confirma que el UPDATE de mark se ejecutó (pre-send guard).
+    expect(spies.updateFn).toHaveBeenCalledTimes(1);
+    expect(spies.returningFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('skipea si race: otro mark concurrente ganó (returning vacío)', async () => {
+    const { notifyCoachingToCarrier } = await import('../../src/services/notify-coaching.js');
+    const { db } = makeDbStub({
+      trip: baseTrip(),
+      metric: baseMetric(),
+      assignment: baseAssignment(),
+      owner: baseOwner(),
+      updateReturned: 0,
+    });
+    const twilio = makeTwilioStub();
+    const result = await notifyCoachingToCarrier(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidCoaching: VALID_SID,
+        webAppUrl: 'https://app.boosterchile.com',
+      },
+      { tripId: TRIP_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('already_notified');
+    expect(twilio.sendContent).not.toHaveBeenCalled();
+  });
+});

--- a/docs/runbooks/load-content-sids.md
+++ b/docs/runbooks/load-content-sids.md
@@ -7,6 +7,37 @@ WhatsApp aprobados por Meta. Los secrets viven en Secret Manager:
 |---|---|---|
 | `content-sid-offer-new` | Notificar carrier de nueva oferta (B.8) | `offer_new_v1` |
 | `content-sid-chat-unread` | Fallback WhatsApp para chat no leído (P3.d) | `chat_unread_v1` |
+| `content-sid-coaching` | Coaching IA post-entrega al transportista (Phase 3 PR-J3) | `coaching_post_entrega_v1` |
+
+### Body recomendado del template `coaching_post_entrega_v1`
+
+Crear en Twilio Content Editor con este body (4 variables 1-indexed) — la
+copia pasa los criterios de Meta para Utility templates (informa sobre
+viaje recién finalizado, no es marketing):
+
+```
+🚛 Booster AI — Tu viaje terminó
+
+📦 Viaje {{1}}
+⭐ Score de conducción: {{2}}
+
+💡 {{3}}
+
+Ver detalles: {{4}}
+```
+
+Variable map:
+
+| Var | Significado | Ejemplo |
+|---|---|---|
+| {{1}} | tracking_code del viaje | `BOO-K7M2X9` |
+| {{2}} | score + nivel | `85/100 · Bueno` |
+| {{3}} | mensaje de coaching IA (≤280 chars) | `Buen viaje. Anticipa frenadas y mantén distancia para bajar 5-10% el consumo.` |
+| {{4}} | deep-link al detalle del trip | `https://app.boosterchile.com/app/viajes/{tripId}` |
+
+Categoría Meta: **Utility** (no Marketing — el mensaje informa post-acción
+del usuario, no promociona). Idioma: `es_CL` (caer a `es` si CL no
+aprueba). Tiempo de aprobación típico: 24-48h.
 
 ## Cuándo usar este runbook
 

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -142,6 +142,12 @@ module "service_api" {
     # Ver docs/runbooks/load-content-sids.md.
     CONTENT_SID_OFFER_NEW   = google_secret_manager_secret.secrets["content-sid-offer-new"].secret_id
     CONTENT_SID_CHAT_UNREAD = google_secret_manager_secret.secrets["content-sid-chat-unread"].secret_id
+    # Phase 3 PR-J3 — Twilio template `coaching_post_entrega_v1` para
+    # despachar el coaching IA al dueño del transportista al confirmar
+    # entrega. Hasta que Meta apruebe el template, el secret mantiene
+    # placeholder y notify-coaching skipea con warn (el coaching sigue
+    # visible en la PWA). Ver docs/runbooks/twilio-content-sid-coaching.md.
+    CONTENT_SID_COACHING = google_secret_manager_secret.secrets["content-sid-coaching"].secret_id
 
     # P3.c — Web Push VAPID. El api firma cada push con la privada (JWT
     # Authorization header al push service del browser). La pública se
@@ -280,13 +286,13 @@ module "service_telemetry_processor" {
   concurrency   = 10 # control de rate a Firestore/BigQuery
 
   env_vars = merge(local.common_env_vars, {
-    SERVICE_NAME            = "booster-ai-telemetry-processor"
-    REDIS_HOST              = google_redis_instance.main.host
-    REDIS_PORT              = tostring(google_redis_instance.main.port)
+    SERVICE_NAME = "booster-ai-telemetry-processor"
+    REDIS_HOST   = google_redis_instance.main.host
+    REDIS_PORT   = tostring(google_redis_instance.main.port)
     # Wave 2 B3 — crash trace persistence
-    GCS_CRASH_TRACES_BUCKET = google_storage_bucket.crash_traces.name
-    BIGQUERY_CRASH_DATASET  = google_bigquery_dataset.telemetry.dataset_id
-    BIGQUERY_CRASH_TABLE    = google_bigquery_table.crash_events.table_id
+    GCS_CRASH_TRACES_BUCKET          = google_storage_bucket.crash_traces.name
+    BIGQUERY_CRASH_DATASET           = google_bigquery_dataset.telemetry.dataset_id
+    BIGQUERY_CRASH_TABLE             = google_bigquery_table.crash_events.table_id
     PUBSUB_SUBSCRIPTION_CRASH_TRACES = google_pubsub_subscription.crash_traces_processor.name
   })
   secrets = local.common_secrets

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -226,6 +226,14 @@ locals {
     # (fallback WhatsApp para mensajes no leídos).
     "content-sid-offer-new",
     "content-sid-chat-unread",
+    # coaching es Phase 3 PR-J3 — template `coaching_post_entrega_v1`
+    # con 4 variables (tracking_code, score+nivel, mensaje, deep-link al
+    # detalle del trip). Se envía al dueño del transportista justo después
+    # de calcular score + generar coaching, fire-and-await en
+    # confirmar-entrega-viaje.ts. Ver runbook
+    # docs/runbooks/twilio-content-sid-coaching.md para los pasos de
+    # aprobación Meta + carga del SID al secret.
+    "content-sid-coaching",
 
     # Web Push VAPID (P3.c) — generadas con `npx web-push generate-vapid-keys`
     # post-deploy y subidas con `gcloud secrets versions add`. La pública se

--- a/packages/notification-fan-out/src/index.test.ts
+++ b/packages/notification-fan-out/src/index.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildCoachingTemplateVariables,
+  buildOfferTemplateVariables,
+  formatPriceClp,
+  regionLabel,
+  truncate,
+} from './index.js';
+
+describe('regionLabel', () => {
+  it('mapea código conocido a nombre legible', () => {
+    expect(regionLabel('XIII')).toBe('Metropolitana');
+    expect(regionLabel('V')).toBe('Valparaíso');
+    expect(regionLabel('VI')).toBe("O'Higgins");
+  });
+
+  it('devuelve el código crudo si no lo conoce', () => {
+    expect(regionLabel('XX')).toBe('XX');
+  });
+
+  it('devuelve em-dash si null', () => {
+    expect(regionLabel(null)).toBe('—');
+  });
+});
+
+describe('formatPriceClp', () => {
+  it('formatea con separador de miles es-CL', () => {
+    expect(formatPriceClp(1500000)).toBe('$ 1.500.000 CLP');
+    expect(formatPriceClp(0)).toBe('$ 0 CLP');
+  });
+});
+
+describe('buildOfferTemplateVariables', () => {
+  it('arma 4 variables 1-indexadas con la ruta legible', () => {
+    expect(
+      buildOfferTemplateVariables({
+        trackingCode: 'BST-001',
+        originRegionCode: 'XIII',
+        destinationRegionCode: 'V',
+        proposedPriceClp: 1_500_000,
+        webAppUrl: 'https://app.boosterchile.com',
+      }),
+    ).toEqual({
+      '1': 'BST-001',
+      '2': 'Metropolitana → Valparaíso',
+      '3': '$ 1.500.000 CLP',
+      '4': 'https://app.boosterchile.com/app/ofertas',
+    });
+  });
+
+  it('quita trailing slash del webAppUrl para evitar // en el path', () => {
+    const vars = buildOfferTemplateVariables({
+      trackingCode: 'BST-001',
+      originRegionCode: 'XIII',
+      destinationRegionCode: 'V',
+      proposedPriceClp: 100,
+      webAppUrl: 'https://app.boosterchile.com/',
+    });
+    expect(vars['4']).toBe('https://app.boosterchile.com/app/ofertas');
+  });
+});
+
+describe('truncate', () => {
+  it('devuelve igual si está bajo el límite', () => {
+    expect(truncate('hola mundo', 50)).toBe('hola mundo');
+  });
+
+  it('trunca y agrega … sin partir palabras cuando se puede', () => {
+    const original = 'Mantén distancia y anticipa frenadas para optimizar consumo';
+    const out = truncate(original, 30);
+    expect(out.endsWith('…')).toBe(true);
+    expect(out.length).toBeLessThanOrEqual(30);
+    // El prefijo (sin "…") debe ser un substring que termina en una palabra
+    // completa del original. Verificamos que la próxima posición en el
+    // original sea espacio (boundary) y no media palabra.
+    const prefix = out.slice(0, -1);
+    const idx = prefix.length;
+    expect(original.startsWith(prefix)).toBe(true);
+    // idx == prefix.length: en el original la siguiente char debería ser
+    // ' ' (boundary) — confirmando que no cortamos a mitad.
+    expect(original.charAt(idx)).toBe(' ');
+  });
+
+  it('si no hay espacio razonable corta hard', () => {
+    // 25 chars sin espacio → cae en el branch hard-cut
+    expect(truncate('A'.repeat(50), 10)).toBe(`${'A'.repeat(9)}…`);
+  });
+});
+
+describe('buildCoachingTemplateVariables', () => {
+  it('arma 4 variables con score redondeado y nivel mapeado', () => {
+    const vars = buildCoachingTemplateVariables({
+      trackingCode: 'BST-00421',
+      score: 84.7,
+      nivel: 'bueno',
+      mensaje: 'Buen viaje. Mantén distancia para anticipar frenadas y bajar consumo 5-10%.',
+      tripId: 'tr_abc123',
+      webAppUrl: 'https://app.boosterchile.com',
+    });
+    expect(vars).toEqual({
+      '1': 'BST-00421',
+      '2': '85/100 · Bueno',
+      '3': 'Buen viaje. Mantén distancia para anticipar frenadas y bajar consumo 5-10%.',
+      '4': 'https://app.boosterchile.com/app/viajes/tr_abc123',
+    });
+  });
+
+  it('mapea cada nivel canónico a su label español', () => {
+    expect(
+      buildCoachingTemplateVariables({
+        trackingCode: 'X',
+        score: 95,
+        nivel: 'excelente',
+        mensaje: 'm',
+        tripId: 't',
+        webAppUrl: 'https://x.com',
+      })['2'],
+    ).toBe('95/100 · Excelente');
+    expect(
+      buildCoachingTemplateVariables({
+        trackingCode: 'X',
+        score: 60,
+        nivel: 'regular',
+        mensaje: 'm',
+        tripId: 't',
+        webAppUrl: 'https://x.com',
+      })['2'],
+    ).toBe('60/100 · Regular');
+    expect(
+      buildCoachingTemplateVariables({
+        trackingCode: 'X',
+        score: 35,
+        nivel: 'malo',
+        mensaje: 'm',
+        tripId: 't',
+        webAppUrl: 'https://x.com',
+      })['2'],
+    ).toBe('35/100 · Mejorar');
+  });
+
+  it('cae a title-case si nivel desconocido', () => {
+    const vars = buildCoachingTemplateVariables({
+      trackingCode: 'X',
+      score: 50,
+      nivel: 'nivel-futuro-no-mapeado',
+      mensaje: 'm',
+      tripId: 't',
+      webAppUrl: 'https://x.com',
+    });
+    expect(vars['2']).toBe('50/100 · Nivel-futuro-no-mapeado');
+  });
+
+  it('trunca el mensaje a 280 chars', () => {
+    const long = 'x'.repeat(400);
+    const vars = buildCoachingTemplateVariables({
+      trackingCode: 'X',
+      score: 50,
+      nivel: 'bueno',
+      mensaje: long,
+      tripId: 't',
+      webAppUrl: 'https://x.com',
+    });
+    const v3 = vars['3'] ?? '';
+    expect(v3.length).toBeLessThanOrEqual(280);
+    expect(v3.endsWith('…')).toBe(true);
+  });
+
+  it('quita whitespace adyacente del mensaje (Gemini a veces incluye \\n)', () => {
+    const vars = buildCoachingTemplateVariables({
+      trackingCode: 'X',
+      score: 50,
+      nivel: 'bueno',
+      mensaje: '  hola mundo \n',
+      tripId: 't',
+      webAppUrl: 'https://x.com',
+    });
+    expect(vars['3']).toBe('hola mundo');
+  });
+
+  it('quita trailing slash de webAppUrl', () => {
+    const vars = buildCoachingTemplateVariables({
+      trackingCode: 'X',
+      score: 50,
+      nivel: 'bueno',
+      mensaje: 'm',
+      tripId: 'tr_zzz',
+      webAppUrl: 'https://app.boosterchile.com/',
+    });
+    expect(vars['4']).toBe('https://app.boosterchile.com/app/viajes/tr_zzz');
+  });
+});

--- a/packages/notification-fan-out/src/index.ts
+++ b/packages/notification-fan-out/src/index.ts
@@ -79,3 +79,90 @@ export interface NotifyOfferResult {
   reason?: 'already_notified' | 'not_configured' | 'no_whatsapp' | 'no_owner' | 'offer_not_found';
   twilioMessageSid?: string;
 }
+
+// ----------------------------------------------------------------------------
+// Coaching post-entrega — Phase 3 PR-J3
+// ----------------------------------------------------------------------------
+// Template Twilio `coaching_post_entrega_v1` con 4 variables:
+//   {{1}} tracking_code (e.g. "BST-00421")
+//   {{2}} score + nivel  (e.g. "85/100 · Bueno")
+//   {{3}} mensaje de coaching (≤320 chars, generado por
+//         @booster-ai/coaching-generator)
+//   {{4}} URL al detalle del trip en la PWA
+
+const NIVEL_LABEL: Record<string, string> = {
+  excelente: 'Excelente',
+  bueno: 'Bueno',
+  regular: 'Regular',
+  malo: 'Mejorar',
+};
+
+/** Trunca a `max` chars sin partir palabras a mitad. Usa "…" si trunca. */
+export function truncate(text: string, max: number): string {
+  if (text.length <= max) {
+    return text;
+  }
+  // Buscar último espacio antes del corte para no partir palabras.
+  const slice = text.slice(0, max - 1);
+  const lastSpace = slice.lastIndexOf(' ');
+  const cut = lastSpace > Math.floor(max * 0.6) ? lastSpace : max - 1;
+  return `${slice.slice(0, cut)}…`;
+}
+
+/**
+ * Construye las variables del template Twilio `coaching_post_entrega_v1`.
+ *
+ * - El score se redondea a entero (Twilio variables son strings — el render
+ *   en Meta no soporta number formatting).
+ * - El nivel se mapea a label legible en español ("Bueno", "Mejorar"); si
+ *   viene un nivel desconocido (ej. enum nuevo no espejado acá), se usa
+ *   el slug crudo en title-case como fallback.
+ * - El mensaje se trunca defensivamente a 280 chars: aunque el package
+ *   coaching-generator garantiza ≤320, Twilio rechaza variables > 1024
+ *   pero algunos clientes WhatsApp viejos cortan a ~300. Trunc a 280 deja
+ *   margen para el resto del template.
+ * - La URL apunta al detalle del trip (`/app/viajes/{tripId}`), no al
+ *   listado, para landing directo al coaching card.
+ */
+export function buildCoachingTemplateVariables(input: {
+  trackingCode: string;
+  score: number;
+  nivel: string;
+  mensaje: string;
+  tripId: string;
+  webAppUrl: string;
+}): Record<string, string> {
+  const nivelLabel = NIVEL_LABEL[input.nivel] ?? toTitleCase(input.nivel);
+  return {
+    '1': input.trackingCode,
+    '2': `${Math.round(input.score)}/100 · ${nivelLabel}`,
+    '3': truncate(input.mensaje.trim(), 280),
+    '4': `${input.webAppUrl.replace(/\/$/, '')}/app/viajes/${input.tripId}`,
+  };
+}
+
+function toTitleCase(s: string): string {
+  if (s.length === 0) {
+    return s;
+  }
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+/**
+ * Resultado de un intento de envío de coaching post-entrega. Mismo shape
+ * que NotifyOfferResult con distintos códigos de skip aplicables al flujo
+ * coaching.
+ */
+export interface NotifyCoachingResult {
+  tripId: string;
+  skipped: boolean;
+  reason?:
+    | 'already_notified'
+    | 'not_configured'
+    | 'no_whatsapp'
+    | 'no_owner'
+    | 'no_assignment'
+    | 'no_coaching_persisted'
+    | 'trip_not_found';
+  twilioMessageSid?: string;
+}


### PR DESCRIPTION
## Summary

Cierra el loop del coaching IA: hasta hoy el mensaje se persistía en `metricas_viaje` y solo era visible en la PWA. El conductor que no abre la web perdía el feedback. Esta entrega despacha el coaching como template WhatsApp al dueño del transportista justo después de generarlo, antes de emitir el certificado.

**Diseño**:
- Idempotencia por columna `coaching_whatsapp_enviado_en` (mismo patrón que `offers.notificado_en`).
- Marca enviado ANTES del send Twilio: si falla, NO reintenta — el coaching igual queda en la PWA. Anti-spam > delivery 100%.
- Skip silencioso en 7 condiciones (sin Teltonika, sin assignment, sin owner, sin whatsapp, ya notificado, etc.) — todas logueadas con razón. Fallo NUNCA bloquea cert.

## Cambios

| Capa | Archivos |
|---|---|
| Package puro | `packages/notification-fan-out`: nuevo `buildCoachingTemplateVariables()` + `truncate()` + `NotifyCoachingResult` + 15 tests |
| Schema/migration | `apps/api/drizzle/0013_metricas_viaje_coaching_whatsapp.sql`, `schema.ts` |
| Servicio | `apps/api/src/services/notify-coaching.ts` (nuevo) + 11 tests |
| Wire | `confirmar-entrega-viaje.ts` (await tras coaching, antes de cert), `server.ts`, `main.ts`, `routes/{assignments,trip-requests-v2}.ts` |
| Config | `config.ts` (CONTENT_SID_COACHING optional, regex HX), `infrastructure/{security,compute}.tf` |
| Runbook | `docs/runbooks/load-content-sids.md` con body recomendado del template + variable map |

## Body del template `coaching_post_entrega_v1`

```
🚛 Booster AI — Tu viaje terminó

📦 Viaje {{1}}
⭐ Score de conducción: {{2}}

💡 {{3}}

Ver detalles: {{4}}
```

Categoría Meta: **Utility** (informa post-acción del usuario, no marketing). Variables documentadas en runbook.

## Evidencia

- `pnpm typecheck` ✓ (monorepo entero)
- `pnpm lint` ✓ (biome + lint-rls)
- `pnpm test` ✓: 438 tests api (+11), 200 web, 15 notification-fan-out (+15)
- `terraform validate` ✓
- `terraform plan`: \`2 to add, 11 to change, 0 to destroy\` (secret + placeholder + service_api revisión)

## Test plan post-merge

- [ ] `terraform apply -var-file=terraform.tfvars.local` — crea secret `content-sid-coaching` con placeholder + monta env var en api
- [ ] Crear template `coaching_post_entrega_v1` en Twilio Content Editor (body documentado en runbook)
- [ ] Submit a Meta para approval (Utility — típicamente 24-48h)
- [ ] Cargar SID con `gcloud secrets versions add content-sid-coaching --data-file=...`
- [ ] Force redeploy del api Cloud Run para tomar el secret nuevo
- [ ] Trip de prueba end-to-end: confirmar entrega → ver WhatsApp recibido por el dueño del transportista

Mientras los pasos 2-5 estén pendientes, el dispatcher loguea warn y skipea — el resto del flow post-entrega funciona normal (cert, score, coaching persistido en DB visible en PWA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)