### PR TITLE
feat(web): voice + visual confirmar entrega en asignación detalle (Phase 4 PR-K4)

### DIFF
--- a/apps/web/src/components/scoring/DeliveryConfirmCard.test.tsx
+++ b/apps/web/src/components/scoring/DeliveryConfirmCard.test.tsx
@@ -1,0 +1,287 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../../lib/api-client.js';
+import type {
+  RecognitionState,
+  RecognizedCommand,
+  VoiceCommandController,
+} from '../../services/voice-commands.js';
+import { DeliveryConfirmCard } from './DeliveryConfirmCard.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function makeRecognizer(initial: RecognitionState = 'idle') {
+  let state: RecognitionState = initial;
+  const stateListeners = new Set<(s: RecognitionState) => void>();
+  const cmdListeners = new Set<(c: RecognizedCommand) => void>();
+  const ctrl: VoiceCommandController = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    abort: vi.fn(),
+    getState: () => state,
+    subscribe: (l) => {
+      stateListeners.add(l);
+      l(state);
+      return () => {
+        stateListeners.delete(l);
+      };
+    },
+    onCommand: (l) => {
+      cmdListeners.add(l);
+      return () => {
+        cmdListeners.delete(l);
+      };
+    },
+    onUnrecognized: () => () => undefined,
+  };
+  return {
+    ctrl,
+    emit: (s: RecognitionState) => {
+      state = s;
+      for (const l of stateListeners) {
+        l(s);
+      }
+    },
+    emitCommand: (cmd: RecognizedCommand) => {
+      for (const l of cmdListeners) {
+        l(cmd);
+      }
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('DeliveryConfirmCard', () => {
+  it('estado inicial idle: pregunta + botón "Sí, ya entregué" + voice button', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    expect(screen.getByText(/¿ya entregaste la carga\?/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sí, ya entregué/i })).toBeInTheDocument();
+    expect(screen.getByTestId('voice-command-button')).toBeInTheDocument();
+  });
+
+  it('click "Sí" → estado confirming + botón "Confirmar entrega"', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /sí, ya entregué/i }));
+    expect(screen.getByRole('button', { name: /confirmar entrega/i })).toBeInTheDocument();
+    expect(screen.getByText(/confirma diciendo "entregado" otra vez/i)).toBeInTheDocument();
+  });
+
+  it('confirming → ratify dispara mutation', async () => {
+    const patchSpy = vi.spyOn(api, 'patch').mockResolvedValue({
+      ok: true,
+      already_delivered: false,
+      delivered_at: '2026-05-10T15:30:00Z',
+    });
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    const onConfirmed = vi.fn();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a-77" recognizer={r.ctrl} onConfirmed={onConfirmed} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /sí, ya entregué/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirmar entrega/i }));
+
+    await waitFor(() =>
+      expect(patchSpy).toHaveBeenCalledWith('/assignments/a-77/confirmar-entrega'),
+    );
+    await waitFor(() => expect(onConfirmed).toHaveBeenCalled());
+    expect(screen.getByText(/entrega confirmada/i)).toBeInTheDocument();
+  });
+
+  it('cancel en confirming → vuelve a idle', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /sí, ya entregué/i }));
+    fireEvent.click(screen.getByRole('button', { name: /cancelar \(volver atrás\)/i }));
+    expect(screen.getByRole('button', { name: /sí, ya entregué/i })).toBeInTheDocument();
+  });
+
+  it('confirming auto-cancel tras 4s sin acción', () => {
+    vi.useFakeTimers();
+    try {
+      const Wrapper = makeWrapper();
+      const r = makeRecognizer();
+      render(
+        <Wrapper>
+          <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+        </Wrapper>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /sí, ya entregué/i }));
+      expect(screen.getByRole('button', { name: /confirmar entrega/i })).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(screen.queryByRole('button', { name: /confirmar entrega/i })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /sí, ya entregué/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('voz primer "entregado" → confirming', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'confirmar_entrega', transcript: 'entregado', confidence: 1 });
+    });
+    expect(screen.getByRole('button', { name: /confirmar entrega/i })).toBeInTheDocument();
+  });
+
+  it('voz segundo "entregado" en confirming → ratify', async () => {
+    const patchSpy = vi.spyOn(api, 'patch').mockResolvedValue({
+      ok: true,
+      already_delivered: false,
+      delivered_at: '2026-05-10T15:30:00Z',
+    });
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a-9" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'confirmar_entrega', transcript: 'entregado', confidence: 1 });
+    });
+    act(() => {
+      r.emitCommand({ intent: 'confirmar_entrega', transcript: 'entregado', confidence: 1 });
+    });
+    await waitFor(() => expect(patchSpy).toHaveBeenCalled());
+  });
+
+  it('voz "cancelar" en confirming → vuelve a idle', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /sí, ya entregué/i }));
+    expect(screen.getByRole('button', { name: /confirmar entrega/i })).toBeInTheDocument();
+
+    act(() => {
+      r.emitCommand({ intent: 'cancelar', transcript: 'cancelar', confidence: 1 });
+    });
+    expect(screen.queryByRole('button', { name: /confirmar entrega/i })).not.toBeInTheDocument();
+  });
+
+  it('error invalid_status → muestra mensaje específico + botón reintentar', async () => {
+    vi.spyOn(api, 'patch').mockRejectedValue(
+      new ApiError(409, 'invalid_status', {
+        code: 'invalid_status',
+        current_status: 'cancelado',
+      }),
+    );
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /sí, ya entregué/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirmar entrega/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/este viaje está en estado "cancelado"/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: /reintentar/i })).toBeInTheDocument();
+  });
+
+  it('error forbidden_owner_mismatch → mensaje específico', async () => {
+    vi.spyOn(api, 'patch').mockRejectedValue(
+      new ApiError(403, 'forbidden_owner_mismatch', { code: 'forbidden_owner_mismatch' }),
+    );
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /sí, ya entregué/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirmar entrega/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/no tienes permisos para confirmar/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('error de red (no ApiError) → mensaje genérico', async () => {
+    vi.spyOn(api, 'patch').mockRejectedValue(new Error('network down'));
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /sí, ya entregué/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirmar entrega/i }));
+    await waitFor(() => expect(screen.getByText(/sin conexión/i)).toBeInTheDocument());
+  });
+
+  it('voz "entregado" en idle, sin segundo comando → auto-cancel tras 4s, sin disparar mutation', () => {
+    vi.useFakeTimers();
+    try {
+      const patchSpy = vi.spyOn(api, 'patch');
+      const Wrapper = makeWrapper();
+      const r = makeRecognizer();
+      render(
+        <Wrapper>
+          <DeliveryConfirmCard assignmentId="a1" recognizer={r.ctrl} />
+        </Wrapper>,
+      );
+      act(() => {
+        r.emitCommand({ intent: 'confirmar_entrega', transcript: 'entregado', confidence: 1 });
+      });
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(patchSpy).not.toHaveBeenCalled();
+      expect(screen.getByRole('button', { name: /sí, ya entregué/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/components/scoring/DeliveryConfirmCard.tsx
+++ b/apps/web/src/components/scoring/DeliveryConfirmCard.tsx
@@ -1,0 +1,235 @@
+import { CheckCircle2, Loader2, Truck } from 'lucide-react';
+import { useState } from 'react';
+import { useConfirmarEntregaMutation } from '../../hooks/use-confirmar-entrega.js';
+import { ApiError } from '../../lib/api-client.js';
+import type { VoiceCommandController } from '../../services/voice-commands.js';
+import { VoiceCommandButton } from '../voice/VoiceCommandButton.js';
+
+/**
+ * Card de confirmación de entrega para el conductor (Phase 4 PR-K4).
+ *
+ * **Surface**: visible en `/app/asignaciones/:id` cuando el trip está
+ * asignado o en proceso (NO entregado). Es la pantalla activa que el
+ * conductor mira al volante en los últimos minutos del viaje.
+ *
+ * **Inputs paralelos**:
+ *   - **Voz** (primario, hands-free): VoiceCommandButton con intent
+ *     `confirmar_entrega`. El conductor dice "entregado" / "ya
+ *     entregué" / "confirmar entrega" → dispara mutation.
+ *   - **Botón visual** (fallback): "Sí, ya entregué" para casos donde
+ *     el mic falla, está denegado, o el navegador no soporta Speech
+ *     Recognition.
+ *
+ * **Doble confirmación**:
+ *   El comando primario (voz O botón) NO dispara la mutation directo —
+ *   abre un estado "confirmando" donde el conductor debe ratificar
+ *   tocando el botón visible o diciendo "entregado" otra vez. Esto
+ *   evita falsos positivos catastróficos: si el conductor está
+ *   conversando y dice "entrega" como sustantivo, queremos un segundo
+ *   gesture intencional antes de marcar el trip como entregado.
+ *
+ *   El estado `confirming` también muestra un timer de 4s con auto-cancel
+ *   — si no se ratifica en ese tiempo, vuelve a `idle`.
+ */
+
+const CONFIRM_TIMEOUT_MS = 4000;
+
+export interface DeliveryConfirmCardProps {
+  assignmentId: string;
+  /** Para tests: stub del recognizer pasado al VoiceCommandButton. */
+  recognizer?: VoiceCommandController;
+  /** Callback opcional cuando la mutation tiene éxito. */
+  onConfirmed?: () => void;
+}
+
+type LocalState = 'idle' | 'confirming' | 'submitting' | 'success' | 'error';
+
+export function DeliveryConfirmCard({
+  assignmentId,
+  recognizer,
+  onConfirmed,
+}: DeliveryConfirmCardProps) {
+  const [localState, setLocalState] = useState<LocalState>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [confirmTimer, setConfirmTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+  const mutation = useConfirmarEntregaMutation();
+
+  const cancelConfirmTimer = (): void => {
+    if (confirmTimer !== null) {
+      clearTimeout(confirmTimer);
+      setConfirmTimer(null);
+    }
+  };
+
+  const handleFirstConfirm = (): void => {
+    if (localState !== 'idle') {
+      return;
+    }
+    setLocalState('confirming');
+    const t = setTimeout(() => {
+      setLocalState('idle');
+      setConfirmTimer(null);
+    }, CONFIRM_TIMEOUT_MS);
+    setConfirmTimer(t);
+  };
+
+  const handleRatify = (): void => {
+    if (localState !== 'confirming') {
+      return;
+    }
+    cancelConfirmTimer();
+    setLocalState('submitting');
+    setErrorMsg(null);
+    mutation.mutate(
+      { assignmentId },
+      {
+        onSuccess: () => {
+          setLocalState('success');
+          onConfirmed?.();
+        },
+        onError: (err) => {
+          setLocalState('error');
+          if (err instanceof ApiError) {
+            const details = (err.details ?? {}) as {
+              code?: string;
+              current_status?: string;
+            };
+            if (err.code === 'invalid_status' || details.code === 'invalid_status') {
+              setErrorMsg(
+                `Este viaje está en estado "${details.current_status ?? 'desconocido'}". No se puede confirmar entrega.`,
+              );
+            } else if (
+              err.code === 'forbidden_owner_mismatch' ||
+              details.code === 'forbidden_owner_mismatch'
+            ) {
+              setErrorMsg('No tienes permisos para confirmar este viaje.');
+            } else {
+              setErrorMsg('No se pudo confirmar la entrega. Intenta otra vez.');
+            }
+          } else {
+            setErrorMsg('Sin conexión. Verifica tu red e intenta otra vez.');
+          }
+        },
+      },
+    );
+  };
+
+  const handleCancel = (): void => {
+    cancelConfirmTimer();
+    setLocalState('idle');
+    setErrorMsg(null);
+  };
+
+  // Voice integration: 1er comando "entregado" → confirming;
+  // 2do comando "entregado" → ratify. Comando "cancelar" en cualquier
+  // estado → cancel.
+  const onVoiceCommand = (cmd: { intent: string }): void => {
+    if (cmd.intent === 'cancelar') {
+      handleCancel();
+      return;
+    }
+    if (cmd.intent === 'confirmar_entrega') {
+      if (localState === 'idle') {
+        handleFirstConfirm();
+      } else if (localState === 'confirming') {
+        handleRatify();
+      }
+    }
+  };
+
+  if (localState === 'success') {
+    return (
+      <section
+        aria-label="Entrega confirmada"
+        className="border-success-200 border-b bg-success-50 px-4 py-4"
+      >
+        <div className="flex items-center gap-3">
+          <CheckCircle2 className="h-6 w-6 text-success-700" aria-hidden />
+          <div>
+            <p className="font-semibold text-success-800 text-sm">Entrega confirmada</p>
+            <p className="mt-0.5 text-success-700 text-xs">
+              Procesando coaching y certificado de carbono…
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Confirmar entrega"
+      className="border-neutral-200 border-b bg-white px-4 py-4"
+    >
+      <div className="flex items-start gap-3">
+        <Truck className="mt-0.5 h-6 w-6 shrink-0 text-primary-700" aria-hidden />
+        <div className="flex-1">
+          <p className="font-semibold text-neutral-900 text-sm">¿Ya entregaste la carga?</p>
+          <p className="mt-0.5 text-neutral-600 text-xs">
+            {localState === 'idle' &&
+              'Di "entregado" o toca el botón. Te pediremos confirmar antes de cerrar el viaje.'}
+            {localState === 'confirming' &&
+              'Confirma diciendo "entregado" otra vez o tocando el botón verde.'}
+            {localState === 'submitting' && 'Confirmando con el sistema…'}
+            {localState === 'error' && (errorMsg ?? 'No se pudo confirmar. Intenta otra vez.')}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-4">
+        <VoiceCommandButton
+          acceptedIntents={new Set(['confirmar_entrega', 'cancelar'])}
+          onCommand={onVoiceCommand}
+          {...(recognizer ? { recognizer } : {})}
+          idleLabel='Di "entregado"'
+        />
+
+        <div className="flex flex-1 flex-col gap-2">
+          {localState === 'idle' && (
+            <button
+              type="button"
+              onClick={handleFirstConfirm}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-primary-50 px-4 py-3 font-medium text-primary-700 text-sm ring-1 ring-primary-700/30 hover:bg-primary-100"
+            >
+              Sí, ya entregué
+            </button>
+          )}
+          {localState === 'confirming' && (
+            <>
+              <button
+                type="button"
+                onClick={handleRatify}
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-success-700 px-4 py-3 font-semibold text-sm text-white shadow hover:bg-success-800"
+              >
+                <CheckCircle2 className="h-4 w-4" aria-hidden /> Confirmar entrega
+              </button>
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="text-neutral-500 text-xs underline"
+              >
+                Cancelar (volver atrás)
+              </button>
+            </>
+          )}
+          {localState === 'submitting' && (
+            <div className="inline-flex items-center justify-center gap-2 rounded-md bg-neutral-100 px-4 py-3 text-neutral-600 text-sm">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Confirmando…
+            </div>
+          )}
+          {localState === 'error' && (
+            <button
+              type="button"
+              onClick={handleFirstConfirm}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-amber-50 px-4 py-3 font-medium text-amber-800 text-sm ring-1 ring-amber-500 hover:bg-amber-100"
+            >
+              Reintentar
+            </button>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/hooks/use-confirmar-entrega.test.tsx
+++ b/apps/web/src/hooks/use-confirmar-entrega.test.tsx
@@ -1,0 +1,114 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../lib/api-client.js';
+import { useConfirmarEntregaMutation } from './use-confirmar-entrega.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return {
+    Wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+    client,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useConfirmarEntregaMutation', () => {
+  it('llama PATCH /assignments/:id/confirmar-entrega', async () => {
+    const patchSpy = vi.spyOn(api, 'patch').mockResolvedValue({
+      ok: true,
+      already_delivered: false,
+      delivered_at: '2026-05-10T15:30:00Z',
+    });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useConfirmarEntregaMutation(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ assignmentId: 'a-123' });
+    });
+
+    expect(patchSpy).toHaveBeenCalledWith('/assignments/a-123/confirmar-entrega');
+  });
+
+  it('expone ok=true + already_delivered=false en el response', async () => {
+    vi.spyOn(api, 'patch').mockResolvedValue({
+      ok: true,
+      already_delivered: false,
+      delivered_at: '2026-05-10T15:30:00Z',
+    });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useConfirmarEntregaMutation(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ assignmentId: 'a-1' });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.already_delivered).toBe(false);
+    expect(result.current.data?.delivered_at).toBe('2026-05-10T15:30:00Z');
+  });
+
+  it('soporta idempotente: already_delivered=true', async () => {
+    vi.spyOn(api, 'patch').mockResolvedValue({
+      ok: true,
+      already_delivered: true,
+      delivered_at: '2026-05-10T15:00:00Z',
+    });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useConfirmarEntregaMutation(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ assignmentId: 'a-1' });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.already_delivered).toBe(true);
+  });
+
+  it('propaga ApiError 409 invalid_status', async () => {
+    vi.spyOn(api, 'patch').mockRejectedValue(
+      new ApiError(409, 'invalid_status', { code: 'invalid_status', current_status: 'cancelado' }),
+    );
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useConfirmarEntregaMutation(), { wrapper: Wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ assignmentId: 'a-2' });
+      } catch {
+        // expected
+      }
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as ApiError).status).toBe(409);
+  });
+
+  it('invalida queries de assignment-detail/score/coaching/offers tras success', async () => {
+    vi.spyOn(api, 'patch').mockResolvedValue({
+      ok: true,
+      already_delivered: false,
+      delivered_at: '2026-05-10T15:00:00Z',
+    });
+    const { Wrapper, client } = makeWrapper();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useConfirmarEntregaMutation(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ assignmentId: 'a-3' });
+    });
+
+    const calls = invalidateSpy.mock.calls.map((c) => (c[0] as { queryKey?: unknown }).queryKey);
+    expect(calls).toContainEqual(['assignment-detail', 'a-3']);
+    expect(calls).toContainEqual(['assignment', 'behavior-score', 'a-3']);
+    expect(calls).toContainEqual(['assignment', 'coaching', 'a-3']);
+    expect(calls).toContainEqual(['offers']);
+  });
+});

