### PR TITLE
test(web): eliminar todos los excludes — coverage gate sin lista de excludes

### DIFF
--- a/apps/web/src/components/map/LiveTrackingScreen.test.tsx
+++ b/apps/web/src/components/map/LiveTrackingScreen.test.tsx
@@ -1,0 +1,235 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const envState: { value: { VITE_GOOGLE_MAPS_API_KEY?: string } } = { value: {} };
+vi.mock('../../lib/env.js', () => ({
+  env: new Proxy(
+    {},
+    {
+      get: (_t, prop: string) => envState.value[prop as 'VITE_GOOGLE_MAPS_API_KEY'],
+    },
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('@vis.gl/react-google-maps', () => ({
+  APIProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="api-provider">{children}</div>
+  ),
+  Map: ({ children }: { children: ReactNode }) => <div data-testid="google-map">{children}</div>,
+  AdvancedMarker: ({ children }: { children: ReactNode }) => (
+    <div data-testid="marker">{children}</div>
+  ),
+  Pin: (props: { background?: string }) => <div data-testid="pin" data-bg={props.background} />,
+  ControlPosition: { RIGHT_TOP: 'RIGHT_TOP' },
+}));
+
+let followFollowing = true;
+const resumeMock = vi.fn();
+vi.mock('./use-follow-vehicle.js', () => ({
+  useFollowVehicle: () => ({
+    get following() {
+      return followFollowing;
+    },
+    pause: vi.fn(),
+    resume: resumeMock,
+  }),
+  FollowVehicle: () => <div data-testid="follow-vehicle" />,
+}));
+
+const { LiveTrackingScreen } = await import('./LiveTrackingScreen.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  followFollowing = true;
+  envState.value = { VITE_GOOGLE_MAPS_API_KEY: 'test-key' };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LiveTrackingScreen — header', () => {
+  it('renderiza título + back link', () => {
+    render(
+      <LiveTrackingScreen
+        title="Vehículo ABCD12"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+      />,
+    );
+    expect(screen.getByText('Vehículo ABCD12')).toBeInTheDocument();
+    expect(screen.getByLabelText('Volver')).toHaveAttribute('to', '/app');
+  });
+
+  it('subtitle opcional → si presente, se renderiza', () => {
+    render(
+      <LiveTrackingScreen
+        title="V1"
+        subtitle="Carga BST-001"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+      />,
+    );
+    expect(screen.getByText('Carga BST-001')).toBeInTheDocument();
+  });
+
+  it('onRefresh presente → muestra botón Refrescar', () => {
+    const onRefresh = vi.fn();
+    render(
+      <LiveTrackingScreen
+        title="V1"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+        onRefresh={onRefresh}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText('Refrescar'));
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('onRefresh ausente → no muestra botón', () => {
+    render(<LiveTrackingScreen title="V1" backTo="/app" latitude={-33.45} longitude={-70.65} />);
+    expect(screen.queryByLabelText('Refrescar')).not.toBeInTheDocument();
+  });
+
+  it('isFetching=true → botón Refrescar deshabilitado', () => {
+    render(
+      <LiveTrackingScreen
+        title="V1"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+        onRefresh={vi.fn()}
+        isFetching
+      />,
+    );
+    expect(screen.getByLabelText('Refrescar')).toBeDisabled();
+  });
+});
+
+describe('LiveTrackingScreen — empty states', () => {
+  it('sin API key → "Mapa no disponible"', () => {
+    envState.value = {};
+    render(<LiveTrackingScreen title="V1" backTo="/app" latitude={-33.45} longitude={-70.65} />);
+    expect(screen.getByText('Mapa no disponible')).toBeInTheDocument();
+  });
+
+  it('con API key pero lat null → "Sin posición GPS aún"', () => {
+    render(<LiveTrackingScreen title="V1" backTo="/app" latitude={null} longitude={null} />);
+    expect(screen.getByText('Sin posición GPS aún')).toBeInTheDocument();
+  });
+
+  it('con API key + lat null + isLoading → "Cargando…"', () => {
+    render(
+      <LiveTrackingScreen title="V1" backTo="/app" latitude={null} longitude={null} isLoading />,
+    );
+    expect(screen.getByText('Cargando…')).toBeInTheDocument();
+  });
+});
+
+describe('LiveTrackingScreen — happy path', () => {
+  it('lat+lng → renderiza GoogleMap + AdvancedMarker', () => {
+    render(<LiveTrackingScreen title="V1" backTo="/app" latitude={-33.45} longitude={-70.65} />);
+    expect(screen.getByTestId('google-map')).toBeInTheDocument();
+    expect(screen.getByTestId('marker')).toBeInTheDocument();
+  });
+
+  it('speedKmh + angleDeg presentes → bottom card muestra valores', () => {
+    render(
+      <LiveTrackingScreen
+        title="V1"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+        speedKmh={62}
+        angleDeg={180}
+      />,
+    );
+    expect(screen.getByText('62 km/h')).toBeInTheDocument();
+    expect(screen.getByText('180°')).toBeInTheDocument();
+  });
+
+  it('speedKmh null → muestra "—"', () => {
+    render(
+      <LiveTrackingScreen
+        title="V1"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+        speedKmh={null}
+      />,
+    );
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('timestamp viejo (>120s) → pin gris (stale)', () => {
+    const oldDate = new Date(Date.now() - 5 * 60_000).toISOString();
+    render(
+      <LiveTrackingScreen
+        title="V1"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+        timestampDevice={oldDate}
+      />,
+    );
+    expect(screen.getByTestId('pin')).toHaveAttribute('data-bg', '#9CA3AF');
+  });
+
+  it('timestamp reciente → pin verde', () => {
+    const fresh = new Date(Date.now() - 10_000).toISOString();
+    render(
+      <LiveTrackingScreen
+        title="V1"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+        timestampDevice={fresh}
+      />,
+    );
+    expect(screen.getByTestId('pin')).toHaveAttribute('data-bg', '#1FA058');
+  });
+
+  it('bottomExtra slot → se renderiza dentro del bottom card', () => {
+    render(
+      <LiveTrackingScreen
+        title="V1"
+        backTo="/app"
+        latitude={-33.45}
+        longitude={-70.65}
+        bottomExtra={<div data-testid="extra-content">extra</div>}
+      />,
+    );
+    expect(screen.getByTestId('extra-content')).toBeInTheDocument();
+  });
+});
+
+describe('LiveTrackingScreen — recenter button', () => {
+  it('follow=true (default) → no muestra botón Recentrar', () => {
+    followFollowing = true;
+    render(<LiveTrackingScreen title="V1" backTo="/app" latitude={-33.45} longitude={-70.65} />);
+    expect(screen.queryByLabelText('Recentrar mapa en el vehículo')).not.toBeInTheDocument();
+  });
+
+  it('follow=false → muestra botón Recentrar y click llama resume', () => {
+    followFollowing = false;
+    render(<LiveTrackingScreen title="V1" backTo="/app" latitude={-33.45} longitude={-70.65} />);
+    const btn = screen.getByLabelText('Recentrar mapa en el vehículo');
+    fireEvent.click(btn);
+    expect(resumeMock).toHaveBeenCalled();
+  });
+
+  it('follow=false pero sin posición → no botón (porque no hay mapa)', () => {
+    followFollowing = false;
+    render(<LiveTrackingScreen title="V1" backTo="/app" latitude={null} longitude={null} />);
+    expect(screen.queryByLabelText('Recentrar mapa en el vehículo')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/map/VehicleMap.test.tsx
+++ b/apps/web/src/components/map/VehicleMap.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const envState: { value: { VITE_GOOGLE_MAPS_API_KEY?: string } } = { value: {} };
+vi.mock('../../lib/env.js', () => ({
+  env: new Proxy(
+    {},
+    {
+      get: (_t, prop: string) => envState.value[prop as 'VITE_GOOGLE_MAPS_API_KEY'],
+    },
+  ),
+}));
+
+// Mock @vis.gl/react-google-maps con stubs simples — no podemos cargar el
+// SDK real sin browser ni API key válida.
+vi.mock('@vis.gl/react-google-maps', () => ({
+  APIProvider: ({ children }: { children: ReactNode }) => (
+    <div data-testid="api-provider">{children}</div>
+  ),
+  Map: ({ children, style }: { children: ReactNode; style?: { height: number } }) => (
+    <div data-testid="google-map" style={style}>
+      {children}
+    </div>
+  ),
+  AdvancedMarker: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div data-testid="marker" data-title={title}>
+      {children}
+    </div>
+  ),
+  Pin: () => <div data-testid="pin" />,
+  MapControl: ({ children }: { children: ReactNode }) => (
+    <div data-testid="map-control">{children}</div>
+  ),
+  ControlPosition: { RIGHT_BOTTOM: 'RIGHT_BOTTOM' },
+}));
+
+// useFollowVehicle stub: simple controller object.
+let followFollowing = true;
+const resumeMock = vi.fn();
+vi.mock('./use-follow-vehicle.js', () => ({
+  useFollowVehicle: () => ({
+    get following() {
+      return followFollowing;
+    },
+    pause: vi.fn(),
+    resume: resumeMock,
+  }),
+  FollowVehicle: () => <div data-testid="follow-vehicle" />,
+}));
+
+const { VehicleMap } = await import('./VehicleMap.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  followFollowing = true;
+  envState.value = {};
+});
+
+describe('VehicleMap — fallbacks', () => {
+  it('sin VITE_GOOGLE_MAPS_API_KEY → render "Mapa no disponible"', () => {
+    // El setup global no setea la API key; env.VITE_GOOGLE_MAPS_API_KEY es undefined.
+    render(<VehicleMap latitude={-33.45} longitude={-70.65} plate="ABCD12" />);
+    expect(screen.getByText('Mapa no disponible')).toBeInTheDocument();
+  });
+
+  it('con API key pero lat/lng null → "Sin posición GPS aún"', () => {
+    envState.value = { VITE_GOOGLE_MAPS_API_KEY: 'test-key' };
+    render(<VehicleMap latitude={null} longitude={null} plate="ABCD12" />);
+    expect(screen.getByText('Sin posición GPS aún')).toBeInTheDocument();
+  });
+
+  it('lat presente y lng null → fallback "Sin posición GPS"', () => {
+    envState.value = { VITE_GOOGLE_MAPS_API_KEY: 'test-key' };
+    render(<VehicleMap latitude={-33.45} longitude={null} plate="ABCD12" />);
+    expect(screen.getByText('Sin posición GPS aún')).toBeInTheDocument();
+  });
+});
+
+describe('VehicleMap — happy path', () => {
+  beforeEach(() => {
+    envState.value = { VITE_GOOGLE_MAPS_API_KEY: 'test-key' };
+  });
+
+  it('renderiza GoogleMap + AdvancedMarker + label de placa', () => {
+    render(<VehicleMap latitude={-33.45} longitude={-70.65} plate="ABCD12" speedKmh={42} />);
+    expect(screen.getByTestId('google-map')).toBeInTheDocument();
+    expect(screen.getByTestId('marker')).toHaveAttribute(
+      'data-title',
+      expect.stringContaining('ABCD12'),
+    );
+    expect(screen.getByTestId('marker')).toHaveAttribute(
+      'data-title',
+      expect.stringContaining('42 km/h'),
+    );
+  });
+
+  it('speedKmh null → label "Detenido o sin velocidad"', () => {
+    render(<VehicleMap latitude={-33.45} longitude={-70.65} plate="ABCD12" speedKmh={null} />);
+    expect(screen.getByText('Detenido o sin velocidad')).toBeInTheDocument();
+  });
+
+  it('speedKmh undefined → label "Detenido"', () => {
+    render(<VehicleMap latitude={-33.45} longitude={-70.65} plate="ABCD12" />);
+    expect(screen.getByText('Detenido o sin velocidad')).toBeInTheDocument();
+  });
+
+  it('timestampDevice presente → muestra "Reportado" + fecha localizada', () => {
+    render(
+      <VehicleMap
+        latitude={-33.45}
+        longitude={-70.65}
+        plate="ABCD12"
+        timestampDevice="2026-05-10T15:30:00Z"
+      />,
+    );
+    expect(screen.getByText(/Reportado/)).toBeInTheDocument();
+  });
+
+  it('timestampDevice Date object → también funciona', () => {
+    render(
+      <VehicleMap
+        latitude={-33.45}
+        longitude={-70.65}
+        plate="ABCD12"
+        timestampDevice={new Date('2026-05-10T15:30:00Z')}
+      />,
+    );
+    expect(screen.getByText(/Reportado/)).toBeInTheDocument();
+  });
+
+  it('follow=true (default) → no muestra botón Recentrar', () => {
+    followFollowing = true;
+    render(<VehicleMap latitude={-33.45} longitude={-70.65} plate="ABCD12" />);
+    expect(screen.queryByLabelText('Recentrar mapa en el vehículo')).not.toBeInTheDocument();
+  });
+
+  it('follow=false → muestra botón Recentrar dentro de MapControl', () => {
+    followFollowing = false;
+    render(<VehicleMap latitude={-33.45} longitude={-70.65} plate="ABCD12" />);
+    expect(screen.getByLabelText('Recentrar mapa en el vehículo')).toBeInTheDocument();
+  });
+
+  it('height prop custom → aplica al style del Map', () => {
+    render(<VehicleMap latitude={-33.45} longitude={-70.65} plate="ABCD12" height={500} />);
+    const map = screen.getByTestId('google-map');
+    expect(map).toHaveStyle({ height: '500px' });
+  });
+});

--- a/apps/web/src/components/scoring/DeliveryConfirmCard.tsx
+++ b/apps/web/src/components/scoring/DeliveryConfirmCard.tsx
@@ -147,7 +147,7 @@ export function DeliveryConfirmCard({
         <div className="flex items-center gap-3">
           <CheckCircle2 className="h-6 w-6 text-success-700" aria-hidden />
           <div>
-            <p className="font-semibold text-success-800 text-sm">Entrega confirmada</p>
+            <p className="font-semibold text-sm text-success-800">Entrega confirmada</p>
             <p className="mt-0.5 text-success-700 text-xs">
               Procesando coaching y certificado de carbono…
             </p>

--- a/apps/web/src/lib/firebase.test.ts
+++ b/apps/web/src/lib/firebase.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const initializeAppMock = vi.fn(() => ({ name: '[DEFAULT]' }));
+const getAuthMock = vi.fn(() => ({ name: 'auth' }));
+const setPersistenceMock = vi.fn(async () => undefined);
+const browserLocalPersistenceMock = { type: 'LOCAL' };
+const setCustomParametersMock = vi.fn();
+function GoogleAuthProviderStub(this: { setCustomParameters: typeof setCustomParametersMock }) {
+  this.setCustomParameters = setCustomParametersMock;
+}
+
+vi.mock('firebase/app', () => ({
+  initializeApp: initializeAppMock,
+}));
+
+vi.mock('firebase/auth', () => ({
+  getAuth: getAuthMock,
+  setPersistence: setPersistenceMock,
+  browserLocalPersistence: browserLocalPersistenceMock,
+  GoogleAuthProvider: GoogleAuthProviderStub,
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  initializeAppMock.mockClear();
+  getAuthMock.mockClear();
+  setPersistenceMock.mockClear();
+  setCustomParametersMock.mockClear();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('lib/firebase', () => {
+  it('inicializa Firebase con la config VITE_FIREBASE_*', async () => {
+    await import('./firebase.js');
+    expect(initializeAppMock).toHaveBeenCalledTimes(1);
+    const config = (initializeAppMock.mock.calls[0] as unknown as [Record<string, string>])?.[0];
+    expect(config).toMatchObject({
+      apiKey: expect.any(String),
+      authDomain: expect.any(String),
+      projectId: expect.any(String),
+      appId: expect.any(String),
+    });
+  });
+
+  it('exporta firebaseApp y firebaseAuth', async () => {
+    const mod = await import('./firebase.js');
+    expect(mod.firebaseApp).toBeDefined();
+    expect(mod.firebaseAuth).toBeDefined();
+    expect(getAuthMock).toHaveBeenCalledWith(mod.firebaseApp);
+  });
+
+  it('aplica browserLocalPersistence al auth', async () => {
+    await import('./firebase.js');
+    expect(setPersistenceMock).toHaveBeenCalledWith(expect.anything(), browserLocalPersistenceMock);
+  });
+
+  it('crea GoogleAuthProvider con setCustomParameters', async () => {
+    const mod = await import('./firebase.js');
+    expect(mod.googleProvider).toBeDefined();
+    expect(setCustomParametersMock).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: 'select_account' }),
+    );
+  });
+});

--- a/apps/web/src/main.test.tsx
+++ b/apps/web/src/main.test.tsx
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const renderMock = vi.fn();
+const createRootMock = vi.fn(() => ({ render: renderMock }));
+vi.mock('react-dom/client', () => ({
+  default: { createRoot: createRootMock },
+  createRoot: createRootMock,
+}));
+
+vi.mock('./router.js', () => ({
+  router: { __test__: 'router-stub' },
+}));
+
+vi.mock('./styles.css', () => ({}));
+
+beforeEach(() => {
+  vi.resetModules();
+  createRootMock.mockClear();
+  renderMock.mockClear();
+  // Limpiar #root entre tests.
+  document.body.innerHTML = '';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('main.tsx', () => {
+  it('monta React en #root', async () => {
+    const root = document.createElement('div');
+    root.id = 'root';
+    document.body.appendChild(root);
+    await import('./main.js');
+    expect(createRootMock).toHaveBeenCalledWith(root);
+    expect(renderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws si no existe #root', async () => {
+    await expect(import('./main.js')).rejects.toThrow(/#root not found/);
+  });
+});

--- a/apps/web/src/router.test.tsx
+++ b/apps/web/src/router.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { router } from './router.js';
+
+describe('router', () => {
+  it('exporta un Router de TanStack válido', () => {
+    expect(router).toBeDefined();
+    expect(router.options.routeTree).toBeDefined();
+  });
+
+  it('defaultPreload="intent" para link prefetch on hover', () => {
+    expect(router.options.defaultPreload).toBe('intent');
+  });
+
+  it('routeTree tiene paths esperados', () => {
+    // Extrae los paths de los hijos del root.
+    const root = router.routeTree;
+    const children = (root.children ?? []) as ReadonlyArray<{ path?: string }>;
+    const paths = children.map((c) => c.path).filter(Boolean);
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        '/',
+        'login',
+        'onboarding',
+        'app',
+        'app/ofertas',
+        'app/perfil',
+        'app/admin/dispositivos',
+        'app/vehiculos',
+        'app/vehiculos/nuevo',
+        'app/vehiculos/$id',
+        'app/vehiculos/$id/live',
+        'app/cargas',
+        'app/cargas/nueva',
+        'app/cargas/$id',
+        'app/cargas/$id/track',
+        'app/certificados',
+        'app/asignaciones/$id',
+      ]),
+    );
+  });
+});

--- a/apps/web/src/routes/__root.test.tsx
+++ b/apps/web/src/routes/__root.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-router', () => ({
+  Outlet: () => <div data-testid="outlet">outlet</div>,
+}));
+
+const { RootComponent } = await import('./__root.js');
+
+describe('RootComponent', () => {
+  it('renderiza <Outlet />', () => {
+    render(<RootComponent />);
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/admin-dispositivos.test.tsx
+++ b/apps/web/src/routes/admin-dispositivos.test.tsx
@@ -1,0 +1,136 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div data-testid="layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../components/EmptyState.js', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+  emptyStateActionClass: 'btn',
+}));
+
+const { AdminDispositivosRoute } = await import('./admin-dispositivos.js');
+
+function makeMe(role: 'dueno' | 'admin' | 'conductor'): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role,
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e',
+        legal_name: 'E',
+        rut: '76',
+        is_generador_carga: false,
+        is_transportista: true,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRoute() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <AdminDispositivosRoute />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AdminDispositivosRoute', () => {
+  it('no onboarded → no renderiza', () => {
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-testid="layout"]')).toBeNull();
+  });
+
+  it('rol conductor → "Acceso restringido"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe('conductor') };
+    renderRoute();
+    expect(screen.getByText('Acceso restringido')).toBeInTheDocument();
+  });
+
+  it('rol admin → renderiza Layout', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ devices: [], vehicles: [] });
+    providedContext = { kind: 'onboarded', me: makeMe('admin') };
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId('layout')).toBeInTheDocument());
+  });
+
+  it('rol dueno + sin dispositivos pendientes → EmptyState', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({ devices: [], vehicles: [] });
+    providedContext = { kind: 'onboarded', me: makeMe('dueno') };
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeInTheDocument());
+  });
+
+  it('rol dueno + dispositivo pendiente → renderiza fila con IMEI', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path.includes('/admin/dispositivos-pendientes')) {
+        return {
+          devices: [
+            {
+              id: 'd1',
+              imei: '111222333',
+              primera_conexion_en: '2026-05-10T10:00:00Z',
+              ultima_conexion_en: '2026-05-10T10:05:00Z',
+              ultima_ip_origen: '1.2.3.4',
+              cantidad_conexiones: 3,
+              modelo_detectado: 'FMC150',
+              estado: 'pendiente',
+            },
+          ],
+        };
+      }
+      if (path === '/vehiculos') {
+        return { vehicles: [{ id: 'v1', plate: 'XYZ123', brand: 'Volvo', model: 'FH' }] };
+      }
+      return {};
+    });
+    providedContext = { kind: 'onboarded', me: makeMe('dueno') };
+    renderRoute();
+    await waitFor(() => expect(screen.getByText('111222333')).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/routes/app.test.tsx
+++ b/apps/web/src/routes/app.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+const signOutUserMock = vi.fn();
+vi.mock('../hooks/use-auth.js', () => ({
+  signOutUser: signOutUserMock,
+}));
+
+const { AppRoute } = await import('./app.js');
+
+function makeMe(
+  role: NonNullable<MeOnboarded['active_membership']>['role'] = 'dueno',
+  isCarrier = true,
+  isShipper = true,
+): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'Felipe', email: 'a@b.cl' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role,
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e1',
+        legal_name: 'Booster SpA',
+        rut: '76',
+        is_generador_carga: isShipper,
+        is_transportista: isCarrier,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AppRoute', () => {
+  it('contexto no onboarded → no renderiza dashboard', () => {
+    const { container } = render(<AppRoute />);
+    expect(container.querySelector('h1')).toBeNull();
+  });
+
+  it('contexto onboarded → renderiza dashboard con título Bienvenido', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<AppRoute />);
+    expect(screen.getByText('Bienvenido a Booster')).toBeInTheDocument();
+    expect(screen.getAllByText('Booster SpA').length).toBeGreaterThan(0);
+    expect(screen.getByText('Felipe')).toBeInTheDocument();
+  });
+
+  it('carrier → muestra card "Ofertas activas"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe('dueno', true, false) };
+    render(<AppRoute />);
+    expect(screen.getByText(/Ofertas activas/)).toBeInTheDocument();
+  });
+
+  it('shipper → muestra card "Crear carga"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe('dueno', false, true) };
+    render(<AppRoute />);
+    expect(screen.getByText(/Crear carga/)).toBeInTheDocument();
+  });
+
+  it('admin + transportista → muestra "Dispositivos pendientes"', () => {
+    providedContext = {
+      kind: 'onboarded',
+      me: makeMe('admin', true, false),
+    };
+    render(<AppRoute />);
+    expect(screen.getByText(/Dispositivos pendientes/)).toBeInTheDocument();
+  });
+
+  it('no admin → no muestra admin dispositivos', () => {
+    providedContext = { kind: 'onboarded', me: makeMe('conductor') };
+    render(<AppRoute />);
+    expect(screen.queryByText(/Dispositivos pendientes/)).not.toBeInTheDocument();
+  });
+
+  it('click Salir → signOutUser', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<AppRoute />);
+    screen.getByRole('button', { name: 'Cerrar sesión' }).click();
+    expect(signOutUserMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/asignacion-detalle.test.tsx
+++ b/apps/web/src/routes/asignacion-detalle.test.tsx
@@ -1,0 +1,177 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useParams: () => ({ id: 'asn-uuid' }),
+}));
+
+vi.mock('../components/chat/ChatPanel.js', () => ({
+  ChatPanel: (props: { title: string; readOnly?: boolean }) => (
+    <div
+      data-testid="chat-panel"
+      data-title={props.title}
+      data-readonly={props.readOnly ?? false}
+    />
+  ),
+}));
+
+vi.mock('../components/chat/PushSubscribeBanner.js', () => ({
+  PushSubscribeBanner: () => <div data-testid="push-banner" />,
+}));
+
+vi.mock('../components/scoring/BehaviorScoreCard.js', () => ({
+  BehaviorScoreCard: () => <div data-testid="behavior-score" />,
+}));
+
+vi.mock('../components/scoring/DeliveryConfirmCard.js', () => ({
+  DeliveryConfirmCard: () => <div data-testid="delivery-confirm" />,
+}));
+
+const { AsignacionDetalleRoute } = await import('./asignacion-detalle.js');
+
+function makeMe(isTransportista: boolean): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role: 'dueno',
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e',
+        legal_name: 'E',
+        rut: '76',
+        is_generador_carga: false,
+        is_transportista: isTransportista,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRoute() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <AsignacionDetalleRoute />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AsignacionDetalleRoute', () => {
+  it('no onboarded → no renderiza', () => {
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-testid="chat-panel"]')).toBeNull();
+  });
+
+  it('onboarded pero no transportista → muestra "Sin permisos"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(false) };
+    renderRoute();
+    expect(screen.getByText('Sin permisos')).toBeInTheDocument();
+  });
+
+  it('transportista + status asignado → muestra DeliveryConfirmCard', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request: {
+        id: 't1',
+        tracking_code: 'BST-001',
+        status: 'asignado',
+        origin: { address_raw: 'A', region_code: 'XIII' },
+        destination: { address_raw: 'B', region_code: 'V' },
+        cargo_type: 'carga_seca',
+        cargo_weight_kg: 5000,
+        shipper_legal_name: 'ACME',
+      },
+      assignment: { id: 'a1', status: 'asignado' } as never,
+    });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId('delivery-confirm')).toBeInTheDocument());
+    expect(screen.queryByTestId('behavior-score')).not.toBeInTheDocument();
+  });
+
+  it('transportista + status entregado → BehaviorScoreCard + chat readOnly', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request: {
+        id: 't1',
+        tracking_code: 'BST-002',
+        status: 'entregado',
+        origin: { address_raw: 'A', region_code: 'XIII' },
+        destination: { address_raw: 'B', region_code: 'V' },
+        cargo_type: 'carga_seca',
+        cargo_weight_kg: 5000,
+        shipper_legal_name: 'ACME',
+      },
+      assignment: { id: 'a1', status: 'entregado' } as never,
+    });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId('behavior-score')).toBeInTheDocument());
+    expect(screen.getByTestId('chat-panel')).toHaveAttribute('data-readonly', 'true');
+    expect(screen.queryByTestId('delivery-confirm')).not.toBeInTheDocument();
+  });
+
+  it('shipper_legal_name null → chat title con fallback', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request: {
+        id: 't1',
+        tracking_code: 'BST-003',
+        status: 'asignado',
+        origin: { address_raw: 'A', region_code: 'XIII' },
+        destination: { address_raw: 'B', region_code: 'V' },
+        cargo_type: 'carga_seca',
+        cargo_weight_kg: 5000,
+        shipper_legal_name: null,
+      },
+      assignment: { id: 'a1', status: 'asignado' } as never,
+    });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByTestId('chat-panel')).toHaveAttribute(
+        'data-title',
+        'Chat con generador de carga',
+      ),
+    );
+  });
+
+  it('sin data (loading) → tracking code es slice del assignment id', () => {
+    vi.spyOn(api, 'get').mockImplementation(() => new Promise<never>(() => undefined));
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    renderRoute();
+    // El header siempre se renderiza con fallback al assignmentId.slice(0,8).
+    expect(screen.getByText(/asn-uuid/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/carga-track.test.tsx
+++ b/apps/web/src/routes/carga-track.test.tsx
@@ -1,0 +1,164 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useParams: () => ({ id: 'trip-1' }),
+}));
+
+vi.mock('../components/map/LiveTrackingScreen.js', () => ({
+  LiveTrackingScreen: (props: {
+    title: string;
+    latitude: number | null;
+    bottomExtra?: ReactNode;
+  }) => (
+    <div data-testid="live-tracking" data-title={props.title} data-has-pos={props.latitude != null}>
+      {props.bottomExtra}
+    </div>
+  ),
+}));
+
+vi.mock('../components/chat/ChatPanel.js', () => ({
+  ChatPanel: () => <div data-testid="chat-panel" />,
+}));
+
+vi.mock('../components/chat/PushSubscribeBanner.js', () => ({
+  PushSubscribeBanner: () => <div data-testid="push-banner" />,
+}));
+
+const { CargaTrackRoute } = await import('./carga-track.js');
+
+function makeMe(): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: null,
+  } as MeOnboarded;
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRoute() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <CargaTrackRoute />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CargaTrackRoute', () => {
+  it('no onboarded → no renderiza tracking', () => {
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-testid="live-tracking"]')).toBeNull();
+  });
+
+  it('onboarded + sin asignación → LiveTrackingScreen sin posición', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request: {
+        id: 't1',
+        status: 'sin_asignar',
+        origin_address_raw: 'A',
+        origin_region_code: 'XIII',
+        destination_address_raw: 'B',
+        destination_region_code: 'V',
+      },
+      assignment: null,
+    });
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByTestId('live-tracking')).toHaveAttribute('data-has-pos', 'false'),
+    );
+  });
+
+  it('onboarded + asignación con ubicación → LiveTrackingScreen con plate en title', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request: {
+        id: 't1',
+        status: 'en_proceso',
+        origin_address_raw: 'A',
+        origin_region_code: 'XIII',
+        destination_address_raw: 'B',
+        destination_region_code: 'V',
+      },
+      assignment: {
+        id: 'a1',
+        status: 'en_proceso',
+        empresa_legal_name: 'Transportes Andes',
+        vehicle_plate: 'ABCD12',
+        vehicle_type: 'camion',
+        driver_name: 'Pedro',
+        ubicacion_actual: {
+          timestamp_device: '2026-05-10T10:00:00Z',
+          latitude: -33.45,
+          longitude: -70.65,
+          speed_kmh: 50,
+          angle_deg: 90,
+        },
+      },
+    });
+    renderRoute();
+    await waitFor(() => {
+      const lt = screen.getByTestId('live-tracking');
+      expect(lt).toHaveAttribute('data-has-pos', 'true');
+      expect(lt).toHaveAttribute('data-title', expect.stringContaining('ABCD12'));
+    });
+  });
+
+  it('click "Chat con transportista" abre ChatPanel overlay', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request: {
+        id: 't1',
+        status: 'en_proceso',
+        origin_address_raw: 'A',
+        origin_region_code: 'XIII',
+        destination_address_raw: 'B',
+        destination_region_code: 'V',
+      },
+      assignment: {
+        id: 'a1',
+        status: 'en_proceso',
+        empresa_legal_name: 'TA',
+        vehicle_plate: 'ABCD12',
+        vehicle_type: null,
+        driver_name: null,
+        ubicacion_actual: null,
+      },
+    });
+    renderRoute();
+    const btn = await screen.findByRole('button', { name: /Abrir chat/ });
+    fireEvent.click(btn);
+    expect(screen.getByTestId('chat-panel')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/cargas.test.tsx
+++ b/apps/web/src/routes/cargas.test.tsx
@@ -1,0 +1,173 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ id: 'trip-1' }),
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div data-testid="layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../components/EmptyState.js', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+  emptyStateActionClass: 'btn',
+}));
+
+vi.mock('../components/map/VehicleMap.js', () => ({
+  VehicleMap: () => <div data-testid="vehicle-map" />,
+}));
+
+const { CargasListRoute, CargasNuevoRoute, CargasDetalleRoute } = await import('./cargas.js');
+
+function makeMe(isShipper: boolean): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role: 'dueno',
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e',
+        legal_name: 'E',
+        rut: '76',
+        is_generador_carga: isShipper,
+        is_transportista: false,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{node}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CargasListRoute', () => {
+  it('no onboarded → no renderiza', () => {
+    const { container } = wrap(<CargasListRoute />);
+    expect(container.querySelector('[data-testid="layout"]')).toBeNull();
+  });
+
+  it('no shipper → "Sin permisos"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(false) };
+    wrap(<CargasListRoute />);
+    expect(screen.getByText(/generador de carga/i)).toBeInTheDocument();
+  });
+
+  it('shipper + lista vacía → mensaje "No tienes cargas activas"', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({ trip_requests: [] });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    wrap(<CargasListRoute />);
+    await waitFor(() => expect(screen.getByText('No tienes cargas activas')).toBeInTheDocument());
+  });
+
+  it('shipper + lista con un trip → renderiza tracking code', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_requests: [
+        {
+          id: 't1',
+          tracking_code: 'BST-001',
+          status: 'esperando_match',
+          origin_address_raw: 'Av X',
+          origin_region_code: 'XIII',
+          destination_address_raw: 'Av Y',
+          destination_region_code: 'V',
+          cargo_type: 'carga_seca',
+          cargo_weight_kg: 5000,
+          cargo_volume_m3: null,
+          pickup_window_start: null,
+          pickup_window_end: null,
+          created_at: '2026-05-10T10:00:00Z',
+        },
+      ],
+    });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    wrap(<CargasListRoute />);
+    await waitFor(() => expect(screen.getAllByText(/BST-001/).length).toBeGreaterThan(0));
+  });
+});
+
+describe('CargasNuevoRoute', () => {
+  it('no onboarded → no renderiza', () => {
+    const { container } = wrap(<CargasNuevoRoute />);
+    expect(container.querySelector('[data-testid="layout"]')).toBeNull();
+  });
+
+  it('no shipper → "Sin permisos"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(false) };
+    wrap(<CargasNuevoRoute />);
+    expect(screen.getByText(/Sin permisos|no opera como generador/i)).toBeInTheDocument();
+  });
+
+  it('shipper → renderiza Layout con form', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    wrap(<CargasNuevoRoute />);
+    expect(screen.getByTestId('layout')).toBeInTheDocument();
+  });
+});
+
+describe('CargasDetalleRoute', () => {
+  it('no onboarded → no renderiza', () => {
+    const { container } = wrap(<CargasDetalleRoute />);
+    expect(container.querySelector('[data-testid="layout"]')).toBeNull();
+  });
+
+  it('onboarded + GET ok → renderiza con tracking_code', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      trip_request: {
+        id: 'trip-1',
+        tracking_code: 'BST-999',
+        status: 'esperando_match',
+        origin_address_raw: 'A',
+        origin_region_code: 'XIII',
+        destination_address_raw: 'B',
+        destination_region_code: 'V',
+        cargo_type: 'carga_seca',
+        cargo_weight_kg: 5000,
+        cargo_volume_m3: null,
+        pickup_window_start: null,
+        pickup_window_end: null,
+        created_at: '2026-05-10T10:00:00Z',
+      },
+      events: [],
+      assignment: null,
+      metrics: null,
+    });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    wrap(<CargasDetalleRoute />);
+    await waitFor(() => expect(screen.getAllByText(/BST-999/).length).toBeGreaterThan(0));
+  });
+});

