### PR TITLE
feat(web): UI wire del marcar_incidente con voz + visual (Phase 4 PR-K6b)

### DIFF
--- a/apps/web/src/components/scoring/IncidentReportCard.test.tsx
+++ b/apps/web/src/components/scoring/IncidentReportCard.test.tsx
@@ -1,0 +1,214 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../../lib/api-client.js';
+import type {
+  RecognitionState,
+  RecognizedCommand,
+  VoiceCommandController,
+} from '../../services/voice-commands.js';
+import { IncidentReportCard } from './IncidentReportCard.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function makeRecognizer(initial: RecognitionState = 'idle') {
+  const state: RecognitionState = initial;
+  const stateListeners = new Set<(s: RecognitionState) => void>();
+  const cmdListeners = new Set<(c: RecognizedCommand) => void>();
+  const ctrl: VoiceCommandController = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    abort: vi.fn(),
+    getState: () => state,
+    subscribe: (l) => {
+      stateListeners.add(l);
+      l(state);
+      return () => {
+        stateListeners.delete(l);
+      };
+    },
+    onCommand: (l) => {
+      cmdListeners.add(l);
+      return () => {
+        cmdListeners.delete(l);
+      };
+    },
+    onUnrecognized: () => () => undefined,
+  };
+  return {
+    ctrl,
+    emitCommand: (cmd: RecognizedCommand) => {
+      for (const l of cmdListeners) {
+        l(cmd);
+      }
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('IncidentReportCard', () => {
+  it('renderiza idle: botón "Reportar incidente" + voice button', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    expect(screen.getByTestId('incident-open-button')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-command-button')).toBeInTheDocument();
+  });
+
+  it('click "Reportar incidente" → panel de selección con 5 botones', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('incident-open-button'));
+    expect(screen.getByText(/¿qué tipo de incidente\?/i)).toBeInTheDocument();
+    expect(screen.getByTestId('incident-type-accidente')).toBeInTheDocument();
+    expect(screen.getByTestId('incident-type-demora')).toBeInTheDocument();
+    expect(screen.getByTestId('incident-type-falla_mecanica')).toBeInTheDocument();
+    expect(screen.getByTestId('incident-type-problema_carga')).toBeInTheDocument();
+    expect(screen.getByTestId('incident-type-otro')).toBeInTheDocument();
+  });
+
+  it('click tipo → POST /assignments/:id/incidents + estado success', async () => {
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({
+      ok: true,
+      trip_event_id: 'e-1',
+      recorded_at: '2026-05-10T18:00:00Z',
+    });
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a-77" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('incident-open-button'));
+    fireEvent.click(screen.getByTestId('incident-type-falla_mecanica'));
+
+    await waitFor(() =>
+      expect(postSpy).toHaveBeenCalledWith('/assignments/a-77/incidents', {
+        incident_type: 'falla_mecanica',
+      }),
+    );
+    await waitFor(() => expect(screen.getByText(/incidente reportado/i)).toBeInTheDocument());
+  });
+
+  it('voz "marcar incidente" en idle → abre panel', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'marcar_incidente', transcript: 'incidente', confidence: 1 });
+    });
+    expect(screen.getByText(/¿qué tipo de incidente\?/i)).toBeInTheDocument();
+  });
+
+  it('voz "cancelar" en panel → cierra panel', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('incident-open-button'));
+    expect(screen.getByText(/¿qué tipo de incidente\?/i)).toBeInTheDocument();
+
+    act(() => {
+      r.emitCommand({ intent: 'cancelar', transcript: 'cancelar', confidence: 1 });
+    });
+    expect(screen.queryByText(/¿qué tipo de incidente\?/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId('incident-open-button')).toBeInTheDocument();
+  });
+
+  it('botón X cierra panel', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('incident-open-button'));
+    fireEvent.click(screen.getByLabelText(/^cancelar$/i));
+    expect(screen.queryByText(/¿qué tipo de incidente\?/i)).not.toBeInTheDocument();
+  });
+
+  it('error 403 → mensaje específico "no permisos"', async () => {
+    vi.spyOn(api, 'post').mockRejectedValue(
+      new ApiError(403, 'forbidden_owner_mismatch', { code: 'forbidden_owner_mismatch' }),
+    );
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('incident-open-button'));
+    fireEvent.click(screen.getByTestId('incident-type-accidente'));
+    await waitFor(() =>
+      expect(screen.getByTestId('incident-error')).toHaveTextContent(/no tienes permisos/i),
+    );
+  });
+
+  it('error 404 → mensaje específico "viaje no encontrado"', async () => {
+    vi.spyOn(api, 'post').mockRejectedValue(
+      new ApiError(404, 'assignment_not_found', { code: 'assignment_not_found' }),
+    );
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('incident-open-button'));
+    fireEvent.click(screen.getByTestId('incident-type-accidente'));
+    await waitFor(() =>
+      expect(screen.getByTestId('incident-error')).toHaveTextContent(/no se encontró el viaje/i),
+    );
+  });
+
+  it('error de red (no ApiError) → mensaje "sin conexión"', async () => {
+    vi.spyOn(api, 'post').mockRejectedValue(new Error('network down'));
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <IncidentReportCard assignmentId="a1" recognizer={r.ctrl} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('incident-open-button'));
+    fireEvent.click(screen.getByTestId('incident-type-otro'));
+    await waitFor(() =>
+      expect(screen.getByTestId('incident-error')).toHaveTextContent(/sin conexión/i),
+    );
+  });
+});