--- a/apps/web/src/hooks/use-confirmar-entrega.ts
+++ b/apps/web/src/hooks/use-confirmar-entrega.ts
@@ -1,0 +1,68 @@
+import { type UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query';
+import { type ApiError, api } from '../lib/api-client.js';
+
+/**
+ * Confirma la entrega de un assignment (Phase 4 PR-K4).
+ *
+ * Consume el endpoint canónico carrier-side:
+ *   PATCH /assignments/:id/confirmar-entrega
+ *
+ * Lifecycle post-success (server-side, ver
+ * apps/api/src/services/confirmar-entrega-viaje.ts):
+ *   1. trip.status → 'entregado'
+ *   2. assignment.status → 'entregado', delivered_at = now()
+ *   3. INSERT trip_events('entrega_confirmada')
+ *   4. Re-derive cert level (ADR-028) + score + coaching IA + cert PDF
+ *      (todo fire-and-forget transparente para el cliente)
+ *
+ * Idempotente — si el trip ya estaba 'entregado', responde
+ * `already_delivered=true` con el deliveredAt actual sin re-disparar.
+ */
+
+export interface ConfirmarEntregaResponse {
+  ok: true;
+  already_delivered: boolean;
+  delivered_at: string; // ISO 8601
+}
+
+export type ConfirmarEntregaErrorCode =
+  | 'trip_not_found'
+  | 'assignment_not_found'
+  | 'no_assignment'
+  | 'forbidden_owner_mismatch'
+  | 'invalid_status';
+
+export interface ConfirmarEntregaErrorBody {
+  error: ConfirmarEntregaErrorCode;
+  code: ConfirmarEntregaErrorCode;
+  current_status?: string;
+}
+
+export function useConfirmarEntregaMutation(): UseMutationResult<
+  ConfirmarEntregaResponse,
+  ApiError,
+  { assignmentId: string }
+> {
+  const queryClient = useQueryClient();
+  return useMutation<ConfirmarEntregaResponse, ApiError, { assignmentId: string }>({
+    mutationFn: ({ assignmentId }) =>
+      api.patch<ConfirmarEntregaResponse>(`/assignments/${assignmentId}/confirmar-entrega`),
+    onSuccess: (_data, { assignmentId }) => {
+      // Invalidar TODO lo relacionado al assignment + sus surfaces.
+      // Coaching y behavior-score recién pasarán a 'disponible' después
+      // del fire-and-forget server-side (~5-10s post-confirm), pero la
+      // invalidation arranca el polling para que la UI lo muestre apenas
+      // esté listo.
+      void queryClient.invalidateQueries({
+        queryKey: ['assignment-detail', assignmentId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['assignment', 'behavior-score', assignmentId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ['assignment', 'coaching', assignmentId],
+      });
+      void queryClient.invalidateQueries({ queryKey: ['offers'] });
+    },
+  });
+}

--- a/apps/web/src/routes/asignacion-detalle.tsx
+++ b/apps/web/src/routes/asignacion-detalle.tsx
@@ -21,6 +21,7 @@ import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { ChatPanel } from '../components/chat/ChatPanel.js';
 import { PushSubscribeBanner } from '../components/chat/PushSubscribeBanner.js';
 import { BehaviorScoreCard } from '../components/scoring/BehaviorScoreCard.js';
+import { DeliveryConfirmCard } from '../components/scoring/DeliveryConfirmCard.js';
 import { api } from '../lib/api-client.js';
 
 interface AssignmentDetail {
@@ -90,6 +91,9 @@ function AsignacionDetallePage() {
     ? `${trip.origin.address_raw} → ${trip.destination.address_raw}`
     : undefined;
   const isClosed = trip?.status === 'entregado' || trip?.status === 'cancelado';
+  // Phase 4 PR-K4 — confirmación de entrega via voz hands-free.
+  // Surface visible mientras el trip está activo (asignado | en_proceso).
+  const isConfirmable = trip?.status === 'asignado' || trip?.status === 'en_proceso';
   const otroLado = trip?.shipper_legal_name ?? 'generador de carga';
 
   return (
@@ -111,6 +115,12 @@ function AsignacionDetallePage() {
           </div>
         </div>
       </div>
+
+      {/* Phase 4 PR-K4 — confirmación de entrega hands-free (voz +
+          botón visual). Visible para el carrier mientras el trip está
+          asignado o en_proceso. Doble confirmación dentro del componente
+          previene falsos positivos. */}
+      {isConfirmable && <DeliveryConfirmCard assignmentId={assignmentId} />}
 
       {/* Behavior score card — Phase 2 PR-I5. Solo se muestra cuando
           el trip está cerrado, porque el score se calcula post-entrega.


### PR DESCRIPTION
## Summary

Cierra el loop voice-first end-to-end: el conductor en \`/app/asignaciones/:id\` puede confirmar entrega diciendo \"entregado\" sin tocar la pantalla. La PWA dispara \`PATCH /assignments/:id/confirmar-entrega\` y el lifecycle server-side completo (status → entregado, score, coaching IA, cert PDF) corre fire-and-forget.

## Diseño anti-falsos-positivos

| Mecanismo | Por qué |
|---|---|
| **Doble confirmación** | 1er \"entregado\" → \`confirming\`; 2do \"entregado\" → mutation. Si el conductor dice \"entrega\" como sustantivo en una conversación, no cierra el viaje. |
| **Auto-cancel 4s** | Si tras la 1ra confirmación no llega ratificación, vuelve silencioso a idle. Sin alertas ruidosas. |
| **Cancel global** | Comando \"cancelar\" / \"olvídalo\" / \"detener\" en cualquier estado vuelve a idle. |
| **Inputs paralelos** | Voz primario (hands-free) + botón visual fallback. NO exclusivos — funciona si el mic está denegado o el browser no soporta Speech Recognition (Firefox). |

## Errores específicos por código de API

- \`invalid_status\` (409): \"Este viaje está en estado X. No se puede confirmar entrega.\"
- \`forbidden_owner_mismatch\` (403): \"No tienes permisos para confirmar este viaje.\"
- Network down: \"Sin conexión. Verifica tu red e intenta otra vez.\"
- Cualquier otro: \"No se pudo confirmar la entrega. Intenta otra vez.\"

Todos con botón \"Reintentar\" que reactiva el flow desde idle.

## Cambios

| Archivo | Tipo | Tests |
|---|---|---|
| \`apps/web/src/hooks/use-confirmar-entrega.ts\` | + nuevo | 5 |
| \`apps/web/src/components/scoring/DeliveryConfirmCard.tsx\` | + nuevo | 12 |
| \`apps/web/src/routes/asignacion-detalle.tsx\` | wire | — |

### Tests breakdown

**\`useConfirmarEntregaMutation\` (5)**: PATCH endpoint correcto, response shapes (already_delivered true/false), idempotente, ApiError 409 propagado, queries invalidadas (assignment-detail / behavior-score / coaching / offers).

**\`DeliveryConfirmCard\` (12)**: idle render, click → confirming, ratify dispara mutation + onConfirmed, cancel manual, auto-cancel 4s (vi.useFakeTimers surgical), voz primer entregado → confirming, voz segundo entregado → ratify, voz cancelar → idle, error invalid_status (mensaje específico + reintentar), error forbidden, error network, voz idle sin segundo → auto-cancel sin mutation.

## Voice-first UX flow

1. Conductor llega a destino, abre \`/app/asignaciones/:id\`
2. Card visible: \"¿Ya entregaste la carga?\" + botón mic + \"Sí, ya entregué\"
3. Conductor dice **\"entregado\"** → estado \`confirming\` + botón verde
4. Conductor dice **\"entregado\"** otra vez (o toca botón) → mutation
5. Success → card cambia a verde \"Entrega confirmada · procesando coaching y certificado\"
6. Server-side fire-and-forget: status + cert + score + coaching IA
7. ~5-10s: \`BehaviorScoreCard\` aparece (\`isClosed=true\`) con coaching y voice player

## Phase 4 progreso

- ✅ PR-K1 vehicle-stopped guard
- ✅ PR-K2 voice recognition framework
- ✅ PR-K3 button + hook
- ✅ PR-K4 confirmar entrega wire (este PR)
- ⏳ PR-K5 onboarding driver-mode (opt-in centralizado a autoplay + commands)
- ⏳ PR-K6 marcar incidente (endpoint backend nuevo)
- ⏳ PR-K7 aceptar oferta por voz en /app/ofertas

## Evidencia

- \`pnpm typecheck\` ✓ (monorepo, 29 tasks)
- \`pnpm lint\` ✓ (biome + lint-rls)
- \`pnpm test\` ✓: web 568 (+17), api 427, todos verdes

## Test plan post-merge

- [ ] Manual mobile: trip activo, decir \"entregado\" 2× → cierra
- [ ] Manual: solo botón visual sin micrófono → mismo flow
- [ ] Manual: Firefox → solo botón visible (mic oculto)
- [ ] Manual: trip ya entregado → sin DeliveryConfirmCard, BehaviorScoreCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)