--- a/apps/web/src/routes/certificados.test.tsx
+++ b/apps/web/src/routes/certificados.test.tsx
@@ -1,0 +1,164 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div data-testid="layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../components/EmptyState.js', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+  emptyStateActionClass: 'btn',
+}));
+
+const descargarMock = vi.fn();
+vi.mock('../lib/cert-download.js', () => ({
+  descargarCertificadoDeViaje: descargarMock,
+  CertDisabledError: class CertDisabledError extends Error {},
+  CertNotIssuedError: class CertNotIssuedError extends Error {},
+}));
+
+const { CertificadosRoute } = await import('./certificados.js');
+
+function makeMe(isShipper: boolean): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role: 'dueno',
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e',
+        legal_name: 'E',
+        rut: '76',
+        is_generador_carga: isShipper,
+        is_transportista: false,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRoute() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <CertificadosRoute />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CertificadosRoute', () => {
+  it('no onboarded → no renderiza Layout', () => {
+    const { container } = renderRoute();
+    expect(container.querySelector('[data-testid="layout"]')).toBeNull();
+  });
+
+  it('onboarded pero no shipper → mensaje "para empresas que operan como generador"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(false) };
+    renderRoute();
+    expect(screen.getByText(/empresas que operan como generador/)).toBeInTheDocument();
+  });
+
+  it('shipper + sin certificados → EmptyState', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      certificates: [],
+      pagination: { limit: 100, offset: 0, returned: 0 },
+    });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId('empty-state')).toBeInTheDocument());
+  });
+
+  it('shipper + certificados → renderiza tracking codes', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      certificates: [
+        {
+          trip_id: 't1',
+          tracking_code: 'BST-001',
+          origin_address: 'A',
+          destination_address: 'B',
+          cargo_type: 'carga_seca',
+          kg_co2e: '50.00',
+          distance_km: '100.00',
+          precision_method: 'modelado',
+          glec_version: 'GLEC v3.0',
+          certificate_sha256: 'abc',
+          certificate_kms_key_version: '1',
+          certificate_issued_at: '2026-05-10T10:00:00Z',
+        },
+      ],
+      pagination: { limit: 100, offset: 0, returned: 1 },
+    });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    renderRoute();
+    await waitFor(() => expect(screen.getByText('BST-001')).toBeInTheDocument());
+  });
+
+  it('click Descargar → invoca descargarCertificadoDeViaje', async () => {
+    descargarMock.mockResolvedValueOnce(undefined);
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      certificates: [
+        {
+          trip_id: 't1',
+          tracking_code: 'BST-001',
+          origin_address: 'A',
+          destination_address: 'B',
+          cargo_type: 'carga_seca',
+          kg_co2e: '50.00',
+          distance_km: '100.00',
+          precision_method: 'modelado',
+          glec_version: 'GLEC v3.0',
+          certificate_sha256: 'abc',
+          certificate_kms_key_version: '1',
+          certificate_issued_at: '2026-05-10T10:00:00Z',
+        },
+      ],
+      pagination: { limit: 100, offset: 0, returned: 1 },
+    });
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    renderRoute();
+    const btn = await screen.findByRole('button', { name: /Descargar/ });
+    fireEvent.click(btn);
+    await waitFor(() => expect(descargarMock).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/routes/index.test.tsx
+++ b/apps/web/src/routes/index.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useAuthMock = vi.fn();
+vi.mock('../hooks/use-auth.js', () => ({
+  useAuth: useAuthMock,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+}));
+
+const { IndexRoute } = await import('./index.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('IndexRoute', () => {
+  it('loading=true → muestra splash "Cargando…"', () => {
+    useAuthMock.mockReturnValue({ user: null, loading: true });
+    render(<IndexRoute />);
+    expect(screen.getByText(/Cargando…/)).toBeInTheDocument();
+  });
+
+  it('loading=false + user null → redirect /login', () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    render(<IndexRoute />);
+    expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/login');
+  });
+
+  it('loading=false + user presente → redirect /app', () => {
+    useAuthMock.mockReturnValue({ user: { uid: 'u' }, loading: false });
+    render(<IndexRoute />);
+    expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app');
+  });
+});

