### PR TITLE
test(web): cubrir todos los excludes razonables (97% coverage)

### DIFF
--- a/apps/web/src/components/chat/ChatPanel.test.tsx
+++ b/apps/web/src/components/chat/ChatPanel.test.tsx
@@ -1,0 +1,379 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mockear use-chat-messages — no queremos correr SSE/queries reales aquí.
+const useChatMessagesMock = vi.fn();
+vi.mock('../../hooks/use-chat-messages.js', () => ({
+  useChatMessages: useChatMessagesMock,
+}));
+
+// Mockear chat-api — los mutations de send se prueban acá.
+const sendChatMessageMock = vi.fn();
+const sendPhotoMessageMock = vi.fn();
+const sendLocationMessageMock = vi.fn();
+const fetchPhotoDownloadUrlMock = vi.fn();
+vi.mock('../../lib/chat-api.js', () => ({
+  sendChatMessage: sendChatMessageMock,
+  sendPhotoMessage: sendPhotoMessageMock,
+  sendLocationMessage: sendLocationMessageMock,
+  fetchPhotoDownloadUrl: fetchPhotoDownloadUrlMock,
+}));
+
+// VehicleMap usa Google Maps; reemplazamos por stub.
+vi.mock('../map/VehicleMap.js', () => ({
+  VehicleMap: ({ latitude, longitude }: { latitude: number; longitude: number }) => (
+    <div data-testid="vehicle-map">{`map ${latitude},${longitude}`}</div>
+  ),
+}));
+
+const { ChatPanel } = await import('./ChatPanel.js');
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderPanel(props: Partial<Parameters<typeof ChatPanel>[0]> = {}) {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <ChatPanel assignmentId="a1" {...props} />
+    </Wrapper>,
+  );
+}
+
+const SAMPLE_TEXT_MSG = {
+  id: 'm1',
+  type: 'texto',
+  text: 'hola',
+  created_at: '2026-05-10T10:00:00Z',
+  sender_role: 'carrier',
+  sender_name: 'Felipe',
+  read_at: null,
+  photo_gcs_uri: null,
+  location_lat: null,
+  location_lng: null,
+};
+
+const SAMPLE_LOCATION_MSG = {
+  id: 'm2',
+  type: 'ubicacion',
+  text: null,
+  created_at: '2026-05-10T10:01:00Z',
+  sender_role: 'shipper',
+  sender_name: 'Ana',
+  read_at: null,
+  photo_gcs_uri: null,
+  location_lat: -33.45,
+  location_lng: -70.65,
+};
+
+const SAMPLE_PHOTO_MSG = {
+  id: 'm3',
+  type: 'foto',
+  text: null,
+  created_at: '2026-05-10T10:02:00Z',
+  sender_role: 'shipper',
+  sender_name: 'Ana',
+  read_at: null,
+  photo_gcs_uri: 'gs://bucket/foo.jpg',
+  location_lat: null,
+  location_lng: null,
+};
+
+function defaultHookReturn(over: Record<string, unknown> = {}) {
+  return {
+    messages: [],
+    viewerRole: 'carrier' as const,
+    isLoading: false,
+    error: null,
+    hasMore: false,
+    loadMore: vi.fn(),
+    isLive: true,
+    isLoadingMore: false,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useChatMessagesMock.mockReturnValue(defaultHookReturn());
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ChatPanel — header', () => {
+  it('default title "Chat" + status En vivo', () => {
+    renderPanel();
+    expect(screen.getByText('Chat')).toBeInTheDocument();
+    expect(screen.getByText('En vivo')).toBeInTheDocument();
+  });
+
+  it('title + subtitle custom', () => {
+    renderPanel({ title: 'Chat con Ana', subtitle: 'Carga BST-001' });
+    expect(screen.getByText('Chat con Ana')).toBeInTheDocument();
+    expect(screen.getByText('Carga BST-001')).toBeInTheDocument();
+  });
+
+  it('isLive=false → muestra "Reconectando…"', () => {
+    useChatMessagesMock.mockReturnValue(defaultHookReturn({ isLive: false }));
+    renderPanel();
+    expect(screen.getByText('Reconectando…')).toBeInTheDocument();
+  });
+
+  it('onClose presente → renderiza X', () => {
+    const onClose = vi.fn();
+    renderPanel({ onClose });
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar chat' }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('sin onClose → no X', () => {
+    renderPanel();
+    expect(screen.queryByRole('button', { name: 'Cerrar chat' })).not.toBeInTheDocument();
+  });
+});
+
+describe('ChatPanel — estados de la lista', () => {
+  it('isLoading → muestra "Cargando mensajes"', () => {
+    useChatMessagesMock.mockReturnValue(defaultHookReturn({ isLoading: true }));
+    renderPanel();
+    expect(screen.getByText(/Cargando mensajes/)).toBeInTheDocument();
+  });
+
+  it('error → mensaje de fallo de carga', () => {
+    useChatMessagesMock.mockReturnValue(defaultHookReturn({ error: new Error('boom') }));
+    renderPanel();
+    expect(screen.getByText(/No pudimos cargar/)).toBeInTheDocument();
+  });
+
+  it('lista vacía + readOnly=false → empezar conversación', () => {
+    renderPanel();
+    expect(screen.getByText(/Empezá la conversación/)).toBeInTheDocument();
+  });
+
+  it('lista vacía + readOnly=true → "Este chat ya está cerrado"', () => {
+    renderPanel({ readOnly: true });
+    expect(screen.getByText(/Este chat ya está cerrado/)).toBeInTheDocument();
+  });
+});
+
+describe('ChatPanel — render mensajes', () => {
+  it('mensaje texto del otro lado → muestra body + nombre', () => {
+    useChatMessagesMock.mockReturnValue(
+      defaultHookReturn({
+        messages: [{ ...SAMPLE_TEXT_MSG, sender_role: 'shipper' }],
+      }),
+    );
+    renderPanel();
+    expect(screen.getByText('hola')).toBeInTheDocument();
+    expect(screen.getByText('Felipe')).toBeInTheDocument();
+  });
+
+  it('mensaje propio (mismo rol que viewer) → no muestra nombre del sender', () => {
+    useChatMessagesMock.mockReturnValue(
+      defaultHookReturn({
+        messages: [{ ...SAMPLE_TEXT_MSG, sender_role: 'carrier' }],
+      }),
+    );
+    renderPanel();
+    expect(screen.getByText('hola')).toBeInTheDocument();
+    expect(screen.queryByText('Felipe')).not.toBeInTheDocument();
+  });
+
+  it('mensaje propio leído → muestra "Leído"', () => {
+    useChatMessagesMock.mockReturnValue(
+      defaultHookReturn({
+        messages: [
+          {
+            ...SAMPLE_TEXT_MSG,
+            sender_role: 'carrier',
+            read_at: '2026-05-10T10:01:00Z',
+          },
+        ],
+      }),
+    );
+    renderPanel();
+    expect(screen.getByText(/Leído/)).toBeInTheDocument();
+  });
+
+  it('mensaje ubicacion → renderiza VehicleMap stub', () => {
+    useChatMessagesMock.mockReturnValue(defaultHookReturn({ messages: [SAMPLE_LOCATION_MSG] }));
+    renderPanel();
+    expect(screen.getByTestId('vehicle-map')).toBeInTheDocument();
+    expect(screen.getByText(/Ubicación compartida/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Abrir en Google Maps/ })).toHaveAttribute(
+      'href',
+      expect.stringContaining('-33.45,-70.65'),
+    );
+  });
+
+  it('mensaje sin contenido → fallback "Mensaje sin contenido"', () => {
+    useChatMessagesMock.mockReturnValue(
+      defaultHookReturn({
+        messages: [{ ...SAMPLE_TEXT_MSG, type: 'desconocido', text: null }],
+      }),
+    );
+    renderPanel();
+    expect(screen.getByText('Mensaje sin contenido')).toBeInTheDocument();
+  });
+});
+
+describe('ChatPanel — paginación', () => {
+  it('hasMore=true → botón "Cargar más viejos"', () => {
+    const loadMore = vi.fn();
+    useChatMessagesMock.mockReturnValue(
+      defaultHookReturn({ messages: [SAMPLE_TEXT_MSG], hasMore: true, loadMore }),
+    );
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: /Cargar más viejos/ }));
+    expect(loadMore).toHaveBeenCalled();
+  });
+
+  it('isLoadingMore=true → botón disabled + texto "Cargando…"', () => {
+    useChatMessagesMock.mockReturnValue(
+      defaultHookReturn({
+        messages: [SAMPLE_TEXT_MSG],
+        hasMore: true,
+        isLoadingMore: true,
+      }),
+    );
+    renderPanel();
+    const btn = screen.getByRole('button', { name: /Cargando…/ });
+    expect(btn).toBeDisabled();
+  });
+});
+
+describe('ChatPanel — composer texto', () => {
+  it('readOnly=true → no muestra composer', () => {
+    renderPanel({ readOnly: true });
+    expect(screen.queryByPlaceholderText(/Escribe un mensaje/)).not.toBeInTheDocument();
+  });
+
+  it('escribir + click enviar → sendChatMessage llamado', async () => {
+    sendChatMessageMock.mockResolvedValueOnce({ id: 'm-new' });
+    renderPanel();
+    const textarea = screen.getByPlaceholderText(/Escribe un mensaje/);
+    fireEvent.change(textarea, { target: { value: 'hola mundo' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar' }));
+    await waitFor(() =>
+      expect(sendChatMessageMock).toHaveBeenCalledWith({
+        assignmentId: 'a1',
+        body: { type: 'texto', text: 'hola mundo' },
+      }),
+    );
+  });
+
+  it('Enter sin Shift → submit', async () => {
+    sendChatMessageMock.mockResolvedValueOnce({ id: 'm-new' });
+    renderPanel();
+    const textarea = screen.getByPlaceholderText(/Escribe un mensaje/);
+    fireEvent.change(textarea, { target: { value: 'enter test' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+    await waitFor(() => expect(sendChatMessageMock).toHaveBeenCalled());
+  });
+
+  it('Enter+Shift → no submit (newline)', () => {
+    renderPanel();
+    const textarea = screen.getByPlaceholderText(/Escribe un mensaje/);
+    fireEvent.change(textarea, { target: { value: 'no submit' } });
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+    expect(sendChatMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('texto vacío → botón disabled', () => {
+    renderPanel();
+    expect(screen.getByRole('button', { name: 'Enviar' })).toBeDisabled();
+  });
+
+  it('texto solo whitespace → no submit aunque clickee Enviar', () => {
+    renderPanel();
+    const textarea = screen.getByPlaceholderText(/Escribe un mensaje/);
+    fireEvent.change(textarea, { target: { value: '   ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar' }));
+    expect(sendChatMessageMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChatPanel — composer foto + ubicación', () => {
+  it('seleccionar archivo → sendPhotoMessage llamado', async () => {
+    sendPhotoMessageMock.mockResolvedValueOnce({ id: 'm-photo' });
+    renderPanel();
+    const file = new File(['x'], 'foo.jpg', { type: 'image/jpeg' });
+    // El input de archivo está oculto; lo encontramos por type=file.
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).not.toBeNull();
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await waitFor(() =>
+      expect(sendPhotoMessageMock).toHaveBeenCalledWith({ assignmentId: 'a1', file }),
+    );
+  });
+
+  it('seleccionar archivo (sin file) → no llama send', () => {
+    renderPanel();
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [] } });
+    expect(sendPhotoMessageMock).not.toHaveBeenCalled();
+  });
+
+  it('click ubicación → sendLocationMessage', async () => {
+    sendLocationMessageMock.mockResolvedValueOnce({ id: 'm-loc' });
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Compartir ubicación' }));
+    await waitFor(() => expect(sendLocationMessageMock).toHaveBeenCalledWith('a1'));
+  });
+
+  it('error al enviar foto → window.alert', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+    sendPhotoMessageMock.mockRejectedValueOnce(new Error('upload boom'));
+    renderPanel();
+    const file = new File(['x'], 'foo.jpg', { type: 'image/jpeg' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+  });
+
+  it('error al compartir ubicación → window.alert', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => undefined);
+    sendLocationMessageMock.mockRejectedValueOnce(new Error('geo denied'));
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Compartir ubicación' }));
+    await waitFor(() => expect(alertSpy).toHaveBeenCalled());
+  });
+});
+
+describe('ChatPanel — PhotoMessage', () => {
+  it('foto loading → spinner visible', () => {
+    fetchPhotoDownloadUrlMock.mockImplementation(() => new Promise<never>(() => undefined));
+    useChatMessagesMock.mockReturnValue(defaultHookReturn({ messages: [SAMPLE_PHOTO_MSG] }));
+    renderPanel();
+    expect(screen.getByText(/Cargando foto/)).toBeInTheDocument();
+  });
+
+  it('foto OK → renderiza <img>', async () => {
+    fetchPhotoDownloadUrlMock.mockResolvedValueOnce({ download_url: 'https://x/foo.jpg' });
+    useChatMessagesMock.mockReturnValue(defaultHookReturn({ messages: [SAMPLE_PHOTO_MSG] }));
+    renderPanel();
+    expect(await screen.findByRole('img', { name: /Foto adjunta/ })).toHaveAttribute(
+      'src',
+      'https://x/foo.jpg',
+    );
+  });
+
+  it('foto falla → mensaje "No se pudo cargar la foto"', async () => {
+    fetchPhotoDownloadUrlMock.mockRejectedValue(new Error('signed url failed'));
+    useChatMessagesMock.mockReturnValue(defaultHookReturn({ messages: [SAMPLE_PHOTO_MSG] }));
+    renderPanel();
+    // PhotoMessage tiene retry:1 → 2 intentos antes de mostrar error.
+    expect(
+      await screen.findByText(/No se pudo cargar la foto/, undefined, { timeout: 3000 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/onboarding/OnboardingForm.test.tsx
+++ b/apps/web/src/components/onboarding/OnboardingForm.test.tsx
@@ -1,0 +1,245 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../../lib/api-client.js';
+
+const navigateMock = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+}));
+
+const { OnboardingForm } = await import('./OnboardingForm.js');
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderForm(
+  props: Partial<Parameters<typeof OnboardingForm>[0]> = {
+    firebaseEmail: 'felipe@boosterchile.com',
+  },
+) {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <OnboardingForm
+        firebaseEmail={props.firebaseEmail ?? 'felipe@boosterchile.com'}
+        firebaseName={props.firebaseName}
+      />
+    </Wrapper>,
+  );
+}
+
+async function fillStep1AndAdvance() {
+  fireEvent.change(screen.getByLabelText(/Nombre completo/), {
+    target: { value: 'Felipe Vicencio' },
+  });
+  fireEvent.change(screen.getByLabelText(/Teléfono móvil/), { target: { value: '+56912345678' } });
+  fireEvent.change(screen.getByLabelText(/^WhatsApp/), { target: { value: '+56912345678' } });
+  // RUT marcado opcional pero el schema rechaza string vacío. Pasamos uno válido.
+  fireEvent.change(screen.getByLabelText(/^RUT/), { target: { value: '11.111.111-1' } });
+  fireEvent.click(screen.getByRole('button', { name: /Siguiente/ }));
+  await screen.findByText('Tu empresa');
+}
+
+async function fillStep2AndAdvance() {
+  fireEvent.change(screen.getByLabelText(/Razón social/), { target: { value: 'Booster SpA' } });
+  fireEvent.change(screen.getByLabelText(/RUT empresa/), { target: { value: '76.123.456-0' } });
+  fireEvent.change(screen.getByLabelText(/Email de contacto/), {
+    target: { value: 'contacto@booster.cl' },
+  });
+  fireEvent.change(screen.getByLabelText(/Teléfono de contacto/), {
+    target: { value: '+56912345678' },
+  });
+  fireEvent.change(screen.getByLabelText(/^Dirección/), {
+    target: { value: 'Av. Apoquindo 4500' },
+  });
+  fireEvent.change(screen.getByLabelText(/^Comuna/), { target: { value: 'Las Condes' } });
+  fireEvent.change(screen.getByLabelText(/^Ciudad/), { target: { value: 'Santiago' } });
+  fireEvent.click(screen.getByRole('button', { name: /Siguiente/ }));
+  await screen.findByText(/¿Cómo opera tu empresa?/);
+}
+
+async function fillStep3AndAdvance() {
+  fireEvent.click(screen.getByRole('button', { name: /Generador de carga/ }));
+  fireEvent.click(screen.getByRole('button', { name: /Siguiente/ }));
+  await screen.findByText(/Resumen/);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('OnboardingForm — render inicial', () => {
+  it('arranca en step 1 con título "Tus datos"', () => {
+    renderForm();
+    expect(screen.getByText('Tus datos')).toBeInTheDocument();
+    expect(screen.getByLabelText(/Nombre completo/)).toBeInTheDocument();
+  });
+
+  it('progress indicator marca step 1 como current', () => {
+    renderForm();
+    const stepLabels = screen.getAllByText(/^[1-4]$/);
+    expect(stepLabels.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('botón Atrás invisible (disabled) en step 1', () => {
+    renderForm();
+    const backBtn = screen.getByRole('button', { name: /Atrás/ });
+    expect(backBtn).toBeDisabled();
+  });
+
+  it('firebaseName prefill → input nombre tiene valor', () => {
+    renderForm({ firebaseName: 'Felipe Pre' });
+    expect(screen.getByLabelText(/Nombre completo/)).toHaveValue('Felipe Pre');
+  });
+});
+
+describe('OnboardingForm — navegación entre steps', () => {
+  it('step 1 con datos válidos → avanza a step 2', async () => {
+    renderForm();
+    await fillStep1AndAdvance();
+    expect(screen.getByText('Tu empresa')).toBeInTheDocument();
+  });
+
+  it('step 1 con teléfono inválido → no avanza, muestra error', async () => {
+    renderForm();
+    fireEvent.change(screen.getByLabelText(/Nombre completo/), { target: { value: 'Felipe' } });
+    fireEvent.change(screen.getByLabelText(/Teléfono móvil/), { target: { value: 'no-tel' } });
+    fireEvent.click(screen.getByRole('button', { name: /Siguiente/ }));
+    // Se quedan al menos 2 errores (teléfono y RUT vacío). Validamos por el rol y que no haya avanzado.
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts.length).toBeGreaterThan(0);
+    expect(screen.queryByText('Tu empresa')).not.toBeInTheDocument();
+  });
+
+  it('step 2 → 3 → 4 navegación completa', async () => {
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    await fillStep3AndAdvance();
+    // En step 4 hay título h2 "Plan" + label de progreso "Plan" → buscar el heading.
+    expect(screen.getByRole('heading', { name: 'Plan' })).toBeInTheDocument();
+  });
+
+  it('Atrás retrocede al step anterior', async () => {
+    renderForm();
+    await fillStep1AndAdvance();
+    fireEvent.click(screen.getByRole('button', { name: /Atrás/ }));
+    expect(await screen.findByText('Tus datos')).toBeInTheDocument();
+  });
+});
+
+describe('OnboardingForm — step 3 toggles', () => {
+  it('toggle "Generador" → aria-pressed=true', async () => {
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    const toggle = screen.getByRole('button', { name: /Generador de carga/ });
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('toggle "Transportista" → aria-pressed=true independiente', async () => {
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    const toggle = screen.getByRole('button', { name: /^Transportista/ });
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+describe('OnboardingForm — step 4 plan + summary', () => {
+  it('plan default "gratis" preseleccionado en summary', async () => {
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    await fillStep3AndAdvance();
+    expect(screen.getByText(/gratis/)).toBeInTheDocument();
+  });
+
+  it('seleccionar plan Estándar → summary actualiza', async () => {
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    await fillStep3AndAdvance();
+    fireEvent.click(screen.getByRole('button', { name: /Estándar/ }));
+    expect(screen.getByText(/estandar/)).toBeInTheDocument();
+  });
+
+  it('summary muestra empresa + rut + operación + plan', async () => {
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    await fillStep3AndAdvance();
+    expect(screen.getByText('Booster SpA')).toBeInTheDocument();
+    expect(screen.getByText('76.123.456-0')).toBeInTheDocument();
+    expect(screen.getAllByText(/Generador de carga/).length).toBeGreaterThan(0);
+  });
+});
+
+describe('OnboardingForm — submit', () => {
+  it('happy path: POST /empresas/onboarding + navigate /app', async () => {
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValueOnce({
+      user: { id: 'u' },
+      empresa: { id: 'emp-uuid' },
+      membership: { id: 'm', role: 'dueno', status: 'activa' },
+    });
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    await fillStep3AndAdvance();
+    fireEvent.click(screen.getByRole('button', { name: /Crear empresa/ }));
+    await waitFor(() =>
+      expect(postSpy).toHaveBeenCalledWith('/empresas/onboarding', expect.any(Object)),
+    );
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith({ to: '/app' }));
+  });
+
+  it('error rut_already_registered → mensaje específico', async () => {
+    vi.spyOn(api, 'post').mockRejectedValueOnce(new ApiError(409, 'rut_already_registered', null));
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    await fillStep3AndAdvance();
+    fireEvent.click(screen.getByRole('button', { name: /Crear empresa/ }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/RUT empresa ya está registrado/);
+  });
+
+  it('error 5xx → mensaje genérico', async () => {
+    vi.spyOn(api, 'post').mockRejectedValueOnce(new ApiError(500, 'internal', null));
+    renderForm();
+    await fillStep1AndAdvance();
+    await fillStep2AndAdvance();
+    await fillStep3AndAdvance();
+    fireEvent.click(screen.getByRole('button', { name: /Crear empresa/ }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/error en nuestro lado/);
+  });
+
+  for (const [code, regex] of [
+    ['user_already_registered', /Ya tienes una empresa registrada/],
+    ['email_in_use', /email ya está registrado/],
+    ['invalid_plan', /plan seleccionado no está disponible/],
+    ['firebase_email_missing', /sesión no tiene email/],
+  ] as const) {
+    it(`error ${code} → ${regex}`, async () => {
+      vi.spyOn(api, 'post').mockRejectedValueOnce(new ApiError(400, code, null));
+      renderForm();
+      await fillStep1AndAdvance();
+      await fillStep2AndAdvance();
+      await fillStep3AndAdvance();
+      fireEvent.click(screen.getByRole('button', { name: /Crear empresa/ }));
+      expect(await screen.findByRole('alert')).toHaveTextContent(regex);
+    });
+  }
+});

--- a/apps/web/src/components/profile/AuthProvidersSection.test.tsx
+++ b/apps/web/src/components/profile/AuthProvidersSection.test.tsx
@@ -1,0 +1,325 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { User } from 'firebase/auth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useAuthMock = vi.fn();
+const getLinkedProvidersMock = vi.fn();
+const linkGoogleProviderMock = vi.fn();
+const linkPasswordProviderMock = vi.fn();
+const reauthCurrentMock = vi.fn();
+const unlinkProviderMock = vi.fn();
+const updatePasswordCurrentMock = vi.fn();
+
+vi.mock('../../hooks/use-auth.js', () => ({
+  useAuth: useAuthMock,
+  getLinkedProviders: getLinkedProvidersMock,
+  linkGoogleProvider: linkGoogleProviderMock,
+  linkPasswordProvider: linkPasswordProviderMock,
+  reauthCurrent: reauthCurrentMock,
+  unlinkProvider: unlinkProviderMock,
+  updatePasswordCurrent: updatePasswordCurrentMock,
+}));
+
+const { AuthProvidersSection } = await import('./AuthProvidersSection.js');
+
+function makeUser(over: Partial<User> = {}): User {
+  return {
+    email: 'felipe@boosterchile.com',
+    reload: vi.fn(async () => undefined),
+    ...over,
+  } as unknown as User;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AuthProvidersSection — guard', () => {
+  it('user null → render null', () => {
+    useAuthMock.mockReturnValue({ user: null });
+    const { container } = render(<AuthProvidersSection />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('AuthProvidersSection — Google linked / unlinked', () => {
+  it('hasGoogle=false → muestra "No vinculada" y botón Vincular', () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['password']);
+    render(<AuthProvidersSection />);
+    expect(screen.getByText('No vinculada')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Vincular/ }).length).toBeGreaterThan(0);
+  });
+
+  it('hasGoogle=true (único) → no muestra Quitar', () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['google.com']);
+    render(<AuthProvidersSection />);
+    expect(screen.getAllByText(/Vinculada con/).length).toBeGreaterThan(0);
+    expect(screen.queryByRole('button', { name: 'Quitar' })).not.toBeInTheDocument();
+  });
+
+  it('hasGoogle=true + más de 1 → muestra Quitar', () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['google.com', 'password']);
+    render(<AuthProvidersSection />);
+    expect(screen.getAllByRole('button', { name: 'Quitar' }).length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('AuthProvidersSection — link Google', () => {
+  it('happy: link + reload + refresh', async () => {
+    const user = makeUser();
+    useAuthMock.mockReturnValue({ user });
+    getLinkedProvidersMock
+      .mockReturnValueOnce(['password'])
+      .mockReturnValue(['google.com', 'password']);
+    linkGoogleProviderMock.mockResolvedValueOnce(undefined);
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Vincular/ })[0]!);
+    await waitFor(() => expect(linkGoogleProviderMock).toHaveBeenCalledWith(user));
+    await waitFor(() => expect(user.reload).toHaveBeenCalled());
+  });
+
+  it('popup cerrado por user → no error visible', async () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['password']);
+    linkGoogleProviderMock.mockRejectedValueOnce(
+      Object.assign(new Error('popup'), { code: 'auth/popup-closed-by-user' }),
+    );
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Vincular/ })[0]!);
+    await waitFor(() => expect(linkGoogleProviderMock).toHaveBeenCalled());
+    expect(screen.queryByText(/No pudimos vincular/)).not.toBeInTheDocument();
+  });
+
+  it('error popup-blocked → mensaje traducido', async () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['password']);
+    linkGoogleProviderMock.mockRejectedValueOnce(
+      Object.assign(new Error('blocked'), { code: 'auth/popup-blocked' }),
+    );
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Vincular/ })[0]!);
+    expect(await screen.findByText(/El navegador bloqueó/)).toBeInTheDocument();
+  });
+
+  it('error code desconocido → fallback "No pudimos vincular"', async () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['password']);
+    linkGoogleProviderMock.mockRejectedValueOnce(
+      Object.assign(new Error('boom'), { code: 'auth/something-else' }),
+    );
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getAllByRole('button', { name: /Vincular/ })[0]!);
+    expect(await screen.findByText(/No pudimos vincular/)).toBeInTheDocument();
+  });
+});
+
+describe('AuthProvidersSection — unlink', () => {
+  it('click Quitar → unlinkProvider + reload', async () => {
+    const user = makeUser();
+    useAuthMock.mockReturnValue({ user });
+    getLinkedProvidersMock.mockReturnValue(['google.com', 'password']);
+    unlinkProviderMock.mockResolvedValueOnce(undefined);
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Quitar' })[0]!);
+    await waitFor(() => expect(unlinkProviderMock).toHaveBeenCalledWith(user, expect.any(String)));
+  });
+});
+
+describe('AuthProvidersSection — PasswordLinkForm', () => {
+  it('hasPassword=false → muestra card "Email + contraseña" con botón Agregar', () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['google.com']);
+    render(<AuthProvidersSection />);
+    expect(screen.getByText(/Agregá una contraseña/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Agregar/ })).toBeInTheDocument();
+  });
+
+  it('click Agregar → abre form con email prefill', () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['google.com']);
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: /Agregar/ }));
+    expect(screen.getByLabelText(/^Email/)).toHaveValue('felipe@boosterchile.com');
+    expect(screen.getByLabelText(/Contraseña nueva/)).toBeInTheDocument();
+  });
+
+  it('cancelar cierra form', () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['google.com']);
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: /Agregar/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+    expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
+  });
+
+  it('submit happy → linkPasswordProvider + reload + cerrar form', async () => {
+    const user = makeUser();
+    useAuthMock.mockReturnValue({ user });
+    getLinkedProvidersMock.mockReturnValue(['google.com']);
+    linkPasswordProviderMock.mockResolvedValueOnce(undefined);
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: /Agregar/ }));
+    fireEvent.change(screen.getByLabelText(/Contraseña nueva/), {
+      target: { value: 'secret123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular' }));
+    await waitFor(() =>
+      expect(linkPasswordProviderMock).toHaveBeenCalledWith(
+        user,
+        'felipe@boosterchile.com',
+        'secret123',
+      ),
+    );
+  });
+
+  it('error requires-recent-login → muestra mensaje + botón Re-autenticar', async () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['google.com']);
+    linkPasswordProviderMock.mockRejectedValueOnce(
+      Object.assign(new Error(''), { code: 'auth/requires-recent-login' }),
+    );
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: /Agregar/ }));
+    fireEvent.change(screen.getByLabelText(/Contraseña nueva/), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular' }));
+    expect(await screen.findByText(/confirmar tu identidad/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Re-autenticar y vincular/ })).toBeInTheDocument();
+  });
+
+  it('Re-autenticar → reauthCurrent + retry link', async () => {
+    const user = makeUser();
+    useAuthMock.mockReturnValue({ user });
+    getLinkedProvidersMock.mockReturnValue(['google.com']);
+    linkPasswordProviderMock
+      .mockRejectedValueOnce(Object.assign(new Error(''), { code: 'auth/requires-recent-login' }))
+      .mockResolvedValueOnce(undefined);
+    reauthCurrentMock.mockResolvedValueOnce(undefined);
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: /Agregar/ }));
+    fireEvent.change(screen.getByLabelText(/Contraseña nueva/), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular' }));
+    await screen.findByRole('button', { name: /Re-autenticar y vincular/ });
+    fireEvent.click(screen.getByRole('button', { name: /Re-autenticar y vincular/ }));
+    await waitFor(() => expect(reauthCurrentMock).toHaveBeenCalledWith(user, { type: 'google' }));
+    await waitFor(() => expect(linkPasswordProviderMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('error genérico durante link → mensaje fallback', async () => {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['google.com']);
+    linkPasswordProviderMock.mockRejectedValueOnce(
+      Object.assign(new Error(''), { code: 'auth/network-request-failed' }),
+    );
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: /Agregar/ }));
+    fireEvent.change(screen.getByLabelText(/Contraseña nueva/), { target: { value: 'secret123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Vincular' }));
+    expect(await screen.findByText(/Sin conexión a internet/)).toBeInTheDocument();
+  });
+});
+
+describe('AuthProvidersSection — ChangePasswordForm', () => {
+  function setupHasPassword() {
+    useAuthMock.mockReturnValue({ user: makeUser() });
+    getLinkedProvidersMock.mockReturnValue(['password', 'google.com']);
+  }
+
+  it('muestra card "Cambiar contraseña" + botón Cambiar', () => {
+    setupHasPassword();
+    render(<AuthProvidersSection />);
+    expect(screen.getAllByText(/Cambiar contraseña/).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole('button', { name: 'Cambiar' })).toBeInTheDocument();
+  });
+
+  it('click Cambiar abre form con 3 inputs', () => {
+    setupHasPassword();
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar' }));
+    expect(screen.getByLabelText(/^Contraseña actual/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Nueva contraseña/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Confirmar nueva contraseña/)).toBeInTheDocument();
+  });
+
+  it('happy: reauth + updatePassword + cierra form con success', async () => {
+    const user = makeUser();
+    useAuthMock.mockReturnValue({ user });
+    getLinkedProvidersMock.mockReturnValue(['password', 'google.com']);
+    reauthCurrentMock.mockResolvedValueOnce(undefined);
+    updatePasswordCurrentMock.mockResolvedValueOnce(undefined);
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar' }));
+    fireEvent.change(screen.getByLabelText(/^Contraseña actual/), { target: { value: 'old123!' } });
+    fireEvent.change(screen.getByLabelText(/^Nueva contraseña/), {
+      target: { value: 'NewPass123' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Confirmar nueva contraseña/), {
+      target: { value: 'NewPass123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar contraseña' }));
+    await waitFor(() => expect(updatePasswordCurrentMock).toHaveBeenCalled());
+    expect(await screen.findByText('Contraseña actualizada.')).toBeInTheDocument();
+  });
+
+  it('contraseña actual incorrecta → error en input currentPassword', async () => {
+    setupHasPassword();
+    reauthCurrentMock.mockRejectedValueOnce(
+      Object.assign(new Error('wrong'), { code: 'auth/wrong-password' }),
+    );
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar' }));
+    fireEvent.change(screen.getByLabelText(/^Contraseña actual/), { target: { value: 'bad' } });
+    fireEvent.change(screen.getByLabelText(/^Nueva contraseña/), {
+      target: { value: 'NewPass123' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Confirmar nueva contraseña/), {
+      target: { value: 'NewPass123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar contraseña' }));
+    expect(await screen.findByText(/Contraseña actual incorrecta/)).toBeInTheDocument();
+  });
+
+  it('confirmPassword no coincide → error de validación', async () => {
+    setupHasPassword();
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar' }));
+    fireEvent.change(screen.getByLabelText(/^Contraseña actual/), { target: { value: 'old' } });
+    fireEvent.change(screen.getByLabelText(/^Nueva contraseña/), {
+      target: { value: 'NewPass123' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Confirmar nueva contraseña/), {
+      target: { value: 'OtraCosa1' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar contraseña' }));
+    expect(await screen.findByText(/No coincide/)).toBeInTheDocument();
+  });
+
+  it('user sin email → error "Tu cuenta no tiene un email asociado"', async () => {
+    useAuthMock.mockReturnValue({ user: makeUser({ email: null } as never) });
+    getLinkedProvidersMock.mockReturnValue(['password', 'google.com']);
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar' }));
+    fireEvent.change(screen.getByLabelText(/^Contraseña actual/), { target: { value: 'a' } });
+    fireEvent.change(screen.getByLabelText(/^Nueva contraseña/), {
+      target: { value: 'NewPass123' },
+    });
+    fireEvent.change(screen.getByLabelText(/^Confirmar nueva contraseña/), {
+      target: { value: 'NewPass123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar contraseña' }));
+    expect(await screen.findByText(/no tiene un email asociado/)).toBeInTheDocument();
+  });
+
+  it('cancelar cierra form', () => {
+    setupHasPassword();
+    render(<AuthProvidersSection />);
+    fireEvent.click(screen.getByRole('button', { name: 'Cambiar' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));
+    expect(screen.queryByLabelText('Contraseña actual')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/profile/TwoFactorSection.test.tsx
+++ b/apps/web/src/components/profile/TwoFactorSection.test.tsx
@@ -1,0 +1,184 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { Auth } from 'firebase/auth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const enrollPhoneAsSecondFactorMock = vi.fn();
+const listEnrolledSecondFactorsMock = vi.fn(
+  () => [] as Array<{ uid: string; displayName: string | null; factorId: string }>,
+);
+const unenrollSecondFactorMock = vi.fn();
+
+vi.mock('../../lib/two-factor.js', () => ({
+  enrollPhoneAsSecondFactor: enrollPhoneAsSecondFactorMock,
+  listEnrolledSecondFactors: listEnrolledSecondFactorsMock,
+  unenrollSecondFactor: unenrollSecondFactorMock,
+}));
+
+vi.mock('../../lib/firebase.js', () => ({
+  firebaseAuth: { __test__: true } as unknown as Auth,
+}));
+
+const { TwoFactorSection } = await import('./TwoFactorSection.js');
+
+const FAKE_AUTH = { __test__: 'override' } as unknown as Auth;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listEnrolledSecondFactorsMock.mockReturnValue([]);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('TwoFactorSection — render', () => {
+  it('sin factors → muestra mensaje "No tienes 2FA activado"', () => {
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    expect(screen.getByText(/No tienes 2FA activado/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Tu teléfono/)).toBeInTheDocument();
+  });
+
+  it('con factors → lista cada uno con botón Desactivar', () => {
+    listEnrolledSecondFactorsMock.mockReturnValue([
+      { uid: 'f1', displayName: 'SMS +569****', factorId: 'phone' },
+    ]);
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    expect(screen.getByText(/SMS \+569\*\*\*\*/)).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /Desactivar/ })).toHaveLength(1);
+  });
+
+  it('factor sin displayName → muestra "Teléfono"', () => {
+    listEnrolledSecondFactorsMock.mockReturnValue([
+      { uid: 'f1', displayName: null, factorId: 'phone' },
+    ]);
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    expect(screen.getByText(/Teléfono/)).toBeInTheDocument();
+  });
+
+  it('initialPhoneE164 prefill', () => {
+    render(<TwoFactorSection authOverride={FAKE_AUTH} initialPhoneE164="+56987654321" />);
+    expect(screen.getByLabelText(/Tu teléfono/)).toHaveValue('+56987654321');
+  });
+});
+
+describe('TwoFactorSection — enroll flow', () => {
+  it('teléfono inválido → error visible sin llamar enroll', async () => {
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    fireEvent.change(screen.getByLabelText(/Tu teléfono/), { target: { value: 'no-es-phone' } });
+    fireEvent.click(screen.getByRole('button', { name: /Activar 2FA/ }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Teléfono inválido/);
+    expect(enrollPhoneAsSecondFactorMock).not.toHaveBeenCalled();
+  });
+
+  it('happy path → llama enroll + muestra success + refresca lista', async () => {
+    enrollPhoneAsSecondFactorMock.mockImplementation(async (opts: any) => {
+      // Simula que el helper invoca promptSmsCode (no esperamos código real).
+      void opts.promptSmsCode;
+      return { ok: true };
+    });
+    listEnrolledSecondFactorsMock
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([{ uid: 'f1', displayName: 'SMS +569****', factorId: 'phone' }]);
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    fireEvent.change(screen.getByLabelText(/Tu teléfono/), { target: { value: '+56912345678' } });
+    fireEvent.click(screen.getByRole('button', { name: /Activar 2FA/ }));
+    expect(await screen.findByText(/2FA activado correctamente/)).toBeInTheDocument();
+    expect(enrollPhoneAsSecondFactorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: FAKE_AUTH,
+        phoneE164: '+56912345678',
+        recaptchaContainerId: 'recaptcha-container-2fa',
+      }),
+    );
+  });
+
+  it('enroll devuelve reason no_user → mensaje específico', async () => {
+    enrollPhoneAsSecondFactorMock.mockResolvedValueOnce({ ok: false, reason: 'no_user' });
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    fireEvent.change(screen.getByLabelText(/Tu teléfono/), { target: { value: '+56912345678' } });
+    fireEvent.click(screen.getByRole('button', { name: /Activar 2FA/ }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/Necesitas estar logueado/);
+  });
+
+  for (const [reason, regex] of [
+    ['phone_invalid', /Formato esperado/],
+    ['sms_cancelled', /Cancelaste el ingreso/],
+    ['sms_invalid', /código SMS es incorrecto/],
+    ['unknown', /Ocurrió un error/],
+  ] as const) {
+    it(`enroll reason=${reason} → ${regex}`, async () => {
+      enrollPhoneAsSecondFactorMock.mockResolvedValueOnce({ ok: false, reason });
+      render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+      fireEvent.change(screen.getByLabelText(/Tu teléfono/), {
+        target: { value: '+56912345678' },
+      });
+      fireEvent.click(screen.getByRole('button', { name: /Activar 2FA/ }));
+      expect(await screen.findByRole('alert')).toHaveTextContent(regex);
+    });
+  }
+});
+
+describe('TwoFactorSection — SMS prompt UI', () => {
+  it('promptSmsCode abre dialog → confirmar resuelve con código', async () => {
+    let resolveValue: string | null | undefined;
+    enrollPhoneAsSecondFactorMock.mockImplementation(async (opts: any) => {
+      resolveValue = await opts.promptSmsCode();
+      return { ok: true };
+    });
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    fireEvent.change(screen.getByLabelText(/Tu teléfono/), { target: { value: '+56912345678' } });
+    fireEvent.click(screen.getByRole('button', { name: /Activar 2FA/ }));
+    const codeInput = await screen.findByPlaceholderText('123456');
+    fireEvent.change(codeInput, { target: { value: '654321' } });
+    fireEvent.click(screen.getByRole('button', { name: /Confirmar/ }));
+    await waitFor(() => expect(resolveValue).toBe('654321'));
+  });
+
+  it('promptSmsCode cancelar → resuelve con null', async () => {
+    let resolveValue: string | null | undefined;
+    enrollPhoneAsSecondFactorMock.mockImplementation(async (opts: any) => {
+      resolveValue = await opts.promptSmsCode();
+      return { ok: false, reason: 'sms_cancelled' };
+    });
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    fireEvent.change(screen.getByLabelText(/Tu teléfono/), { target: { value: '+56912345678' } });
+    fireEvent.click(screen.getByRole('button', { name: /Activar 2FA/ }));
+    await screen.findByPlaceholderText('123456');
+    fireEvent.click(screen.getByRole('button', { name: /Cancelar/ }));
+    await waitFor(() => expect(resolveValue).toBeNull());
+  });
+
+  it('confirmar sin código → botón disabled', async () => {
+    enrollPhoneAsSecondFactorMock.mockImplementation(async (opts: any) => {
+      void opts.promptSmsCode();
+      return { ok: false, reason: 'sms_cancelled' };
+    });
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    fireEvent.change(screen.getByLabelText(/Tu teléfono/), { target: { value: '+56912345678' } });
+    fireEvent.click(screen.getByRole('button', { name: /Activar 2FA/ }));
+    await screen.findByPlaceholderText('123456');
+    expect(screen.getByRole('button', { name: /Confirmar/ })).toBeDisabled();
+  });
+});
+
+describe('TwoFactorSection — unenroll', () => {
+  it('happy → llama unenroll + success + refresca', async () => {
+    listEnrolledSecondFactorsMock
+      .mockReturnValueOnce([{ uid: 'f1', displayName: 'SMS', factorId: 'phone' }])
+      .mockReturnValueOnce([]);
+    unenrollSecondFactorMock.mockResolvedValueOnce({ ok: true });
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    fireEvent.click(screen.getByRole('button', { name: /Desactivar/ }));
+    expect(await screen.findByText(/Factor desactivado/)).toBeInTheDocument();
+    expect(unenrollSecondFactorMock).toHaveBeenCalledWith({ auth: FAKE_AUTH, factorUid: 'f1' });
+  });
+
+  it('unenroll falla → error visible', async () => {
+    listEnrolledSecondFactorsMock.mockReturnValue([
+      { uid: 'f1', displayName: 'SMS', factorId: 'phone' },
+    ]);
+    unenrollSecondFactorMock.mockResolvedValueOnce({ ok: false });
+    render(<TwoFactorSection authOverride={FAKE_AUTH} />);
+    fireEvent.click(screen.getByRole('button', { name: /Desactivar/ }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/No se pudo desactivar/);
+  });
+});

--- a/apps/web/src/hooks/use-chat-messages.test.tsx
+++ b/apps/web/src/hooks/use-chat-messages.test.tsx
@@ -1,0 +1,167 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchChatMessagesMock = vi.fn();
+const markChatReadMock = vi.fn();
+vi.mock('../lib/chat-api.js', () => ({
+  fetchChatMessages: fetchChatMessagesMock,
+  markChatRead: markChatReadMock,
+}));
+
+let chatStreamOpts: {
+  assignmentId: string | null;
+  onMessage: (msg: { message_id: string; assignment_id: string }) => void;
+  onConnect?: () => void;
+  onDisconnect?: () => void;
+  enabled?: boolean;
+} | null = null;
+vi.mock('./use-chat-stream.js', () => ({
+  useChatStream: (opts: typeof chatStreamOpts) => {
+    chatStreamOpts = opts;
+  },
+}));
+
+const { useChatMessages } = await import('./use-chat-messages.js');
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  chatStreamOpts = null;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const PAGE_1 = {
+  messages: [
+    { id: 'm2', body: 'hola 2', created_at: '2026-05-10T10:01:00Z', sender_role: 'shipper' },
+    { id: 'm1', body: 'hola 1', created_at: '2026-05-10T10:00:00Z', sender_role: 'carrier' },
+  ],
+  next_cursor: 'cursor-page-2',
+  viewer_role: 'carrier',
+};
+const PAGE_2 = {
+  messages: [
+    { id: 'm0', body: 'mas viejo', created_at: '2026-05-10T09:59:00Z', sender_role: 'shipper' },
+  ],
+  next_cursor: null,
+  viewer_role: 'carrier',
+};
+
+describe('useChatMessages — query', () => {
+  it('enabled=true (default) → fetch página inicial sin cursor', async () => {
+    fetchChatMessagesMock.mockResolvedValueOnce(PAGE_1);
+    markChatReadMock.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useChatMessages('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(fetchChatMessagesMock).toHaveBeenCalledWith({ assignmentId: 'a1', limit: 50 });
+    expect(result.current.messages).toHaveLength(2);
+    expect(result.current.viewerRole).toBe('carrier');
+    expect(result.current.hasMore).toBe(true);
+  });
+
+  it('enabled=false → no fetch + no SSE habilitado', () => {
+    renderHook(() => useChatMessages('a1', { enabled: false }), { wrapper: makeWrapper() });
+    expect(fetchChatMessagesMock).not.toHaveBeenCalled();
+    expect(chatStreamOpts?.assignmentId).toBeNull();
+  });
+
+  it('viewerRole=null inicialmente (sin data)', () => {
+    fetchChatMessagesMock.mockImplementation(() => new Promise<never>(() => undefined));
+    const { result } = renderHook(() => useChatMessages('a1'), { wrapper: makeWrapper() });
+    expect(result.current.viewerRole).toBeNull();
+    expect(result.current.messages).toEqual([]);
+  });
+});
+
+describe('useChatMessages — loadMore', () => {
+  it('loadMore → fetch siguiente página con cursor', async () => {
+    fetchChatMessagesMock.mockResolvedValueOnce(PAGE_1).mockResolvedValueOnce(PAGE_2);
+    const { result } = renderHook(() => useChatMessages('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.hasMore).toBe(true));
+    await act(async () => {
+      result.current.loadMore();
+    });
+    await waitFor(() => expect(result.current.messages).toHaveLength(3));
+    expect(fetchChatMessagesMock).toHaveBeenCalledWith({
+      assignmentId: 'a1',
+      cursor: 'cursor-page-2',
+      limit: 50,
+    });
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('loadMore sin hasNextPage → no-op', async () => {
+    fetchChatMessagesMock.mockResolvedValueOnce({ ...PAGE_1, next_cursor: null });
+    const { result } = renderHook(() => useChatMessages('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.hasMore).toBe(false));
+    fetchChatMessagesMock.mockClear();
+    await act(async () => {
+      result.current.loadMore();
+    });
+    expect(fetchChatMessagesMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('useChatMessages — SSE wired', () => {
+  it('onConnect del stream → isLive=true', async () => {
+    fetchChatMessagesMock.mockResolvedValueOnce(PAGE_1);
+    const { result } = renderHook(() => useChatMessages('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(chatStreamOpts).not.toBeNull());
+    act(() => {
+      chatStreamOpts?.onConnect?.();
+    });
+    expect(result.current.isLive).toBe(true);
+  });
+
+  it('onDisconnect → isLive=false', async () => {
+    fetchChatMessagesMock.mockResolvedValueOnce(PAGE_1);
+    const { result } = renderHook(() => useChatMessages('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(chatStreamOpts).not.toBeNull());
+    act(() => {
+      chatStreamOpts?.onConnect?.();
+      chatStreamOpts?.onDisconnect?.();
+    });
+    expect(result.current.isLive).toBe(false);
+  });
+
+  it('onMessage del stream → invalida query y dispara markRead', async () => {
+    fetchChatMessagesMock.mockResolvedValue(PAGE_1);
+    markChatReadMock.mockResolvedValue(undefined);
+    renderHook(() => useChatMessages('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(chatStreamOpts).not.toBeNull());
+    await waitFor(() => expect(markChatReadMock).toHaveBeenCalled());
+    markChatReadMock.mockClear();
+    fetchChatMessagesMock.mockClear();
+    act(() => {
+      chatStreamOpts?.onMessage({ message_id: 'm9', assignment_id: 'a1' });
+    });
+    await waitFor(() => expect(fetchChatMessagesMock).toHaveBeenCalled());
+    expect(markChatReadMock).toHaveBeenCalled();
+  });
+});
+
+describe('useChatMessages — markRead inicial', () => {
+  it('al recibir primera page → markRead se dispara una vez', async () => {
+    fetchChatMessagesMock.mockResolvedValueOnce(PAGE_1);
+    markChatReadMock.mockResolvedValue(undefined);
+    renderHook(() => useChatMessages('a1'), { wrapper: makeWrapper() });
+    await waitFor(() => expect(markChatReadMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('enabled=false → no markRead', async () => {
+    renderHook(() => useChatMessages('a1', { enabled: false }), { wrapper: makeWrapper() });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(markChatReadMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/use-chat-stream.test.tsx
+++ b/apps/web/src/hooks/use-chat-stream.test.tsx
@@ -1,0 +1,155 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getIdTokenMock = vi.fn(async () => 'firebase-id-token');
+const currentUserState: { value: { getIdToken: typeof getIdTokenMock } | null } = {
+  value: { getIdToken: getIdTokenMock },
+};
+vi.mock('../lib/firebase.js', () => ({
+  firebaseAuth: {
+    get currentUser() {
+      return currentUserState.value;
+    },
+  },
+}));
+
+const { useChatStream } = await import('./use-chat-stream.js');
+
+interface FakeEventSource {
+  url: string;
+  listeners: Map<string, ((ev: MessageEvent) => void)[]>;
+  onerror: (() => void) | null;
+  closed: boolean;
+  emit: (type: string, data?: unknown) => void;
+  close: () => void;
+}
+
+let lastEventSource: FakeEventSource | null = null;
+
+class StubEventSource implements FakeEventSource {
+  listeners = new Map<string, ((ev: MessageEvent) => void)[]>();
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  constructor(public url: string) {
+    lastEventSource = this;
+  }
+
+  addEventListener(type: string, cb: (ev: MessageEvent) => void) {
+    const arr = this.listeners.get(type) ?? [];
+    arr.push(cb);
+    this.listeners.set(type, arr);
+  }
+
+  emit(type: string, data?: unknown) {
+    const cbs = this.listeners.get(type) ?? [];
+    for (const cb of cbs) {
+      cb({ data: typeof data === 'string' ? data : JSON.stringify(data) } as MessageEvent);
+    }
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+beforeEach(() => {
+  lastEventSource = null;
+  currentUserState.value = { getIdToken: getIdTokenMock };
+  getIdTokenMock.mockClear();
+  (globalThis as any).EventSource = StubEventSource;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  Reflect.deleteProperty(globalThis as any, 'EventSource');
+});
+
+async function flushPromises() {
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('useChatStream', () => {
+  it('enabled=false → no abre EventSource', async () => {
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn(), enabled: false }));
+    await flushPromises();
+    expect(lastEventSource).toBeNull();
+  });
+
+  it('assignmentId=null → no abre EventSource', async () => {
+    renderHook(() => useChatStream({ assignmentId: null, onMessage: vi.fn() }));
+    await flushPromises();
+    expect(lastEventSource).toBeNull();
+  });
+
+  it('sin currentUser → no abre EventSource (timer agendado)', async () => {
+    currentUserState.value = null;
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn() }));
+    await flushPromises();
+    expect(lastEventSource).toBeNull();
+  });
+
+  it('happy path: connect → onMessage parsea JSON y llama callback', async () => {
+    const onMessage = vi.fn();
+    const onConnect = vi.fn();
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage, onConnect }));
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    expect(lastEventSource?.url).toContain('/assignments/a1/messages/stream');
+    expect(lastEventSource?.url).toContain('auth=firebase-id-token');
+
+    lastEventSource?.emit('connected');
+    expect(onConnect).toHaveBeenCalled();
+
+    lastEventSource?.emit('message', { message_id: 'm1', assignment_id: 'a1' });
+    expect(onMessage).toHaveBeenCalledWith({ message_id: 'm1', assignment_id: 'a1' });
+  });
+
+  it('payload no-JSON → log warn, no crash, no callback', async () => {
+    const onMessage = vi.fn();
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage }));
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    lastEventSource?.emit('message', 'not-valid-json{');
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('heartbeat → no-op (no llama onMessage)', async () => {
+    const onMessage = vi.fn();
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage }));
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    lastEventSource?.emit('heartbeat');
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it('onerror → close + onDisconnect (reconnect agendado con backoff)', async () => {
+    const onDisconnect = vi.fn();
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn(), onDisconnect }));
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    const first = lastEventSource;
+    first?.onerror?.();
+    expect(onDisconnect).toHaveBeenCalled();
+    expect(first?.closed).toBe(true);
+  });
+
+  it('cleanup en unmount → close + cancela reconnect timer', async () => {
+    const { unmount } = renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn() }));
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    const es = lastEventSource;
+    unmount();
+    expect(es?.closed).toBe(true);
+  });
+
+  it('cambio de assignmentId → cierra el stream anterior y abre uno nuevo', async () => {
+    const { rerender } = renderHook(
+      ({ id }: { id: string }) => useChatStream({ assignmentId: id, onMessage: vi.fn() }),
+      { initialProps: { id: 'a1' } },
+    );
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    const first = lastEventSource;
+    expect(first?.url).toContain('/assignments/a1/');
+
+    rerender({ id: 'a2' });
+    await waitFor(() => expect(lastEventSource?.url).toContain('/assignments/a2/'));
+    expect(first?.closed).toBe(true);
+  });
+});

--- a/apps/web/src/lib/two-factor.test.ts
+++ b/apps/web/src/lib/two-factor.test.ts
@@ -1,0 +1,250 @@
+import type { Auth, MultiFactorError } from 'firebase/auth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const verifyPhoneNumberMock = vi.fn();
+const getSessionMock = vi.fn();
+const enrollMock = vi.fn();
+const unenrollMock = vi.fn();
+const enrolledFactorsMock = vi.fn(
+  () => [] as Array<{ uid: string; displayName: string | null; factorId: string }>,
+);
+const recaptchaClearMock = vi.fn();
+function RecaptchaVerifierStub(this: { clear: typeof recaptchaClearMock }) {
+  this.clear = recaptchaClearMock;
+}
+function PhoneAuthProviderStub(this: { verifyPhoneNumber: typeof verifyPhoneNumberMock }) {
+  this.verifyPhoneNumber = verifyPhoneNumberMock;
+}
+const phoneCredentialMock = vi.fn(() => ({ kind: 'cred' }));
+const phoneAssertionMock = vi.fn(() => ({ kind: 'assertion' }));
+const getMultiFactorResolverMock = vi.fn();
+
+vi.mock('firebase/auth', () => ({
+  multiFactor: vi.fn(() => ({
+    getSession: getSessionMock,
+    enroll: enrollMock,
+    unenroll: unenrollMock,
+    get enrolledFactors() {
+      return enrolledFactorsMock();
+    },
+  })),
+  PhoneAuthProvider: Object.assign(PhoneAuthProviderStub, {
+    credential: phoneCredentialMock,
+  }),
+  PhoneMultiFactorGenerator: {
+    FACTOR_ID: 'phone',
+    assertion: phoneAssertionMock,
+  },
+  RecaptchaVerifier: RecaptchaVerifierStub,
+  getMultiFactorResolver: getMultiFactorResolverMock,
+}));
+
+const {
+  enrollPhoneAsSecondFactor,
+  listEnrolledSecondFactors,
+  resolveMultiFactorSignIn,
+  unenrollSecondFactor,
+} = await import('./two-factor.js');
+
+function makeAuth(currentUser: { uid: string } | null = { uid: 'u1' }): Auth {
+  return { currentUser } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  enrolledFactorsMock.mockReturnValue([]);
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('enrollPhoneAsSecondFactor', () => {
+  const baseOpts = {
+    phoneE164: '+56912345678',
+    recaptchaContainerId: 'recaptcha-x',
+    promptSmsCode: vi.fn(async () => '123456'),
+  };
+
+  it('no_user → ok:false reason no_user', async () => {
+    const r = await enrollPhoneAsSecondFactor({ auth: makeAuth(null), ...baseOpts });
+    expect(r).toEqual({ ok: false, reason: 'no_user' });
+  });
+
+  it('phone con formato inválido → reason phone_invalid', async () => {
+    const r = await enrollPhoneAsSecondFactor({
+      auth: makeAuth(),
+      ...baseOpts,
+      phoneE164: 'no-es-phone',
+    });
+    expect(r).toEqual({ ok: false, reason: 'phone_invalid' });
+  });
+
+  it('happy path: getSession + verifyPhoneNumber + enroll → ok:true', async () => {
+    getSessionMock.mockResolvedValueOnce({ session: 'sess' });
+    verifyPhoneNumberMock.mockResolvedValueOnce('verif-id');
+    enrollMock.mockResolvedValueOnce(undefined);
+
+    const r = await enrollPhoneAsSecondFactor({ auth: makeAuth(), ...baseOpts });
+    expect(r).toEqual({ ok: true });
+    expect(phoneCredentialMock).toHaveBeenCalledWith('verif-id', '123456');
+    expect(enrollMock).toHaveBeenCalled();
+    expect(recaptchaClearMock).toHaveBeenCalled();
+  });
+
+  it('user cancela el SMS prompt → reason sms_cancelled', async () => {
+    getSessionMock.mockResolvedValueOnce({ session: 'sess' });
+    verifyPhoneNumberMock.mockResolvedValueOnce('verif-id');
+    const opts = { ...baseOpts, promptSmsCode: vi.fn(async () => null) };
+    const r = await enrollPhoneAsSecondFactor({ auth: makeAuth(), ...opts });
+    expect(r).toEqual({ ok: false, reason: 'sms_cancelled' });
+    expect(enrollMock).not.toHaveBeenCalled();
+    expect(recaptchaClearMock).toHaveBeenCalled();
+  });
+
+  it('Firebase devuelve auth/invalid-verification-code → reason sms_invalid', async () => {
+    getSessionMock.mockResolvedValueOnce({ session: 'sess' });
+    verifyPhoneNumberMock.mockResolvedValueOnce('verif-id');
+    enrollMock.mockRejectedValueOnce(
+      Object.assign(new Error('bad code'), { code: 'auth/invalid-verification-code' }),
+    );
+    const r = await enrollPhoneAsSecondFactor({ auth: makeAuth(), ...baseOpts });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('sms_invalid');
+      expect(r.detail).toContain('bad code');
+    }
+  });
+
+  it('error genérico (network) → reason unknown con detail', async () => {
+    getSessionMock.mockRejectedValueOnce(new Error('network down'));
+    const r = await enrollPhoneAsSecondFactor({ auth: makeAuth(), ...baseOpts });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('unknown');
+      expect(r.detail).toContain('network down');
+    }
+  });
+});
+
+describe('listEnrolledSecondFactors', () => {
+  it('sin user → []', () => {
+    expect(listEnrolledSecondFactors({ auth: makeAuth(null) })).toEqual([]);
+  });
+
+  it('con factors → mapea uid/displayName/factorId', () => {
+    enrolledFactorsMock.mockReturnValueOnce([
+      { uid: 'f1', displayName: 'SMS +569****', factorId: 'phone' },
+      { uid: 'f2', displayName: null, factorId: 'totp' },
+    ]);
+    const result = listEnrolledSecondFactors({ auth: makeAuth() });
+    expect(result).toEqual([
+      { uid: 'f1', displayName: 'SMS +569****', factorId: 'phone' },
+      { uid: 'f2', displayName: null, factorId: 'totp' },
+    ]);
+  });
+});
+
+describe('unenrollSecondFactor', () => {
+  it('sin user → ok:false', async () => {
+    const r = await unenrollSecondFactor({ auth: makeAuth(null), factorUid: 'f1' });
+    expect(r).toEqual({ ok: false });
+  });
+
+  it('happy → ok:true + multiFactor.unenroll llamado', async () => {
+    unenrollMock.mockResolvedValueOnce(undefined);
+    const r = await unenrollSecondFactor({ auth: makeAuth(), factorUid: 'f1' });
+    expect(r).toEqual({ ok: true });
+    expect(unenrollMock).toHaveBeenCalledWith('f1');
+  });
+
+  it('Firebase falla → ok:false', async () => {
+    unenrollMock.mockRejectedValueOnce(new Error('not found'));
+    const r = await unenrollSecondFactor({ auth: makeAuth(), factorUid: 'f1' });
+    expect(r).toEqual({ ok: false });
+  });
+});
+
+describe('resolveMultiFactorSignIn', () => {
+  const opts = {
+    recaptchaContainerId: 'rc',
+    promptSmsCode: vi.fn(async () => '654321'),
+  };
+  const fakeError = {} as MultiFactorError;
+
+  it('sin phone factor en hints → reason no_phone_factor', async () => {
+    getMultiFactorResolverMock.mockReturnValueOnce({
+      hints: [{ factorId: 'totp' }],
+      session: { session: 's' },
+      resolveSignIn: vi.fn(),
+    });
+    const r = await resolveMultiFactorSignIn({ auth: makeAuth(), error: fakeError, ...opts });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('no_phone_factor');
+    }
+  });
+
+  it('happy path → ok:true', async () => {
+    const resolveSignIn = vi.fn(async () => undefined);
+    getMultiFactorResolverMock.mockReturnValueOnce({
+      hints: [{ factorId: 'phone' }],
+      session: { session: 's' },
+      resolveSignIn,
+    });
+    verifyPhoneNumberMock.mockResolvedValueOnce('verif-id');
+
+    const r = await resolveMultiFactorSignIn({ auth: makeAuth(), error: fakeError, ...opts });
+    expect(r).toEqual({ ok: true });
+    expect(resolveSignIn).toHaveBeenCalled();
+  });
+
+  it('user cancela → reason sms_cancelled', async () => {
+    getMultiFactorResolverMock.mockReturnValueOnce({
+      hints: [{ factorId: 'phone' }],
+      session: { session: 's' },
+      resolveSignIn: vi.fn(),
+    });
+    verifyPhoneNumberMock.mockResolvedValueOnce('verif-id');
+    const r = await resolveMultiFactorSignIn({
+      auth: makeAuth(),
+      error: fakeError,
+      ...opts,
+      promptSmsCode: vi.fn(async () => null),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('sms_cancelled');
+    }
+  });
+
+  it('Firebase devuelve auth/invalid-verification-code → reason sms_invalid', async () => {
+    const resolveSignIn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error('bad'), { code: 'auth/invalid-verification-code' }),
+      );
+    getMultiFactorResolverMock.mockReturnValueOnce({
+      hints: [{ factorId: 'phone' }],
+      session: { session: 's' },
+      resolveSignIn,
+    });
+    verifyPhoneNumberMock.mockResolvedValueOnce('verif-id');
+
+    const r = await resolveMultiFactorSignIn({ auth: makeAuth(), error: fakeError, ...opts });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('sms_invalid');
+    }
+  });
+
+  it('error genérico → reason unknown', async () => {
+    getMultiFactorResolverMock.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    const r = await resolveMultiFactorSignIn({ auth: makeAuth(), error: fakeError, ...opts });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toBe('unknown');
+    }
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -29,24 +29,14 @@ export default defineConfig({
         'src/router.tsx', // TanStack Router config con lazy imports — tested e2e
         'src/sw.ts', // Service Worker — runtime de browser, no jsdom
         'src/lib/firebase.ts', // initializeApp + setPersistence side-effects at-import
-        // 2FA helpers + UI: integran con Firebase Phone Auth + reCAPTCHA.
-        // Se testean mejor con Playwright e2e contra Firebase real (no
-        // mockeable significativamente). Ver ADR-028 §"Acciones derivadas §6".
-        'src/lib/two-factor.ts',
-        'src/components/profile/TwoFactorSection.tsx',
         // Páginas grandes con TanStack Router + lazy imports + form complejos +
         // mapas Google. Se testean mejor con Playwright e2e contra build real.
         'src/routes/**',
-        // Components UI complejos con Google Maps + SSE + form-hook + Firebase
-        // — testeables sólo con Playwright e2e contra build real.
-        'src/components/map/**',
-        'src/components/chat/ChatPanel.tsx',
-        'src/components/profile/AuthProvidersSection.tsx',
-        'src/components/onboarding/OnboardingForm.tsx',
-        'src/components/map/**',
-        // Hooks que sólo tienen sentido in-browser (SSE EventSource, telemetría).
-        'src/hooks/use-chat-stream.ts',
-        'src/hooks/use-chat-messages.ts',
+        // Componentes que dependen del SDK Google Maps en runtime — sólo
+        // se cubren con Playwright e2e contra build real. use-follow-vehicle
+        // es lógica pura y SI tiene tests unitarios.
+        'src/components/map/VehicleMap.tsx',
+        'src/components/map/LiveTrackingScreen.tsx',
       ],
       // Gates bloqueantes — el CI verifica coverage-summary.json.
       // CLAUDE.md objetivo: 80%/75%/80%/80%. Cumplido sobre el subset testable


### PR DESCRIPTION
## Resumen

Web coverage **87% → 96.07% lines / 77% → 90.71% branches / 84% → 97.24% functions** cubriendo los 7 archivos antes excluidos por integración con Firebase Phone Auth, SSE, Google Maps y forms multi-step.

Tests web: **299 → 423 (+124)** en 7 archivos nuevos.

## Cambios — tests nuevos

| Archivo | Tests | Cobertura previa |
|---------|-------|------------------|
| \`two-factor.test.ts\` | 16 | excluido (Firebase Phone) |
| \`use-chat-stream.test.tsx\` | 9 | excluido (SSE EventSource) |
| \`use-chat-messages.test.tsx\` | 10 | excluido (SSE wired + paginación) |
| \`TwoFactorSection.test.tsx\` | 16 | excluido (Firebase Phone UI) |
| \`ChatPanel.test.tsx\` | 30 | excluido (UI compleja + foto) |
| \`AuthProvidersSection.test.tsx\` | 23 | excluido (Firebase OAuth linking) |
| \`OnboardingForm.test.tsx\` | 20 | excluido (multi-step 673 líneas) |

## Excludes restantes (mantener)

Los siguientes archivos quedan excluidos del coverage porque genuinamente no tienen lógica unit-testeable en jsdom — su valor está en e2e Playwright:

- \`src/main.tsx\` — bootstrap React DOM
- \`src/router.tsx\` — TanStack Router config con lazy imports
- \`src/sw.ts\` — Service Worker (runtime browser)
- \`src/lib/firebase.ts\` — initializeApp + setPersistence side-effect at-import
- \`src/routes/**\` — pages que componen todo (e2e responsibility)
- \`src/components/map/VehicleMap.tsx\` — Google Maps SDK runtime
- \`src/components/map/LiveTrackingScreen.tsx\` — Google Maps SDK runtime

## Test plan

- [x] \`pnpm lint\` verde
- [x] \`pnpm typecheck\` verde (29/29 paquetes)
- [x] \`pnpm --filter @booster-ai/web test\` 423/423 verde
- [x] Coverage cumple threshold 80/75/75/80 con margen amplio
- [ ] CI: 14 checks SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)