### PR TITLE
feat(web): VoiceCommandButton + useVoiceCommand hook (Phase 4 PR-K3)

### DIFF
--- a/apps/web/src/components/voice/VoiceCommandButton.test.tsx
+++ b/apps/web/src/components/voice/VoiceCommandButton.test.tsx
@@ -1,0 +1,217 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  RecognitionState,
+  RecognizedCommand,
+  VoiceCommandController,
+} from '../../services/voice-commands.js';
+import { VoiceCommandButton } from './VoiceCommandButton.js';
+
+/**
+ * Stub VoiceCommandController con state observable.
+ */
+function makeRecognizer(initial: RecognitionState = 'idle') {
+  let state: RecognitionState = initial;
+  const stateListeners = new Set<(s: RecognitionState) => void>();
+  const cmdListeners = new Set<(c: RecognizedCommand) => void>();
+  const unrecListeners = new Set<(t: string) => void>();
+  const start = vi.fn();
+  const stop = vi.fn();
+  const abort = vi.fn();
+  const ctrl: VoiceCommandController = {
+    start,
+    stop,
+    abort,
+    getState: () => state,
+    subscribe: (l) => {
+      stateListeners.add(l);
+      l(state);
+      return () => {
+        stateListeners.delete(l);
+      };
+    },
+    onCommand: (l) => {
+      cmdListeners.add(l);
+      return () => {
+        cmdListeners.delete(l);
+      };
+    },
+    onUnrecognized: (l) => {
+      unrecListeners.add(l);
+      return () => {
+        unrecListeners.delete(l);
+      };
+    },
+  };
+  return {
+    ctrl,
+    spies: { start, stop, abort },
+    emit: (s: RecognitionState) => {
+      state = s;
+      for (const l of stateListeners) {
+        l(s);
+      }
+    },
+    emitCommand: (cmd: RecognizedCommand) => {
+      for (const l of cmdListeners) {
+        l(cmd);
+      }
+    },
+    emitUnrecognized: (t: string) => {
+      for (const l of unrecListeners) {
+        l(t);
+      }
+    },
+  };
+}
+
+const ALL_INTENTS = new Set([
+  'confirmar_entrega',
+  'aceptar_oferta',
+  'cancelar',
+  'repetir',
+  'marcar_incidente',
+] as const);
+
+describe('VoiceCommandButton', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renderiza botón Hablar en idle', () => {
+    const r = makeRecognizer('idle');
+    render(
+      <VoiceCommandButton acceptedIntents={ALL_INTENTS} onCommand={vi.fn()} recognizer={r.ctrl} />,
+    );
+    expect(screen.getByRole('button', { name: /activar comando por voz/i })).toBeInTheDocument();
+    expect(screen.getByText(/^Hablar$/)).toBeInTheDocument();
+  });
+
+  it('click idle → recognizer.start', () => {
+    const r = makeRecognizer('idle');
+    render(
+      <VoiceCommandButton acceptedIntents={ALL_INTENTS} onCommand={vi.fn()} recognizer={r.ctrl} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /activar comando por voz/i }));
+    expect(r.spies.start).toHaveBeenCalled();
+  });
+
+  it('click listening → recognizer.stop', () => {
+    const r = makeRecognizer('idle');
+    render(
+      <VoiceCommandButton acceptedIntents={ALL_INTENTS} onCommand={vi.fn()} recognizer={r.ctrl} />,
+    );
+    act(() => {
+      r.emit('listening');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /detener escucha/i }));
+    expect(r.spies.stop).toHaveBeenCalled();
+  });
+
+  it('listening: aria-pressed=true + label "Detener"', () => {
+    const r = makeRecognizer('idle');
+    render(
+      <VoiceCommandButton acceptedIntents={ALL_INTENTS} onCommand={vi.fn()} recognizer={r.ctrl} />,
+    );
+    act(() => {
+      r.emit('listening');
+    });
+    const btn = screen.getByRole('button', { name: /detener escucha/i });
+    expect(btn).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText(/^Detener$/)).toBeInTheDocument();
+  });
+
+  it('processing: button disabled + label "Procesando…"', () => {
+    const r = makeRecognizer('idle');
+    render(
+      <VoiceCommandButton acceptedIntents={ALL_INTENTS} onCommand={vi.fn()} recognizer={r.ctrl} />,
+    );
+    act(() => {
+      r.emit('processing');
+    });
+    expect(screen.getByText(/procesando/i)).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('error: muestra hint "Activa el micrófono"', () => {
+    const r = makeRecognizer('idle');
+    render(
+      <VoiceCommandButton acceptedIntents={ALL_INTENTS} onCommand={vi.fn()} recognizer={r.ctrl} />,
+    );
+    act(() => {
+      r.emit('error');
+    });
+    expect(screen.getByText(/activa el micrófono/i)).toBeInTheDocument();
+  });
+
+  it('unsupported: componente se oculta', () => {
+    const r = makeRecognizer('unsupported');
+    render(
+      <VoiceCommandButton acceptedIntents={ALL_INTENTS} onCommand={vi.fn()} recognizer={r.ctrl} />,
+    );
+    expect(screen.queryByTestId('voice-command-button')).not.toBeInTheDocument();
+  });
+
+  it('comando intent aceptado → onCommand', () => {
+    const r = makeRecognizer('idle');
+    const onCommand = vi.fn();
+    render(
+      <VoiceCommandButton
+        acceptedIntents={new Set(['confirmar_entrega'])}
+        onCommand={onCommand}
+        recognizer={r.ctrl}
+      />,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'confirmar_entrega', transcript: 'entregado', confidence: 1 });
+    });
+    expect(onCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'confirmar_entrega' }),
+    );
+  });
+
+  it('comando fuera del set → onUnknown si se pasa', () => {
+    const r = makeRecognizer('idle');
+    const onCommand = vi.fn();
+    const onUnknown = vi.fn();
+    render(
+      <VoiceCommandButton
+        acceptedIntents={new Set(['confirmar_entrega'])}
+        onCommand={onCommand}
+        onUnknown={onUnknown}
+        recognizer={r.ctrl}
+      />,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'tomo oferta', confidence: 1 });
+    });
+    expect(onCommand).not.toHaveBeenCalled();
+    expect(onUnknown).toHaveBeenCalled();
+  });
+
+  it('unrecognized: muestra hint "No entendí …"', () => {
+    const r = makeRecognizer('idle');
+    render(
+      <VoiceCommandButton acceptedIntents={ALL_INTENTS} onCommand={vi.fn()} recognizer={r.ctrl} />,
+    );
+    act(() => {
+      r.emitUnrecognized('cómo está el tiempo');
+    });
+    expect(screen.getByTestId('voice-unrecognized-hint')).toHaveTextContent(
+      /no entendí "cómo está el tiempo"/i,
+    );
+  });
+
+  it('idleLabel custom', () => {
+    const r = makeRecognizer('idle');
+    render(
+      <VoiceCommandButton
+        acceptedIntents={ALL_INTENTS}
+        onCommand={vi.fn()}
+        recognizer={r.ctrl}
+        idleLabel="Toca y di entregado"
+      />,
+    );
+    expect(screen.getByText('Toca y di entregado')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/voice/VoiceCommandButton.tsx
+++ b/apps/web/src/components/voice/VoiceCommandButton.tsx
@@ -1,0 +1,164 @@
+import { Mic, MicOff, Square } from 'lucide-react';
+import { useVoiceCommand } from '../../hooks/use-voice-command.js';
+import type {
+  CommandIntent,
+  RecognizedCommand,
+  VoiceCommandController,
+} from '../../services/voice-commands.js';
+
+/**
+ * Botón push-to-talk grande para el conductor (Phase 4 PR-K3).
+ *
+ * **Diseño hands-free**:
+ *   - Un solo botón circular grande (≥ 64px hit-area según WCAG SC 2.5.5).
+ *   - Tap para empezar a escuchar (mic abre); el browser cierra solo
+ *     cuando detecta silencio o el conductor toca "Detener".
+ *   - 4 estados visuales:
+ *     - idle: Mic icon, fondo neutro, "Toca para hablar"
+ *     - listening: Square icon (símbolo de stop), fondo primary
+ *       pulsante, "Escuchando…"
+ *     - processing: spinner sutil, "Procesando…"
+ *     - error: MicOff icon + texto "Permitir micrófono" si denegado
+ *   - Si el browser no soporta Web Speech Recognition (Firefox), el
+ *     botón se oculta. El caller debe proveer fallback visual (botones
+ *     comunes).
+ *
+ * **Accesibilidad**:
+ *   - aria-pressed refleja listening.
+ *   - aria-live="polite" anuncia transcript reconocido o "no entendí".
+ *
+ * **Composición**:
+ *   El botón es deliberadamente "tonto" — recibe handlers como props,
+ *   no sabe de assignments ni offers. Cada pantalla del conductor
+ *   monta este botón con su propio set de intents soportados.
+ */
+
+export interface VoiceCommandButtonProps {
+  /**
+   * Intents que esta pantalla acepta. Si el conductor dice un comando
+   * fuera del set, se dispara `onUnknown` (con feedback "no se puede
+   * hacer eso aquí") en vez de la acción.
+   */
+  acceptedIntents: ReadonlySet<CommandIntent>;
+  /** Handler para cada intent reconocido + aceptado. */
+  onCommand: (cmd: RecognizedCommand) => void;
+  /** Opcional: handler para intent fuera del set aceptado. */
+  onUnknown?: (cmd: RecognizedCommand) => void;
+  /** Inyectable para tests. */
+  recognizer?: VoiceCommandController;
+  /**
+   * Label visible debajo del botón. Default "Toca para hablar".
+   * Algunas pantallas pueden personalizar ("Toca y di entregado").
+   */
+  idleLabel?: string;
+}
+
+export function VoiceCommandButton({
+  acceptedIntents,
+  onCommand,
+  onUnknown,
+  recognizer,
+  idleLabel = 'Toca para hablar',
+}: VoiceCommandButtonProps) {
+  const { state, lastUnrecognized, start, stop } = useVoiceCommand({
+    acceptedIntents,
+    onCommand,
+    ...(onUnknown ? { onUnknown } : {}),
+    ...(recognizer ? { recognizer } : {}),
+  });
+
+  if (state === 'unsupported') {
+    return null;
+  }
+
+  const isListening = state === 'listening';
+  const isProcessing = state === 'processing';
+  const isError = state === 'error';
+
+  const handleClick = (): void => {
+    if (isListening || isProcessing) {
+      stop();
+    } else {
+      start();
+    }
+  };
+
+  const buttonLabel = (() => {
+    if (isError) {
+      return 'Permitir micrófono';
+    }
+    if (isListening) {
+      return 'Detener';
+    }
+    if (isProcessing) {
+      return 'Procesando…';
+    }
+    return 'Hablar';
+  })();
+
+  const ariaLabel = (() => {
+    if (isError) {
+      return 'Activar permisos del micrófono';
+    }
+    if (isListening) {
+      return 'Detener escucha';
+    }
+    return 'Activar comando por voz';
+  })();
+
+  return (
+    <div className="flex flex-col items-center gap-2" data-testid="voice-command-button">
+      <button
+        type="button"
+        onClick={handleClick}
+        aria-pressed={isListening}
+        aria-label={ariaLabel}
+        disabled={isProcessing}
+        className={[
+          'flex h-20 w-20 items-center justify-center rounded-full transition',
+          'shadow-lg',
+          isListening
+            ? 'animate-pulse bg-primary-700 text-white'
+            : isError
+              ? 'bg-amber-100 text-amber-800 ring-2 ring-amber-500'
+              : 'bg-primary-50 text-primary-700 ring-2 ring-primary-700/30 hover:bg-primary-100',
+        ].join(' ')}
+      >
+        {isError ? (
+          <MicOff className="h-8 w-8" aria-hidden />
+        ) : isListening ? (
+          <Square className="h-8 w-8" aria-hidden />
+        ) : (
+          <Mic className="h-8 w-8" aria-hidden />
+        )}
+      </button>
+
+      <p className="font-medium text-neutral-800 text-sm">{buttonLabel}</p>
+      {!isListening && !isError && !isProcessing && (
+        <p className="text-neutral-500 text-xs">{idleLabel}</p>
+      )}
+      {isError && (
+        <p className="max-w-[200px] text-center text-amber-700 text-xs">
+          Activa el micrófono en los ajustes del navegador para usar comandos por voz.
+        </p>
+      )}
+
+      {/* Live region para feedback no-visual. */}
+      <span className="sr-only" aria-live="polite" aria-atomic="true">
+        {isListening ? 'Escuchando comando' : ''}
+        {lastUnrecognized && state === 'idle'
+          ? `No entendí: ${lastUnrecognized}. Intenta otra vez.`
+          : ''}
+      </span>
+
+      {lastUnrecognized && state === 'idle' && (
+        <p
+          className="max-w-[240px] text-center text-neutral-500 text-xs"
+          data-testid="voice-unrecognized-hint"
+        >
+          No entendí "{lastUnrecognized}". Intenta de nuevo.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-voice-command.test.tsx
+++ b/apps/web/src/hooks/use-voice-command.test.tsx
@@ -1,0 +1,183 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type {
+  RecognitionState,
+  RecognizedCommand,
+  VoiceCommandController,
+} from '../services/voice-commands.js';
+import { useVoiceCommand } from './use-voice-command.js';
+
+/**
+ * Stub VoiceCommandController con state observable + emisores manuales
+ * de comandos / unrecognized.
+ */
+function makeRecognizer(initial: RecognitionState = 'idle') {
+  let state: RecognitionState = initial;
+  const stateListeners = new Set<(s: RecognitionState) => void>();
+  const cmdListeners = new Set<(c: RecognizedCommand) => void>();
+  const unrecListeners = new Set<(t: string) => void>();
+  const start = vi.fn();
+  const stop = vi.fn();
+  const abort = vi.fn();
+
+  const ctrl: VoiceCommandController = {
+    start,
+    stop,
+    abort,
+    getState: () => state,
+    subscribe: (l) => {
+      stateListeners.add(l);
+      l(state);
+      return () => {
+        stateListeners.delete(l);
+      };
+    },
+    onCommand: (l) => {
+      cmdListeners.add(l);
+      return () => {
+        cmdListeners.delete(l);
+      };
+    },
+    onUnrecognized: (l) => {
+      unrecListeners.add(l);
+      return () => {
+        unrecListeners.delete(l);
+      };
+    },
+  };
+
+  return {
+    ctrl,
+    spies: { start, stop, abort },
+    emit: (s: RecognitionState) => {
+      state = s;
+      for (const l of stateListeners) {
+        l(s);
+      }
+    },
+    emitCommand: (cmd: RecognizedCommand) => {
+      for (const l of cmdListeners) {
+        l(cmd);
+      }
+    },
+    emitUnrecognized: (t: string) => {
+      for (const l of unrecListeners) {
+        l(t);
+      }
+    },
+  };
+}
+
+describe('useVoiceCommand', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('expone state inicial del recognizer', () => {
+    const r = makeRecognizer('idle');
+    const { result } = renderHook(() => useVoiceCommand({ recognizer: r.ctrl }));
+    expect(result.current.state).toBe('idle');
+  });
+
+  it('start/stop/abort proxy al recognizer', () => {
+    const r = makeRecognizer('idle');
+    const { result } = renderHook(() => useVoiceCommand({ recognizer: r.ctrl }));
+    result.current.start();
+    expect(r.spies.start).toHaveBeenCalled();
+    result.current.stop();
+    expect(r.spies.stop).toHaveBeenCalled();
+    result.current.abort();
+    expect(r.spies.abort).toHaveBeenCalled();
+  });
+
+  it('estado reactivo al emit del recognizer', async () => {
+    const r = makeRecognizer('idle');
+    const { result } = renderHook(() => useVoiceCommand({ recognizer: r.ctrl }));
+    r.emit('listening');
+    await waitFor(() => expect(result.current.state).toBe('listening'));
+  });
+
+  it('intent en acceptedIntents → onCommand + auto-stop', () => {
+    const r = makeRecognizer('idle');
+    const onCommand = vi.fn();
+    renderHook(() =>
+      useVoiceCommand({
+        recognizer: r.ctrl,
+        acceptedIntents: new Set(['confirmar_entrega']),
+        onCommand,
+      }),
+    );
+    r.emitCommand({ intent: 'confirmar_entrega', transcript: 'entregado', confidence: 0.9 });
+    expect(onCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ intent: 'confirmar_entrega' }),
+    );
+    expect(r.spies.stop).toHaveBeenCalled();
+  });
+
+  it('intent fuera de acceptedIntents → onUnknown, NO onCommand, NO auto-stop', () => {
+    const r = makeRecognizer('idle');
+    const onCommand = vi.fn();
+    const onUnknown = vi.fn();
+    renderHook(() =>
+      useVoiceCommand({
+        recognizer: r.ctrl,
+        acceptedIntents: new Set(['confirmar_entrega']),
+        onCommand,
+        onUnknown,
+      }),
+    );
+    r.emitCommand({ intent: 'aceptar_oferta', transcript: 'acepto la oferta', confidence: 1 });
+    expect(onCommand).not.toHaveBeenCalled();
+    expect(onUnknown).toHaveBeenCalled();
+    expect(r.spies.stop).not.toHaveBeenCalled();
+  });
+
+  it('sin acceptedIntents → onCommand siempre se llama', () => {
+    const r = makeRecognizer('idle');
+    const onCommand = vi.fn();
+    renderHook(() => useVoiceCommand({ recognizer: r.ctrl, onCommand }));
+    r.emitCommand({ intent: 'aceptar_oferta', transcript: 'tomo oferta', confidence: 1 });
+    r.emitCommand({ intent: 'cancelar', transcript: 'cancelar', confidence: 1 });
+    expect(onCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it('onUnrecognized → guarda lastUnrecognized + invoca handler', async () => {
+    const r = makeRecognizer('idle');
+    const onUnrec = vi.fn();
+    const { result } = renderHook(() =>
+      useVoiceCommand({ recognizer: r.ctrl, onUnrecognized: onUnrec }),
+    );
+    r.emitUnrecognized('cómo está el tiempo');
+    await waitFor(() => expect(result.current.lastUnrecognized).toBe('cómo está el tiempo'));
+    expect(onUnrec).toHaveBeenCalledWith('cómo está el tiempo');
+  });
+
+  it('handlers son refs vivos — cambiar prop NO re-suscribe', () => {
+    const r = makeRecognizer('idle');
+    const onCommand1 = vi.fn();
+    const onCommand2 = vi.fn();
+    const { rerender } = renderHook(
+      ({ handler }: { handler: (c: RecognizedCommand) => void }) =>
+        useVoiceCommand({
+          recognizer: r.ctrl,
+          onCommand: handler,
+        }),
+      { initialProps: { handler: onCommand1 } },
+    );
+
+    r.emitCommand({ intent: 'cancelar', transcript: 'cancelar', confidence: 1 });
+    expect(onCommand1).toHaveBeenCalledTimes(1);
+
+    rerender({ handler: onCommand2 });
+    r.emitCommand({ intent: 'cancelar', transcript: 'cancelar', confidence: 1 });
+    expect(onCommand2).toHaveBeenCalledTimes(1);
+    expect(onCommand1).toHaveBeenCalledTimes(1); // sin doble call
+  });
+
+  it('unmount aborta el recognizer (libera mic)', () => {
+    const r = makeRecognizer('idle');
+    const { unmount } = renderHook(() => useVoiceCommand({ recognizer: r.ctrl }));
+    unmount();
+    expect(r.spies.abort).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/use-voice-command.ts
+++ b/apps/web/src/hooks/use-voice-command.ts
@@ -1,0 +1,128 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  type CommandIntent,
+  type RecognitionState,
+  type RecognizedCommand,
+  type VoiceCommandController,
+  createVoiceCommandRecognizer,
+} from '../services/voice-commands.js';
+
+/**
+ * Hook que encapsula el ciclo de vida del recognizer de comandos por
+ * voz (Phase 4 PR-K3). El componente caller pasa los intents que le
+ * interesan + sus handlers; el hook se ocupa del subscribe/unsubscribe,
+ * del state, y de exponer los métodos start/stop/abort al componente.
+ *
+ * **Filtrado por intents soportados**:
+ *   El caller pasa un set de intents que tiene sentido en su contexto
+ *   (ej. la pantalla de detalle de assignment soporta `confirmar_entrega`
+ *   y `repetir`, pero no `aceptar_oferta`). Si el conductor dice un
+ *   comando fuera del set, el hook lo trata como `onUnknown` (feedback
+ *   "no entiendo eso acá") en vez de disparar la acción incorrecta.
+ *
+ * **Auto-stop tras comando**:
+ *   Push-to-talk natural: cuando reconoce un comando válido, llamamos
+ *   `stop()` automáticamente (el recognizer ya devolvió un final
+ *   result; el browser dispara onend en cualquier caso, pero el stop
+ *   explícito acelera la transición a 'idle').
+ */
+
+export interface UseVoiceCommandOpts {
+  /**
+   * Set de intents que el caller acepta. Si el recognizer detecta un
+   * intent fuera de este set, llama a `onUnknown` con el comando
+   * detectado (para feedback "no entiendo eso acá"). Default: todos
+   * los intents soportados.
+   */
+  acceptedIntents?: ReadonlySet<CommandIntent>;
+  /** Handler para cada intent reconocido + aceptado. */
+  onCommand?: (cmd: RecognizedCommand) => void;
+  /**
+   * Handler para intent reconocido pero NO en `acceptedIntents`. Útil
+   * para dar feedback "no se puede hacer eso aquí".
+   */
+  onUnknown?: (cmd: RecognizedCommand) => void;
+  /**
+   * Handler para transcript final que el parser no pudo mapear a
+   * ningún intent. Útil para feedback "no te entendí".
+   */
+  onUnrecognized?: (transcript: string) => void;
+  /**
+   * Inyectable para tests. Default: createVoiceCommandRecognizer().
+   */
+  recognizer?: VoiceCommandController;
+}
+
+export interface UseVoiceCommandResult {
+  /** Estado del recognizer. */
+  state: RecognitionState;
+  /** Última transcripción no reconocida (para feedback "no entendí"). */
+  lastUnrecognized: string | null;
+  /** Inicia listening (push-to-talk). */
+  start: () => void;
+  /** Detiene listening sin abortar. */
+  stop: () => void;
+  /** Aborta inmediatamente. */
+  abort: () => void;
+}
+
+export function useVoiceCommand(opts: UseVoiceCommandOpts = {}): UseVoiceCommandResult {
+  const {
+    recognizer: injectedRecognizer,
+    acceptedIntents,
+    onCommand,
+    onUnknown,
+    onUnrecognized,
+  } = opts;
+
+  // Mantenemos los handlers en refs para no re-suscribir cada render
+  // si el caller pasa funciones inline.
+  const onCommandRef = useRef(onCommand);
+  const onUnknownRef = useRef(onUnknown);
+  const onUnrecognizedRef = useRef(onUnrecognized);
+  onCommandRef.current = onCommand;
+  onUnknownRef.current = onUnknown;
+  onUnrecognizedRef.current = onUnrecognized;
+
+  const recognizer = useMemo<VoiceCommandController>(
+    () => injectedRecognizer ?? createVoiceCommandRecognizer(),
+    [injectedRecognizer],
+  );
+
+  const [state, setState] = useState<RecognitionState>(() => recognizer.getState());
+  const [lastUnrecognized, setLastUnrecognized] = useState<string | null>(null);
+
+  useEffect(() => {
+    const unsubState = recognizer.subscribe(setState);
+    const unsubCmd = recognizer.onCommand((cmd) => {
+      if (acceptedIntents && !acceptedIntents.has(cmd.intent)) {
+        onUnknownRef.current?.(cmd);
+        return;
+      }
+      onCommandRef.current?.(cmd);
+      // Auto-stop para liberar el mic.
+      recognizer.stop();
+    });
+    const unsubUnrec = recognizer.onUnrecognized((t) => {
+      setLastUnrecognized(t);
+      onUnrecognizedRef.current?.(t);
+    });
+    return () => {
+      unsubState();
+      unsubCmd();
+      unsubUnrec();
+      // Si el componente se desmonta mientras escucha, abortamos para
+      // soltar el mic — sin esto el browser puede mantenerlo activo
+      // hasta el next gesture.
+      recognizer.abort();
+    };
+  }, [recognizer, acceptedIntents]);
+
+  return {
+    state,
+    lastUnrecognized,
+    start: () => recognizer.start(),
+    stop: () => recognizer.stop(),
+    abort: () => recognizer.abort(),
+  };
+}


### PR DESCRIPTION
## Summary

Capa UI reusable del voice-first driver UX. Cada pantalla del conductor monta un \`VoiceCommandButton\` con el set de intents que acepta + handlers locales. El hook \`useVoiceCommand\` encapsula el lifecycle del recognizer.

Este PR entrega framework UI; el wire a pantallas concretas (detalle de assignment, listado de ofertas) viene en PR-K4.

## Hook \`useVoiceCommand\`

| Feature | Detalle |
|---|---|
| Filtrado por intent | \`acceptedIntents\` opt: comandos fuera del set → \`onUnknown\` (no la acción) |
| Auto-stop tras comando | Libera el mic rápidamente |
| Handlers en refs vivos | Cambiar handler en re-render NO re-suscribe |
| Abort en unmount | Libera mic si el usuario navega out |

## Componente \`VoiceCommandButton\`

Tonto/reusable:
- Botón circular 80×80px (WCAG SC 2.5.5: ≥ 64px hit-area)
- 4 estados visuales: \`idle\` (Mic) → \`listening\` (Square pulsante) → \`processing\` (disabled) → \`error\` (MicOff + \"permitir micrófono\")
- \`aria-pressed\` + \`aria-live\` polite con transcripts
- Retorna \`null\` si Web Speech no soportado (Firefox graceful)
- Hint visual \"No entendí …\" cuando \`lastUnrecognized\`
- \`idleLabel\` custom (ej. \"Toca y di entregado\")

## Cambios

| Archivo | Tipo | Tests |
|---|---|---|
| \`apps/web/src/hooks/use-voice-command.ts\` | + nuevo | 9 |
| \`apps/web/src/components/voice/VoiceCommandButton.tsx\` | + nuevo | 11 |

### Tests breakdown

**\`useVoiceCommand\` (9)**: state inicial, proxy start/stop/abort, reactivo al emit, intent en accepted → onCommand+auto-stop, fuera del set → onUnknown sin auto-stop, sin acceptedIntents siempre llama, lastUnrecognized se persiste, handlers en refs vivos (no re-subscribe), unmount aborta.

**\`VoiceCommandButton\` (11)**: render idle, click idle → start, click listening → stop, listening (aria-pressed=true + label \"Detener\"), processing (disabled + \"Procesando…\"), error (hint visible), unsupported (oculto), comando aceptado → onCommand, fuera del set → onUnknown, unrecognized (hint visible), idleLabel custom.

## Próximo (PR-K4, no incluido)

Wire del componente a pantallas concretas:
- **Detalle de assignment**: \`acceptedIntents={['confirmar_entrega','repetir','cancelar']}\`
- **Listado de ofertas**: \`acceptedIntents={['aceptar_oferta','cancelar']}\`
- **Driver-mode global** (futuro): botón flotante con todos los intents según contexto navegado

## Evidencia

- \`pnpm typecheck\` ✓ (monorepo, 29 tasks)
- \`pnpm lint\` ✓ (biome + lint-rls)
- \`pnpm test\` ✓: web 551 (+20), api 427, todos verdes

🤖 Generated with [Claude Code](https://claude.com/claude-code)