### PR TITLE
feat(web): voice delivery del coaching IA hands-free (Phase 3 PR-J3 v2)

### DIFF
--- a/apps/web/src/components/scoring/BehaviorScoreCard.tsx
+++ b/apps/web/src/components/scoring/BehaviorScoreCard.tsx
@@ -7,6 +7,7 @@ import {
   useBehaviorScore,
   useCoaching,
 } from '../../hooks/use-behavior-score.js';
+import { CoachingVoicePlayer } from './CoachingVoicePlayer.js';
 
 /**
  * Card que muestra el behavior score del trip (Phase 2 PR-I5).
@@ -197,6 +198,11 @@ function CoachingMessage({
         <span className="font-semibold">{sourceLabel}</span>
       </header>
       <p className="text-neutral-800 text-sm leading-snug">{data.message}</p>
+      {/* Phase 3 PR-J3 — voice delivery hands-free. Botón único play/stop
+          + checkbox de auto-play persistido. Si el browser no soporta
+          speechSynthesis (rarísimo), el componente se oculta y queda
+          sólo el texto. */}
+      <CoachingVoicePlayer message={data.message} />
     </section>
   );
 }

--- a/apps/web/src/components/scoring/CoachingVoicePlayer.test.tsx
+++ b/apps/web/src/components/scoring/CoachingVoicePlayer.test.tsx
@@ -1,0 +1,150 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CoachingVoiceController, VoiceState } from '../../services/coaching-voice.js';
+import { CoachingVoicePlayer } from './CoachingVoicePlayer.js';
+
+/**
+ * Stub controller: state observable + spies en play/stop.
+ */
+function makeController(initial: VoiceState = 'idle'): CoachingVoiceController & {
+  spies: { play: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> };
+  emit: (s: VoiceState) => void;
+} {
+  let state: VoiceState = initial;
+  const listeners = new Set<(s: VoiceState) => void>();
+  const play = vi.fn((_text: string) => undefined);
+  const stop = vi.fn();
+  return {
+    play,
+    stop,
+    getState: () => state,
+    subscribe: (l) => {
+      listeners.add(l);
+      l(state);
+      return () => {
+        listeners.delete(l);
+      };
+    },
+    emit: (s: VoiceState) => {
+      state = s;
+      for (const l of listeners) {
+        l(s);
+      }
+    },
+    spies: { play, stop },
+  };
+}
+
+describe('CoachingVoicePlayer', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renderiza botón Escuchar en estado idle', () => {
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="hola" controller={ctrl} />);
+    const btn = screen.getByRole('button', { name: /escuchar coaching/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('click → llama controller.play con el message', () => {
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="Anticipa frenadas." controller={ctrl} />);
+    fireEvent.click(screen.getByRole('button', { name: /escuchar coaching/i }));
+    expect(ctrl.spies.play).toHaveBeenCalledWith('Anticipa frenadas.');
+  });
+
+  it('cambia a Detener cuando state=speaking', () => {
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="hola" controller={ctrl} />);
+    act(() => {
+      ctrl.emit('speaking');
+    });
+    const btn = screen.getByRole('button', { name: /detener reproducción/i });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('click en Detener → controller.stop', () => {
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="hola" controller={ctrl} />);
+    act(() => {
+      ctrl.emit('speaking');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /detener reproducción/i }));
+    expect(ctrl.spies.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it('state=unsupported → componente se oculta', () => {
+    const ctrl = makeController('unsupported');
+    render(<CoachingVoicePlayer message="hola" controller={ctrl} />);
+    expect(screen.queryByTestId('coaching-voice-player')).not.toBeInTheDocument();
+  });
+
+  it('state=error → muestra mensaje degradado', () => {
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="hola" controller={ctrl} />);
+    act(() => {
+      ctrl.emit('error');
+    });
+    expect(screen.getByText(/no se pudo reproducir el audio/i)).toBeInTheDocument();
+  });
+
+  it('checkbox auto-play default OFF cuando localStorage vacío', () => {
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="hola" controller={ctrl} />);
+    const checkbox = screen.getByRole('checkbox', {
+      name: /reproducir automáticamente al terminar viajes/i,
+    });
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('toggle checkbox → persiste en localStorage', () => {
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="hola" controller={ctrl} />);
+    const checkbox = screen.getByRole('checkbox', {
+      name: /reproducir automáticamente al terminar viajes/i,
+    });
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+    expect(window.localStorage.getItem('booster:coaching-voice:autoplay-enabled')).toBe('1');
+
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+    expect(window.localStorage.getItem('booster:coaching-voice:autoplay-enabled')).toBeNull();
+  });
+
+  it('auto-play opt-in: arranca al montar si localStorage flag está', () => {
+    window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="Mantén distancia." controller={ctrl} />);
+    expect(ctrl.spies.play).toHaveBeenCalledWith('Mantén distancia.');
+  });
+
+  it('auto-play OFF: NO arranca al montar', () => {
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="Mantén distancia." controller={ctrl} />);
+    expect(ctrl.spies.play).not.toHaveBeenCalled();
+  });
+
+  it('auto-play con message vacío: NO arranca (defensivo)', () => {
+    window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
+    const ctrl = makeController('idle');
+    render(<CoachingVoicePlayer message="   " controller={ctrl} />);
+    expect(ctrl.spies.play).not.toHaveBeenCalled();
+  });
+
+  it('aria-live region anuncia speaking a screen readers', () => {
+    const ctrl = makeController('idle');
+    const { container } = render(<CoachingVoicePlayer message="hola" controller={ctrl} />);
+    act(() => {
+      ctrl.emit('speaking');
+    });
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live?.textContent).toMatch(/reproduciendo coaching/i);
+  });
+});