--- a/apps/web/src/components/scoring/IncidentReportCard.tsx
+++ b/apps/web/src/components/scoring/IncidentReportCard.tsx
@@ -1,0 +1,214 @@
+import { AlertTriangle, CheckCircle2, Loader2, X } from 'lucide-react';
+import { useState } from 'react';
+import {
+  INCIDENT_TYPES,
+  INCIDENT_TYPE_LABELS,
+  type IncidentType,
+  useReportarIncidenteMutation,
+} from '../../hooks/use-reportar-incidente.js';
+import { useVoiceCommand } from '../../hooks/use-voice-command.js';
+import { ApiError } from '../../lib/api-client.js';
+import type { RecognizedCommand, VoiceCommandController } from '../../services/voice-commands.js';
+import { VoiceCommandButton } from '../voice/VoiceCommandButton.js';
+
+/**
+ * Card de reportar incidente para el conductor (Phase 4 PR-K6b).
+ *
+ * Visible en `/app/asignaciones/:id` cuando el trip está activo
+ * (asignado | en_proceso). Cierra el loop voice-first del
+ * `marcar_incidente` intent del PR-K2 framework.
+ *
+ * **UX hands-free**:
+ *   - Estado idle: botón secundario "Reportar incidente" (botón
+ *     pequeño, no compite visualmente con el StatusCard de entrega).
+ *   - Voice command "marcar incidente" / "tengo un problema" →
+ *     abre el panel de selección de tipo.
+ *   - Panel: 5 botones grandes (≥56px hit-area) uno por tipo. El
+ *     conductor toca o dice el tipo.
+ *   - Comando "cancelar" en cualquier estado → cierra panel.
+ *   - Submit → toast success / error, no requiere navegación.
+ *
+ * **NO incluye**:
+ *   - Foto / archivo adjunto (PR-K6c futuro)
+ *   - Descripción libre (PR-K6c — voice dictation o teclado)
+ *   - Selección de severidad (todos los incidentes son operacionales,
+ *     no jerarquizamos en v1)
+ *
+ * El backend persiste el incidente como tripEvent — el shipper lo ve
+ * en el timeline del trip (futuro PR-K6c agregará push notif).
+ */
+
+export interface IncidentReportCardProps {
+  assignmentId: string;
+  /** Inyectable para tests. */
+  recognizer?: VoiceCommandController;
+}
+
+type LocalState = 'idle' | 'selecting' | 'submitting' | 'success' | 'error';
+
+const SUCCESS_TOAST_MS = 5000;
+
+export function IncidentReportCard({ assignmentId, recognizer }: IncidentReportCardProps) {
+  const [localState, setLocalState] = useState<LocalState>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const mutation = useReportarIncidenteMutation();
+
+  const openPanel = (): void => {
+    setLocalState('selecting');
+    setErrorMsg(null);
+  };
+
+  const closePanel = (): void => {
+    setLocalState('idle');
+    setErrorMsg(null);
+  };
+
+  // Voice listener a nivel de la card — vive independiente del
+  // VoiceCommandButton que solo aparece en idle. Esto permite que
+  // "cancelar" funcione mientras el panel de selección está abierto
+  // (cuando el VoiceCommandButton está unmounted).
+  const handleVoiceCommand = (cmd: RecognizedCommand): void => {
+    if (cmd.intent === 'cancelar') {
+      closePanel();
+      return;
+    }
+    if (cmd.intent === 'marcar_incidente') {
+      // setLocalState con función para evitar stale closure: si el
+      // estado ya cambió a selecting/submitting/etc., no re-abrimos.
+      setLocalState((prev) => (prev === 'idle' ? 'selecting' : prev));
+    }
+  };
+
+  useVoiceCommand({
+    acceptedIntents: new Set(['marcar_incidente', 'cancelar']),
+    onCommand: handleVoiceCommand,
+    ...(recognizer ? { recognizer } : {}),
+  });
+
+  const submitIncident = (incidentType: IncidentType): void => {
+    setLocalState('submitting');
+    setErrorMsg(null);
+    mutation.mutate(
+      { assignmentId, incidentType },
+      {
+        onSuccess: () => {
+          setLocalState('success');
+          // Auto-volver a idle tras un tiempo para dejar la card lista
+          // si el conductor reporta otro incidente en el mismo trip.
+          setTimeout(() => setLocalState('idle'), SUCCESS_TOAST_MS);
+        },
+        onError: (err) => {
+          setLocalState('error');
+          if (err instanceof ApiError && err.status === 403) {
+            setErrorMsg('No tienes permisos para reportar incidentes en este viaje.');
+          } else if (err instanceof ApiError && err.status === 404) {
+            setErrorMsg('No se encontró el viaje. Refresca la página.');
+          } else if (err instanceof ApiError) {
+            setErrorMsg('No se pudo registrar el incidente. Intenta otra vez.');
+          } else {
+            setErrorMsg('Sin conexión. Verifica tu red e intenta otra vez.');
+          }
+        },
+      },
+    );
+  };
+
+  if (localState === 'success') {
+    return (
+      <section
+        aria-label="Incidente reportado"
+        className="border-success-200 border-b bg-success-50 px-4 py-3"
+      >
+        <div className="flex items-center gap-3">
+          <CheckCircle2 className="h-5 w-5 text-success-700" aria-hidden />
+          <p className="font-medium text-sm text-success-800">
+            Incidente reportado. El generador de carga fue notificado.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  if (localState === 'idle') {
+    return (
+      <section
+        aria-label="Reportar incidente"
+        className="border-neutral-200 border-b bg-white px-4 py-3"
+      >
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={openPanel}
+            className="inline-flex items-center gap-2 rounded-md bg-amber-50 px-3 py-2 font-medium text-amber-800 text-sm ring-1 ring-amber-500/30 hover:bg-amber-100"
+            data-testid="incident-open-button"
+          >
+            <AlertTriangle className="h-4 w-4" aria-hidden />
+            Reportar incidente
+          </button>
+          <span className="text-neutral-500 text-xs">o di "marcar incidente"</span>
+          {/* VoiceCommandButton compacto al lado para activar el flow
+              hands-free. Comparte intents marcar_incidente + cancelar. */}
+          {/* VoiceCommandButton solo en idle — el listener real vive
+              en useVoiceCommand a nivel de IncidentReportCard, así que
+              "cancelar" funciona aún cuando este botón está unmounted
+              (panel de selección abierto). */}
+          <VoiceCommandButton
+            acceptedIntents={new Set(['marcar_incidente', 'cancelar'])}
+            onCommand={() => undefined /* no-op: listener vive arriba */}
+            {...(recognizer ? { recognizer } : {})}
+            idleLabel='Di "incidente"'
+          />
+        </div>
+      </section>
+    );
+  }
+
+  // Panel selecting: 5 botones grandes (uno por tipo) + voz cancel.
+  return (
+    <section
+      aria-label="Selecciona tipo de incidente"
+      className="border-amber-200 border-b bg-amber-50 px-4 py-4"
+    >
+      <div className="mb-3 flex items-center justify-between">
+        <p className="font-semibold text-amber-900 text-sm">¿Qué tipo de incidente?</p>
+        <button
+          type="button"
+          onClick={closePanel}
+          aria-label="Cancelar"
+          disabled={localState === 'submitting'}
+          className="rounded p-1 text-amber-700 hover:bg-amber-100 disabled:opacity-50"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {INCIDENT_TYPES.map((t) => (
+          <button
+            key={t}
+            type="button"
+            onClick={() => submitIncident(t)}
+            disabled={localState === 'submitting'}
+            className="flex min-h-[56px] items-center justify-center rounded-md bg-white px-4 py-3 font-medium text-amber-900 text-sm ring-1 ring-amber-500/30 hover:bg-amber-100 disabled:opacity-50"
+            data-testid={`incident-type-${t}`}
+          >
+            {INCIDENT_TYPE_LABELS[t]}
+          </button>
+        ))}
+      </div>
+
+      {localState === 'submitting' && (
+        <div className="mt-3 inline-flex items-center gap-2 text-amber-800 text-xs">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+          Registrando…
+        </div>
+      )}
+
+      {localState === 'error' && errorMsg && (
+        <p className="mt-3 text-amber-900 text-xs" data-testid="incident-error">
+          {errorMsg}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/hooks/use-reportar-incidente.test.tsx
+++ b/apps/web/src/hooks/use-reportar-incidente.test.tsx
@@ -1,0 +1,137 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../lib/api-client.js';
+import {
+  INCIDENT_TYPES,
+  INCIDENT_TYPE_LABELS,
+  useReportarIncidenteMutation,
+} from './use-reportar-incidente.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return {
+    Wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+    client,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('INCIDENT_TYPES + LABELS', () => {
+  it('5 tipos canónicos', () => {
+    expect(INCIDENT_TYPES.length).toBe(5);
+    expect(INCIDENT_TYPES).toEqual([
+      'accidente',
+      'demora',
+      'falla_mecanica',
+      'problema_carga',
+      'otro',
+    ]);
+  });
+
+  it('cada tipo tiene label legible', () => {
+    for (const t of INCIDENT_TYPES) {
+      expect(INCIDENT_TYPE_LABELS[t]).toBeTruthy();
+      expect(INCIDENT_TYPE_LABELS[t].length).toBeGreaterThan(2);
+    }
+  });
+});
+
+describe('useReportarIncidenteMutation', () => {
+  it('llama POST /assignments/:id/incidents con body correcto', async () => {
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({
+      ok: true,
+      trip_event_id: 'e-1',
+      recorded_at: '2026-05-10T18:00:00Z',
+    });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useReportarIncidenteMutation(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        assignmentId: 'a-1',
+        incidentType: 'demora',
+        description: 'tráfico denso',
+      });
+    });
+
+    expect(postSpy).toHaveBeenCalledWith('/assignments/a-1/incidents', {
+      incident_type: 'demora',
+      description: 'tráfico denso',
+    });
+  });
+
+  it('description opcional: NO se envía si es undefined', async () => {
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({
+      ok: true,
+      trip_event_id: 'e-1',
+      recorded_at: '2026-05-10T18:00:00Z',
+    });
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useReportarIncidenteMutation(), { wrapper: Wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        assignmentId: 'a-1',
+        incidentType: 'accidente',
+      });
+    });
+
+    expect(postSpy).toHaveBeenCalledWith('/assignments/a-1/incidents', {
+      incident_type: 'accidente',
+    });
+  });
+
+  it('invalida assignment-detail tras success', async () => {
+    vi.spyOn(api, 'post').mockResolvedValue({
+      ok: true,
+      trip_event_id: 'e-1',
+      recorded_at: '2026-05-10T18:00:00Z',
+    });
+    const { Wrapper, client } = makeWrapper();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useReportarIncidenteMutation(), { wrapper: Wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({
+        assignmentId: 'a-77',
+        incidentType: 'falla_mecanica',
+      });
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const calls = invalidateSpy.mock.calls.map((c) => (c[0] as { queryKey?: unknown }).queryKey);
+    expect(calls).toContainEqual(['assignment-detail', 'a-77']);
+  });
+
+  it('propaga ApiError 403', async () => {
+    vi.spyOn(api, 'post').mockRejectedValue(
+      new ApiError(403, 'forbidden_owner_mismatch', { code: 'forbidden_owner_mismatch' }),
+    );
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useReportarIncidenteMutation(), { wrapper: Wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          assignmentId: 'a-1',
+          incidentType: 'otro',
+        });
+      } catch {
+        // expected
+      }
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as ApiError).status).toBe(403);
+  });
+});