--- a/apps/web/src/routes/login.test.tsx
+++ b/apps/web/src/routes/login.test.tsx
@@ -1,0 +1,178 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useAuthMock = vi.fn();
+const signInWithGoogleMock = vi.fn();
+const signInWithEmailMock = vi.fn();
+const signUpWithEmailMock = vi.fn();
+const requestPasswordResetMock = vi.fn();
+vi.mock('../hooks/use-auth.js', () => ({
+  useAuth: useAuthMock,
+  signInWithGoogle: signInWithGoogleMock,
+  signInWithEmail: signInWithEmailMock,
+  signUpWithEmail: signUpWithEmailMock,
+  requestPasswordReset: requestPasswordResetMock,
+}));
+
+const navigateMock = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+  Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+}));
+
+const { LoginRoute } = await import('./login.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LoginRoute — auth state', () => {
+  it('user presente → redirige a /app', () => {
+    useAuthMock.mockReturnValue({ user: { uid: 'u' }, loading: false });
+    render(<LoginRoute />);
+    expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app');
+  });
+
+  it('user null + loading → render form', () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    render(<LoginRoute />);
+    expect(screen.getByRole('button', { name: /Continuar con Google/ })).toBeInTheDocument();
+  });
+});
+
+describe('LoginRoute — Google sign in', () => {
+  it('click Google → signInWithGoogle + navigate /app', async () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    signInWithGoogleMock.mockResolvedValueOnce(undefined);
+    render(<LoginRoute />);
+    fireEvent.click(screen.getByRole('button', { name: /Continuar con Google/ }));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith({ to: '/app' }));
+  });
+
+  it('Google popup cancelado → no error visible', async () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    signInWithGoogleMock.mockRejectedValueOnce(
+      Object.assign(new Error(''), { code: 'auth/popup-closed-by-user' }),
+    );
+    render(<LoginRoute />);
+    fireEvent.click(screen.getByRole('button', { name: /Continuar con Google/ }));
+    await waitFor(() => expect(signInWithGoogleMock).toHaveBeenCalled());
+    expect(screen.queryByText(/No pudimos iniciar sesión/)).not.toBeInTheDocument();
+  });
+
+  it('Google error otro código → muestra mensaje genérico', async () => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+    signInWithGoogleMock.mockRejectedValueOnce(
+      Object.assign(new Error(''), { code: 'auth/network-request-failed' }),
+    );
+    render(<LoginRoute />);
+    fireEvent.click(screen.getByRole('button', { name: /Continuar con Google/ }));
+    expect(await screen.findByText(/Sin conexión a internet/)).toBeInTheDocument();
+  });
+});
+
+describe('LoginRoute — sign in con email/password', () => {
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+  });
+
+  it('email inválido → error en input email', async () => {
+    render(<LoginRoute />);
+    fireEvent.change(screen.getByLabelText(/^Email/), { target: { value: 'no-email' } });
+    fireEvent.change(screen.getByLabelText(/^Contraseña/), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/ }));
+    expect(await screen.findByText(/Email inválido/)).toBeInTheDocument();
+  });
+
+  it('password < 6 → error password', async () => {
+    render(<LoginRoute />);
+    fireEvent.change(screen.getByLabelText(/^Email/), { target: { value: 'a@b.cl' } });
+    fireEvent.change(screen.getByLabelText(/Contraseña/), { target: { value: '123' } });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/ }));
+    expect(await screen.findByText(/Mínimo 6 caracteres/)).toBeInTheDocument();
+  });
+
+  it('happy → signInWithEmail + navigate', async () => {
+    signInWithEmailMock.mockResolvedValueOnce(undefined);
+    render(<LoginRoute />);
+    fireEvent.change(screen.getByLabelText(/^Email/), { target: { value: 'a@b.cl' } });
+    fireEvent.change(screen.getByLabelText(/^Contraseña/), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/ }));
+    await waitFor(() => expect(signInWithEmailMock).toHaveBeenCalledWith('a@b.cl', '123456'));
+    await waitFor(() => expect(navigateMock).toHaveBeenCalledWith({ to: '/app' }));
+  });
+
+  it('error wrong-password → mensaje traducido', async () => {
+    signInWithEmailMock.mockRejectedValueOnce(
+      Object.assign(new Error(''), { code: 'auth/wrong-password' }),
+    );
+    render(<LoginRoute />);
+    fireEvent.change(screen.getByLabelText(/^Email/), { target: { value: 'a@b.cl' } });
+    fireEvent.change(screen.getByLabelText(/^Contraseña/), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /Entrar/ }));
+    expect(await screen.findByText(/Contraseña incorrecta/)).toBeInTheDocument();
+  });
+});
+
+describe('LoginRoute — sign up mode', () => {
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+  });
+
+  it('switch a sign-up → muestra campo Nombre', () => {
+    render(<LoginRoute />);
+    fireEvent.click(screen.getByRole('button', { name: /Crea una/ }));
+    expect(screen.getByLabelText(/^Tu nombre/)).toBeInTheDocument();
+  });
+
+  it('sign-up sin nombre → error', async () => {
+    render(<LoginRoute />);
+    fireEvent.click(screen.getByRole('button', { name: /Crea una/ }));
+    fireEvent.change(screen.getByLabelText(/^Email/), { target: { value: 'a@b.cl' } });
+    fireEvent.change(screen.getByLabelText(/^Contraseña/), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /Crear cuenta/ }));
+    expect(await screen.findByText(/Ingresa tu nombre/)).toBeInTheDocument();
+  });
+
+  it('sign-up happy → signUpWithEmail + navigate', async () => {
+    signUpWithEmailMock.mockResolvedValueOnce(undefined);
+    render(<LoginRoute />);
+    fireEvent.click(screen.getByRole('button', { name: /Crea una/ }));
+    fireEvent.change(screen.getByLabelText(/Tu nombre/), { target: { value: 'Felipe' } });
+    fireEvent.change(screen.getByLabelText(/^Email/), { target: { value: 'a@b.cl' } });
+    fireEvent.change(screen.getByLabelText(/^Contraseña/), { target: { value: '123456' } });
+    fireEvent.click(screen.getByRole('button', { name: /Crear cuenta/ }));
+    await waitFor(() =>
+      expect(signUpWithEmailMock).toHaveBeenCalledWith({
+        email: 'a@b.cl',
+        password: '123456',
+        displayName: 'Felipe',
+      }),
+    );
+  });
+});
+
+describe('LoginRoute — reset password', () => {
+  beforeEach(() => {
+    useAuthMock.mockReturnValue({ user: null, loading: false });
+  });
+
+  it('switch a reset → muestra solo email', () => {
+    render(<LoginRoute />);
+    fireEvent.click(screen.getByRole('button', { name: /Olvidé mi contraseña/ }));
+    expect(screen.queryByLabelText(/^Contraseña/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Enviar link/ })).toBeInTheDocument();
+  });
+
+  it('reset envía email + muestra confirmación', async () => {
+    requestPasswordResetMock.mockResolvedValueOnce(undefined);
+    render(<LoginRoute />);
+    fireEvent.click(screen.getByRole('button', { name: /Olvidé mi contraseña/ }));
+    fireEvent.change(screen.getByLabelText(/^Email/), { target: { value: 'a@b.cl' } });
+    fireEvent.click(screen.getByRole('button', { name: /Enviar link/ }));
+    expect(await screen.findByText(/te llegó un email/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/ofertas.test.tsx
+++ b/apps/web/src/routes/ofertas.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+const useOffersMineMock = vi.fn();
+vi.mock('../hooks/use-offers.js', () => ({
+  useOffersMine: useOffersMineMock,
+}));
+
+const signOutUserMock = vi.fn();
+vi.mock('../hooks/use-auth.js', () => ({
+  signOutUser: signOutUserMock,
+}));
+
+vi.mock('../components/offers/OfferCard.js', () => ({
+  OfferCard: (props: { offer: { id: string } }) => (
+    <div data-testid="offer-card" data-id={props.offer.id} />
+  ),
+}));
+
+vi.mock('../components/EmptyState.js', () => ({
+  EmptyState: (props: { title: string }) => <div data-testid="empty-state">{props.title}</div>,
+}));
+
+const { OfertasRoute } = await import('./ofertas.js');
+
+function makeMe(isTransportista: boolean): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'Felipe', email: 'a@b.cl' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role: 'dueno',
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e1',
+        legal_name: 'Booster SpA',
+        rut: '76',
+        is_generador_carga: false,
+        is_transportista: isTransportista,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('OfertasRoute', () => {
+  it('contexto no onboarded → no renderiza', () => {
+    const { container } = render(<OfertasRoute />);
+    expect(container.querySelector('h1')).toBeNull();
+  });
+
+  it('empresa no transportista → warning', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(false) };
+    useOffersMineMock.mockReturnValue({ isLoading: false, isError: false, data: undefined });
+    render(<OfertasRoute />);
+    expect(screen.getByText(/no opera como carrier/)).toBeInTheDocument();
+  });
+
+  it('carrier + loading → "Cargando ofertas"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    useOffersMineMock.mockReturnValue({ isLoading: true, isError: false, data: undefined });
+    render(<OfertasRoute />);
+    expect(screen.getByText(/Cargando ofertas/)).toBeInTheDocument();
+  });
+
+  it('carrier + error → mensaje de error', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    useOffersMineMock.mockReturnValue({ isLoading: false, isError: true, data: undefined });
+    render(<OfertasRoute />);
+    expect(screen.getByText(/No pudimos cargar las ofertas/)).toBeInTheDocument();
+  });
+
+  it('carrier + offers vacías → EmptyState', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    useOffersMineMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { offers: [] },
+      refetch: vi.fn(),
+      isFetching: false,
+    });
+    render(<OfertasRoute />);
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+  });
+
+  it('carrier + offers presentes → renderiza OfferCard por cada uno', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    useOffersMineMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: {
+        offers: [
+          { id: 'o1', status: 'pendiente' },
+          { id: 'o2', status: 'pendiente' },
+        ],
+      },
+      refetch: vi.fn(),
+      isFetching: false,
+    });
+    render(<OfertasRoute />);
+    expect(screen.getAllByTestId('offer-card')).toHaveLength(2);
+  });
+
+  it('click Actualizar → refetch', () => {
+    const refetch = vi.fn();
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    useOffersMineMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { offers: [] },
+      refetch,
+      isFetching: false,
+    });
+    render(<OfertasRoute />);
+    screen.getByRole('button', { name: /Actualizar/ }).click();
+    expect(refetch).toHaveBeenCalled();
+  });
+
+  it('isFetching=true → botón muestra "Actualizando"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    useOffersMineMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { offers: [] },
+      refetch: vi.fn(),
+      isFetching: true,
+    });
+    render(<OfertasRoute />);
+    expect(screen.getByRole('button', { name: /Actualizando/ })).toBeDisabled();
+  });
+
+  it('click Salir → signOutUser', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    useOffersMineMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { offers: [] },
+      refetch: vi.fn(),
+      isFetching: false,
+    });
+    render(<OfertasRoute />);
+    screen.getByRole('button', { name: /Salir/ }).click();
+    expect(signOutUserMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routes/onboarding.test.tsx
+++ b/apps/web/src/routes/onboarding.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+
+type MeNeedsOnboarding = Extract<MeResponse, { needs_onboarding: true }>;
+type ProtectedContext =
+  | { kind: 'onboarded'; me: Extract<MeResponse, { needs_onboarding: false }> }
+  | { kind: 'pre-onboarding'; me: MeNeedsOnboarding }
+  | { kind: 'unmanaged' };
+
+let providedContext: ProtectedContext = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: ProtectedContext) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('../components/onboarding/OnboardingForm.js', () => ({
+  OnboardingForm: ({
+    firebaseEmail,
+    firebaseName,
+  }: {
+    firebaseEmail: string;
+    firebaseName: string | undefined;
+  }) => (
+    <div data-testid="onboarding-form" data-email={firebaseEmail} data-name={firebaseName ?? ''} />
+  ),
+}));
+
+const { OnboardingRoute } = await import('./onboarding.js');
+
+function makeMe(name?: string, email?: string): MeNeedsOnboarding {
+  return {
+    needs_onboarding: true,
+    firebase: {
+      uid: 'fb-uid',
+      email: email ?? 'felipe@boosterchile.com',
+      name: name ?? 'Felipe Vicencio',
+      picture: undefined,
+      email_verified: true,
+    },
+  };
+}
+
+describe('OnboardingRoute', () => {
+  it('contexto no pre-onboarding → no renderiza form', () => {
+    providedContext = { kind: 'unmanaged' };
+    const { container } = render(<OnboardingRoute />);
+    expect(container.querySelector('[data-testid="onboarding-form"]')).toBeNull();
+  });
+
+  it('contexto pre-onboarding → renderiza bienvenida + OnboardingForm', () => {
+    providedContext = { kind: 'pre-onboarding', me: makeMe('Felipe Vicencio') };
+    render(<OnboardingRoute />);
+    expect(screen.getByText(/Bienvenido, Felipe/)).toBeInTheDocument();
+    expect(screen.getByTestId('onboarding-form')).toHaveAttribute(
+      'data-email',
+      'felipe@boosterchile.com',
+    );
+  });
+
+  it('me.firebase.name undefined → muestra solo "Bienvenido" sin nombre', () => {
+    const me = makeMe(undefined);
+    me.firebase.name = undefined;
+    providedContext = { kind: 'pre-onboarding', me };
+    render(<OnboardingRoute />);
+    expect(screen.getByText(/^Bienvenido$/)).toBeInTheDocument();
+  });
+
+  it('me.firebase.email undefined → onboarding form recibe string vacío', () => {
+    const me = makeMe('Test User');
+    me.firebase.email = undefined;
+    providedContext = { kind: 'pre-onboarding', me };
+    render(<OnboardingRoute />);
+    expect(screen.getByTestId('onboarding-form')).toHaveAttribute('data-email', '');
+  });
+});

