### PR TITLE
feat(api): consignee_phone field — tracking link directo al destinatario (Phase 5 PR-L3b)

### DIFF
--- a/apps/api/drizzle/0014_trips_consignee_phone.sql
+++ b/apps/api/drizzle/0014_trips_consignee_phone.sql
@@ -1,0 +1,27 @@
+-- Migration 0014 — Datos del consignee en trips (Phase 5 PR-L3b)
+--
+-- Agrega 2 columnas opcionales para que el shipper pueda capturar al
+-- destinatario final de la carga al crear el trip:
+--
+--   destinatario_nombre       — para mostrar en saludo del template
+--   destinatario_whatsapp_e164 — phone E.164 al que se envía el link
+--                                público de tracking al asignar
+--
+-- Si ambos están presentes, notify-tracking-link.ts (PR-L3) envía el
+-- WhatsApp DIRECTAMENTE al consignee. Si están NULL, fallback al
+-- shipper (patrón v1 de PR-L3 — el shipper forwarda manualmente).
+--
+-- Por qué opt-in:
+--   - Privacy: el shipper típico tiene la relación con su consignee
+--     y prefiere NO compartir el número con la plataforma — solo
+--     quien quiere la experiencia Uber-like llena estos campos.
+--   - GDPR/Ley 19.628 Chile: capturar phone de un tercero requiere
+--     base legal — el shipper actúa como controlador de los datos
+--     del consignee (legitimate interest: notificar entrega).
+--
+-- Riesgo deploy: bajo. ADD COLUMN nullable = metadata-only en
+-- Postgres ≥ 11. Reversible vía DROP COLUMN.
+
+ALTER TABLE "viajes"
+  ADD COLUMN "destinatario_nombre" varchar(100),
+  ADD COLUMN "destinatario_whatsapp_e164" varchar(20);

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1779062400000,
       "tag": "0013_assignments_public_tracking_token",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1779148800000,
+      "tag": "0014_trips_consignee_phone",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -556,6 +556,15 @@ export const trips = pgTable(
     pickupWindowEnd: timestamp('recogida_ventana_fin', { withTimezone: true }),
     /** Precio sugerido por generador de carga o admin. Null si pricing-engine sugerirá. */
     proposedPriceClp: integer('precio_propuesto_clp'),
+    /**
+     * Phase 5 PR-L3b — Datos opcionales del consignee. Si presentes,
+     * el WhatsApp tracking link se envía DIRECTO al destinatario al
+     * asignar (vs forwarding manual del shipper). Opt-in deliberado
+     * por privacy: shipper decide si quiere experiencia Uber-like
+     * para su recipient.
+     */
+    consigneeName: varchar('destinatario_nombre', { length: 100 }),
+    consigneeWhatsappE164: varchar('destinatario_whatsapp_e164', { length: 20 }),
     status: tripStatusEnum('estado').notNull().default('esperando_match'),
     createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),

--- a/apps/api/src/routes/trip-requests-v2.ts
+++ b/apps/api/src/routes/trip-requests-v2.ts
@@ -141,6 +141,11 @@ export function createTripRequestsV2Routes(opts: {
         ...(input.proposed_price_clp !== null
           ? { proposedPriceClp: input.proposed_price_clp }
           : {}),
+        // Phase 5 PR-L3b — datos consignee opt-in para tracking link directo.
+        ...(input.consignee?.name ? { consigneeName: input.consignee.name } : {}),
+        ...(input.consignee?.phone_e164
+          ? { consigneeWhatsappE164: input.consignee.phone_e164 }
+          : {}),
         status: 'esperando_match',
       })
       .returning();

--- a/apps/api/src/services/notify-tracking-link.ts
+++ b/apps/api/src/services/notify-tracking-link.ts
@@ -7,12 +7,18 @@
  *   - Resumen de ruta (origen → destino)
  *   - Botón "Ver seguimiento" → https://app.boosterchile.com/tracking/<token>
  *