--- a/apps/web/src/components/scoring/CoachingVoicePlayer.tsx
+++ b/apps/web/src/components/scoring/CoachingVoicePlayer.tsx
@@ -1,0 +1,145 @@
+import { Pause, Volume2 } from 'lucide-react';
+import { type ChangeEvent, useEffect, useMemo, useState } from 'react';
+import {
+  type CoachingVoiceController,
+  type VoiceState,
+  createCoachingVoice,
+  loadAutoplayPreference,
+  saveAutoplayPreference,
+} from '../../services/coaching-voice.js';
+
+/**
+ * Botón único para reproducir el coaching IA por voz al conductor
+ * (Phase 3 PR-J3, redefinida tras feedback PO — ver
+ * playbooks/002-canal-coaching-voz-no-whatsapp.md).
+ *
+ * **Diseño hands-free**:
+ *   - Un solo botón de acción primaria (Play/Pause). Toggle con tap.
+ *   - Preferencia de auto-play persistida en localStorage. Default OFF
+ *     (mute). Cuando ON, el componente arranca a hablar al montarse —
+ *     útil para que el conductor termine el viaje, abra el detalle, y
+ *     escuche sin tocar nada.
+ *   - Un único checkbox secundario para activar auto-play en futuros
+ *     viajes ("Escuchar automáticamente al terminar viajes"). Visible
+ *     solo cuando el state es 'idle' o 'speaking', no en 'unsupported'.
+ *   - Sin slider de volumen, sin rate, sin elección de voz. Lo decide
+ *     el OS.
+ *
+ * **Degradación**:
+ *   - Si el browser no soporta speechSynthesis (rarísimo en 2026 —
+ *     IE/legacy), el player se oculta. El mensaje sigue visible en
+ *     texto en la `BehaviorScoreCard` parent.
+ *
+ * **Accesibilidad**:
+ *   - aria-pressed refleja state de play.
+ *   - aria-live="polite" anuncia "Reproduciendo coaching" / "Coaching
+ *     terminado" al lector de pantalla, sin interrumpir.
+ */
+
+export interface CoachingVoicePlayerProps {
+  /** Texto del coaching a reproducir. */
+  message: string;
+  /**
+   * Inyectable para tests. Default: createCoachingVoice() singleton
+   * por mount. Tests pueden pasar uno con synth stubeado.
+   */
+  controller?: CoachingVoiceController;
+}
+
+export function CoachingVoicePlayer({ message, controller }: CoachingVoicePlayerProps) {
+  // useMemo evita re-construir el controller en cada render. La función
+  // factory crea su propia instancia de speechSynthesis singleton, así
+  // que dos players en la misma página comparten la cola del browser
+  // (uno cancela al otro al hacer play — comportamiento deseado).
+  const ctrl = useMemo(() => controller ?? createCoachingVoice(), [controller]);
+  const [state, setState] = useState<VoiceState>(ctrl.getState());
+  const [autoplayEnabled, setAutoplayEnabled] = useState(() => loadAutoplayPreference());
+
+  useEffect(() => {
+    return ctrl.subscribe(setState);
+  }, [ctrl]);
+
+  // Auto-play opt-in: al montar con preferencia activa, hablar de inmediato.
+  // No re-disparamos en cada cambio de message — el conductor abrió el
+  // detalle del trip, escuchó una vez, listo. Si quiere repetir, click
+  // manual.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deliberadamente solo al mount
+  useEffect(() => {
+    if (autoplayEnabled && state === 'idle' && message.trim().length > 0) {
+      ctrl.play(message);
+    }
+  }, []);
+
+  if (state === 'unsupported') {
+    // El navegador no soporta TTS. Ocultarse — el texto sigue visible
+    // arriba en la card parent, no perdemos información.
+    return null;
+  }
+
+  const isSpeaking = state === 'speaking';
+  const isError = state === 'error';
+
+  const handleToggle = (): void => {
+    if (isSpeaking) {
+      ctrl.stop();
+    } else {
+      ctrl.play(message);
+    }
+  };
+
+  const handleAutoplayChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    const next = e.target.checked;
+    setAutoplayEnabled(next);
+    saveAutoplayPreference(next);
+  };
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-3" data-testid="coaching-voice-player">
+      <button
+        type="button"
+        onClick={handleToggle}
+        aria-pressed={isSpeaking}
+        aria-label={isSpeaking ? 'Detener reproducción' : 'Escuchar coaching por voz'}
+        className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 font-medium text-xs transition ${
+          isSpeaking
+            ? 'bg-primary-700 text-white hover:bg-primary-800'
+            : 'bg-primary-50 text-primary-700 ring-1 ring-primary-700/20 hover:bg-primary-100'
+        }`}
+      >
+        {isSpeaking ? (
+          <>
+            <Pause className="h-3.5 w-3.5" aria-hidden />
+            <span>Detener</span>
+          </>
+        ) : (
+          <>
+            <Volume2 className="h-3.5 w-3.5" aria-hidden />
+            <span>Escuchar</span>
+          </>
+        )}
+      </button>
+
+      <label className="inline-flex cursor-pointer items-center gap-1.5 text-neutral-600 text-xs">
+        <input
+          type="checkbox"
+          checked={autoplayEnabled}
+          onChange={handleAutoplayChange}
+          className="h-3.5 w-3.5 rounded border-neutral-300 text-primary-600 focus:ring-primary-500"
+        />
+        <span>Reproducir automáticamente al terminar viajes</span>
+      </label>
+
+      {/* Live region para lectores de pantalla. No visible. */}
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {isSpeaking ? 'Reproduciendo coaching' : ''}
+        {isError ? 'Error reproduciendo audio. El texto sigue disponible.' : ''}
+      </span>
+
+      {isError && (
+        <span className="text-amber-700 text-xs">
+          No se pudo reproducir el audio. El texto está disponible arriba.
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/services/coaching-voice.test.ts
+++ b/apps/web/src/services/coaching-voice.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createCoachingVoice,
+  isSpeechSupported,
+  loadAutoplayPreference,
+  pickSpanishVoice,
+  saveAutoplayPreference,
+} from './coaching-voice.js';
+
+/** Stub mínimo de SpeechSynthesisVoice. */
+function v(lang: string, name = lang, isDefault = false): SpeechSynthesisVoice {
+  return {
+    voiceURI: name,
+    name,
+    lang,
+    default: isDefault,
+    localService: true,
+  } as SpeechSynthesisVoice;
+}
+
+describe('pickSpanishVoice', () => {
+  it('devuelve null si no hay voces', () => {
+    expect(pickSpanishVoice([])).toBeNull();
+  });
+
+  it('prefiere es-CL exact si existe', () => {
+    const voices = [v('en-US', 'English'), v('es-MX', 'Mexican'), v('es-CL', 'Chilean')];
+    expect(pickSpanishVoice(voices)?.lang).toBe('es-CL');
+  });
+
+  it('cae a es-MX si no hay es-CL', () => {
+    const voices = [v('en-US'), v('es-MX'), v('es-ES')];
+    expect(pickSpanishVoice(voices)?.lang).toBe('es-MX');
+  });
+
+  it('cae a es-419 si no hay es-CL/MX', () => {
+    const voices = [v('en-US'), v('es-419'), v('es-ES')];
+    expect(pickSpanishVoice(voices)?.lang).toBe('es-419');
+  });
+
+  it('cae a es-ES si no hay LATAM', () => {
+    const voices = [v('en-US'), v('es-ES')];
+    expect(pickSpanishVoice(voices)?.lang).toBe('es-ES');
+  });
+
+  it('matchea cualquier es-* prefix si no hay específicos', () => {
+    const voices = [v('en-US'), v('es-AR-1', 'Argentine')];
+    // ningún byLang directo, pero startsWith('es') captura.
+    expect(pickSpanishVoice(voices)?.lang).toBe('es-AR-1');
+  });
+
+  it('cae a default voice si no hay español', () => {
+    const voices = [v('fr-FR'), v('en-US', 'EN', true)];
+    expect(pickSpanishVoice(voices)?.lang).toBe('en-US');
+  });
+
+  it('cae a primera voz si no hay español ni default', () => {
+    const voices = [v('fr-FR'), v('en-US')];
+    expect(pickSpanishVoice(voices)?.lang).toBe('fr-FR');
+  });
+
+  it('matching es case-insensitive', () => {
+    const voices = [v('ES-cl'), v('en-US')];
+    expect(pickSpanishVoice(voices)?.lang).toBe('ES-cl');
+  });
+});
+
+describe('autoplay preference', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('default false cuando no hay nada en localStorage', () => {
+    expect(loadAutoplayPreference()).toBe(false);
+  });
+
+  it('save true → load true', () => {
+    saveAutoplayPreference(true);
+    expect(loadAutoplayPreference()).toBe(true);
+  });
+
+  it('save false elimina la key (default off)', () => {
+    saveAutoplayPreference(true);
+    saveAutoplayPreference(false);
+    expect(window.localStorage.getItem('booster:coaching-voice:autoplay-enabled')).toBeNull();
+    expect(loadAutoplayPreference()).toBe(false);
+  });
+
+  it('robusto si localStorage tira (private mode)', () => {
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota exceeded', 'QuotaExceededError');
+    });
+    expect(() => saveAutoplayPreference(true)).not.toThrow();
+    setItemSpy.mockRestore();
+  });
+});
+
+describe('isSpeechSupported', () => {
+  it('true en jsdom (window.speechSynthesis polyfilled por nuestro setup)', () => {
+    // jsdom no provee speechSynthesis nativo; lo stubeamos para simular soporte.
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: { getVoices: () => [], cancel: () => undefined, speak: () => undefined },
+    });
+    expect(isSpeechSupported()).toBe(true);
+  });
+
+  it('false si window.speechSynthesis no existe', () => {
+    const original = (window as { speechSynthesis?: SpeechSynthesis }).speechSynthesis;
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: undefined,
+    });
+    expect(isSpeechSupported()).toBe(false);
+    Object.defineProperty(window, 'speechSynthesis', {
+      configurable: true,
+      value: original,
+    });
+  });
+});
+
+describe('createCoachingVoice', () => {
+  /** Mock instalable de SpeechSynthesis. */
+  function makeSynthMock(voices: SpeechSynthesisVoice[] = [v('es-CL')]) {
+    return {
+      cancel: vi.fn(),
+      speak: vi.fn(),
+      getVoices: vi.fn(() => voices),
+      pause: vi.fn(),
+      resume: vi.fn(),
+      paused: false,
+      pending: false,
+      speaking: false,
+    } as unknown as SpeechSynthesis;
+  }
+
+  /** Mock del constructor SpeechSynthesisUtterance que captura lo creado. */
+  function makeUtteranceCtor() {
+    interface UtterCaptured {
+      text: string;
+      lang?: string;
+      voice?: SpeechSynthesisVoice;
+      rate?: number;
+      pitch?: number;
+      volume?: number;
+      onstart?: () => void;
+      onend?: () => void;
+      onerror?: (e: { error: string }) => void;
+    }
+    const created: UtterCaptured[] = [];
+    // Class-style mock para que `new Ctor(...)` funcione (vi.fn no se
+    // puede invocar con `new` salvo que sea una clase).
+    class Ctor implements UtterCaptured {
+      text: string;
+      lang?: string;
+      voice?: SpeechSynthesisVoice;
+      rate?: number;
+      pitch?: number;
+      volume?: number;
+      onstart?: () => void;
+      onend?: () => void;
+      onerror?: (e: { error: string }) => void;
+      constructor(text: string) {
+        this.text = text;
+        created.push(this);
+      }
+    }
+    return { Ctor: Ctor as unknown as typeof SpeechSynthesisUtterance, created };
+  }
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('estado inicial: idle si synth + Utterance están', () => {
+    const synth = makeSynthMock();
+    const { Ctor } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+    expect(voice.getState()).toBe('idle');
+  });
+
+  it('estado inicial: unsupported si synth ausente', () => {
+    const { Ctor } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth: null, UtteranceCtor: Ctor });
+    expect(voice.getState()).toBe('unsupported');
+  });
+
+  it('play cancela cualquier utterance previo y arranca uno nuevo', () => {
+    const synth = makeSynthMock();
+    const { Ctor, created } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+    voice.play('Anticipa frenadas, mantén distancia.');
+
+    expect(synth.cancel).toHaveBeenCalledTimes(1);
+    expect(synth.speak).toHaveBeenCalledTimes(1);
+    expect(created).toHaveLength(1);
+    expect(created[0]?.text).toBe('Anticipa frenadas, mantén distancia.');
+    expect(created[0]?.rate).toBe(0.95);
+    expect(created[0]?.lang).toBe('es-CL');
+    expect(created[0]?.voice?.lang).toBe('es-CL');
+  });
+
+  it('play con texto vacío o whitespace → no-op', () => {
+    const synth = makeSynthMock();
+    const { Ctor } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+    voice.play('');
+    voice.play('   \n\t  ');
+    expect(synth.speak).not.toHaveBeenCalled();
+  });
+
+  it('subscribe es invocado con state actual + cambios', () => {
+    const synth = makeSynthMock();
+    const { Ctor, created } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+
+    const states: string[] = [];
+    voice.subscribe((s) => states.push(s));
+    expect(states).toEqual(['idle']);
+
+    voice.play('hola');
+    // simulamos onstart del browser
+    created[0]?.onstart?.();
+    expect(states).toContain('speaking');
+
+    // simulamos onend
+    created[0]?.onend?.();
+    expect(states[states.length - 1]).toBe('idle');
+  });
+
+  it('onerror con canceled/interrupted no marca error', () => {
+    const synth = makeSynthMock();
+    const { Ctor, created } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+    voice.play('hola');
+    created[0]?.onstart?.();
+    expect(voice.getState()).toBe('speaking');
+
+    // Simular cancel-related error → no debería marcar 'error'.
+    created[0]?.onerror?.({ error: 'interrupted' });
+    expect(voice.getState()).toBe('idle');
+  });
+
+  it('onerror con error real marca state=error', () => {
+    const synth = makeSynthMock();
+    const { Ctor, created } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+    voice.play('hola');
+    created[0]?.onerror?.({ error: 'synthesis-failed' });
+    expect(voice.getState()).toBe('error');
+  });
+
+  it('stop cancela y vuelve a idle', () => {
+    const synth = makeSynthMock();
+    const { Ctor, created } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+    voice.play('hola');
+    created[0]?.onstart?.();
+    expect(voice.getState()).toBe('speaking');
+
+    voice.stop();
+    expect(synth.cancel).toHaveBeenCalledTimes(2); // 1× pre-play + 1× stop
+    expect(voice.getState()).toBe('idle');
+  });
+
+  it('play en estado unsupported → no-op silencioso', () => {
+    const { Ctor, created } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth: null, UtteranceCtor: Ctor });
+    voice.play('hola');
+    expect(created).toHaveLength(0);
+  });
+
+  it('synth.speak throw → state=error', () => {
+    const synth = makeSynthMock();
+    (synth.speak as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('boom');
+    });
+    const { Ctor } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+    voice.play('hola');
+    expect(voice.getState()).toBe('error');
+  });
+
+  it('unsubscribe deja de recibir cambios', () => {
+    const synth = makeSynthMock();
+    const { Ctor, created } = makeUtteranceCtor();
+    const voice = createCoachingVoice({ synth, UtteranceCtor: Ctor });
+
+    const states: string[] = [];
+    const unsub = voice.subscribe((s) => states.push(s));
+    expect(states).toEqual(['idle']);
+    unsub();
+
+    voice.play('hola');
+    created[0]?.onstart?.();
+    expect(states).toEqual(['idle']); // sin nuevos events post-unsub
+  });
+});

--- a/apps/web/src/services/coaching-voice.ts
+++ b/apps/web/src/services/coaching-voice.ts
@@ -1,0 +1,261 @@
+/**
+ * Wrapper sobre Web Speech API (`speechSynthesis`) para reproducir el
+ * coaching IA al conductor de manera hands-free.
+ *
+ * **Por qué no Google Cloud Text-to-Speech** (server-side):
+ *   - Web Speech API es 100% client-side, sin coste por viaje.
+ *   - Funciona offline una vez que el browser tiene la voz cargada.
+ *   - Latencia 0 entre click → audio (vs ~500ms round-trip a backend TTS).
+ *   - Voz nativa del OS — más natural en móviles modernos (iOS Siri,
+ *     Android Google TTS) que un MP3 sintético genérico.
+ *
+ *   Trade-off: la calidad de voz varía por browser/OS. iOS Safari y
+ *   Chrome desktop tienen voces excelentes en español; Firefox Linux es
+ *   más robótica. Aceptable para el caso de uso (mensaje corto, datos
+ *   operacionales, no entretenimiento).
+ *
+ * **API design**:
+ *   - `pickSpanishVoice()`: elige la mejor voz disponible (es-CL > es-* > default).
+ *     Pure function, testeable con stub de getVoices().
+ *   - `createCoachingVoice()`: factoría que devuelve un controller con
+ *     `play(text)`, `stop()`, `getState()` + `subscribe(cb)`. Encapsula la
+ *     instancia única de `speechSynthesis` (singleton por design — el
+ *     browser solo permite una utterance activa a la vez).
+ *   - `loadAutoplayPreference()` / `saveAutoplayPreference()`: persist
+ *     opt-in del conductor en localStorage. Default `false` (mute) por
+ *     seguridad — el conductor ACTIVA, nunca asumimos.
+ *
+ * **No**:
+ *   - Cola de utterances. Si el conductor toca play en el medio de un
+ *     mensaje, cancelamos el actual y arrancamos el nuevo. Anti-frustración
+ *     y simplifica state.
+ *   - Volume / rate / pitch ajustables. Ruido excesivo de UI; usamos
+ *     defaults sanos (rate=0.95 levemente más lento para claridad,
+ *     pitch=1.0 normal, volume=1.0).
+ */
+
+const AUTOPLAY_KEY = 'booster:coaching-voice:autoplay-enabled';
+
+export type VoiceState = 'idle' | 'speaking' | 'unsupported' | 'error';
+
+export interface CoachingVoiceController {
+  /**
+   * Reproduce el texto. Si ya hay algo reproduciéndose, lo cancela y
+   * arranca el nuevo. Si no hay soporte, no-op (el state queda en
+   * 'unsupported' y el caller debe ocultarse/mostrar fallback visual).
+   */
+  play: (text: string) => void;
+  /** Detiene la reproducción actual. */
+  stop: () => void;
+  /** Estado actual sincrónico (para UI inicial). */
+  getState: () => VoiceState;
+  /**
+   * Suscribe a cambios de estado. Devuelve función unsubscribe. El
+   * listener se llama ANTES del primer play() con el state actual.
+   */
+  subscribe: (listener: (state: VoiceState) => void) => () => void;
+}
+
+/**
+ * Verdadero si el browser soporta speechSynthesis con al menos una voz.
+ * Se evalúa al construir el controller — si despues de la construcción
+ * cambia (extension instala una voz nueva), el caller debe re-construir.
+ */
+export function isSpeechSupported(): boolean {
+  if (typeof window === 'undefined' || typeof window.speechSynthesis === 'undefined') {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Elige la mejor voz disponible para el coaching. Preferencias:
+ *   1. es-CL (chileno nativo)
+ *   2. es-MX, es-419 (latinoamericano — neutro pero entendible)
+ *   3. es-ES (España — entendible aunque con seseo)
+ *   4. cualquier es-*
+ *   5. default voice del browser (último recurso)
+ *
+ * Función pura — recibe lista de voces, no consulta `speechSynthesis`.
+ * Esto permite testear con fixtures.
+ */
+export function pickSpanishVoice(voices: SpeechSynthesisVoice[]): SpeechSynthesisVoice | null {
+  if (voices.length === 0) {
+    return null;
+  }
+  const byLang = (suffix: string): SpeechSynthesisVoice | undefined =>
+    voices.find((v) => v.lang.toLowerCase() === suffix.toLowerCase()) ??
+    voices.find((v) => v.lang.toLowerCase().startsWith(suffix.toLowerCase()));
+
+  return (
+    byLang('es-CL') ??
+    byLang('es-MX') ??
+    byLang('es-419') ??
+    byLang('es-ES') ??
+    voices.find((v) => v.lang.toLowerCase().startsWith('es')) ??
+    voices.find((v) => v.default) ??
+    voices[0] ??
+    null
+  );
+}
+
+/**
+ * Devuelve la preferencia de auto-play del conductor. Default `false`:
+ * NUNCA reproducimos audio sin click explícito en el primer uso.
+ *
+ * El conductor activa una vez en onboarding driver-mode (futuro PR), o
+ * vía toggle en la configuración. Una vez ON, los próximos coachings se
+ * disparan automáticamente al detectar entrega confirmada.
+ */
+export function loadAutoplayPreference(): boolean {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(AUTOPLAY_KEY) === '1';
+  } catch {
+    // localStorage puede tirar SecurityError en private mode + Safari.
+    return false;
+  }
+}
+
+export function saveAutoplayPreference(enabled: boolean): void {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+  try {
+    if (enabled) {
+      window.localStorage.setItem(AUTOPLAY_KEY, '1');
+    } else {
+      window.localStorage.removeItem(AUTOPLAY_KEY);
+    }
+  } catch {
+    // ignore — autoplay default-false es safe.
+  }
+}
+
+export interface CreateCoachingVoiceOpts {
+  /**
+   * Inyectable para tests. Default: `window.speechSynthesis`. Pasar
+   * `null` explícitamente para forzar el state 'unsupported' en tests
+   * que validan UI degradada (sin él, el `??` cae al window real).
+   */
+  synth?: SpeechSynthesis | null;
+  /**
+   * Inyectable para tests. Default: `window.SpeechSynthesisUtterance`.
+   */
+  UtteranceCtor?: typeof SpeechSynthesisUtterance | null;
+  /**
+   * Velocidad. Default 0.95 (levemente más lento que normal — al volante
+   * el conductor no puede re-leer; preferimos claridad).
+   */
+  rate?: number;
+}
+
+export function createCoachingVoice(opts: CreateCoachingVoiceOpts = {}): CoachingVoiceController {
+  // `null` explícito → forzar unsupported (tests). `undefined` → default
+  // a window.* (prod). Distinguir con 'in' permite que el caller fuerce.
+  const synth: SpeechSynthesis | null =
+    'synth' in opts
+      ? (opts.synth ?? null)
+      : typeof window !== 'undefined' && typeof window.speechSynthesis !== 'undefined'
+        ? window.speechSynthesis
+        : null;
+  const UtteranceCtor: typeof SpeechSynthesisUtterance | null =
+    'UtteranceCtor' in opts
+      ? (opts.UtteranceCtor ?? null)
+      : typeof window !== 'undefined' && typeof window.SpeechSynthesisUtterance !== 'undefined'
+        ? window.SpeechSynthesisUtterance
+        : null;
+  const rate = opts.rate ?? 0.95;
+
+  let state: VoiceState = synth && UtteranceCtor ? 'idle' : 'unsupported';
+  const listeners = new Set<(s: VoiceState) => void>();
+
+  const setState = (next: VoiceState): void => {
+    if (state === next) {
+      return;
+    }
+    state = next;
+    for (const l of listeners) {
+      l(state);
+    }
+  };
+
+  const play = (text: string): void => {
+    if (state === 'unsupported' || !synth || !UtteranceCtor) {
+      return;
+    }
+    const trimmed = text.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+
+    // Si está hablando algo, cancelamos antes — el browser dispara
+    // 'end' del actual y luego procesamos el nuevo. Esto previene
+    // utterances apiladas en la cola del browser.
+    try {
+      synth.cancel();
+    } catch {
+      // ignore — cancel puede tirar en algunos browsers exóticos.
+    }
+
+    const utter = new UtteranceCtor(trimmed);
+    utter.rate = rate;
+    utter.pitch = 1.0;
+    utter.volume = 1.0;
+    utter.lang = 'es-CL';
+
+    // Voice picking puede ser asíncrono en algunos browsers (Chrome
+    // desktop emite 'voiceschanged' al cargar). Si getVoices() está
+    // vacío al momento de crear utter, dejamos que el browser use el
+    // default — mejor un audio en otro idioma que silencio.
+    const voice = pickSpanishVoice(synth.getVoices());
+    if (voice) {
+      utter.voice = voice;
+    }
+
+    utter.onstart = () => setState('speaking');
+    utter.onend = () => setState('idle');
+    utter.onerror = (event) => {
+      // 'canceled' / 'interrupted' son resultado esperable del cancel()
+      // antes de play() — NO los tratamos como error.
+      const errCode = event.error;
+      if (errCode === 'canceled' || errCode === 'interrupted') {
+        setState('idle');
+        return;
+      }
+      setState('error');
+    };
+
+    try {
+      synth.speak(utter);
+    } catch {
+      setState('error');
+    }
+  };
+
+  const stop = (): void => {
+    if (!synth) {
+      return;
+    }
+    try {
+      synth.cancel();
+    } catch {
+      // ignore.
+    }
+    setState('idle');
+  };
+
+  const getState = (): VoiceState => state;
+
+  const subscribe = (listener: (s: VoiceState) => void): (() => void) => {
+    listeners.add(listener);
+    listener(state);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  return { play, stop, getState, subscribe };
+}


### PR DESCRIPTION
## Summary

Implementa la entrega por voz que reemplaza al WhatsApp template cerrado en PR #112. Cierra Phase 3 con el canal correcto: el conductor escucha el coaching sin tocar la pantalla mientras conduce. Ver [playbook 002](../blob/main/playbooks/002-canal-coaching-voz-no-whatsapp.md) para la decisión de canal.

## Diseño

- **Web Speech API client-side**: cero coste por viaje, latencia 0, voz nativa del OS (iOS Siri / Android Google TTS). Trade-off documentado: Firefox Linux es robótica, aceptable para el caso de uso.
- **Singleton del browser**: \`speechSynthesis\` sólo permite una utterance activa; \`play()\` siempre cancela la previa antes (anti-cola).
- **Auto-play opt-in**: localStorage flag default OFF — NUNCA reproducimos sin click explícito en el primer uso. Cuando ON, la PWA arranca al detectar coaching disponible al final del viaje.
- **UI mínima hands-free**: un botón único Play/Pause + un checkbox \"Reproducir automáticamente al terminar viajes\". Sin slider de volumen, sin rate, sin elección de voz — defaults sanos (rate=0.95, pitch=1.0, lang=es-CL).
- **Selección de voz**: \`pickSpanishVoice()\` preferencia \`es-CL > es-MX > es-419 > es-ES > cualquier es-* > default\`. Pure function testeable con fixtures.
- **Degradación**: si el browser no soporta \`speechSynthesis\` (rarísimo en 2026), el componente se oculta. El texto sigue visible en la BehaviorScoreCard parent — no perdemos información.
- **Accesibilidad**: \`aria-pressed\` en el botón, \`aria-live=\"polite\"\` anuncia \"Reproduciendo coaching\" al lector de pantalla, \`sr-only\` no interfiere con la UI visual.

## Cambios

| Archivo | Tipo | Tests |
|---|---|---|
| \`apps/web/src/services/coaching-voice.ts\` | + nuevo | 26 |
| \`apps/web/src/components/scoring/CoachingVoicePlayer.tsx\` | + nuevo | 12 |
| \`apps/web/src/components/scoring/BehaviorScoreCard.tsx\` | wire del player |  |

### Tests breakdown

**\`coaching-voice.test.ts\` (26)**: pickSpanishVoice (8 priority cases incluyendo case-insensitive y fallbacks), autoplay preference (default, persist, reset, robust en private mode), isSpeechSupported, createCoachingVoice (estado inicial, play/stop, cancel pre-play, text vacío, subscribe/unsubscribe, onerror canceled vs real, synth.speak throw).

**\`CoachingVoicePlayer.test.tsx\` (12)**: render idle/speaking/error/unsupported, click play/stop, checkbox persistence, autoplay opt-in arranca al montar, autoplay con message vacío no arranca (defensivo), aria-live region.

## Evidencia

- \`pnpm typecheck\` ✓ (monorepo, 29 tasks)
- \`pnpm lint\` ✓ (biome + lint-rls)
- \`pnpm test\` ✓: web 337 tests (+38 nuevos), api 427, todos los packages verdes
- Lighthouse a11y manual al renderizar: pendiente post-deploy via Playwright e2e

## Test plan

- [x] CI: lint + typecheck + tests pasan
- [ ] Manual post-merge: confirmar viaje en staging → click Play → escuchar audio en es-CL en Chrome desktop
- [ ] Manual post-merge: activar auto-play → confirmar siguiente viaje → audio arranca automáticamente
- [ ] Manual post-merge: probar en iOS Safari (calidad de voz Siri esperada)
- [ ] Cobertura web sigue ≥80% en CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)