--- a/apps/web/src/routes/perfil.test.tsx
+++ b/apps/web/src/routes/perfil.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type ProtectedContext =
+  | { kind: 'onboarded'; me: MeOnboarded }
+  | { kind: 'pre-onboarding'; me: Extract<MeResponse, { needs_onboarding: true }> }
+  | { kind: 'unmanaged' };
+
+let providedContext: ProtectedContext = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: ProtectedContext) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div data-testid="layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../components/profile/ProfileForm.js', () => ({
+  ProfileForm: (props: { initial: { full_name: string } }) => (
+    <div data-testid="profile-form" data-name={props.initial.full_name} />
+  ),
+}));
+
+vi.mock('../components/profile/AuthProvidersSection.js', () => ({
+  AuthProvidersSection: () => <div data-testid="auth-providers" />,
+}));
+
+vi.mock('../components/profile/TwoFactorSection.js', () => ({
+  TwoFactorSection: (props: { initialPhoneE164?: string | null }) => (
+    <div data-testid="two-factor" data-phone={props.initialPhoneE164 ?? ''} />
+  ),
+}));
+
+const { PerfilRoute } = await import('./perfil.js');
+
+function makeMe(over: Partial<MeOnboarded['user']> = {}): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: {
+      id: 'u',
+      email: 'felipe@boosterchile.com',
+      full_name: 'Felipe Vicencio',
+      phone: '+56912345678',
+      whatsapp_e164: '+56912345678',
+      rut: '12.345.678-9',
+      is_platform_admin: false,
+      status: 'activo',
+      ...over,
+    },
+    memberships: [],
+    active_membership: null,
+  } as MeOnboarded;
+}
+
+describe('PerfilRoute', () => {
+  it('contexto no onboarded → no renderiza página', () => {
+    providedContext = { kind: 'unmanaged' };
+    const { container } = render(<PerfilRoute />);
+    expect(container.querySelector('[data-testid="profile-form"]')).toBeNull();
+  });
+
+  it('contexto onboarded → renderiza Layout + ProfileForm + AuthProviders + TwoFactor', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<PerfilRoute />);
+    expect(screen.getByTestId('layout')).toHaveAttribute('data-title', 'Mi cuenta');
+    expect(screen.getByTestId('profile-form')).toHaveAttribute('data-name', 'Felipe Vicencio');
+    expect(screen.getByTestId('auth-providers')).toBeInTheDocument();
+    expect(screen.getByTestId('two-factor')).toHaveAttribute('data-phone', '+56912345678');
+  });
+
+  it('whatsapp null + phone presente → TwoFactor recibe phone como fallback', () => {
+    providedContext = { kind: 'onboarded', me: makeMe({ whatsapp_e164: null }) };
+    render(<PerfilRoute />);
+    expect(screen.getByTestId('two-factor')).toHaveAttribute('data-phone', '+56912345678');
+  });
+
+  it('whatsapp y phone null → TwoFactor recibe string vacío', () => {
+    providedContext = {
+      kind: 'onboarded',
+      me: makeMe({ whatsapp_e164: null, phone: null }),
+    };
+    render(<PerfilRoute />);
+    expect(screen.getByTestId('two-factor')).toHaveAttribute('data-phone', '');
+  });
+});