--- a/apps/web/src/hooks/use-reportar-incidente.ts
+++ b/apps/web/src/hooks/use-reportar-incidente.ts
@@ -1,0 +1,66 @@
+import { type UseMutationResult, useMutation, useQueryClient } from '@tanstack/react-query';
+import { type ApiError, api } from '../lib/api-client.js';
+
+/**
+ * Reporta un incidente operacional durante un viaje (Phase 4 PR-K6b).
+ *
+ * Consume el endpoint:
+ *   POST /assignments/:id/incidents
+ *   Body: { incident_type, description? }
+ *
+ * Lifecycle: persiste como `tripEvent` audit-only (server-side
+ * reportar-incidente.ts). NO bloquea ni cancela el viaje.
+ *
+ * Side effects post-success:
+ *   - Invalida queries de assignment-detail para que aparezca el
+ *     evento en el timeline del trip cuando el shipper lo abra.
+ */
+
+export const INCIDENT_TYPES = [
+  'accidente',
+  'demora',
+  'falla_mecanica',
+  'problema_carga',
+  'otro',
+] as const;
+
+export type IncidentType = (typeof INCIDENT_TYPES)[number];
+
+/** Labels legibles en español para mostrar en UI. */
+export const INCIDENT_TYPE_LABELS: Record<IncidentType, string> = {
+  accidente: 'Accidente',
+  demora: 'Demora',
+  falla_mecanica: 'Falla mecánica',
+  problema_carga: 'Problema con la carga',
+  otro: 'Otro',
+};
+
+export interface ReportarIncidenteResponse {
+  ok: true;
+  trip_event_id: string;
+  recorded_at: string;
+}
+
+export function useReportarIncidenteMutation(): UseMutationResult<
+  ReportarIncidenteResponse,
+  ApiError,
+  { assignmentId: string; incidentType: IncidentType; description?: string }
+> {
+  const queryClient = useQueryClient();
+  return useMutation<
+    ReportarIncidenteResponse,
+    ApiError,
+    { assignmentId: string; incidentType: IncidentType; description?: string }
+  >({
+    mutationFn: ({ assignmentId, incidentType, description }) =>
+      api.post<ReportarIncidenteResponse>(`/assignments/${assignmentId}/incidents`, {
+        incident_type: incidentType,
+        ...(description ? { description } : {}),
+      }),
+    onSuccess: (_data, { assignmentId }) => {
+      void queryClient.invalidateQueries({
+        queryKey: ['assignment-detail', assignmentId],
+      });
+    },
+  });
+}