- * **Por qué al shipper y NO al consignee directamente** (v1):
- *   El schema de `trips` aún NO tiene `consignee_phone` field. PR-L3b
- *   agregará el campo + UI de captura para enviar al destinatario
- *   final. Mientras tanto, el shipper recibe el link y lo forwarda
- *   manualmente a su consignee — patrón aceptable para una primera
- *   iteración (el shipper conoce a su consignee y puede compartir).
+ * **Recipient resolution** (Phase 5 PR-L3b):
+ *   Si el trip tiene `consigneeWhatsappE164` (capturado opt-in en el
+ *   form de crear carga), el link va DIRECTO al consignee — patrón
+ *   "Uber-like" donde el destinatario sigue el envío sin involucrar
+ *   al shipper.
+ *
+ *   Si el campo está NULL (default — shipper no quiso compartir el
+ *   phone del recipient), fallback al shipper user (createdByUserId).
+ *   El shipper forwarda manualmente.
+ *
+ *   Esta política se reporta en el resultado vía `recipient` para
+ *   audit/analytics.
  *
  * **Idempotencia**: igual que notify-offer.ts, marcar via columna
  * `tracking_link_enviado_en` en assignments. Mismo patrón anti-spam:
@@ -72,6 +78,7 @@ export async function notifyTrackingLinkAtAssignment(
 
   // Cargar assignment + trip + shipper user en un solo round-trip.
   // El shipper user es `trips.createdByUserId` (quien creó la carga).
+  // El consignee phone (opt-in) viene de trips directamente.
   const rows = await db
     .select({
       assignmentId: assignments.id,
@@ -79,6 +86,7 @@ export async function notifyTrackingLinkAtAssignment(
       trackingCode: trips.trackingCode,
       originRegion: trips.originRegionCode,
       destRegion: trips.destinationRegionCode,
+      consigneeWhatsapp: trips.consigneeWhatsappE164,
       shipperUserId: trips.createdByUserId,
       shipperWhatsapp: users.whatsappE164,
     })
@@ -103,18 +111,26 @@ export async function notifyTrackingLinkAtAssignment(
     return { assignmentId, skipped: true, reason: 'no_token' };
   }
 
-  if (!row.shipperUserId) {
-    logger.info(
-      { assignmentId },
-      'notifyTrackingLinkAtAssignment skipped — trip sin createdByUserId',
-    );
-    return { assignmentId, skipped: true, reason: 'no_owner' };
-  }
+  // Phase 5 PR-L3b — recipient resolution: preferir consignee si opt-in.
+  // El consignee es siempre el destinatario más relevante para tracking;
+  // el shipper queda como fallback si el campo está NULL.
+  const recipient: { phone: string; role: 'consignee' | 'shipper' } | null = row.consigneeWhatsapp
+    ? { phone: row.consigneeWhatsapp, role: 'consignee' }
+    : row.shipperWhatsapp
+      ? { phone: row.shipperWhatsapp, role: 'shipper' }
+      : null;
 
-  if (!row.shipperWhatsapp) {
+  if (!recipient) {
+    if (!row.shipperUserId) {
+      logger.info(
+        { assignmentId },
+        'notifyTrackingLinkAtAssignment skipped — sin consignee phone y trip sin createdByUserId',
+      );
+      return { assignmentId, skipped: true, reason: 'no_owner' };
+    }
     logger.info(
       { assignmentId, shipperUserId: row.shipperUserId },
-      'notifyTrackingLinkAtAssignment skipped — shipper user sin whatsapp_e164',
+      'notifyTrackingLinkAtAssignment skipped — sin consignee phone y shipper user sin whatsapp_e164',
     );
     return { assignmentId, skipped: true, reason: 'no_whatsapp' };
   }
@@ -128,7 +144,7 @@ export async function notifyTrackingLinkAtAssignment(
   });
 
   const response = await twilioClient.sendContent({
-    to: row.shipperWhatsapp,
+    to: recipient.phone,
     contentSid: contentSidTracking,
     contentVariables: variables,
   });
@@ -136,12 +152,17 @@ export async function notifyTrackingLinkAtAssignment(
   logger.info(
     {
       assignmentId,
-      shipperUserId: row.shipperUserId,
+      recipientRole: recipient.role,
       trackingCode: row.trackingCode,
       twilioSid: response.sid,
     },
     'notifyTrackingLinkAtAssignment sent',
   );
 
-  return { assignmentId, skipped: false, twilioMessageSid: response.sid };
+  return {
+    assignmentId,
+    skipped: false,
+    twilioMessageSid: response.sid,
+    recipient: recipient.role,
+  };
 }

--- a/apps/api/test/unit/notify-tracking-link.test.ts
+++ b/apps/api/test/unit/notify-tracking-link.test.ts
@@ -36,6 +36,7 @@ interface JoinRow {
   trackingCode: string;
   originRegion: string | null;
   destRegion: string | null;
+  consigneeWhatsapp: string | null;
   shipperUserId: string | null;
   shipperWhatsapp: string | null;
 }
@@ -74,6 +75,7 @@ const baseRow = (overrides: Partial<JoinRow> = {}): JoinRow => ({
   trackingCode: 'BOO-XYZ987',
   originRegion: 'XIII',
   destRegion: 'IV',
+  consigneeWhatsapp: null, // default: sin consignee opt-in
   shipperUserId: '00000000-0000-0000-0000-000000000b02',
   shipperWhatsapp: '+56912345678',
   ...overrides,
@@ -156,11 +158,15 @@ describe('notifyTrackingLinkAtAssignment', () => {
     expect(result.reason).toBe('no_token');
   });
 
-  it('skipea si shipperUserId null (trip sin createdByUserId)', async () => {
+  it('skipea si shipperUserId null + shipperWhatsapp null + sin consignee → no_owner', async () => {
+    // En la práctica: leftJoin users on createdByUserId IS NULL → todos los
+    // campos del user vienen NULL. Ambas columnas se mueven juntas.
     const { notifyTrackingLinkAtAssignment } = await import(
       '../../src/services/notify-tracking-link.js'
     );
-    const { db } = makeDbStub({ row: baseRow({ shipperUserId: null }) });
+    const { db } = makeDbStub({
+      row: baseRow({ shipperUserId: null, shipperWhatsapp: null, consigneeWhatsapp: null }),
+    });
     const result = await notifyTrackingLinkAtAssignment(
       {
         db,
@@ -174,7 +180,7 @@ describe('notifyTrackingLinkAtAssignment', () => {
     expect(result.reason).toBe('no_owner');
   });
 
-  it('skipea si shipper sin whatsapp_e164', async () => {
+  it('skipea si shipper sin whatsapp_e164 (con shipperUserId set) → no_whatsapp', async () => {
     const { notifyTrackingLinkAtAssignment } = await import(
       '../../src/services/notify-tracking-link.js'
     );
@@ -192,7 +198,7 @@ describe('notifyTrackingLinkAtAssignment', () => {
     expect(result.reason).toBe('no_whatsapp');
   });
 
-  it('envía con variables correctas (1=tracking_code, 2=origen, 3=destino, 4=token)', async () => {
+  it('envía con variables correctas (1=tracking_code, 2=origen, 3=destino, 4=token) — fallback shipper', async () => {
     const { notifyTrackingLinkAtAssignment } = await import(
       '../../src/services/notify-tracking-link.js'
     );
@@ -217,6 +223,7 @@ describe('notifyTrackingLinkAtAssignment', () => {
     );
     expect(result.skipped).toBe(false);
     expect(result.twilioMessageSid).toBe('SM_real');
+    expect(result.recipient).toBe('shipper');
     expect(sendContent).toHaveBeenCalledWith({
       to: '+56912345678',
       contentSid: VALID_SID,
@@ -227,6 +234,89 @@ describe('notifyTrackingLinkAtAssignment', () => {
         '4': TOKEN,
       },
     });
+  });
+
+  it('PR-L3b — consignee opt-in: envía DIRECTO al consignee (no al shipper)', async () => {
+    const { notifyTrackingLinkAtAssignment } = await import(
+      '../../src/services/notify-tracking-link.js'
+    );
+    const { db } = makeDbStub({
+      row: baseRow({ consigneeWhatsapp: '+56987654321' }),
+    });
+    const sendContent = vi.fn().mockResolvedValue({
+      sid: 'SM_consignee',
+      status: 'queued',
+      to: 'whatsapp:+56987654321',
+      from: 'whatsapp:+19383365293',
+      body: '...',
+      date_created: '2026-05-10T20:00:00Z',
+    });
+    const twilio = makeTwilioStub({ sendContent });
+    const result = await notifyTrackingLinkAtAssignment(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidTracking: VALID_SID,
+      },
+      { assignmentId: ASSIGNMENT_ID },
+    );
+    expect(result.skipped).toBe(false);
+    expect(result.recipient).toBe('consignee');
+    // El destino es el phone del consignee, NO del shipper.
+    expect(sendContent).toHaveBeenCalledWith(expect.objectContaining({ to: '+56987654321' }));
+  });
+
+  it('PR-L3b — consignee + shipper ambos presentes: gana consignee', async () => {
+    const { notifyTrackingLinkAtAssignment } = await import(
+      '../../src/services/notify-tracking-link.js'
+    );
+    const { db } = makeDbStub({
+      row: baseRow({
+        consigneeWhatsapp: '+56987654321',
+        shipperWhatsapp: '+56912345678',
+      }),
+    });
+    const sendContent = vi.fn().mockResolvedValue({
+      sid: 'SM_x',
+      status: 'queued',
+      to: 'x',
+      from: 'x',
+      body: '',
+      date_created: 'x',
+    });
+    const twilio = makeTwilioStub({ sendContent });
+    const result = await notifyTrackingLinkAtAssignment(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: twilio,
+        contentSidTracking: VALID_SID,
+      },
+      { assignmentId: ASSIGNMENT_ID },
+    );
+    expect(result.recipient).toBe('consignee');
+    expect(sendContent).toHaveBeenCalledWith(expect.objectContaining({ to: '+56987654321' }));
+  });
+
+  it('PR-L3b — sin consignee ni shipper whatsapp: skip no_whatsapp', async () => {
+    const { notifyTrackingLinkAtAssignment } = await import(
+      '../../src/services/notify-tracking-link.js'
+    );
+    const { db } = makeDbStub({
+      row: baseRow({ consigneeWhatsapp: null, shipperWhatsapp: null }),
+    });
+    const result = await notifyTrackingLinkAtAssignment(
+      {
+        db,
+        logger: noopLogger,
+        twilioClient: makeTwilioStub(),
+        contentSidTracking: VALID_SID,
+      },
+      { assignmentId: ASSIGNMENT_ID },
+    );
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toBe('no_whatsapp');
   });
 
   it('regiones unknown se mapean a placeholder em-dash', async () => {

--- a/packages/notification-fan-out/src/index.ts
+++ b/packages/notification-fan-out/src/index.ts
@@ -124,4 +124,10 @@ export interface NotifyTrackingLinkResult {
     | 'no_token'
     | 'assignment_not_found';
   twilioMessageSid?: string;
+  /**
+   * Phase 5 PR-L3b — A quién se envió el link cuando skipped=false.
+   * 'consignee' = directo al destinatario (opt-in en form). 'shipper'
+   * = fallback al generador de carga (forwarding manual).
+   */
+  recipient?: 'consignee' | 'shipper';
 }

--- a/packages/shared-schemas/src/trip-request-create.ts
+++ b/packages/shared-schemas/src/trip-request-create.ts
@@ -73,6 +73,34 @@ export const tripRequestCreateInputSchema = z
     }),
     /** Precio sugerido por shipper en CLP. Null = pricing-engine sugiere. */
     proposed_price_clp: z.number().int().nonnegative().nullable(),
+    /**
+     * Phase 5 PR-L3b — Datos opcionales del consignee (destinatario en
+     * el lugar de entrega). Si están presentes:
+     *   - El link público de tracking se envía DIRECTAMENTE al
+     *     consignee vía WhatsApp al asignar (vs forwarding manual del
+     *     shipper).
+     *   - El destinatario aparece como rol abstracto en el chat
+     *     conductor↔destinatario (futuro PR-L5).
+     *
+     * Opt-in deliberado: el shipper típico tiene la relación con el
+     * consignee y prefiere NO compartir su número con plataforma —
+     * solo quien quiere la experiencia "Uber-like" para su recipient
+     * llena estos campos.
+     */
+    consignee: z
+      .object({
+        /** Nombre legible del destinatario. Para mostrar en saludo del template. */
+        name: z.string().trim().min(1).max(100).optional(),
+        /**
+         * Phone E.164 (con +). Validamos formato pero NO carrier-side —
+         * Twilio rechazará al envío si el número no tiene WhatsApp.
+         */
+        phone_e164: z
+          .string()
+          .regex(/^\+\d{8,15}$/, 'Debe estar en formato E.164 (+56912345678)')
+          .optional(),
+      })
+      .optional(),
   })
   .superRefine((data, ctx) => {
     const startMs = Date.parse(data.pickup_window.start_at);


### PR DESCRIPTION
## Summary

Cierra el patrón **Uber-like** del feedback original PO: el consignee (destinatario) recibe el link público de tracking DIRECTO en su WhatsApp al asignar el trip, sin requerir forwarding manual del shipper. Opt-in del shipper al crear la carga.

## Diseño

| Decisión | Por qué |
|---|---|
| Opt-in deliberado | Shipper decide si comparte el phone del recipient. Privacy-first — Ley 19.628 Chile: shipper como controlador con legitimate interest |
| Fallback chain | 1. consignee → 2. shipper (PR-L3 v1) → 3. skip. Reporta cuál ganó en \`recipient\` field |
| Validación E.164 | Regex \`/^\\+\\d{8,15}\$/\` en zod schema. Twilio rechaza al envío si no tiene WhatsApp |
| Sin retry en error | Anti-spam: si Twilio rechaza, log + sigue. El consignee no recibe; sin re-intento agresivo |

## Recipient resolution

\`\`\`
if (consigneeWhatsappE164) → recipient='consignee'
else if (shipper.whatsappE164) → recipient='shipper'  // PR-L3 v1 fallback
else → skip
\`\`\`

El campo \`recipient\` en \`NotifyTrackingLinkResult\` reporta cuál ganó. Útil para analytics (\"% de trips con consignee opt-in\").

## Cambios

| Archivo | Cambio | Tests |
|---|---|---|
| \`apps/api/drizzle/0014_trips_consignee_phone.sql\` | + migration | — |
| \`apps/api/src/db/schema.ts\` | + columns \`consigneeName\`, \`consigneeWhatsappE164\` | — |
| \`packages/shared-schemas/src/trip-request-create.ts\` | + \`consignee\` field opcional con regex E.164 | — |
| \`apps/api/src/routes/trip-requests-v2.ts\` | persist consignee fields en INSERT | — |
| \`apps/api/src/services/notify-tracking-link.ts\` | recipient resolution + role en resultado | +3 |
| \`packages/notification-fan-out/src/index.ts\` | + \`recipient\` field en result | — |

### Tests breakdown (3 nuevos)

- consignee opt-in → envía DIRECTO al consignee, recipient='consignee'
- consignee + shipper ambos presentes → gana consignee
- sin consignee ni shipper whatsapp → skip 'no_whatsapp'

## Pendiente UI (PR-L3c)

Form \`cargas/nueva.tsx\` agregar 2 inputs opcionales:
- \"Nombre del destinatario\"
- \"WhatsApp del destinatario\" (E.164 con prefijo +56)

Mientras tanto, settable via API directa (\`POST /trip-requests-v2\` acepta el field).

## Estado del producto end-to-end (post-merge)

- ✅ Conductor: voice-first hands-free
- ✅ Consignee/Shipper: link público + página dedicada
- ✅ Distribución link al consignee directo (este PR — pendiente Meta approval del template)
- ✅ Sostenibilidad: certificado IFRS S2
- ✅ Cost guardrails + eval suite Gemini

## Evidencia

- \`pnpm typecheck\` ✓ (monorepo, 29 tasks)
- \`pnpm lint\` ✓
- \`pnpm test\` ✓: api 467 (+3), todos verdes

## Test plan post-merge

- [ ] terraform apply (idempotente, no nuevos recursos)
- [ ] migration 0014 corre en boot del api
- [ ] POST /trip-requests-v2 con \`consignee: { name, phone_e164 }\` persiste OK
- [ ] Aceptar oferta de un trip con consignee → log debe mostrar \`recipientRole=consignee\`
- [ ] (Tras Meta approve) → consignee recibe WhatsApp directamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)