--- a/apps/web/src/routes/vehiculo-live.test.tsx
+++ b/apps/web/src/routes/vehiculo-live.test.tsx
@@ -1,0 +1,135 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../lib/api-client.js';
+
+type ProtectedContext = { kind: 'onboarded' | 'unmanaged' | 'pre-onboarding' };
+let providedContext: ProtectedContext = { kind: 'onboarded' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: ProtectedContext) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useParams: () => ({ id: 'veh-123' }),
+}));
+
+interface LiveProps {
+  title: string;
+  subtitle?: string;
+  backTo: string;
+  latitude: number | null;
+  longitude: number | null;
+}
+let captured: LiveProps | null = null;
+vi.mock('../components/map/LiveTrackingScreen.js', () => ({
+  LiveTrackingScreen: (props: LiveProps) => {
+    captured = props;
+    return <div data-testid="live-tracking" data-title={props.title} data-back={props.backTo} />;
+  },
+}));
+
+const { VehiculoLiveRoute } = await import('./vehiculo-live.js');
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  captured = null;
+  providedContext = { kind: 'onboarded' };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('VehiculoLiveRoute', () => {
+  it('contexto no onboarded → no renderiza tracking', () => {
+    providedContext = { kind: 'unmanaged' };
+    const Wrapper = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <VehiculoLiveRoute />
+      </Wrapper>,
+    );
+    expect(container.querySelector('[data-testid="live-tracking"]')).toBeNull();
+  });
+
+  it('happy: GET /vehiculos/:id/ubicacion + pasa props a LiveTrackingScreen', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      vehicle_id: 'veh-123',
+      plate: 'ABCD12',
+      teltonika_imei: '111222333',
+      ubicacion: {
+        timestamp_device: '2026-05-10T10:00:00Z',
+        latitude: -33.45,
+        longitude: -70.65,
+        altitude_m: null,
+        angle_deg: 90,
+        satellites: 12,
+        speed_kmh: 50,
+        priority: 1,
+      },
+    });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <VehiculoLiveRoute />
+      </Wrapper>,
+    );
+    await waitFor(() => expect(captured?.latitude).toBe(-33.45));
+    expect(captured?.title).toBe('ABCD12 · En vivo');
+    expect(captured?.subtitle).toBe('IMEI 111222333');
+    expect(captured?.backTo).toBe('/app/vehiculos/veh-123');
+  });
+
+  it('sin Teltonika → subtitle "Sin Teltonika asociado"', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      vehicle_id: 'v',
+      plate: 'PQR456',
+      teltonika_imei: null,
+      ubicacion: {
+        timestamp_device: '2026-05-10T10:00:00Z',
+        latitude: null,
+        longitude: null,
+        altitude_m: null,
+        angle_deg: null,
+        satellites: null,
+        speed_kmh: null,
+        priority: 1,
+      },
+    });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <VehiculoLiveRoute />
+      </Wrapper>,
+    );
+    await waitFor(() => expect(captured?.subtitle).toBe('Sin Teltonika asociado'));
+    expect(captured?.title).toBe('Vehículo en vivo');
+  });
+
+  it('API error → captured props con title genérico', async () => {
+    vi.spyOn(api, 'get').mockRejectedValueOnce(new Error('boom'));
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <VehiculoLiveRoute />
+      </Wrapper>,
+    );
+    // El queryFn captura el error y devuelve null → captured.title="Vehículo en vivo"
+    await waitFor(() => expect(captured?.title).toBeDefined());
+    expect(captured?.title).toBe('Vehículo en vivo');
+    expect(captured?.latitude).toBeNull();
+  });
+});

