### PR TITLE
feat(api): progress signals en tracking público (Phase 5 PR-L2)

### DIFF
--- a/apps/api/src/services/get-public-tracking.ts
+++ b/apps/api/src/services/get-public-tracking.ts
@@ -1,6 +1,6 @@
 /**
  * Lookup público del estado de un trip por `tracking_token_publico`
- * (Phase 5 PR-L1).
+ * (Phase 5 PR-L1 + L2).
  *
  * Sin auth — el endpoint que llama esto NO requiere login. La defensa
  * es la opacidad del token (UUID v4, 122 bits de entropía no
@@ -12,7 +12,13 @@
  *   - Trip: tracking_code, status, origen / destino (texto), tipo de carga
  *   - Vehículo: tipo + plate parcial (últimos 4 chars) + posición
  *     reciente (lat/lng + speed) si <30 min vieja
- *   - ETA: placeholder en este PR — algoritmo viene en PR-L2
+ *   - Progress (PR-L2): avg_speed_kmh_last_15min + last_position_age_seconds
+ *     para que el consignee pueda interpretar el progreso ("se está
+ *     moviendo", "lleva 5 min sin reportar")
+ *   - ETA: aún null — la fórmula real necesita coords de destino que el
+ *     trips schema NO tiene (solo address text). Difiere a PR-L2b: o
+ *     geocodificar y guardar lat/lng al crear el trip, o llamar Routes
+ *     API on-demand con caché 60s.
  *
  * **Datos NO expuestos**:
  *   - Plate completa, RUT del transportista, precio acordado
@@ -36,6 +42,32 @@ export interface PublicTrackingPosition {
   speed_kmh: number | null;
 }
 
+/**
+ * Señales de progreso del viaje calculadas a partir del historial
+ * reciente de telemetría (Phase 5 PR-L2). El frontend las usa para
+ * interpretar el contexto: "se está moviendo a buen ritmo" vs "está
+ * detenido hace mucho" vs "perdió señal hace 5 min".
+ */
+export interface PublicTrackingProgress {
+  /**
+   * Velocidad promedio en los últimos 15 min (km/h). Null si hay <2
+   * lecturas en la ventana o si todas reportan 0 (vehículo parado).
+   *
+   * Útil para detectar "lleva 30 min sin moverse" vs "va a 70 km/h
+   * sostenido". Más estable que `position.speed_kmh` que es la lectura
+   * instantánea (puede ser 0 en un semáforo aunque el viaje esté en
+   * ritmo normal).
+   */
+  avg_speed_kmh_last_15min: number | null;
+  /**
+   * Edad de la última posición en segundos. 0 = recién llegó, 600 = 10 min.
+   * El frontend muestra "actualizado hace X min" para que el consignee
+   * tenga confianza calibrada en la posición. Null si no hay posición
+   * (ningún ping <30min).
+   */
+  last_position_age_seconds: number | null;
+}
+
 export interface PublicTrackingResponse {
   status: 'found';
   trip: {
@@ -53,7 +85,9 @@ export interface PublicTrackingResponse {
   };
   /** Posición reciente del vehículo. null si no hay lectura <30min. */
   position: PublicTrackingPosition | null;
-  /** ETA placeholder. PR-L2. */
+  /** Señales de progreso (PR-L2). */
+  progress: PublicTrackingProgress;
+  /** ETA placeholder hasta PR-L2b (geocoding o Routes API on-demand). */
   eta_minutes: null;
 }
 
@@ -61,6 +95,8 @@ export type PublicTrackingResult = PublicTrackingResponse | { status: 'not_found
 
 /** Threshold de "telemetría reciente". Las posiciones más viejas no se exponen. */
 const POSITION_FRESH_MINUTES = 30;
+/** Ventana para calcular avg_speed_kmh_last_15min. */
+const AVG_SPEED_WINDOW_MINUTES = 15;
 
 export async function getPublicTracking(opts: {
   db: Db;
@@ -100,9 +136,18 @@ export async function getPublicTracking(opts: {
     return { status: 'not_found' };
   }
 
-  // Last position dentro del threshold.
-  const cutoff = new Date(Date.now() - POSITION_FRESH_MINUTES * 60_000);
-  const posRows = await db
+  // Cargamos los pings de la ventana de avg_speed (15min) — más amplia
+  // que la de fresh-position (30min) sería innecesario; necesitamos solo
+  // pings de los últimos 15 min para el promedio. La última posición
+  // viene del primer elemento (orderBy DESC), y avg_speed agrega TODA
+  // la lista.
+  //
+  // POSITION_FRESH_MINUTES (30) > AVG_SPEED_WINDOW_MINUTES (15): si hay
+  // un ping a 20min, lo mostramos como posición "vieja" pero NO lo
+  // metemos al avg de 15min.
+  const now = Date.now();
+  const positionCutoff = new Date(now - POSITION_FRESH_MINUTES * 60_000);
+  const pings = await db
     .select({
       timestamp: telemetryPoints.timestampDevice,
       latitude: telemetryPoints.latitude,
@@ -115,22 +160,27 @@ export async function getPublicTracking(opts: {
         eq(telemetryPoints.vehicleId, row.vehicleId),
         isNotNull(telemetryPoints.latitude),
         isNotNull(telemetryPoints.longitude),
-        gte(telemetryPoints.timestampDevice, cutoff),
+        gte(telemetryPoints.timestampDevice, positionCutoff),
       ),
     )
     .orderBy(desc(telemetryPoints.timestampDevice))
-    .limit(1);
+    .limit(200); // cap defensivo: 200 pings cubre ~30min a 1Hz
 
-  const posRow = posRows[0];
+  const latest = pings[0];
   const position: PublicTrackingPosition | null =
-    posRow && posRow.latitude !== null && posRow.longitude !== null
+    latest && latest.latitude !== null && latest.longitude !== null
       ? {
-          timestamp: posRow.timestamp.toISOString(),
-          latitude: Number(posRow.latitude),
-          longitude: Number(posRow.longitude),
-          speed_kmh: posRow.speedKmh,
+          timestamp: latest.timestamp.toISOString(),
+          latitude: Number(latest.latitude),
+          longitude: Number(latest.longitude),
+          speed_kmh: latest.speedKmh,
         }
       : null;
+
+  const progress = computeProgress({
+    pings: pings.map((p) => ({ timestamp: p.timestamp, speedKmh: p.speedKmh })),
+    nowMs: now,
+  });
 
   return {
     status: 'found',
@@ -146,7 +196,60 @@ export async function getPublicTracking(opts: {
       plate_partial: maskPlate(row.vehiclePlate),
     },
     position,
+    progress,
     eta_minutes: null,
+  };
+}
+
+/**
+ * Calcula las señales de progreso a partir del historial reciente de
+ * telemetría. **Pure function** — recibe los pings ya filtrados por la
+ * caller, no toca la DB.
+ *
+ * Reglas:
+ *   - `avg_speed_kmh_last_15min` = promedio de speedKmh sobre pings con
+ *     timestamp dentro de 15min. Excluye speedKmh=null. Devuelve null si
+ *     hay <2 pings en la ventana O si todos los speeds son 0 (vehículo
+ *     parado — exponer "0 km/h" puede ser confuso, mejor null).
+ *   - `last_position_age_seconds` = (now - latest.timestamp) en segundos.
+ *     Null si no hay pings.
+ *
+ * El cap defensivo de pings en la query (200) garantiza que esta función
+ * corre en O(N) pequeño aún en viajes largos con muchos pings.
+ */
+export function computeProgress(opts: {
+  pings: Array<{ timestamp: Date; speedKmh: number | null }>;
+  nowMs: number;
+}): PublicTrackingProgress {
+  const { pings, nowMs } = opts;
+
+  if (pings.length === 0) {
+    return { avg_speed_kmh_last_15min: null, last_position_age_seconds: null };
+  }
+
+  const latest = pings[0]; // pings vienen orderBy DESC
+  const lastPositionAgeSeconds = latest
+    ? Math.max(0, Math.floor((nowMs - latest.timestamp.getTime()) / 1000))
+    : null;
+
+  const avgSpeedCutoff = nowMs - AVG_SPEED_WINDOW_MINUTES * 60_000;
+  const speedsInWindow = pings
+    .filter((p) => p.timestamp.getTime() >= avgSpeedCutoff && p.speedKmh !== null)
+    .map((p) => p.speedKmh as number);
+
+  let avgSpeed: number | null = null;
+  if (speedsInWindow.length >= 2) {
+    const sum = speedsInWindow.reduce((acc, s) => acc + s, 0);
+    const avg = sum / speedsInWindow.length;
+    // Si el avg es 0 (todas las lecturas en cero), devolver null —
+    // ambiguo entre "vehículo detenido legítimamente" y "GPS roto".
+    // El UI prefiere mostrar nada vs un "0 km/h" que confunde.
+    avgSpeed = avg > 0 ? Number(avg.toFixed(1)) : null;
+  }
+
+  return {
+    avg_speed_kmh_last_15min: avgSpeed,
+    last_position_age_seconds: lastPositionAgeSeconds,
   };
 }
 

--- a/apps/api/test/unit/get-public-tracking.test.ts
+++ b/apps/api/test/unit/get-public-tracking.test.ts
@@ -103,16 +103,16 @@ describe('getPublicTracking', () => {
       vehicleType: string;
       vehiclePlate: string;
     } | null;
-    positionRow?: {
+    pings?: Array<{
       timestamp: Date;
       latitude: string | null;
       longitude: string | null;
       speedKmh: number | null;
-    } | null;
+    }>;
   }) {
     const responses: Array<unknown[]> = [
       opts.assignmentRow ? [opts.assignmentRow] : [],
-      opts.positionRow ? [opts.positionRow] : [],
+      opts.pings ?? [],
     ];
     let callIdx = 0;
 
@@ -156,7 +156,7 @@ describe('getPublicTracking', () => {
     expect(result.status).toBe('not_found');
   });
 
-  it('found con sin posición reciente → response sin position', async () => {
+  it('found sin pings → position null + progress null', async () => {
     const { getPublicTracking } = await import('../../src/services/get-public-tracking.js');
     const { db } = makeDbStub({
       assignmentRow: {
@@ -170,7 +170,7 @@ describe('getPublicTracking', () => {
         vehicleType: 'camion_3_4',
         vehiclePlate: 'GR-AS12',
       },
-      positionRow: null,
+      pings: [],
     });
     const result = await getPublicTracking({ db, logger: noopLogger, token: VALID_TOKEN });
     expect(result.status).toBe('found');
@@ -179,13 +179,19 @@ describe('getPublicTracking', () => {
       expect(result.trip.status).toBe('en_proceso');
       expect(result.vehicle.plate_partial).toBe('***AS12');
       expect(result.position).toBeNull();
+      expect(result.progress.avg_speed_kmh_last_15min).toBeNull();
+      expect(result.progress.last_position_age_seconds).toBeNull();
       expect(result.eta_minutes).toBeNull();
     }
   });
 
-  it('found con posición reciente → response con position numérica', async () => {
+  it('found con pings recientes → position numérica + progress poblado', async () => {
     const { getPublicTracking } = await import('../../src/services/get-public-tracking.js');
-    const ts = new Date('2026-05-10T15:00:00Z');
+    // Timestamps relativos a "ahora" — el service usa Date.now() para el
+    // cutoff de la ventana 15min; si fijamos timestamps en un date
+    // estático del pasado, caen fuera de la ventana en vez de la entrada.
+    const now = Date.now();
+    const ts = new Date(now - 60_000); // 1 min atrás → IN window
     const { db } = makeDbStub({
       assignmentRow: {
         assignmentId: 'a1',
@@ -198,12 +204,22 @@ describe('getPublicTracking', () => {
         vehicleType: 'camion_3_4',
         vehiclePlate: 'GR-AS12',
       },
-      positionRow: {
-        timestamp: ts,
-        latitude: '-33.4172',
-        longitude: '-70.6063',
-        speedKmh: 65,
-      },
+      pings: [
+        // DESC: el primero es el más reciente.
+        { timestamp: ts, latitude: '-33.4172', longitude: '-70.6063', speedKmh: 65 },
+        {
+          timestamp: new Date(now - 5 * 60_000), // 5 min atrás → IN
+          latitude: '-33.4',
+          longitude: '-70.6',
+          speedKmh: 60,
+        },
+        {
+          timestamp: new Date(now - 10 * 60_000), // 10 min atrás → IN
+          latitude: '-33.39',
+          longitude: '-70.59',
+          speedKmh: 70,
+        },
+      ],
     });
     const result = await getPublicTracking({ db, logger: noopLogger, token: VALID_TOKEN });
     expect(result.status).toBe('found');
@@ -212,6 +228,11 @@ describe('getPublicTracking', () => {
       expect(result.position.longitude).toBeCloseTo(-70.6063, 4);
       expect(result.position.speed_kmh).toBe(65);
       expect(result.position.timestamp).toBe(ts.toISOString());
+      // progress: avg de [65, 60, 70] = 65.0
+      expect(result.progress.avg_speed_kmh_last_15min).toBeCloseTo(65, 1);
+      // last_position_age_seconds debería ser ~60 ± slack del runtime.
+      expect(result.progress.last_position_age_seconds).toBeGreaterThanOrEqual(59);
+      expect(result.progress.last_position_age_seconds).toBeLessThanOrEqual(62);
     }
   });
 
@@ -229,7 +250,7 @@ describe('getPublicTracking', () => {
         vehicleType: 'camion_3_4',
         vehiclePlate: 'TOPSECRET99',
       },
-      positionRow: null,
+      pings: [],
     });
     const result = await getPublicTracking({ db, logger: noopLogger, token: VALID_TOKEN });
     expect(result.status).toBe('found');
@@ -238,5 +259,91 @@ describe('getPublicTracking', () => {
       expect(result.vehicle.plate_partial).toBe('*******ET99');
       expect(result.vehicle.plate_partial).not.toContain('TOPSECRET');
     }
+  });
+});
+
+describe('computeProgress', () => {
+  const NOW_MS = new Date('2026-05-10T15:00:00Z').getTime();
+
+  it('sin pings → todo null', async () => {
+    const { computeProgress } = await import('../../src/services/get-public-tracking.js');
+    expect(computeProgress({ pings: [], nowMs: NOW_MS })).toEqual({
+      avg_speed_kmh_last_15min: null,
+      last_position_age_seconds: null,
+    });
+  });
+
+  it('1 ping → last_position_age computed, avg_speed null (necesita ≥2)', async () => {
+    const { computeProgress } = await import('../../src/services/get-public-tracking.js');
+    const result = computeProgress({
+      pings: [{ timestamp: new Date(NOW_MS - 30_000), speedKmh: 50 }],
+      nowMs: NOW_MS,
+    });
+    expect(result.last_position_age_seconds).toBe(30);
+    expect(result.avg_speed_kmh_last_15min).toBeNull();
+  });
+
+  it('2+ pings con speeds positivos → avg_speed redondeado a 1 decimal', async () => {
+    const { computeProgress } = await import('../../src/services/get-public-tracking.js');
+    const result = computeProgress({
+      pings: [
+        { timestamp: new Date(NOW_MS - 60_000), speedKmh: 60 },
+        { timestamp: new Date(NOW_MS - 120_000), speedKmh: 70 },
+        { timestamp: new Date(NOW_MS - 180_000), speedKmh: 80 },
+      ],
+      nowMs: NOW_MS,
+    });
+    expect(result.avg_speed_kmh_last_15min).toBeCloseTo(70, 1);
+    expect(result.last_position_age_seconds).toBe(60);
+  });
+
+  it('todos los speeds = 0 → avg_speed null (ambiguo: parado vs GPS roto)', async () => {
+    const { computeProgress } = await import('../../src/services/get-public-tracking.js');
+    const result = computeProgress({
+      pings: [
+        { timestamp: new Date(NOW_MS - 60_000), speedKmh: 0 },
+        { timestamp: new Date(NOW_MS - 120_000), speedKmh: 0 },
+      ],
+      nowMs: NOW_MS,
+    });
+    expect(result.avg_speed_kmh_last_15min).toBeNull();
+  });
+
+  it('pings con speedKmh=null se excluyen del avg', async () => {
+    const { computeProgress } = await import('../../src/services/get-public-tracking.js');
+    const result = computeProgress({
+      pings: [
+        { timestamp: new Date(NOW_MS - 60_000), speedKmh: null },
+        { timestamp: new Date(NOW_MS - 120_000), speedKmh: 60 },
+        { timestamp: new Date(NOW_MS - 180_000), speedKmh: 80 },
+      ],
+      nowMs: NOW_MS,
+    });
+    expect(result.avg_speed_kmh_last_15min).toBeCloseTo(70, 1);
+  });
+
+  it('pings fuera de ventana 15min se excluyen del avg', async () => {
+    const { computeProgress } = await import('../../src/services/get-public-tracking.js');
+    const result = computeProgress({
+      pings: [
+        { timestamp: new Date(NOW_MS - 60_000), speedKmh: 60 }, // 1 min — IN
+        { timestamp: new Date(NOW_MS - 16 * 60_000), speedKmh: 200 }, // 16 min — OUT
+        { timestamp: new Date(NOW_MS - 25 * 60_000), speedKmh: 200 }, // 25 min — OUT
+      ],
+      nowMs: NOW_MS,
+    });
+    // Solo el primero está en ventana; con <2 → avg null.
+    expect(result.avg_speed_kmh_last_15min).toBeNull();
+    // Pero last_position_age usa el más reciente.
+    expect(result.last_position_age_seconds).toBe(60);
+  });
+
+  it('last_position_age clamped a 0 si timestamp futuro (clock skew)', async () => {
+    const { computeProgress } = await import('../../src/services/get-public-tracking.js');
+    const result = computeProgress({
+      pings: [{ timestamp: new Date(NOW_MS + 30_000), speedKmh: 50 }], // 30s futuro
+      nowMs: NOW_MS,
+    });
+    expect(result.last_position_age_seconds).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

Agrega un bloque \`progress\` al response del endpoint público de tracking con dos señales calculadas a partir del historial reciente de telemetría. El consignee puede distinguir \"se está moviendo a buen ritmo\" vs \"lleva 30 min sin moverse\" vs \"perdió señal\".

ETA real (\`eta_minutes\`) sigue siendo \`null\` en este PR — trips schema NO tiene lat/lng del destino, solo address text. Difiere a PR-L2b.

## Nuevos campos en el response

\`\`\`json
{
  ...,
  \"position\": { ... },
  \"progress\": {
    \"avg_speed_kmh_last_15min\": 65.3,
    \"last_position_age_seconds\": 47
  },
  \"eta_minutes\": null
}
\`\`\`

| Campo | Cuándo es null | Por qué |
|---|---|---|
| \`avg_speed_kmh_last_15min\` | <2 pings en ventana O todos speeds=0 | Ambiguo entre \"detenido legítimo\" y \"GPS roto\" |
| \`last_position_age_seconds\` | sin pings <30min | Mismo threshold que el de \`position\` |

## Diseño

- **\`computeProgress\` función pura**: toda la lógica de ventana 15min + filtros separada de la query DB. 7 tests dedicados al pure path.
- **Una sola query telemetría** con \`LIMIT 200\` cubre latest position + avg_speed window. Mejor que 2 queries separadas.
- **Cap defensivo 200 pings**: O(N) pequeño aún con telemetría densa (1Hz × 30min = 1800 pings).
- **Clock skew tolerance**: timestamps futuros se clampan a age=0.

## Cambios

| Archivo | Cambio | Tests |
|---|---|---|
| \`apps/api/src/services/get-public-tracking.ts\` | + \`PublicTrackingProgress\`, + \`computeProgress\` puro, refactor query | actualizados |
| \`apps/api/test/unit/get-public-tracking.test.ts\` | stub \`pings: []\` + 7 tests nuevos del path puro | +7 |

### Tests breakdown

**\`computeProgress\` (7)**: sin pings → todo null, 1 ping → age computed pero avg null (necesita ≥2), 2+ pings → avg redondeado, todos speeds=0 → avg null, speedKmh=null se excluye, pings fuera de ventana se excluyen, clock skew futuro → age clamped a 0.

## Próximo

- **PR-L2b**: ETA real — geocoding al crear trip (1× cost, simple) o Routes API on-demand con cache 60s (no schema change)
- **PR-L3**: WhatsApp template \`tracking_link_v1\` al shipper + consignee al asignar
- **PR-L4**: página pública \`/tracking/:token\` en apps/web con mapa Maps JS API

## Evidencia

- \`pnpm typecheck\` ✓ (monorepo, 29 tasks)
- \`pnpm lint\` ✓ (biome + lint-rls)
- \`pnpm test\` ✓: api 456 (+7), todos verdes

🤖 Generated with [Claude Code](https://claude.com/claude-code)