### PR TITLE
feat(api): public consignee tracking endpoint + token UUID v4 (Phase 5 PR-L1)

### DIFF
--- a/apps/api/drizzle/0013_assignments_public_tracking_token.sql
+++ b/apps/api/drizzle/0013_assignments_public_tracking_token.sql
@@ -1,0 +1,34 @@
+-- Migration 0014 — Token público de tracking del consignee (Phase 5 PR-L1)
+--
+-- Añade `tracking_token_publico` UUID UNIQUE a la tabla `asignaciones`
+-- para habilitar el caso "Uber-like": cuando un trip se asigna, el
+-- generador de carga + opcional consignee reciben un link público
+-- al endpoint GET /public/tracking/:token donde pueden ver el progreso
+-- del viaje sin auth.
+--
+-- Diseño:
+--   - UUID v4 random — opaco, no enumerable, no leakea info del trip
+--   - UNIQUE — un token por assignment; si se filtra, lo invalidas con
+--     un UPDATE (futuro PR rotación)
+--   - NULLABLE para backwards-compat con assignments existentes
+--     (se generan en el INSERT de futuras assignments, los viejos
+--     quedan sin link y la PWA cae al flujo legacy)
+--   - Index unique para lookup constante O(log n)
+--
+-- Riesgo deploy: bajo. ADD COLUMN nullable es metadata-only en Postgres
+-- ≥ 11. Reversible vía DROP COLUMN.
+--
+-- Por qué token y no signed JWT:
+--   - JWT exige rotación de signing key (operacional ruido). Token UUID
+--     en DB es revocable con DELETE/UPDATE.
+--   - JWT carga claims (timestamps) que no necesitamos — el lookup contra
+--     DB ya da fresh status.
+--   - Para tracking público, opacidad > self-contained. Si el token se
+--     filtra en logs públicos, lo rotamos sin tocar otros sistemas.
+
+ALTER TABLE "asignaciones"
+  ADD COLUMN "tracking_token_publico" uuid;
+
+CREATE UNIQUE INDEX "idx_asignaciones_tracking_token"
+  ON "asignaciones" ("tracking_token_publico")
+  WHERE "tracking_token_publico" IS NOT NULL;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1778976000000,
       "tag": "0012_metricas_viaje_coaching",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1779062400000,