--- a/apps/web/src/routes/vehiculos.test.tsx
+++ b/apps/web/src/routes/vehiculos.test.tsx
@@ -1,0 +1,184 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ id: 'veh-1' }),
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div data-testid="layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock('../components/EmptyState.js', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+  emptyStateActionClass: 'btn',
+}));
+
+vi.mock('../components/map/VehicleMap.js', () => ({
+  VehicleMap: () => <div data-testid="vehicle-map" />,
+}));
+
+const { VehiculosListRoute, VehiculosNuevoRoute, VehiculosDetalleRoute } = await import(
+  './vehiculos.js'
+);
+
+function makeMe(): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role: 'dueno',
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e',
+        legal_name: 'E',
+        rut: '76',
+        is_generador_carga: false,
+        is_transportista: true,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{node}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('VehiculosListRoute', () => {
+  it('no onboarded → no renderiza', () => {
+    const { container } = wrap(<VehiculosListRoute />);
+    expect(container.querySelector('[data-testid="layout"]')).toBeNull();
+  });
+
+  it('onboarded + lista vacía → mensaje "Aún no tienes vehículos"', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({ vehicles: [] });
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    wrap(<VehiculosListRoute />);
+    await waitFor(() => expect(screen.getByText(/Aún no tienes vehículos/)).toBeInTheDocument());
+  });
+
+  it('onboarded + vehículos → renderiza plate', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      vehicles: [
+        {
+          id: 'v1',
+          plate: 'ABCD12',
+          type: 'camion_pequeno',
+          capacity_kg: 5000,
+          capacity_m3: null,
+          year: 2020,
+          brand: null,
+          model: null,
+          fuel_type: 'diesel',
+          curb_weight_kg: null,
+          consumption_l_per_100km_baseline: null,
+          teltonika_imei: null,
+          rut: null,
+          status: 'activo',
+          available_for_assignment: true,
+          notes: null,
+          created_at: '2026-05-10T10:00:00Z',
+        },
+      ],
+    });
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    wrap(<VehiculosListRoute />);
+    // formatPlateForDisplay puede insertar espacios/separadores; basta verificar
+    // que el dígito de patente quede visible en la página.
+    await waitFor(() =>
+      expect(
+        screen.getAllByText((_t, n) => n?.textContent?.includes('AB·CD·12') ?? false).length,
+      ).toBeGreaterThan(0),
+    );
+  });
+});
+
+describe('VehiculosNuevoRoute', () => {
+  it('no onboarded → no renderiza', () => {
+    const { container } = wrap(<VehiculosNuevoRoute />);
+    expect(container.querySelector('[data-testid="layout"]')).toBeNull();
+  });
+
+  it('onboarded → renderiza Layout', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    wrap(<VehiculosNuevoRoute />);
+    expect(screen.getByTestId('layout')).toBeInTheDocument();
+  });
+});
+
+describe('VehiculosDetalleRoute', () => {
+  it('no onboarded → no renderiza', () => {
+    const { container } = wrap(<VehiculosDetalleRoute />);
+    expect(container.querySelector('[data-testid="layout"]')).toBeNull();
+  });
+
+  it('onboarded + GET ok → renderiza plate del detalle', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path === '/vehiculos/veh-1') {
+        return {
+          vehicle: {
+            id: 'veh-1',
+            plate: 'XYZ789',
+            type: 'camion_grande',
+            capacity_kg: 20000,
+            capacity_m3: null,
+            year: 2022,
+            brand: 'Volvo',
+            model: 'FH',
+            fuel_type: 'diesel',
+            curb_weight_kg: 10000,
+            consumption_l_per_100km_baseline: '32.5',
+            teltonika_imei: null,
+            rut: null,
+            status: 'activo',
+            available_for_assignment: true,
+            notes: null,
+            created_at: '2026-05-10T10:00:00Z',
+          },
+        };
+      }
+      // Otras queries devolverán null/objetos vacíos.
+      return {} as never;
+    });
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    wrap(<VehiculosDetalleRoute />);
+    await waitFor(() =>
+      expect(
+        screen.getAllByText((_t, n) => n?.textContent?.includes('XY') ?? false).length,
+      ).toBeGreaterThan(0),
+    );
+  });
+});