--- a/apps/web/src/routes/asignacion-detalle.tsx
+++ b/apps/web/src/routes/asignacion-detalle.tsx
@@ -22,6 +22,7 @@ import { ChatPanel } from '../components/chat/ChatPanel.js';
 import { PushSubscribeBanner } from '../components/chat/PushSubscribeBanner.js';
 import { BehaviorScoreCard } from '../components/scoring/BehaviorScoreCard.js';
 import { DeliveryConfirmCard } from '../components/scoring/DeliveryConfirmCard.js';
+import { IncidentReportCard } from '../components/scoring/IncidentReportCard.js';
 import { api } from '../lib/api-client.js';
 
 interface AssignmentDetail {
@@ -121,6 +122,12 @@ function AsignacionDetallePage() {
           asignado o en_proceso. Doble confirmación dentro del componente
           previene falsos positivos. */}
       {isConfirmable && <DeliveryConfirmCard assignmentId={assignmentId} />}
+
+      {/* Phase 4 PR-K6b — reportar incidente operacional (accidente,
+          demora, falla mecánica, etc.). Voice command "marcar
+          incidente" abre panel de selección. Visible mientras el trip
+          esté activo (mismo predicate que delivery confirm). */}
+      {isConfirmable && <IncidentReportCard assignmentId={assignmentId} />}
 
       {/* Behavior score card — Phase 2 PR-I5. Solo se muestra cuando
           el trip está cerrado, porque el score se calcula post-entrega.


### PR DESCRIPTION
## Summary

Cierra el voice command framework end-to-end: el conductor dice **\"marcar incidente\"** o toca el botón → panel de selección con 5 botones grandes hands-free (≥56px hit-area) → submit al endpoint PR-K6 → toast confirmación.

## Voice listener arquitectura — refactor importante

El \`useVoiceCommand\` vive a **nivel de IncidentReportCard**, NO sólo dentro del VoiceCommandButton. Razón: cuando el panel de selección se abre, el VoiceCommandButton se unmounta, pero queremos que \"cancelar\" siga funcionando para que el conductor pueda salir sin tocar.

Solución: dos \`useVoiceCommand\` activos en idle (uno en button + uno en card). En selecting solo queda el de la card. Auto-stop post-comando es idempotente.

## UX hands-free

| Estado | Renderiza |
|---|---|
| idle | botón \"Reportar incidente\" + VoiceCommandButton + hint \"o di marcar incidente\" |
| selecting | panel amber con 5 botones grandes (uno por tipo) |
| submitting | spinner inline |
| success | card verde auto-cierra a 5s |
| error | mensaje específico por código (403/404/network) |

## Cambios

| Archivo | Cambio | Tests |
|---|---|---|
| \`apps/web/src/hooks/use-reportar-incidente.ts\` | + mutation + INCIDENT_TYPES/LABELS | 5 |
| \`apps/web/src/components/scoring/IncidentReportCard.tsx\` | + state machine + useVoiceCommand parent-level | 10 |
| \`apps/web/src/routes/asignacion-detalle.tsx\` | wire bajo DeliveryConfirmCard | — |

### Tests breakdown (15)

**\`use-reportar-incidente\` (5)**: 5 tipos canónicos, labels legibles, body shape con/sin description, invalida assignment-detail, propaga ApiError 403.

**\`IncidentReportCard\` (10)**: render idle, click → panel, click tipo → POST + success, voz \"marcar incidente\" → panel, voz \"cancelar\" → cierra (valida arquitectura voice listener arriba), botón X cierra, errores específicos 403/404/network.

## Phase 4 voice-first driver UX — COMPLETA

- ✅ K1: vehicle-stopped guard
- ✅ K2: voice recognition framework
- ✅ K3: VoiceCommandButton + hook
- ✅ K4: confirmar entrega voice + visual
- ✅ K6: incidents endpoint backend
- ✅ K6b: marcar incidente UI wire (este PR)
- ⏳ K7: aceptar oferta por voz (último intent sin caller — opcional)

## Evidencia

- \`pnpm typecheck\` ✓ (29 tasks)
- \`pnpm lint\` ✓ (warnings pre-existing en otros archivos, no nuevos)
- \`pnpm test\` ✓: web 728 (+15), api 494, todos verdes

🤖 Generated with [Claude Code](https://claude.com/claude-code)