+      "tag": "0013_assignments_public_tracking_token",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -645,6 +645,15 @@ export const assignments = pgTable(
     pickedUpAt: timestamp('recogido_en', { withTimezone: true }),
     deliveredAt: timestamp('entregado_en', { withTimezone: true }),
     cancelledAt: timestamp('cancelado_en', { withTimezone: true }),
+    /**
+     * Phase 5 PR-L1 — Token público opaco (UUID v4) para que el
+     * generador de carga + consignee (futuro) puedan tracker el viaje
+     * vía link sin auth: GET /public/tracking/:token. Se genera en el
+     * INSERT de la assignment (offer-actions.ts). NULLABLE para
+     * backwards-compat con assignments pre-Phase-5; los nuevos siempre
+     * lo tienen.
+     */
+    publicTrackingToken: uuid('tracking_token_publico'),
     createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/apps/api/src/routes/public-tracking.ts
+++ b/apps/api/src/routes/public-tracking.ts
@@ -1,0 +1,51 @@
+/**
+ * Endpoint público para tracking del shipper / consignee (Phase 5 PR-L1).
+ *
+ * GET /public/tracking/:token  → estado del trip + posición reciente
+ *
+ * **No requiere auth** — la defensa es la opacidad del token. El handler
+ * NUNCA expone:
+ *   - Plate completa (solo últimos 4 chars)
+ *   - Driver name / RUT
+ *   - Precio
+ *   - Telemetría histórica más vieja que 30 min
+ *
+ * **Rate limiting**: TODO post-deploy con Cloud Armor o middleware
+ * propio. Por ahora confiamos en la opacidad UUID + el threshold de
+ * tokens enumerables (122 bits). Pre-MVP es aceptable; antes de
+ * publicarlo masivamente metemos cap (ej. 60 req/min por IP por token).
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import { Hono } from 'hono';
+import type { Db } from '../db/client.js';
+import { getPublicTracking } from '../services/get-public-tracking.js';
+
+export function createPublicTrackingRoutes(opts: { db: Db; logger: Logger }) {
+  const app = new Hono();
+
+  app.get('/:token', async (c) => {
+    const token = c.req.param('token');
+
+    const result = await getPublicTracking({
+      db: opts.db,
+      logger: opts.logger,
+      token,
+    });
+
+    if (result.status === 'not_found') {
+      // 404 con mensaje neutro — no leak de "el token tiene formato
+      // inválido" vs "el token no existe en DB".
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    // Cache 30s en CDN/browser. El position se actualiza cada ~30s
+    // típicamente (Teltonika emite cada 10-30s en movimiento), y queremos
+    // evitar bombardeo si el consignee abre el link y refresh repetido.
+    c.header('Cache-Control', 'public, max-age=30');
+
+    return c.json(result);
+  });
+
+  return app;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -19,6 +19,7 @@ import { createHealthRouter } from './routes/health.js';
 import { createMeConsentsRoutes } from './routes/me-consents.js';
 import { createMeRoutes } from './routes/me.js';
 import { createOfferRoutes } from './routes/offers.js';
+import { createPublicTrackingRoutes } from './routes/public-tracking.js';
 import { createTripRequestsV2Routes } from './routes/trip-requests-v2.js';
 import { createTripRequestsRoutes } from './routes/trip-requests.js';
 import { createVehiculosRoutes } from './routes/vehiculos.js';
@@ -109,6 +110,12 @@ export function createServer(opts: CreateServerOptions): Hono {
         : {}),
     }),
   );
+
+  // Phase 5 PR-L1 — Public tracking del shipper / consignee. NO auth:
+  // la defensa es la opacidad del token UUID v4 (122 bits, no enumerable).
+  // El handler restringe los datos expuestos (plate parcial, sin
+  // driver name, telemetría sólo <30min).
+  app.route('/public/tracking', createPublicTrackingRoutes({ db: opts.db, logger }));
 
   // Protected routes — OIDC token from allowed Cloud Run SA required
   const authMiddleware = createAuthMiddleware({

--- a/apps/api/src/services/get-public-tracking.ts
+++ b/apps/api/src/services/get-public-tracking.ts
@@ -1,0 +1,176 @@
+/**
+ * Lookup público del estado de un trip por `tracking_token_publico`
+ * (Phase 5 PR-L1).
+ *
+ * Sin auth — el endpoint que llama esto NO requiere login. La defensa
+ * es la opacidad del token (UUID v4, 122 bits de entropía no
+ * enumerable) + la **mínima exposición de datos**: solo lo necesario
+ * para que el shipper o consignee sepa "dónde está mi carga", nunca
+ * datos del transportista (RUT, plate completa) ni precios.
+ *
+ * **Datos expuestos por design**:
+ *   - Trip: tracking_code, status, origen / destino (texto), tipo de carga
+ *   - Vehículo: tipo + plate parcial (últimos 4 chars) + posición
+ *     reciente (lat/lng + speed) si <30 min vieja
+ *   - ETA: placeholder en este PR — algoritmo viene en PR-L2
+ *
+ * **Datos NO expuestos**:
+ *   - Plate completa, RUT del transportista, precio acordado
+ *   - Driver name (privacy del conductor; el chat se hará con role abstracto)
+ *   - Telemetría histórica más vieja que 30min
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import { and, desc, eq, gte, isNotNull } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { assignments, telemetryPoints, trips, vehicles } from '../db/schema.js';
+
+export interface PublicTrackingPosition {
+  /** ISO 8601 cuando el GPS lo emitió. */
+  timestamp: string;
+  /** Latitud decimal. */
+  latitude: number;
+  /** Longitud decimal. */
+  longitude: number;
+  /** Velocidad estimada en km/h. */
+  speed_kmh: number | null;
+}
+
+export interface PublicTrackingResponse {
+  status: 'found';
+  trip: {
+    tracking_code: string;
+    status: string;
+    origin_address: string;
+    destination_address: string;
+    cargo_type: string;
+  };
+  vehicle: {
+    /** Tipo del vehículo (e.g. 'camion_3_4'). */
+    type: string;
+    /** Últimos 4 chars de la plate, formato `**** XX12`. Privacy. */
+    plate_partial: string;
+  };
+  /** Posición reciente del vehículo. null si no hay lectura <30min. */
+  position: PublicTrackingPosition | null;
+  /** ETA placeholder. PR-L2. */
+  eta_minutes: null;
+}
+
+export type PublicTrackingResult = PublicTrackingResponse | { status: 'not_found' };
+
+/** Threshold de "telemetría reciente". Las posiciones más viejas no se exponen. */
+const POSITION_FRESH_MINUTES = 30;
+
+export async function getPublicTracking(opts: {
+  db: Db;
+  logger: Logger;
+  token: string;
+}): Promise<PublicTrackingResult> {
+  const { db, logger, token } = opts;
+
+  // Validar formato UUID antes de query — si no parece UUID, no
+  // pegamos la DB (defensa contra scanning).
+  if (!isUuidLike(token)) {
+    return { status: 'not_found' };
+  }
+
+  // Lookup por token. Index UNIQUE garantiza O(log n).
+  const rows = await db
+    .select({
+      assignmentId: assignments.id,
+      tripStatus: trips.status,
+      trackingCode: trips.trackingCode,
+      originAddr: trips.originAddressRaw,
+      destAddr: trips.destinationAddressRaw,
+      cargoType: trips.cargoType,
+      vehicleId: vehicles.id,
+      vehicleType: vehicles.vehicleType,
+      vehiclePlate: vehicles.plate,
+    })
+    .from(assignments)
+    .innerJoin(trips, eq(trips.id, assignments.tripId))
+    .innerJoin(vehicles, eq(vehicles.id, assignments.vehicleId))
+    .where(eq(assignments.publicTrackingToken, token))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    logger.info({ token: token.slice(0, 8) }, 'public tracking: token not found');
+    return { status: 'not_found' };
+  }
+
+  // Last position dentro del threshold.
+  const cutoff = new Date(Date.now() - POSITION_FRESH_MINUTES * 60_000);
+  const posRows = await db
+    .select({
+      timestamp: telemetryPoints.timestampDevice,
+      latitude: telemetryPoints.latitude,
+      longitude: telemetryPoints.longitude,
+      speedKmh: telemetryPoints.speedKmh,
+    })
+    .from(telemetryPoints)
+    .where(
+      and(
+        eq(telemetryPoints.vehicleId, row.vehicleId),
+        isNotNull(telemetryPoints.latitude),
+        isNotNull(telemetryPoints.longitude),
+        gte(telemetryPoints.timestampDevice, cutoff),
+      ),
+    )
+    .orderBy(desc(telemetryPoints.timestampDevice))
+    .limit(1);
+
+  const posRow = posRows[0];
+  const position: PublicTrackingPosition | null =
+    posRow && posRow.latitude !== null && posRow.longitude !== null
+      ? {
+          timestamp: posRow.timestamp.toISOString(),
+          latitude: Number(posRow.latitude),
+          longitude: Number(posRow.longitude),
+          speed_kmh: posRow.speedKmh,
+        }
+      : null;
+
+  return {
+    status: 'found',
+    trip: {
+      tracking_code: row.trackingCode,
+      status: row.tripStatus,
+      origin_address: row.originAddr,
+      destination_address: row.destAddr,
+      cargo_type: row.cargoType,
+    },
+    vehicle: {
+      type: row.vehicleType,
+      plate_partial: maskPlate(row.vehiclePlate),
+    },
+    position,
+    eta_minutes: null,
+  };
+}
+
+/**
+ * Devuelve la plate enmascarada — solo los últimos 4 chars visibles,
+ * el resto reemplazado por `*`. Privacy: el consignee no necesita
+ * la plate completa, solo identificar visualmente al vehículo cuando
+ * llegue ("la mía es la que termina en KZ12").
+ */
+export function maskPlate(plate: string): string {
+  const trimmed = plate.replace(/\s+/g, '').toUpperCase();
+  if (trimmed.length <= 4) {
+    return trimmed;
+  }
+  const visible = trimmed.slice(-4);
+  const masked = '*'.repeat(trimmed.length - 4);
+  return `${masked}${visible}`;
+}
+
+/**
+ * Validación lightweight de formato UUID (8-4-4-4-12 hex). No usamos
+ * el package `uuid` por evitar la dep — el regex es suficiente para
+ * descartar tokens malformados antes de query.
+ */
+export function isUuidLike(s: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s);
+}

