### PR TITLE
feat(web): vehicle-stopped guard para auto-play del coaching IA (Phase 4 PR-K1)

### DIFF
--- a/apps/web/src/components/scoring/CoachingVoicePlayer.test.tsx
+++ b/apps/web/src/components/scoring/CoachingVoicePlayer.test.tsx
@@ -1,7 +1,38 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { CoachingVoiceController, VoiceState } from '../../services/coaching-voice.js';
+import type { StoppedDetector, StoppedState } from '../../services/stopped-detector.js';
 import { CoachingVoicePlayer } from './CoachingVoicePlayer.js';
+
+/**
+ * Stub StoppedDetector con state observable + control manual.
+ */
+function makeStoppedDetector(initial: StoppedState = 'unknown'): StoppedDetector & {
+  emit: (s: StoppedState) => void;
+  spies: { stop: ReturnType<typeof vi.fn> };
+} {
+  let state: StoppedState = initial;
+  const listeners = new Set<(s: StoppedState) => void>();
+  const stop = vi.fn();
+  return {
+    getState: () => state,
+    subscribe: (l) => {
+      listeners.add(l);
+      l(state);
+      return () => {
+        listeners.delete(l);
+      };
+    },
+    stop,
+    emit: (s: StoppedState) => {
+      state = s;
+      for (const l of listeners) {
+        l(s);
+      }
+    },
+    spies: { stop },
+  };
+}
 
 /**
  * Stub controller: state observable + spies en play/stop.
@@ -118,24 +149,105 @@ describe('CoachingVoicePlayer', () => {
     expect(window.localStorage.getItem('booster:coaching-voice:autoplay-enabled')).toBeNull();
   });
 
-  it('auto-play opt-in: arranca al montar si localStorage flag está', () => {
+  it('auto-play opt-in con guard desactivado (stoppedDetector=null): arranca al montar', () => {
     window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
     const ctrl = makeController('idle');
-    render(<CoachingVoicePlayer message="Mantén distancia." controller={ctrl} />);
+    render(
+      <CoachingVoicePlayer message="Mantén distancia." controller={ctrl} stoppedDetector={null} />,
+    );
     expect(ctrl.spies.play).toHaveBeenCalledWith('Mantén distancia.');
   });
 
   it('auto-play OFF: NO arranca al montar', () => {
     const ctrl = makeController('idle');
-    render(<CoachingVoicePlayer message="Mantén distancia." controller={ctrl} />);
+    render(
+      <CoachingVoicePlayer message="Mantén distancia." controller={ctrl} stoppedDetector={null} />,
+    );
     expect(ctrl.spies.play).not.toHaveBeenCalled();
   });
 
   it('auto-play con message vacío: NO arranca (defensivo)', () => {
     window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
     const ctrl = makeController('idle');
-    render(<CoachingVoicePlayer message="   " controller={ctrl} />);
+    render(<CoachingVoicePlayer message="   " controller={ctrl} stoppedDetector={null} />);
     expect(ctrl.spies.play).not.toHaveBeenCalled();
+  });
+
+  // Phase 4 PR-K1 — guard de vehículo parado
+  describe('stopped guard (Phase 4 PR-K1)', () => {
+    it('auto-play + stoppedDetector unknown: NO arranca (espera certeza)', () => {
+      window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
+      const ctrl = makeController('idle');
+      const det = makeStoppedDetector('unknown');
+      render(
+        <CoachingVoicePlayer message="hola mundo coach" controller={ctrl} stoppedDetector={det} />,
+      );
+      expect(ctrl.spies.play).not.toHaveBeenCalled();
+    });
+
+    it('auto-play + stoppedDetector moving: NO arranca + muestra hint', () => {
+      window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
+      const ctrl = makeController('idle');
+      const det = makeStoppedDetector('moving');
+      render(
+        <CoachingVoicePlayer message="hola mundo coach" controller={ctrl} stoppedDetector={det} />,
+      );
+      expect(ctrl.spies.play).not.toHaveBeenCalled();
+      expect(screen.getByTestId('autoplay-waiting-stopped')).toBeInTheDocument();
+    });
+
+    it('auto-play + stoppedDetector stopped: arranca al montar', () => {
+      window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
+      const ctrl = makeController('idle');
+      const det = makeStoppedDetector('stopped');
+      render(
+        <CoachingVoicePlayer message="hola mundo coach" controller={ctrl} stoppedDetector={det} />,
+      );
+      expect(ctrl.spies.play).toHaveBeenCalledWith('hola mundo coach');
+    });
+
+    it('auto-play + transición moving → stopped: arranca cuando se detiene', () => {
+      window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
+      const ctrl = makeController('idle');
+      const det = makeStoppedDetector('moving');
+      render(
+        <CoachingVoicePlayer message="hola mundo coach" controller={ctrl} stoppedDetector={det} />,
+      );
+      expect(ctrl.spies.play).not.toHaveBeenCalled();
+
+      act(() => {
+        det.emit('stopped');
+      });
+      expect(ctrl.spies.play).toHaveBeenCalledWith('hola mundo coach');
+    });
+
+    it('auto-play + denied: arranca igual (respetar opt-in del conductor)', () => {
+      window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
+      const ctrl = makeController('idle');
+      const det = makeStoppedDetector('denied');
+      render(
+        <CoachingVoicePlayer message="hola mundo coach" controller={ctrl} stoppedDetector={det} />,
+      );
+      expect(ctrl.spies.play).toHaveBeenCalled();
+    });
+
+    it('hint "esperando vehículo detenga" NO se muestra si auto-play OFF', () => {
+      const ctrl = makeController('idle');
+      const det = makeStoppedDetector('moving');
+      render(<CoachingVoicePlayer message="hola" controller={ctrl} stoppedDetector={det} />);
+      expect(screen.queryByTestId('autoplay-waiting-stopped')).not.toBeInTheDocument();
+    });
+
+    it('detector.stop() es llamado al unmount', () => {
+      window.localStorage.setItem('booster:coaching-voice:autoplay-enabled', '1');
+      const ctrl = makeController('idle');
+      const det = makeStoppedDetector('stopped');
+      const { unmount } = render(
+        <CoachingVoicePlayer message="hola" controller={ctrl} stoppedDetector={det} />,
+      );
+      unmount();
+      expect(det.spies.stop).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('aria-live region anuncia speaking a screen readers', () => {

--- a/apps/web/src/components/scoring/CoachingVoicePlayer.tsx
+++ b/apps/web/src/components/scoring/CoachingVoicePlayer.tsx
@@ -7,6 +7,11 @@ import {
   loadAutoplayPreference,
   saveAutoplayPreference,
 } from '../../services/coaching-voice.js';
+import {
+  type StoppedDetector,
+  type StoppedState,
+  createStoppedDetector,
+} from '../../services/stopped-detector.js';
 
 /**
  * Botón único para reproducir el coaching IA por voz al conductor
@@ -44,9 +49,21 @@ export interface CoachingVoicePlayerProps {
    * por mount. Tests pueden pasar uno con synth stubeado.
    */
   controller?: CoachingVoiceController;