--- a/apps/web/src/sw.test.ts
+++ b/apps/web/src/sw.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const clientsClaimMock = vi.fn();
+vi.mock('workbox-core', () => ({ clientsClaim: clientsClaimMock }));
+
+const precacheAndRouteMock = vi.fn();
+vi.mock('workbox-precaching', () => ({ precacheAndRoute: precacheAndRouteMock }));
+
+const registerRouteMock = vi.fn();
+vi.mock('workbox-routing', () => ({ registerRoute: registerRouteMock }));
+
+const CacheFirstMock = vi.fn(function CacheFirst(this: Record<string, unknown>, opts: unknown) {
+  this.opts = opts;
+});
+vi.mock('workbox-strategies', () => ({ CacheFirst: CacheFirstMock }));
+
+const ExpirationPluginMock = vi.fn(function ExpirationPlugin(
+  this: Record<string, unknown>,
+  opts: unknown,
+) {
+  this.opts = opts;
+});
+vi.mock('workbox-expiration', () => ({ ExpirationPlugin: ExpirationPluginMock }));
+
+interface SwGlobal {
+  skipWaiting: ReturnType<typeof vi.fn>;
+  __WB_MANIFEST: unknown[];
+  addEventListener: ReturnType<typeof vi.fn>;
+  registration: { showNotification: ReturnType<typeof vi.fn> };
+  clients: { matchAll: ReturnType<typeof vi.fn>; openWindow: ReturnType<typeof vi.fn> };
+  location: { origin: string };
+}
+
+let swGlobal: SwGlobal;
+const listeners = new Map<string, ((ev: unknown) => void)[]>();
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  listeners.clear();
+  swGlobal = {
+    skipWaiting: vi.fn(),
+    __WB_MANIFEST: [{ url: '/a.js', revision: 'abc' }],
+    addEventListener: vi.fn((type: string, cb: (ev: unknown) => void) => {
+      const arr = listeners.get(type) ?? [];
+      arr.push(cb);
+      listeners.set(type, arr);
+    }),
+    registration: { showNotification: vi.fn(async () => undefined) },
+    clients: {
+      matchAll: vi.fn(),
+      openWindow: vi.fn(async () => undefined),
+    },
+    location: { origin: 'https://app.boosterchile.com' },
+  };
+  // El módulo sw.ts referencia `self` como ServiceWorkerGlobalScope.
+  (globalThis as unknown as { self: SwGlobal }).self = swGlobal;
+});
+
+afterEach(() => {
+  // biome-ignore lint/performance/noDelete: cleanup after test
+  delete (globalThis as unknown as { self?: SwGlobal }).self;
+  vi.restoreAllMocks();
+});
+
+describe('sw — bootstrap', () => {
+  it('llama skipWaiting + clientsClaim + precacheAndRoute', async () => {
+    await import('./sw.js');
+    expect(swGlobal.skipWaiting).toHaveBeenCalled();
+    expect(clientsClaimMock).toHaveBeenCalled();
+    expect(precacheAndRouteMock).toHaveBeenCalledWith(swGlobal.__WB_MANIFEST);
+  });
+
+  it('registra rutas para Google Fonts stylesheets y webfonts', async () => {
+    await import('./sw.js');
+    expect(registerRouteMock).toHaveBeenCalledTimes(2);
+    expect(CacheFirstMock).toHaveBeenCalledTimes(2);
+    const cacheNames = CacheFirstMock.mock.calls.map(
+      (c) => (c[0] as { cacheName: string }).cacheName,
+    );
+    expect(cacheNames).toEqual(
+      expect.arrayContaining(['google-fonts-stylesheets', 'google-fonts-webfonts']),
+    );
+  });
+
+  it('registra listeners push y notificationclick', async () => {
+    await import('./sw.js');
+    expect(listeners.has('push')).toBe(true);
+    expect(listeners.has('notificationclick')).toBe(true);
+  });
+});
+
+describe('sw — push handler', () => {
+  async function getPushHandler() {
+    await import('./sw.js');
+    return listeners.get('push')?.[0];
+  }
+
+  it('payload válido → showNotification con title + body + data', async () => {
+    const handler = await getPushHandler();
+    const event = {
+      data: {
+        json: () => ({
+          title: 'Nueva oferta',
+          body: 'Carga Santiago → Concepción',
+          tag: 'offer-123',
+          data: { assignment_id: 'a1', message_id: 'm1', url: '/app/ofertas' },
+        }),
+      },
+      waitUntil: (p: Promise<unknown>) => p,
+    };
+    handler?.(event);
+    expect(swGlobal.registration.showNotification).toHaveBeenCalledWith(
+      'Nueva oferta',
+      expect.objectContaining({
+        body: 'Carga Santiago → Concepción',
+        tag: 'offer-123',
+      }),
+    );
+  });
+
+  it('payload corrupto (json throws) → notificación genérica', async () => {
+    const handler = await getPushHandler();
+    const event = {
+      data: {
+        json: () => {
+          throw new Error('bad json');
+        },
+      },
+      waitUntil: (p: Promise<unknown>) => p,
+    };
+    handler?.(event);
+    expect(swGlobal.registration.showNotification).toHaveBeenCalledWith(
+      'Booster',
+      expect.objectContaining({ body: 'Nuevo mensaje' }),
+    );
+  });
+
+  it('event.data undefined → notificación genérica', async () => {
+    const handler = await getPushHandler();
+    const event = { data: undefined, waitUntil: (p: Promise<unknown>) => p };
+    handler?.(event);
+    expect(swGlobal.registration.showNotification).toHaveBeenCalledWith(
+      'Booster',
+      expect.objectContaining({ body: 'Nuevo mensaje' }),
+    );
+  });
+});
+
+describe('sw — notificationclick handler', () => {
+  async function getClickHandler() {
+    await import('./sw.js');
+    return listeners.get('notificationclick')?.[0];
+  }
+
+  it('sin url en data → no abre window', async () => {
+    const handler = await getClickHandler();
+    const event = {
+      notification: { close: vi.fn(), data: undefined },
+      waitUntil: (p: Promise<unknown>) => p,
+    };
+    handler?.(event);
+    expect(event.notification.close).toHaveBeenCalled();
+    expect(swGlobal.clients.openWindow).not.toHaveBeenCalled();
+  });
+
+  it('exact match URL → focus en el client existente', async () => {
+    const handler = await getClickHandler();
+    const focusMock = vi.fn(async () => undefined);
+    swGlobal.clients.matchAll.mockResolvedValueOnce([
+      { url: 'https://app.boosterchile.com/app/chat', focus: focusMock, navigate: vi.fn() },
+    ]);
+    const event = {
+      notification: { close: vi.fn(), data: { url: '/app/chat' } },
+      waitUntil: (p: Promise<unknown>) => p,
+    };
+    await handler?.(event);
+    // Sleep a bit so the IIFE inside waitUntil ejecuta.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(focusMock).toHaveBeenCalled();
+  });
+
+  it('same origin pero distinta URL → focus + navigate', async () => {
+    const handler = await getClickHandler();
+    const focusMock = vi.fn(async () => undefined);
+    const navigateMock = vi.fn(async () => undefined);
+    swGlobal.clients.matchAll.mockResolvedValueOnce([
+      {
+        url: 'https://app.boosterchile.com/app/dashboard',
+        focus: focusMock,
+        navigate: navigateMock,
+      },
+    ]);
+    const event = {
+      notification: { close: vi.fn(), data: { url: '/app/chat' } },
+      waitUntil: (p: Promise<unknown>) => p,
+    };
+    await handler?.(event);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(focusMock).toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith('https://app.boosterchile.com/app/chat');
+  });
+
+  it('sin clients abiertos → openWindow', async () => {
+    const handler = await getClickHandler();
+    swGlobal.clients.matchAll.mockResolvedValueOnce([]);
+    const event = {
+      notification: { close: vi.fn(), data: { url: '/app/chat' } },
+      waitUntil: (p: Promise<unknown>) => p,
+    };
+    await handler?.(event);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(swGlobal.clients.openWindow).toHaveBeenCalledWith(
+      'https://app.boosterchile.com/app/chat',
+    );
+  });
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -25,18 +25,6 @@ export default defineConfig({
         'src/**/index.ts',
         'src/**/*.test.{ts,tsx}',
         'src/**/*.spec.{ts,tsx}',
-        'src/main.tsx',
-        'src/router.tsx', // TanStack Router config con lazy imports — tested e2e
-        'src/sw.ts', // Service Worker — runtime de browser, no jsdom
-        'src/lib/firebase.ts', // initializeApp + setPersistence side-effects at-import
-        // Páginas grandes con TanStack Router + lazy imports + form complejos +
-        // mapas Google. Se testean mejor con Playwright e2e contra build real.
-        'src/routes/**',
-        // Componentes que dependen del SDK Google Maps en runtime — sólo
-        // se cubren con Playwright e2e contra build real. use-follow-vehicle
-        // es lógica pura y SI tiene tests unitarios.
-        'src/components/map/VehicleMap.tsx',
-        'src/components/map/LiveTrackingScreen.tsx',
       ],
       // Gates bloqueantes — el CI verifica coverage-summary.json.
       // CLAUDE.md objetivo: 80%/75%/80%/80%. Cumplido sobre el subset testable


### PR DESCRIPTION
## Resumen

Coverage web sin lista de excludes — TODOS los archivos productivos están bajo el gate. Tests web: **423 → 697 (+274)** en **18 archivos nuevos**.

Resultado: **89.10% lines · 79.34% branches · 87.08% functions · 89.17% statements** sobre toda la superficie de \`apps/web/src\`, ampliamente sobre threshold 80/75/75/80.

## Cambios

**18 archivos de tests nuevos cubriendo los excludes restantes:**

### Infra (19 tests)
- \`lib/firebase.test.ts\` (4) — initializeApp + persistencia + Google provider
- \`main.test.tsx\` (2) — createRoot mount + guard #root
- \`router.test.tsx\` (3) — paths del routeTree + defaultPreload
- \`sw.test.ts\` (10) — Workbox + push + notificationclick (matchAll exact/origin/openWindow)

### Map components (28 tests)
- \`components/map/VehicleMap.test.tsx\` (11)
- \`components/map/LiveTrackingScreen.test.tsx\` (17)

### Routes (85 tests)
- \`routes/__root.test.tsx\` (1)
- \`routes/index.test.tsx\` (3) — splash + redirects
- \`routes/onboarding.test.tsx\` (4)
- \`routes/perfil.test.tsx\` (4) — Layout + 3 sections
- \`routes/vehiculo-live.test.tsx\` (4) — props pass-through al LiveTrackingScreen
- \`routes/ofertas.test.tsx\` (9) — carrier check + estados + refetch + sign out
- \`routes/login.test.tsx\` (14) — Google + email/password + sign up + reset
- \`routes/app.test.tsx\` (7) — dashboard por rol
- \`routes/asignacion-detalle.test.tsx\` (6) — DeliveryConfirm pre + BehaviorScore post
- \`routes/carga-track.test.tsx\` (4)
- \`routes/admin-dispositivos.test.tsx\` (5) — gating + EmptyState
- \`routes/certificados.test.tsx\` (5) — shipper-only + lista + download
- \`routes/cargas.test.tsx\` (9) — List + Nuevo + Detalle
- \`routes/vehiculos.test.tsx\` (7) — List + Nuevo + Detalle

### \`apps/web/vitest.config.ts\`
Exclude list reducido a solo los patrones técnicos:
\`\`\`
exclude: [
  'src/**/*.d.ts',
  'src/**/index.ts',
  'src/**/*.test.{ts,tsx}',
  'src/**/*.spec.{ts,tsx}',
]
\`\`\`

Todo el código productivo (\`src/main.tsx\`, \`src/router.tsx\`, \`src/sw.ts\`, \`src/routes/**\`, \`src/components/map/**\`, \`src/lib/firebase.ts\`) entra al gate.

## Test plan

- [x] \`pnpm lint\` verde
- [x] \`pnpm typecheck\` verde (29/29 paquetes)
- [x] \`pnpm --filter @booster-ai/web test\` 697/697 verde
- [x] Coverage 89.10% lines / 79.34% branches / 87.08% functions — sobre threshold
- [ ] CI: 14 checks SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)