--- a/apps/api/src/services/offer-actions.ts
+++ b/apps/api/src/services/offer-actions.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import type { Logger } from '@booster-ai/logger';
 import { and, eq, ne } from 'drizzle-orm';
 import { config } from '../config.js';
@@ -112,6 +113,9 @@ export async function acceptOffer(opts: {
       }
 
       // 3. Crear assignment. UNIQUE (viaje_id) protege contra race.
+      // Phase 5 PR-L1 — generamos `publicTrackingToken` UUID v4 al insert
+      // para habilitar el tracking público del consignee/shipper sin auth
+      // (futuro WhatsApp template + página /tracking/:token).
       const [assignment] = await tx
         .insert(assignments)
         .values({
@@ -122,6 +126,7 @@ export async function acceptOffer(opts: {
           status: 'asignado',
           agreedPriceClp: offer.proposedPriceClp,
           acceptedAt: now,
+          publicTrackingToken: randomUUID(),
         })
         .returning();
       if (!assignment) {

--- a/apps/api/test/unit/get-public-tracking.test.ts
+++ b/apps/api/test/unit/get-public-tracking.test.ts
@@ -1,0 +1,242 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isUuidLike, maskPlate } from '../../src/services/get-public-tracking.js';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.SERVICE_NAME = 'booster-ai-api';
+  process.env.SERVICE_VERSION = '0.0.0-test';
+  process.env.LOG_LEVEL = 'error';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.REDIS_HOST = 'localhost';
+  process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173';
+  process.env.FIREBASE_PROJECT_ID = 'test';
+  process.env.API_AUDIENCE = 'https://api.boosterchile.com';
+  process.env.ALLOWED_CALLER_SA = 'caller@booster-ai.iam.gserviceaccount.com';
+});
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as Parameters<
+  typeof import('../../src/services/get-public-tracking.js').getPublicTracking
+>[0]['logger'];
+
+const VALID_TOKEN = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('isUuidLike', () => {
+  it('UUID v4 válido → true', () => {
+    expect(isUuidLike(VALID_TOKEN)).toBe(true);
+  });
+
+  it('UUID v1 también pasa (el regex acepta cualquier hex 8-4-4-4-12)', () => {
+    expect(isUuidLike('00000000-0000-1000-8000-000000000000')).toBe(true);
+  });
+
+  it('case-insensitive', () => {
+    expect(isUuidLike('550E8400-E29B-41D4-A716-446655440000')).toBe(true);
+  });
+
+  it('sin guiones → false', () => {
+    expect(isUuidLike('550e8400e29b41d4a716446655440000')).toBe(false);
+  });
+
+  it('chars no-hex → false', () => {
+    expect(isUuidLike('zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz')).toBe(false);
+  });
+
+  it('strings random → false', () => {
+    expect(isUuidLike('not-a-token')).toBe(false);
+    expect(isUuidLike('')).toBe(false);
+    expect(isUuidLike('hello world')).toBe(false);
+  });
+
+  it('SQL injection attempt → false (no pasa el regex)', () => {
+    expect(isUuidLike("' OR 1=1 --")).toBe(false);
+  });
+});
+
+describe('maskPlate', () => {
+  it('plate típica chilena XXNN-NN → enmascara prefijo', () => {
+    expect(maskPlate('GR-AS12')).toBe('***AS12');
+  });
+
+  it('plate sin guion ni espacios', () => {
+    expect(maskPlate('GRAS12')).toBe('**AS12');
+  });
+
+  it('plate corta (≤4 chars) NO enmascara — fallback', () => {
+    expect(maskPlate('AB12')).toBe('AB12');
+    expect(maskPlate('AB')).toBe('AB');
+  });
+
+  it('case insensitive normaliza a uppercase', () => {
+    expect(maskPlate('gras12')).toBe('**AS12');
+  });
+
+  it('strip de espacios internos', () => {
+    expect(maskPlate('GR AS 12')).toBe('**AS12');
+  });
+});
+
+describe('getPublicTracking', () => {
+  /**
+   * Stub del DB con dos selects en cadena: assignment+trip+vehicle, luego
+   * telemetry points. Ambos usan select().from().*.where().limit().
+   * El segundo además tiene innerJoin / orderBy.
+   */
+  function makeDbStub(opts: {
+    assignmentRow?: {
+      assignmentId: string;
+      tripStatus: string;
+      trackingCode: string;
+      originAddr: string;
+      destAddr: string;
+      cargoType: string;
+      vehicleId: string;
+      vehicleType: string;
+      vehiclePlate: string;
+    } | null;
+    positionRow?: {
+      timestamp: Date;
+      latitude: string | null;
+      longitude: string | null;
+      speedKmh: number | null;
+    } | null;
+  }) {
+    const responses: Array<unknown[]> = [
+      opts.assignmentRow ? [opts.assignmentRow] : [],
+      opts.positionRow ? [opts.positionRow] : [],
+    ];
+    let callIdx = 0;
+
+    const limitFn = vi.fn(() => Promise.resolve(responses[callIdx++] ?? []));
+    const orderByFn = vi.fn(() => ({ limit: limitFn }));
+    const whereFn = vi.fn(() => ({ limit: limitFn, orderBy: orderByFn }));
+    const innerJoin2 = vi.fn(() => ({ where: whereFn, innerJoin: () => ({ where: whereFn }) }));
+    const innerJoin1 = vi.fn(() => ({ innerJoin: innerJoin2, where: whereFn }));
+    const fromFn = vi.fn(() => ({ innerJoin: innerJoin1, where: whereFn }));
+    const selectFn = vi.fn(() => ({ from: fromFn }));
+
+    return { db: { select: selectFn } as never };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('token con formato inválido → not_found sin pegar DB', async () => {
+    const { getPublicTracking } = await import('../../src/services/get-public-tracking.js');
+    const { db } = makeDbStub({});
+    const result = await getPublicTracking({ db, logger: noopLogger, token: 'not-a-token' });
+    expect(result.status).toBe('not_found');
+  });
+
+  it('SQL injection attempt → not_found (regex defensa)', async () => {
+    const { getPublicTracking } = await import('../../src/services/get-public-tracking.js');
+    const { db } = makeDbStub({});
+    const result = await getPublicTracking({
+      db,
+      logger: noopLogger,
+      token: "' OR 1=1 --",
+    });
+    expect(result.status).toBe('not_found');
+  });
+
+  it('token válido pero no existe en DB → not_found', async () => {
+    const { getPublicTracking } = await import('../../src/services/get-public-tracking.js');
+    const { db } = makeDbStub({ assignmentRow: null });
+    const result = await getPublicTracking({ db, logger: noopLogger, token: VALID_TOKEN });
+    expect(result.status).toBe('not_found');
+  });
+
+  it('found con sin posición reciente → response sin position', async () => {
+    const { getPublicTracking } = await import('../../src/services/get-public-tracking.js');
+    const { db } = makeDbStub({
+      assignmentRow: {
+        assignmentId: 'a1',
+        tripStatus: 'en_proceso',
+        trackingCode: 'BOO-XYZ987',
+        originAddr: 'Av. Apoquindo 123, Las Condes',
+        destAddr: 'Calle Coquimbo 45, La Serena',
+        cargoType: 'carga_seca',
+        vehicleId: 'v1',
+        vehicleType: 'camion_3_4',
+        vehiclePlate: 'GR-AS12',
+      },
+      positionRow: null,
+    });
+    const result = await getPublicTracking({ db, logger: noopLogger, token: VALID_TOKEN });
+    expect(result.status).toBe('found');
+    if (result.status === 'found') {
+      expect(result.trip.tracking_code).toBe('BOO-XYZ987');
+      expect(result.trip.status).toBe('en_proceso');
+      expect(result.vehicle.plate_partial).toBe('***AS12');
+      expect(result.position).toBeNull();
+      expect(result.eta_minutes).toBeNull();
+    }
+  });
+
+  it('found con posición reciente → response con position numérica', async () => {
+    const { getPublicTracking } = await import('../../src/services/get-public-tracking.js');
+    const ts = new Date('2026-05-10T15:00:00Z');
+    const { db } = makeDbStub({
+      assignmentRow: {
+        assignmentId: 'a1',
+        tripStatus: 'en_proceso',
+        trackingCode: 'BOO-XYZ987',
+        originAddr: 'origen',
+        destAddr: 'destino',
+        cargoType: 'carga_seca',
+        vehicleId: 'v1',
+        vehicleType: 'camion_3_4',
+        vehiclePlate: 'GR-AS12',
+      },
+      positionRow: {
+        timestamp: ts,
+        latitude: '-33.4172',
+        longitude: '-70.6063',
+        speedKmh: 65,
+      },
+    });
+    const result = await getPublicTracking({ db, logger: noopLogger, token: VALID_TOKEN });
+    expect(result.status).toBe('found');
+    if (result.status === 'found' && result.position) {
+      expect(result.position.latitude).toBeCloseTo(-33.4172, 4);
+      expect(result.position.longitude).toBeCloseTo(-70.6063, 4);
+      expect(result.position.speed_kmh).toBe(65);
+      expect(result.position.timestamp).toBe(ts.toISOString());
+    }
+  });
+
+  it('NO expone vehiclePlate completa — solo enmascarada', async () => {
+    const { getPublicTracking } = await import('../../src/services/get-public-tracking.js');
+    const { db } = makeDbStub({
+      assignmentRow: {
+        assignmentId: 'a1',
+        tripStatus: 'asignado',
+        trackingCode: 'BOO-1',
+        originAddr: 'A',
+        destAddr: 'B',
+        cargoType: 'carga_seca',
+        vehicleId: 'v1',
+        vehicleType: 'camion_3_4',
+        vehiclePlate: 'TOPSECRET99',
+      },
+      positionRow: null,
+    });
+    const result = await getPublicTracking({ db, logger: noopLogger, token: VALID_TOKEN });
+    expect(result.status).toBe('found');
+    if (result.status === 'found') {
+      // 11 chars TOPSECRET99 → 7 estrellas + ET99 (últimos 4)
+      expect(result.vehicle.plate_partial).toBe('*******ET99');
+      expect(result.vehicle.plate_partial).not.toContain('TOPSECRET');
+    }
+  });
+});

--- a/apps/api/test/unit/public-tracking-route.test.ts
+++ b/apps/api/test/unit/public-tracking-route.test.ts
@@ -1,0 +1,109 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.SERVICE_NAME = 'booster-ai-api';
+  process.env.SERVICE_VERSION = '0.0.0-test';
+  process.env.LOG_LEVEL = 'error';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.REDIS_HOST = 'localhost';
+  process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173';
+  process.env.FIREBASE_PROJECT_ID = 'test';
+  process.env.API_AUDIENCE = 'https://api.boosterchile.com';
+  process.env.ALLOWED_CALLER_SA = 'test-sa@test.iam.gserviceaccount.com';
+});
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as Parameters<
+  typeof import('../../src/routes/public-tracking.js').createPublicTrackingRoutes
+>[0]['logger'];
+
+const VALID_TOKEN = '550e8400-e29b-41d4-a716-446655440000';
+
+describe('GET /public/tracking/:token', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('token desconocido (UUID válido pero sin row) → 404 not_found', async () => {
+    vi.doMock('../../src/services/get-public-tracking.js', () => ({
+      getPublicTracking: vi.fn().mockResolvedValue({ status: 'not_found' }),
+    }));
+    const { createPublicTrackingRoutes } = await import('../../src/routes/public-tracking.js');
+    const app = createPublicTrackingRoutes({ db: {} as never, logger: noopLogger });
+    const res = await app.request(`/${VALID_TOKEN}`);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body).toEqual({ error: 'not_found' });
+  });
+
+  it('token con formato inválido → 404 (mismo neutro que not found en DB)', async () => {
+    vi.doMock('../../src/services/get-public-tracking.js', () => ({
+      getPublicTracking: vi.fn().mockResolvedValue({ status: 'not_found' }),
+    }));
+    const { createPublicTrackingRoutes } = await import('../../src/routes/public-tracking.js');
+    const app = createPublicTrackingRoutes({ db: {} as never, logger: noopLogger });
+    const res = await app.request('/not-a-token');
+    expect(res.status).toBe(404);
+  });
+
+  it('token válido + row → 200 con shape esperado + Cache-Control', async () => {
+    vi.doMock('../../src/services/get-public-tracking.js', () => ({
+      getPublicTracking: vi.fn().mockResolvedValue({
+        status: 'found',
+        trip: {
+          tracking_code: 'BOO-X1',
+          status: 'en_proceso',
+          origin_address: 'A',
+          destination_address: 'B',
+          cargo_type: 'carga_seca',
+        },
+        vehicle: { type: 'camion_3_4', plate_partial: '***AS12' },
+        position: null,
+        eta_minutes: null,
+      }),
+    }));
+    const { createPublicTrackingRoutes } = await import('../../src/routes/public-tracking.js');
+    const app = createPublicTrackingRoutes({ db: {} as never, logger: noopLogger });
+    const res = await app.request(`/${VALID_TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toContain('max-age=30');
+    const body = (await res.json()) as { trip: { tracking_code: string } };
+    expect(body.trip.tracking_code).toBe('BOO-X1');
+  });
+
+  it('handler no recibe driver_name ni precio (defensa privacy via service shape)', async () => {
+    vi.doMock('../../src/services/get-public-tracking.js', () => ({
+      getPublicTracking: vi.fn().mockResolvedValue({
+        status: 'found',
+        trip: {
+          tracking_code: 'BOO-X',
+          status: 'asignado',
+          origin_address: 'A',
+          destination_address: 'B',
+          cargo_type: 'carga_seca',
+        },
+        vehicle: { type: 'camion_3_4', plate_partial: '***1234' },
+        position: null,
+        eta_minutes: null,
+      }),
+    }));
+    const { createPublicTrackingRoutes } = await import('../../src/routes/public-tracking.js');
+    const app = createPublicTrackingRoutes({ db: {} as never, logger: noopLogger });
+    const res = await app.request(`/${VALID_TOKEN}`);
+    const body = JSON.stringify(await res.json());
+    expect(body).not.toContain('driver_name');
+    expect(body).not.toContain('agreed_price');
+    expect(body).not.toContain('precio');
+  });
+});


### PR DESCRIPTION
## Summary

Foundation del caso de uso \"Uber-like\" mencionado por el Product Owner: generador de carga + consignee acceden por link a un endpoint público (sin auth) para ver el progreso del viaje. Token UUID v4 opaco generado al aceptar oferta.

## Diseño

| Decisión | Por qué |
|---|---|
| UUID v4 random (no JWT) | Revocable con UPDATE/DELETE sin tocar otros sistemas. Sin claim-leak. Opacidad > self-contained. |
| NO auth en el endpoint | La defensa es opacidad del token (122 bits no enumerables) + exposición mínima de datos |
| Plate enmascarada (\\*\\*\\*\\* XX12) | Privacy del transportista — el consignee solo necesita identificar el vehículo cuando llegue |
| Sin driver name, sin precio, sin RUT | Privacy de transportista + shipper |
| Telemetría sólo <30min | No leak de historial; coherente con \"dónde está mi carga ahora\" |
| Regex UUID antes de query | Bloquea scanning + SQL-injection-like inputs sin pegar la DB |
| Cache-Control public, max-age=30 | Position se actualiza ~30s; evita bombardeo si el consignee refresca |

## Cambios

| Archivo | Tipo | Tests |
|---|---|---|
| \`apps/api/drizzle/0013_assignments_public_tracking_token.sql\` | + migration | — |
| \`apps/api/src/db/schema.ts\` | columna nueva | — |
| \`apps/api/src/services/offer-actions.ts\` | randomUUID() en INSERT assignment | — |
| \`apps/api/src/services/get-public-tracking.ts\` | + nuevo (lookup + helpers puros) | 18 |
| \`apps/api/src/routes/public-tracking.ts\` | + nuevo (GET /:token sin auth) | 4 |
| \`apps/api/src/server.ts\` | wire ANTES del authMiddleware | — |

### Tests breakdown

**\`isUuidLike\` (6)**: UUID v4 ✓, UUID v1 ✓, case-insensitive, sin guiones, chars no-hex, SQL injection.

**\`maskPlate\` (5)**: plate XXNN-NN, sin guion, ≤4 chars (sin enmascarar), case insensitive, espacios stripping.

**\`getPublicTracking\` (5)**: token formato inválido → not_found sin DB, SQL injection → not_found, token válido sin row → not_found, found sin posición, found con posición numérica, NO expone plate completa.

**Route handler (4)**: not_found → 404 neutro, formato inválido → 404, found → 200 + Cache-Control + body shape, NO incluye driver_name/precio/agreed_price.

## Próximo

- **PR-L2**: ETA real basada en distance_to_destination + avg_speed histórico
- **PR-L3**: WhatsApp template \`tracking_link_v1\` enviado al shipper + consignee al asignar
- **PR-L4**: página pública \`/tracking/:token\` en apps/web con mapa Maps JS API

## Evidencia

- \`pnpm typecheck\` ✓ (monorepo, 29 tasks)
- \`pnpm lint\` ✓ (biome + lint-rls)
- \`pnpm test\` ✓: api 449 (+22), todos verdes

## Test plan post-merge

- [ ] Aceptar oferta → verificar que assignment.tracking_token_publico se generó
- [ ] curl https://api.../public/tracking/<token> → 200 con shape esperado
- [ ] curl ...token-malformado → 404
- [ ] curl ...token-no-existente → 404 (mismo body que malformado)
- [ ] Confirmar que respose NO incluye driver_name ni precio (pagar grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)