+  /**
+   * Inyectable para tests. Default: createStoppedDetector() basado en
+   * navigator.geolocation. Si auto-play está activo, gateamos el play
+   * inicial detrás de state='stopped' para no distraer al volante.
+   * Pasar `null` desactiva el guard (auto-play arranca al instante —
+   * útil para escenarios sin GPS o tests).
+   */
+  stoppedDetector?: StoppedDetector | null;
 }
 
-export function CoachingVoicePlayer({ message, controller }: CoachingVoicePlayerProps) {
+export function CoachingVoicePlayer({
+  message,
+  controller,
+  stoppedDetector,
+}: CoachingVoicePlayerProps) {
   // useMemo evita re-construir el controller en cada render. La función
   // factory crea su propia instancia de speechSynthesis singleton, así
   // que dos players en la misma página comparten la cola del browser
@@ -55,20 +72,60 @@ export function CoachingVoicePlayer({ message, controller }: CoachingVoicePlayer
   const [state, setState] = useState<VoiceState>(ctrl.getState());
   const [autoplayEnabled, setAutoplayEnabled] = useState(() => loadAutoplayPreference());
 
+  // Detector de vehículo parado (Phase 4 PR-K1). Solo se construye si
+  // auto-play está activo — sin auto-play no necesitamos saber el estado
+  // de movimiento, y evitamos pedir permisos GPS sin razón. Pasar
+  // explícitamente `null` desactiva el guard.
+  const det = useMemo<StoppedDetector | null>(() => {
+    if (stoppedDetector !== undefined) {
+      return stoppedDetector;
+    }
+    if (!autoplayEnabled) {
+      return null;
+    }
+    return createStoppedDetector();
+  }, [stoppedDetector, autoplayEnabled]);
+
+  const [stoppedState, setStoppedState] = useState<StoppedState>(
+    () => det?.getState() ?? 'unknown',
+  );
+
   useEffect(() => {
     return ctrl.subscribe(setState);
   }, [ctrl]);
 
-  // Auto-play opt-in: al montar con preferencia activa, hablar de inmediato.
-  // No re-disparamos en cada cambio de message — el conductor abrió el
-  // detalle del trip, escuchó una vez, listo. Si quiere repetir, click
-  // manual.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: deliberadamente solo al mount
   useEffect(() => {
-    if (autoplayEnabled && state === 'idle' && message.trim().length > 0) {
-      ctrl.play(message);
+    if (!det) {
+      return;
     }
-  }, []);
+    const unsub = det.subscribe(setStoppedState);
+    return () => {
+      unsub();
+      det.stop();
+    };
+  }, [det]);
+
+  // Auto-play opt-in:
+  //   - Sin auto-play (default): no arranca solo. Click manual siempre.
+  //   - Con auto-play + det desactivado (null): arranca al montar.
+  //   - Con auto-play + det activo: arranca cuando state pasa a 'stopped'.
+  //     Si el usuario rechaza permisos GPS (state='denied'), también
+  //     arranca — sin GPS no podemos verificar pero respetamos opt-in
+  //     explícito (el conductor sabe lo que activa).
+  //
+  // Solo disparamos UNA vez: marcador `played` evita repetir si el
+  // detector flap entre stopped/moving/stopped en el mismo trip.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deliberadamente solo al cambio de stoppedState/state
+  useEffect(() => {
+    if (!autoplayEnabled || message.trim().length === 0 || state !== 'idle') {
+      return;
+    }
+    const guardOk = det === null || stoppedState === 'stopped' || stoppedState === 'denied';
+    if (!guardOk) {
+      return;
+    }
+    ctrl.play(message);
+  }, [autoplayEnabled, stoppedState, det]);
 
   if (state === 'unsupported') {
     // El navegador no soporta TTS. Ocultarse — el texto sigue visible
@@ -138,6 +195,15 @@ export function CoachingVoicePlayer({ message, controller }: CoachingVoicePlayer
       {isError && (
         <span className="text-amber-700 text-xs">
           No se pudo reproducir el audio. El texto está disponible arriba.
+        </span>
+      )}
+
+      {/* Phase 4 PR-K1 — feedback visual cuando el auto-play está
+          esperando que el vehículo se detenga. No bloquea el botón
+          manual; sólo informa por qué no arrancó solo. */}
+      {autoplayEnabled && stoppedState === 'moving' && state === 'idle' && (
+        <span className="text-neutral-500 text-xs" data-testid="autoplay-waiting-stopped">
+          Reproducción automática en pausa — esperando que el vehículo se detenga.
         </span>
       )}
     </div>

--- a/apps/web/src/services/stopped-detector.test.ts
+++ b/apps/web/src/services/stopped-detector.test.ts
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type StoppedState,
+  createStoppedDetector,
+  nextState,
+  speedMpsToKmh,
+} from './stopped-detector.js';
+
+describe('speedMpsToKmh', () => {
+  it('null/undefined → null', () => {
+    expect(speedMpsToKmh(null)).toBeNull();
+    expect(speedMpsToKmh(undefined)).toBeNull();
+  });
+
+  it('NaN → null', () => {
+    expect(speedMpsToKmh(Number.NaN)).toBeNull();
+  });
+
+  it('negativo → null (browser dice "no sé")', () => {
+    expect(speedMpsToKmh(-1)).toBeNull();
+  });
+
+  it('0 m/s → 0 km/h', () => {
+    expect(speedMpsToKmh(0)).toBe(0);
+  });
+
+  it('10 m/s → 36 km/h', () => {
+    expect(speedMpsToKmh(10)).toBe(36);
+  });
+
+  it('27.78 m/s ≈ 100 km/h', () => {
+    const kmh = speedMpsToKmh(27.78);
+    expect(kmh).toBeCloseTo(100, 1);
+  });
+});
+
+describe('nextState (histeresis)', () => {
+  it('null observado → no-change (sin lectura)', () => {
+    expect(nextState('stopped', null)).toBe('no-change');
+    expect(nextState('moving', null)).toBe('no-change');
+    expect(nextState('unknown', null)).toBe('no-change');
+  });
+
+  it('≤ 3 km/h desde unknown → stopped', () => {
+    expect(nextState('unknown', 0)).toBe('stopped');
+    expect(nextState('unknown', 3)).toBe('stopped');
+  });
+
+  it('≤ 3 km/h desde stopped → no-change', () => {
+    expect(nextState('stopped', 1)).toBe('no-change');
+  });
+
+  it('≤ 3 km/h desde moving → stopped', () => {
+    expect(nextState('moving', 2)).toBe('stopped');
+  });
+
+  it('≥ 8 km/h desde stopped → moving', () => {
+    expect(nextState('stopped', 8)).toBe('moving');
+    expect(nextState('stopped', 50)).toBe('moving');
+  });
+
+  it('≥ 8 km/h desde moving → no-change', () => {
+    expect(nextState('moving', 30)).toBe('no-change');
+  });
+
+  it('banda muerta (3 < kmh < 8) → no-change para preservar estado', () => {
+    expect(nextState('stopped', 4)).toBe('no-change');
+    expect(nextState('stopped', 7)).toBe('no-change');
+    expect(nextState('moving', 4)).toBe('no-change');
+    expect(nextState('moving', 7)).toBe('no-change');
+  });
+
+  it('banda muerta desde unknown → no-change (esperamos certeza)', () => {
+    expect(nextState('unknown', 5)).toBe('no-change');
+  });
+});
+
+describe('createStoppedDetector', () => {
+  /** Stub instalable de Geolocation API. */
+  function makeGeoMock() {
+    let nextWatchId = 1;
+    const watchers: Array<{
+      id: number;
+      success: PositionCallback;
+      error: PositionErrorCallback | null;
+    }> = [];
+
+    const watchPosition = vi.fn(
+      (success: PositionCallback, error?: PositionErrorCallback | null) => {
+        const id = nextWatchId++;
+        watchers.push({ id, success, error: error ?? null });
+        return id;
+      },
+    );
+    const clearWatch = vi.fn((id: number) => {
+      const idx = watchers.findIndex((w) => w.id === id);
+      if (idx >= 0) {
+        watchers.splice(idx, 1);
+      }
+    });
+    return {
+      geo: {
+        watchPosition,
+        clearWatch,
+        getCurrentPosition: vi.fn(),
+      } as unknown as Geolocation,
+      emitPos: (speedMps: number | null) => {
+        const pos = {
+          coords: { speed: speedMps as number, latitude: 0, longitude: 0 },
+          timestamp: Date.now(),
+        } as unknown as GeolocationPosition;
+        for (const w of watchers) {
+          w.success(pos);
+        }
+      },
+      emitError: (code: number) => {
+        const err = {
+          code,
+          message: 'mock',
+          PERMISSION_DENIED: 1,
+          POSITION_UNAVAILABLE: 2,
+          TIMEOUT: 3,
+        } as unknown as GeolocationPositionError;
+        for (const w of watchers) {
+          w.error?.(err);
+        }
+      },
+      watchers,
+      spies: { watchPosition, clearWatch },
+    };
+  }
+
+  let scheduledTimers: Array<{ id: number; cb: () => void; ms: number }> = [];
+  let nextTimerId = 1;
+  const fakeSetTimeout = ((cb: () => void, ms: number) => {
+    const id = nextTimerId++;
+    scheduledTimers.push({ id, cb, ms });
+    return id as unknown as ReturnType<typeof setTimeout>;
+  }) as typeof setTimeout;
+  const fakeClearTimeout = ((id: number) => {
+    const idx = scheduledTimers.findIndex((t) => t.id === id);
+    if (idx >= 0) {
+      scheduledTimers.splice(idx, 1);
+    }
+  }) as typeof clearTimeout;
+  const flushTimers = (): void => {
+    while (scheduledTimers.length > 0) {
+      const t = scheduledTimers.shift();
+      t?.cb();
+    }
+  };
+
+  beforeEach(() => {
+    scheduledTimers = [];
+    nextTimerId = 1;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('estado inicial: unknown', () => {
+    const { geo } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+    expect(det.getState()).toBe('unknown');
+  });
+
+  it('sin geo (null) → unknown perpetuo', () => {
+    const det = createStoppedDetector({
+      geolocation: null,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+    expect(det.getState()).toBe('unknown');
+  });
+
+  it('observación stopped sostenida → state=stopped tras HOLD_MS', () => {
+    const { geo, emitPos } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+      holdMs: 4000,
+    });
+
+    emitPos(0); // 0 m/s = 0 km/h
+    expect(det.getState()).toBe('unknown'); // todavía pending
+
+    flushTimers();
+    expect(det.getState()).toBe('stopped');
+  });
+
+  it('observación moving sostenida → state=moving tras HOLD_MS', () => {
+    const { geo, emitPos } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+
+    emitPos(15); // 15 m/s = 54 km/h
+    flushTimers();
+    expect(det.getState()).toBe('moving');
+  });
+
+  it('flap entre stopped/moving → no-change si el opuesto NO se sostiene', () => {
+    const { geo, emitPos } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+
+    emitPos(0); // pending stopped
+    flushTimers();
+    expect(det.getState()).toBe('stopped');
+
+    // Spike de 10 km/h por una sola lectura, luego vuelve a parado.
+    emitPos(2.78); // 10 km/h → pending moving
+    expect(det.getState()).toBe('stopped'); // todavía pending, no aplicado
+    emitPos(0); // de nuevo stopped → cancela pending
+    flushTimers();
+    expect(det.getState()).toBe('stopped'); // se mantuvo
+  });
+
+  it('banda muerta (5 km/h) preserva el estado', () => {
+    const { geo, emitPos } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+
+    emitPos(0); // → stopped
+    flushTimers();
+    expect(det.getState()).toBe('stopped');
+
+    emitPos(1.4); // 5 km/h, banda muerta
+    flushTimers();
+    expect(det.getState()).toBe('stopped'); // no cambia
+  });
+
+  it('PERMISSION_DENIED → state=denied + clearWatch', () => {
+    const { geo, emitError, spies } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+
+    emitError(1); // PERMISSION_DENIED
+    expect(det.getState()).toBe('denied');
+    expect(spies.clearWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('POSITION_UNAVAILABLE / TIMEOUT NO afectan state', () => {
+    const { geo, emitError } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+
+    emitError(2); // POSITION_UNAVAILABLE
+    emitError(3); // TIMEOUT
+    expect(det.getState()).toBe('unknown');
+  });
+
+  it('subscribe recibe state actual + cambios; unsubscribe deja de recibir', () => {
+    const { geo, emitPos } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+
+    const states: StoppedState[] = [];
+    const unsub = det.subscribe((s) => states.push(s));
+    expect(states).toEqual(['unknown']);
+
+    emitPos(0);
+    flushTimers();
+    expect(states).toEqual(['unknown', 'stopped']);
+
+    unsub();
+    emitPos(15);
+    flushTimers();
+    expect(states).toEqual(['unknown', 'stopped']); // sin cambios post-unsub
+  });
+
+  it('stop() cancela watch + pending timer; idempotente', () => {
+    const { geo, emitPos, spies } = makeGeoMock();
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+
+    emitPos(0); // pending stopped
+    expect(scheduledTimers.length).toBe(1);
+
+    det.stop();
+    expect(spies.clearWatch).toHaveBeenCalledTimes(1);
+    expect(scheduledTimers.length).toBe(0); // pending cancelado
+
+    det.stop(); // idempotente — no doble-clearWatch
+    expect(spies.clearWatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('watchPosition throws (HTTPS sin permisos) → state=denied', () => {
+    const geo = {
+      watchPosition: vi.fn(() => {
+        throw new DOMException('insecure', 'SecurityError');
+      }),
+      clearWatch: vi.fn(),
+      getCurrentPosition: vi.fn(),
+    } as unknown as Geolocation;
+    const det = createStoppedDetector({
+      geolocation: geo,
+      setTimeoutFn: fakeSetTimeout,
+      clearTimeoutFn: fakeClearTimeout,
+    });
+    expect(det.getState()).toBe('denied');
+  });
+});

--- a/apps/web/src/services/stopped-detector.ts
+++ b/apps/web/src/services/stopped-detector.ts
@@ -1,0 +1,243 @@
+/**
+ * Detector de "vehículo parado" basado en Geolocation API (Phase 4 PR-K1).
+ *
+ * **Por qué este detector existe**:
+ *   El playbook 002 (canal coaching = voz) define que el auto-play del
+ *   coaching IA debe disparar solo cuando el conductor está parado —
+ *   nunca al volante en movimiento. Este módulo implementa esa garantía.
+ *
+ * **Estrategia**:
+ *   `navigator.geolocation.watchPosition()` reporta `coords.speed` en
+ *   m/s. Convertimos a km/h y aplicamos un threshold ≤ 3 km/h ≈ caminar
+ *   lento (un camión parado con motor encendido nunca llega a 3 km/h por
+ *   GPS noise; un camión avanzando incluso lento sí). El threshold viene
+ *   con histeresis para evitar flapping en idle con drift GPS.
+ *
+ * **Estados**:
+ *   - `'unknown'`: aún no llegó la primera lectura, o el browser no
+ *     reporta `speed` (algunos vehículos en interior).
+ *   - `'denied'`: el usuario rechazó permisos. UX cae a "auto-play sólo
+ *     manual" (la app no puede asumir parado sin lectura).
+ *   - `'stopped'`: speed ≤ STOP_KMH durante ≥ HOLD_MS sostenido.
+ *   - `'moving'`: speed > MOVE_KMH durante ≥ HOLD_MS sostenido.
+ *
+ * **Por qué histeresis (STOP_KMH=3 vs MOVE_KMH=8)**:
+ *   Si usamos un solo threshold, un GPS con jitter típico de ±5 km/h
+ *   alterna entre stopped/moving sin parar — y el auto-play arranca y
+ *   se interrumpe. La banda muerta entre 3-8 km/h evita el flap.
+ *
+ * **No**:
+ *   - Detección activa de "estoy manejando" via accelerómetro o sensor
+ *     de movimiento del device. Privacy + complejidad. La velocidad GPS
+ *     ya es suficiente para el caso de uso.
+ *   - Buffer de promedio rolling sobre N lecturas. Cumple lo mismo que
+ *     el HOLD_MS sostenido pero más complejo. Si en producción el flap
+ *     persiste, agregar.
+ */
+
+/** Velocidad ≤ este valor en km/h durante HOLD_MS → 'stopped'. */
+const STOP_KMH = 3;
+/** Velocidad ≥ este valor en km/h durante HOLD_MS → 'moving'. */
+const MOVE_KMH = 8;
+/** Tiempo sostenido en cualquiera de los rangos antes de cambiar de estado. */
+const HOLD_MS = 4000;
+
+export type StoppedState = 'unknown' | 'stopped' | 'moving' | 'denied';
+
+export interface StoppedDetector {
+  /** Estado actual sincrónico. */
+  getState: () => StoppedState;
+  /**
+   * Suscribe a cambios. El listener recibe el state actual al instante
+   * de subscribe (igual que CoachingVoiceController.subscribe).
+   * Devuelve unsubscribe.
+   */
+  subscribe: (listener: (state: StoppedState) => void) => () => void;
+  /** Detiene el watch de geolocation. Idempotente. */
+  stop: () => void;
+}
+
+/**
+ * Convierte velocidad en m/s a km/h. Pure.
+ *
+ * `null`/`undefined` → `null` (significa "el browser no reportó speed";
+ * no inferimos parado).
+ */
+export function speedMpsToKmh(speedMps: number | null | undefined): number | null {
+  if (speedMps === null || speedMps === undefined || Number.isNaN(speedMps)) {
+    return null;
+  }
+  // m/s × 3.6 = km/h. Speed negativa no tiene sentido (pero el browser
+  // a veces reporta -1 cuando no sabe — tratar como null).
+  if (speedMps < 0) {
+    return null;
+  }
+  return speedMps * 3.6;
+}
+
+/**
+ * Decide el próximo estado dado el estado actual + velocidad observada.
+ *
+ * Pure function — toda la lógica de histeresis vive acá. El detector
+ * factory orquesta el timing (HOLD_MS) y el plumbing de geolocation.
+ */
+export function nextState(
+  current: StoppedState,
+  observedKmh: number | null,
+): 'stopped' | 'moving' | 'unknown' | 'no-change' {
+  if (observedKmh === null) {
+    // Sin lectura — no movemos al state. Si era 'stopped' y se pierde
+    // el GPS, mantenemos 'stopped' (más seguro que volver a 'unknown').
+    return 'no-change';
+  }
+  if (observedKmh <= STOP_KMH) {
+    return current === 'stopped' ? 'no-change' : 'stopped';
+  }
+  if (observedKmh >= MOVE_KMH) {
+    return current === 'moving' ? 'no-change' : 'moving';
+  }
+  // Banda muerta (3 < kmh < 8) — mantenemos el estado actual.
+  return 'no-change';
+}
+
+export interface CreateStoppedDetectorOpts {
+  /**
+   * Geolocation API. Default `navigator.geolocation`. Pasar `null`
+   * explícitamente para tests / no-soporte.
+   */
+  geolocation?: Geolocation | null;
+  /**
+   * Para tests: factory de timers (default global setTimeout/clearTimeout).
+   */
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+  /** Override del HOLD_MS (default 4000). Útil para tests rápidos. */
+  holdMs?: number;
+}
+
+/**
+ * Crea un detector con `watchPosition`. El watch se mantiene activo
+ * hasta `stop()`.
+ *
+ * Si geolocation no está disponible (o `null` explícito), el detector
+ * inicia en 'unknown' y nunca cambia. Caller decide qué hacer con eso
+ * (en el coaching player: gateamos auto-play hasta que sea 'stopped').
+ */
+export function createStoppedDetector(opts: CreateStoppedDetectorOpts = {}): StoppedDetector {
+  const geo: Geolocation | null =
+    'geolocation' in opts
+      ? (opts.geolocation ?? null)
+      : typeof navigator !== 'undefined' && typeof navigator.geolocation !== 'undefined'
+        ? navigator.geolocation
+        : null;
+  const setTimeoutImpl = opts.setTimeoutFn ?? setTimeout;
+  const clearTimeoutImpl = opts.clearTimeoutFn ?? clearTimeout;
+  const holdMs = opts.holdMs ?? HOLD_MS;
+
+  let state: StoppedState = 'unknown';
+  const listeners = new Set<(s: StoppedState) => void>();
+  let pendingTransition: {
+    target: 'stopped' | 'moving';
+    timer: ReturnType<typeof setTimeout>;
+  } | null = null;
+  let watchId: number | null = null;
+
+  const setState = (next: StoppedState): void => {
+    if (state === next) {
+      return;
+    }
+    state = next;
+    for (const l of listeners) {
+      l(state);
+    }
+  };
+
+  const cancelPending = (): void => {
+    if (pendingTransition) {
+      clearTimeoutImpl(pendingTransition.timer);
+      pendingTransition = null;
+    }
+  };
+
+  const handlePosition = (position: GeolocationPosition): void => {
+    const kmh = speedMpsToKmh(position.coords.speed);
+    const nxt = nextState(state, kmh);
+
+    if (nxt === 'no-change') {
+      // Si la observación reafirma el state actual o cae en banda muerta,
+      // cancelamos cualquier pending hacia el opuesto.
+      cancelPending();
+      return;
+    }
+
+    // 'unknown' transition no aplica acá (solo lo seteamos al inicio).
+    if (nxt === 'stopped' || nxt === 'moving') {
+      // Si ya hay pending hacia el mismo target, dejarlo correr.
+      if (pendingTransition?.target === nxt) {
+        return;
+      }
+      cancelPending();
+      pendingTransition = {
+        target: nxt,
+        timer: setTimeoutImpl(() => {
+          setState(nxt);
+          pendingTransition = null;
+        }, holdMs),
+      };
+    }
+  };
+
+  const handleError = (err: GeolocationPositionError): void => {
+    if (err.code === err.PERMISSION_DENIED) {
+      cancelPending();
+      setState('denied');
+      // Stop el watch — no se va a recuperar sin acción del usuario.
+      if (geo && watchId !== null) {
+        try {
+          geo.clearWatch(watchId);
+        } catch {
+          // ignore.
+        }
+        watchId = null;
+      }
+    }
+    // POSITION_UNAVAILABLE / TIMEOUT son transitorios — no movemos state.
+  };
+
+  if (geo) {
+    try {
+      watchId = geo.watchPosition(handlePosition, handleError, {
+        enableHighAccuracy: false,
+        // 30s timeout es generoso — el auto-play no es time-critical.
+        timeout: 30_000,
+        maximumAge: 5_000,
+      });
+    } catch {
+      // Algunos browsers tiran SecurityError si watchPosition no está
+      // permitido en el contexto (e.g. no-HTTPS). Tratamos como denied.
+      setState('denied');
+    }
+  }
+
+  const stop = (): void => {
+    cancelPending();
+    if (geo && watchId !== null) {
+      try {
+        geo.clearWatch(watchId);
+      } catch {
+        // ignore.
+      }
+      watchId = null;
+    }
+  };
+
+  const subscribe = (listener: (s: StoppedState) => void): (() => void) => {
+    listeners.add(listener);
+    listener(state);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  return { getState: () => state, subscribe, stop };
+}


### PR DESCRIPTION
## Summary

Cierra acción derivada §2 del [playbook 002](../blob/main/playbooks/002-canal-coaching-voz-no-whatsapp.md): el auto-play del coaching IA ahora SOLO arranca cuando el conductor está detenido. El flap GPS típico (±5 km/h) se neutraliza con histeresis. Si el conductor rechaza permisos, respetamos su opt-in explícito.

## Diseño

| Decisión | Valor | Por qué |
|---|---|---|
| Threshold stopped | ≤ 3 km/h | un camión parado con motor encendido no llega por GPS noise |
| Threshold moving | ≥ 8 km/h | banda muerta 3-8 evita flap por jitter |
| HOLD_MS | 4000 ms | ráfagas de speed alto (bache) no interrumpen estado actual |
| Estado denied (sin permisos) | auto-play arranca igual | respetar opt-in explícito del conductor |
| Estado unknown (sin lectura aún) | auto-play espera | evita audio inesperado en los primeros segundos |
| GPS only (no accelerómetro) | más simple, mejor privacy | speed reportado por watchPosition es suficiente |

## Cambios

| Archivo | Tipo | Tests |
|---|---|---|
| \`apps/web/src/services/stopped-detector.ts\` | + nuevo | 25 |
| \`apps/web/src/components/scoring/CoachingVoicePlayer.tsx\` | nuevo prop \`stoppedDetector\` + hint visual | 7 nuevos |

### Tests breakdown

**\`stopped-detector.test.ts\` (25)**: speedMpsToKmh (null/NaN/negativos/positivos), nextState (todas las transiciones de histeresis + banda muerta), createStoppedDetector (estado inicial, sostenido stopped/moving, flap canceling, banda muerta preserva, PERMISSION_DENIED, POSITION_UNAVAILABLE no afecta, subscribe/unsubscribe, stop idempotente, watchPosition throws → denied).

**\`CoachingVoicePlayer.test.tsx\` (+7 nuevos)**: auto-play con detector unknown/moving/stopped/denied, transición moving→stopped dispara play, hint visual aparece sólo si autoplay+moving, stop() en unmount.

## UX flow

1. Conductor confirma entrega → app navega al detalle
2. Player monta. Si autoplay OFF → botón Escuchar manual visible, sin guard.
3. Si autoplay ON → detector se construye automáticamente
4. Detector consulta GPS → mientras 'unknown' o 'moving', NO arranca + muestra hint
5. Cuando GPS reporta ≤3 km/h sostenido 4s → state='stopped' → audio arranca
6. Si el conductor rechazó permisos GPS → audio arranca igual (opt-in explícito)

## Evidencia

- \`pnpm typecheck\` ✓ (monorepo, 29 tasks)
- \`pnpm lint\` ✓ (biome + lint-rls)
- \`pnpm test\` ✓: web 369 (+32), api 427, todos verdes

## Test plan post-merge

- [ ] Manual mobile: confirmar entrega con vehículo en movimiento → ver hint, sin audio
- [ ] Manual mobile: detener el vehículo → audio arranca tras ~4s
- [ ] Manual desktop: rechazar permisos GPS → audio arranca igual
- [ ] iOS Safari: confirmar funcionamiento del watchPosition con permisos

🤖 Generated with [Claude Code](https://claude.com/claude-code)