### PR TITLE
feat(pricing-v2): activación con escala mínima (ADR-031)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -265,24 +265,29 @@ const apiEnvSchema = commonEnvSchema
     GEMINI_API_KEY: z.string().min(1).optional(),
 
     /**
-     * Feature flag para activar pricing v2 (ADR-030). Default `false`.
+     * Feature flag para activar pricing v2 (ADR-030 + ADR-031).
      *
-     * Cuando es `false`:
-     *   - `liquidarTrip()` retorna `{ status: 'skipped_flag_disabled' }`
-     *     y NO escribe en `liquidaciones` ni `facturas_booster_clp`.
+     * Default por entorno (ADR-031 §2):
+     *   - production → `true` (activación inmediata para el primer carrier)
+     *   - dev/test/staging → `false` (preservar tests existentes)
+     *
+     * Comportamiento cuando es `false`:
+     *   - `liquidarTrip()` retorna `skipped_flag_disabled` sin tocar BD.
      *   - El cron mensual de cobro de membresías no factura.
      *
-     * Cuando es `true`:
+     * Comportamiento cuando es `true`:
      *   - El service evalúa carrier_memberships + consent T&Cs v2 antes
      *     de emitir cualquier cobro. Sin consent firmado, las liquidaciones
-     *     quedan en estado `pending_consent`.
-     *   - Sovos integration debe estar configurada (ADR-024) para que el
-     *     job de emisión de DTE no acumule liquidaciones bloqueadas.
+     *     quedan en `pending_consent` (DTE emisión bloqueada por el carrier,
+     *     no por Booster).
+     *   - DTE Tipo 33 se emite vía Sovos cuando esté integrado;
+     *     mientras tanto las liquidaciones quedan `lista_para_dte`
+     *     (auditables, válidas contablemente, sin presentación SII).
      *
-     * Prender este flag en prod requiere cumplir los 6 criterios del
-     * ADR-030 §"Activación en producción".
+     * Override explícito: setear `PRICING_V2_ACTIVATED=false` en Cloud Run
+     * env revierte la activación en segundos sin tocar BD ni código.
      */
-    PRICING_V2_ACTIVATED: z.coerce.boolean().default(false),
+    PRICING_V2_ACTIVATED: z.coerce.boolean().default(process.env.NODE_ENV === 'production'),
   });
 
 export type ApiEnv = z.infer<typeof apiEnvSchema>;

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1,10 +1,10 @@
 import type { Logger } from '@booster-ai/logger';
 import { profileUpdateInputSchema } from '@booster-ai/shared-schemas';
 import { zValidator } from '@hono/zod-validator';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
 import type { Db } from '../db/client.js';
-import { empresas, memberships, users } from '../db/schema.js';
+import { carrierMemberships, empresas, memberships, users } from '../db/schema.js';
 import type { FirebaseClaims } from '../middleware/firebase-auth.js';
 
 /**
@@ -218,6 +218,174 @@ export function createMeRoutes(opts: { db: Db; logger: Logger }) {
         status: updated.status,
       },
     });
+  });
+
+  /**
+   * POST /me/consent/terms-v2 — registra la aceptación de T&Cs v2
+   * por parte del carrier (ADR-031 §4).
+   *
+   * Resuelve la empresa activa del user vía el header `X-Empresa-Id`
+   * (mismo patrón que el resto de endpoints). Si esa empresa tiene una
+   * `carrier_memberships` activa, popula `consent_terms_v2_aceptado_en`
+   * con `now()` + IP + user-agent.
+   *
+   * Idempotente: si ya hay consent (no-null), retorna 200 con el
+   * timestamp original (no se sobrescribe — la fecha del primer
+   * consent es la legalmente vinculante).
+   */
+  app.post('/consent/terms-v2', async (c) => {
+    const claims = c.get('firebaseClaims') as FirebaseClaims | undefined;
+    if (!claims) {
+      return c.json({ error: 'internal_server_error' }, 500);
+    }
+
+    const empresaIdHeader = c.req.header('x-empresa-id');
+    if (!empresaIdHeader) {
+      return c.json(
+        {
+          error: 'no_active_empresa',
+          message: 'Header X-Empresa-Id requerido',
+        },
+        400,
+      );
+    }
+
+    // Verificar que el user pertenece a esa empresa con membership
+    // activa (RLS aplicación-enforced).
+    const userRows = await opts.db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.firebaseUid, claims.uid))
+      .limit(1);
+    const user = userRows[0];
+    if (!user) {
+      return c.json({ error: 'user_not_found' }, 404);
+    }
+
+    const memshipRows = await opts.db
+      .select({ id: memberships.id })
+      .from(memberships)
+      .where(
+        and(
+          eq(memberships.userId, user.id),
+          eq(memberships.empresaId, empresaIdHeader),
+          eq(memberships.status, 'activa'),
+        ),
+      )
+      .limit(1);
+    if (!memshipRows[0]) {
+      return c.json(
+        {
+          error: 'forbidden_no_membership',
+          message: 'No tienes membership activa en esta empresa',
+        },
+        403,
+      );
+    }
+
+    // Lookup carrier_memberships activa de la empresa.
+    const carrierMemRows = await opts.db
+      .select({
+        id: carrierMemberships.id,
+        consentTermsV2AceptadoEn: carrierMemberships.consentTermsV2AceptadoEn,
+      })
+      .from(carrierMemberships)
+      .where(
+        and(
+          eq(carrierMemberships.empresaId, empresaIdHeader),
+          eq(carrierMemberships.status, 'activa'),
+        ),
+      )
+      .limit(1);
+    const carrierMem = carrierMemRows[0];
+    if (!carrierMem) {
+      return c.json(
+        {
+          error: 'no_carrier_membership',
+          message:
+            'Tu empresa no tiene una membresía de transportista activa. Esta funcionalidad es solo para transportistas.',
+        },
+        409,
+      );
+    }
+
+    // Idempotencia: si ya hay consent, no sobrescribir.
+    if (carrierMem.consentTermsV2AceptadoEn) {
+      return c.json({
+        ok: true,
+        accepted_at: carrierMem.consentTermsV2AceptadoEn.toISOString(),
+        already_accepted: true,
+      });
+    }
+
+    const now = new Date();
+    const ip =
+      c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ?? c.req.header('x-real-ip') ?? null;
+    const userAgent = c.req.header('user-agent') ?? null;
+
+    await opts.db
+      .update(carrierMemberships)
+      .set({
+        consentTermsV2AceptadoEn: now,
+        consentTermsV2Ip: ip,
+        consentTermsV2UserAgent: userAgent,
+        updatedAt: now,
+      })
+      .where(eq(carrierMemberships.id, carrierMem.id));
+
+    opts.logger.info(
+      {
+        userId: user.id,
+        empresaId: empresaIdHeader,
+        carrierMembershipId: carrierMem.id,
+        ip,
+      },
+      'consent terms-v2 aceptado',
+    );
+
+    return c.json({
+      ok: true,
+      accepted_at: now.toISOString(),
+      already_accepted: false,
+    });
+  });
+
+  /**
+   * GET /me/consent/terms-v2 — consulta si el carrier ya aceptó.
+   * Útil para que el frontend decida mostrar el banner.
+   */
+  app.get('/consent/terms-v2', async (c) => {
+    const empresaIdHeader = c.req.header('x-empresa-id');
+    if (!empresaIdHeader) {
+      return c.json({ accepted: false, reason: 'no_active_empresa' });
+    }
+
+    const carrierMemRows = await opts.db
+      .select({
+        consentTermsV2AceptadoEn: carrierMemberships.consentTermsV2AceptadoEn,
+      })
+      .from(carrierMemberships)
+      .where(
+        and(
+          eq(carrierMemberships.empresaId, empresaIdHeader),
+          eq(carrierMemberships.status, 'activa'),
+        ),
+      )
+      .limit(1);
+    const carrierMem = carrierMemRows[0];
+    if (!carrierMem) {
+      // No es carrier → no aplica T&Cs v2; reportar accepted=true para
+      // que el frontend no muestre banner a empresas no-transportistas.
+      return c.json({ accepted: true, reason: 'not_a_carrier' });
+    }
+
+    if (carrierMem.consentTermsV2AceptadoEn) {
+      return c.json({
+        accepted: true,
+        accepted_at: carrierMem.consentTermsV2AceptadoEn.toISOString(),
+      });
+    }
+    return c.json({ accepted: false, reason: 'pending' });
   });
 
   return app;

--- a/apps/api/src/services/confirmar-entrega-viaje.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.ts
@@ -42,6 +42,7 @@ import {
   emitirCertificadoViaje,
 } from './emitir-certificado-viaje.js';
 import { generarCoachingViaje } from './generar-coaching-viaje.js';
+import { liquidarTrip } from './liquidar-trip.js';
 
 /**
  * Status del trip en los que es válido confirmar entrega. Si está
@@ -236,6 +237,46 @@ export async function confirmarEntregaViaje(opts: {
         { err, tripId },
         'generarCoachingViaje fallo — sin coaching persistido para este trip',
       );
+    }
+
+    // Pricing v2 — liquidación post-entrega (ADR-031 §5). Fire-and-forget:
+    // si falla, log error pero NO revierte el deliveredAt. El job futuro
+    // de "reconciliar liquidaciones pendientes" puede tomar trips
+    // entregados sin liquidación. Idempotente vía UNIQUE en asignacion_id.
+    const asgForLiq = await db
+      .select({ id: assignments.id })
+      .from(assignments)
+      .where(eq(assignments.tripId, tripId))
+      .limit(1);
+    const assignmentIdForLiq = asgForLiq[0]?.id;
+    if (assignmentIdForLiq) {
+      liquidarTrip({
+        db,
+        logger,
+        assignmentId: assignmentIdForLiq,
+        pricingV2Activated: appConfig.PRICING_V2_ACTIVATED,
+      })
+        .then((res) => {
+          if (res.status === 'liquidacion_creada' || res.status === 'ya_liquidada') {
+            logger.info(
+              {
+                tripId,
+                assignmentId: assignmentIdForLiq,
+                status: res.status,
+                liquidacionId: res.liquidacionId,
+              },
+              'liquidación post-entrega',
+            );
+          } else {
+            logger.debug({ tripId, status: res.status }, 'liquidación post-entrega skipped');
+          }
+        })
+        .catch((err) => {
+          logger.error(
+            { err, tripId, assignmentId: assignmentIdForLiq },
+            'liquidarTrip falló — revisar manualmente o esperar job de reconciliación',
+          );
+        });
     }
 
     emitirCertificadoViaje({ db, logger, tripId, config })

--- a/apps/api/src/services/onboarding.ts
+++ b/apps/api/src/services/onboarding.ts
@@ -6,6 +6,7 @@ import {
   type EmpresaRow,
   type MembershipRow,
   type UserRow,
+  carrierMemberships,
   empresas,
   memberships,
   plans,
@@ -172,6 +173,17 @@ export async function onboardEmpresa(opts: {
     const membership = membershipInsert[0];
     if (!membership) {
       throw new Error('Insert membership returned no row');
+    }
+
+    // 8. Si la empresa opera como transportista, crear automáticamente
+    // carrier_memberships tier 'free' activa (ADR-031 §3). El consent
+    // T&Cs v2 queda null hasta que el carrier acepte vía UI.
+    if (empresa.isTransportista) {
+      await tx.insert(carrierMemberships).values({
+        empresaId: empresa.id,
+        tierSlug: 'free',
+        status: 'activa',
+      });
     }
 
     logger.info(

--- a/apps/api/test/unit/me-consent-terms-v2.test.ts
+++ b/apps/api/test/unit/me-consent-terms-v2.test.ts
@@ -1,0 +1,257 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMeRoutes } from '../../src/routes/me.js';
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+interface DbQueues {
+  selects?: unknown[][];
+  updates?: unknown[][];
+}
+
+function makeDb(opts: DbQueues = {}) {
+  const selects = [...(opts.selects ?? [])];
+  const updates = [...(opts.updates ?? [])];
+
+  const buildSelectChain = () => {
+    const chain: Record<string, unknown> = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      limit: vi.fn(async () => selects.shift() ?? []),
+    };
+    return chain;
+  };
+  const buildUpdateChain = () => ({
+    set: vi.fn(() => ({
+      where: vi.fn(async () => updates.shift() ?? []),
+    })),
+  });
+
+  return {
+    select: vi.fn(() => buildSelectChain()),
+    update: vi.fn(() => buildUpdateChain()),
+  };
+}
+
+const USER_ID = '11111111-1111-1111-1111-111111111111';
+const EMPRESA_ID = '22222222-2222-2222-2222-222222222222';
+const CARRIER_MEM_ID = '33333333-3333-3333-3333-333333333333';
+
+function buildApp(db: ReturnType<typeof makeDb>, claimsUid = 'fb-uid') {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('firebaseClaims', { uid: claimsUid } as never);
+    await next();
+  });
+  app.route('/me', createMeRoutes({ db: db as never, logger: noopLogger }));
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('POST /me/consent/terms-v2', () => {
+  it('sin X-Empresa-Id → 400 no_active_empresa', async () => {
+    const db = makeDb();
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', { method: 'POST' });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('no_active_empresa');
+  });
+
+  it('user no encontrado → 404', async () => {
+    const db = makeDb({ selects: [[]] }); // user lookup vacío
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', {
+      method: 'POST',
+      headers: { 'X-Empresa-Id': EMPRESA_ID },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('sin membership activa en la empresa → 403', async () => {
+    const db = makeDb({
+      selects: [
+        [{ id: USER_ID }], // user OK
+        [], // membership vacía
+      ],
+    });
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', {
+      method: 'POST',
+      headers: { 'X-Empresa-Id': EMPRESA_ID },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('forbidden_no_membership');
+  });
+
+  it('empresa no es carrier (sin carrier_memberships) → 409 no_carrier_membership', async () => {
+    const db = makeDb({
+      selects: [
+        [{ id: USER_ID }],
+        [{ id: 'm1' }],
+        [], // carrier_memberships vacío
+      ],
+    });
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', {
+      method: 'POST',
+      headers: { 'X-Empresa-Id': EMPRESA_ID },
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('no_carrier_membership');
+  });
+
+  it('idempotente: ya aceptado → 200 already_accepted=true sin UPDATE', async () => {
+    const prevDate = new Date('2026-05-01T00:00:00Z');
+    const db = makeDb({
+      selects: [
+        [{ id: USER_ID }],
+        [{ id: 'm1' }],
+        [
+          {
+            id: CARRIER_MEM_ID,
+            consentTermsV2AceptadoEn: prevDate,
+          },
+        ],
+      ],
+    });
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', {
+      method: 'POST',
+      headers: { 'X-Empresa-Id': EMPRESA_ID },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      accepted_at: string;
+      already_accepted: boolean;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.already_accepted).toBe(true);
+    expect(body.accepted_at).toBe(prevDate.toISOString());
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('happy path: pendiente → UPDATE con IP + UA + timestamp', async () => {
+    const db = makeDb({
+      selects: [
+        [{ id: USER_ID }],
+        [{ id: 'm1' }],
+        [{ id: CARRIER_MEM_ID, consentTermsV2AceptadoEn: null }],
+      ],
+      updates: [[{ id: CARRIER_MEM_ID }]],
+    });
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', {
+      method: 'POST',
+      headers: {
+        'X-Empresa-Id': EMPRESA_ID,
+        'x-forwarded-for': '1.2.3.4',
+        'user-agent': 'TestUA/1.0',
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; already_accepted: boolean };
+    expect(body.ok).toBe(true);
+    expect(body.already_accepted).toBe(false);
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it('x-forwarded-for con múltiples IPs → captura solo la primera', async () => {
+    const setSpy = vi.fn(() => ({ where: vi.fn(async () => []) }));
+    const db = {
+      select: vi.fn(() => {
+        const chain: Record<string, unknown> = {
+          from: vi.fn(() => chain),
+          where: vi.fn(() => chain),
+        };
+        let i = 0;
+        const responses = [
+          [{ id: USER_ID }],
+          [{ id: 'm1' }],
+          [{ id: CARRIER_MEM_ID, consentTermsV2AceptadoEn: null }],
+        ];
+        chain.limit = vi.fn(async () => responses[i++] ?? []);
+        return chain;
+      }),
+      update: vi.fn(() => ({ set: setSpy })),
+    };
+    const app = buildApp(db as never);
+    await app.request('/me/consent/terms-v2', {
+      method: 'POST',
+      headers: {
+        'X-Empresa-Id': EMPRESA_ID,
+        'x-forwarded-for': '1.2.3.4, 5.6.7.8, 9.10.11.12',
+      },
+    });
+    expect(setSpy).toHaveBeenCalledWith(expect.objectContaining({ consentTermsV2Ip: '1.2.3.4' }));
+  });
+});
+
+describe('GET /me/consent/terms-v2', () => {
+  it('sin X-Empresa-Id → accepted:false, reason:no_active_empresa', async () => {
+    const db = makeDb();
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2');
+    const body = (await res.json()) as { accepted: boolean; reason: string };
+    expect(body.accepted).toBe(false);
+    expect(body.reason).toBe('no_active_empresa');
+  });
+
+  it('empresa no es carrier → accepted:true, reason:not_a_carrier', async () => {
+    const db = makeDb({
+      selects: [[]], // carrier_memberships vacío
+    });
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', {
+      headers: { 'X-Empresa-Id': EMPRESA_ID },
+    });
+    const body = (await res.json()) as { accepted: boolean; reason: string };
+    expect(body.accepted).toBe(true);
+    expect(body.reason).toBe('not_a_carrier');
+  });
+
+  it('carrier sin consent → accepted:false, reason:pending', async () => {
+    const db = makeDb({
+      selects: [[{ consentTermsV2AceptadoEn: null }]],
+    });
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', {
+      headers: { 'X-Empresa-Id': EMPRESA_ID },
+    });
+    const body = (await res.json()) as { accepted: boolean; reason: string };
+    expect(body.accepted).toBe(false);
+    expect(body.reason).toBe('pending');
+  });
+
+  it('carrier con consent → accepted:true + accepted_at', async () => {
+    const date = new Date('2026-05-10T00:00:00Z');
+    const db = makeDb({
+      selects: [[{ consentTermsV2AceptadoEn: date }]],
+    });
+    const app = buildApp(db);
+    const res = await app.request('/me/consent/terms-v2', {
+      headers: { 'X-Empresa-Id': EMPRESA_ID },
+    });
+    const body = (await res.json()) as { accepted: boolean; accepted_at: string };
+    expect(body.accepted).toBe(true);
+    expect(body.accepted_at).toBe(date.toISOString());
+  });
+});

--- a/apps/web/src/components/ConsentTermsBanner.test.tsx
+++ b/apps/web/src/components/ConsentTermsBanner.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../lib/api-client.js';
+import { ConsentTermsBanner } from './ConsentTermsBanner.js';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderBanner() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <ConsentTermsBanner />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ConsentTermsBanner', () => {
+  it('isLoading → null (sin flash)', () => {
+    vi.spyOn(api, 'get').mockImplementation(() => new Promise<never>(() => undefined));
+    const { container } = renderBanner();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('accepted=true → null', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      accepted: true,
+      accepted_at: '2026-05-10T12:00:00Z',
+    });
+    const { container } = renderBanner();
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+
+  it('reason=not_a_carrier → null (no aplica a shippers)', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      accepted: true,
+      reason: 'not_a_carrier',
+    });
+    const { container } = renderBanner();
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+
+  it('reason=no_active_empresa → null', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      accepted: false,
+      reason: 'no_active_empresa',
+    });
+    const { container } = renderBanner();
+    await waitFor(() => expect(container.firstChild).toBeNull());
+  });
+
+  it('accepted=false reason=pending → muestra banner con link a /legal/terminos', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      accepted: false,
+      reason: 'pending',
+    });
+    renderBanner();
+    expect(
+      await screen.findByText(/Necesitamos tu aceptación de Términos de Servicio v2/),
+    ).toBeInTheDocument();
+    const link = screen.getByText(/Revisar y aceptar/).closest('a');
+    expect(link).toHaveAttribute('to', '/legal/terminos');
+  });
+});

--- a/apps/web/src/components/ConsentTermsBanner.tsx
+++ b/apps/web/src/components/ConsentTermsBanner.tsx
@@ -1,0 +1,56 @@
+import { Link } from '@tanstack/react-router';
+import { AlertCircle } from 'lucide-react';
+import { useConsentTermsV2 } from '../hooks/use-consent-terms-v2.js';
+
+/**
+ * Banner persistente que invita al carrier a aceptar T&Cs v2 (ADR-031 §4).
+ *
+ * Se muestra cuando:
+ *   - Usuario logueado en una empresa transportista
+ *   - `carrier_memberships.consent_terms_v2_aceptado_en` IS NULL
+ *
+ * Se oculta:
+ *   - Si la empresa activa NO es carrier (backend devuelve accepted=true
+ *     con reason=not_a_carrier)
+ *   - Si ya aceptó
+ *   - Mientras la query está cargando (evita flash visual)
+ *   - Sin empresa activa (no hay carrier_memberships que evaluar)
+ *
+ * Diseñado para ir dentro de `Layout` justo bajo el header.
+ */
+export function ConsentTermsBanner() {
+  const { data, isLoading } = useConsentTermsV2();
+
+  if (isLoading || !data) {
+    return null;
+  }
+  if (data.accepted) {
+    return null;
+  }
+  if (data.reason && data.reason !== 'pending') {
+    return null;
+  }
+
+  return (
+    <output className="block border-amber-200 border-b bg-amber-50 px-4 py-3 sm:px-6">
+      <div className="mx-auto flex max-w-6xl items-start gap-3">
+        <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-amber-700" aria-hidden />
+        <div className="flex-1 text-sm">
+          <p className="font-medium text-amber-900">
+            Necesitamos tu aceptación de Términos de Servicio v2
+          </p>
+          <p className="mt-0.5 text-amber-800">
+            Para liquidar tus viajes (cálculo de comisión + emisión de DTE) necesitamos que aceptes
+            los nuevos Términos de Servicio.
+          </p>
+          <Link
+            to="/legal/terminos"
+            className="mt-2 inline-flex items-center gap-1 font-medium text-amber-900 text-sm underline-offset-2 transition hover:underline"
+          >
+            Revisar y aceptar →
+          </Link>
+        </div>
+      </div>
+    </output>
+  );
+}

--- a/apps/web/src/components/Layout.test.tsx
+++ b/apps/web/src/components/Layout.test.tsx
@@ -19,6 +19,10 @@ vi.mock('../hooks/use-auth.js', () => ({
   signOutUser: vi.fn(async () => undefined),
 }));
 
+vi.mock('./ConsentTermsBanner.js', () => ({
+  ConsentTermsBanner: () => null,
+}));
+
 import { signOutUser } from '../hooks/use-auth.js';
 import { Layout } from './Layout.js';
 

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -5,6 +5,7 @@ import { signOutUser } from '../hooks/use-auth.js';
 import type { MeResponse } from '../hooks/use-me.js';
 import { useSwitchCompany } from '../hooks/use-switch-company.js';
 import { CompanySwitcher } from './CompanySwitcher.js';
+import { ConsentTermsBanner } from './ConsentTermsBanner.js';
 
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 
@@ -166,6 +167,7 @@ export function Layout({
           </div>
         )}
       </header>
+      <ConsentTermsBanner />
       <main className="flex-1">
         <div className="mx-auto max-w-6xl px-4 py-6 sm:px-6 sm:py-10">{children}</div>
       </main>

--- a/apps/web/src/hooks/use-consent-terms-v2.test.tsx
+++ b/apps/web/src/hooks/use-consent-terms-v2.test.tsx
@@ -1,0 +1,90 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../lib/api-client.js';
+import { useAcceptTermsV2Mutation, useConsentTermsV2 } from './use-consent-terms-v2.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useConsentTermsV2', () => {
+  it('accepted=true → reportado tras fetch', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      accepted: true,
+      accepted_at: '2026-05-10T12:00:00Z',
+    });
+    const { result } = renderHook(() => useConsentTermsV2(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.accepted).toBe(true);
+  });
+
+  it('accepted=false reason=pending → carrier sin consent', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({ accepted: false, reason: 'pending' });
+    const { result } = renderHook(() => useConsentTermsV2(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.accepted).toBe(false);
+    expect(result.current.data?.reason).toBe('pending');
+  });
+
+  it('reason=not_a_carrier → accepted true (no aplica)', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      accepted: true,
+      reason: 'not_a_carrier',
+    });
+    const { result } = renderHook(() => useConsentTermsV2(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.accepted).toBe(true);
+    expect(result.current.data?.reason).toBe('not_a_carrier');
+  });
+
+  it('enabled=false → no fetch', () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValue({ accepted: false });
+    renderHook(() => useConsentTermsV2({ enabled: false }), { wrapper: makeWrapper() });
+    expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAcceptTermsV2Mutation', () => {
+  it('mutate → POST /me/consent/terms-v2 con body vacío', async () => {
+    const spy = vi.spyOn(api, 'post').mockResolvedValueOnce({
+      ok: true,
+      accepted_at: '2026-05-10T12:00:00Z',
+      already_accepted: false,
+    });
+    const { result } = renderHook(() => useAcceptTermsV2Mutation(), { wrapper: makeWrapper() });
+    let response: { already_accepted: boolean } | undefined;
+    await act(async () => {
+      response = (await result.current.mutateAsync()) as { already_accepted: boolean };
+    });
+    expect(spy).toHaveBeenCalledWith('/me/consent/terms-v2', {});
+    expect(response?.already_accepted).toBe(false);
+  });
+
+  it('already_accepted=true → respuesta idempotente reportada', async () => {
+    vi.spyOn(api, 'post').mockResolvedValueOnce({
+      ok: true,
+      accepted_at: '2026-05-01T10:00:00Z',
+      already_accepted: true,
+    });
+    const { result } = renderHook(() => useAcceptTermsV2Mutation(), { wrapper: makeWrapper() });
+    let response: { already_accepted: boolean } | undefined;
+    await act(async () => {
+      response = (await result.current.mutateAsync()) as { already_accepted: boolean };
+    });
+    expect(response?.already_accepted).toBe(true);
+  });
+});

--- a/apps/web/src/hooks/use-consent-terms-v2.ts
+++ b/apps/web/src/hooks/use-consent-terms-v2.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { api } from '../lib/api-client.js';
+
+/**
+ * Estado de aceptación de T&Cs v2 del carrier activo (ADR-031 §4).
+ *
+ * El backend evalúa por `X-Empresa-Id` (header inyectado por api-client
+ * desde el localStorage). Si la empresa activa NO es carrier, devuelve
+ * `accepted=true, reason='not_a_carrier'` para que el banner no se
+ * muestre a generadores de carga.
+ */
+export interface ConsentTermsV2Response {
+  accepted: boolean;
+  accepted_at?: string;
+  reason?: 'no_active_empresa' | 'not_a_carrier' | 'pending';
+}
+
+export function useConsentTermsV2(opts: { enabled?: boolean } = {}) {
+  return useQuery<ConsentTermsV2Response>({
+    queryKey: ['consent', 'terms-v2'],
+    queryFn: () => api.get<ConsentTermsV2Response>('/me/consent/terms-v2'),
+    enabled: opts.enabled ?? true,
+    staleTime: 5 * 60 * 1000, // 5 min — no cambia con frecuencia
+    retry: (failureCount) => failureCount < 2,
+  });
+}
+
+export interface AcceptTermsV2Response {
+  ok: true;
+  accepted_at: string;
+  already_accepted: boolean;
+}
+
+export function useAcceptTermsV2Mutation() {
+  const qc = useQueryClient();
+  return useMutation<AcceptTermsV2Response, Error>({
+    mutationFn: () => api.post<AcceptTermsV2Response>('/me/consent/terms-v2', {}),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['consent', 'terms-v2'] });
+    },
+  });
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -7,6 +7,7 @@ import { CargaTrackRoute } from './routes/carga-track.js';
 import { CargasDetalleRoute, CargasListRoute, CargasNuevoRoute } from './routes/cargas.js';
 import { CertificadosRoute } from './routes/certificados.js';
 import { IndexRoute } from './routes/index.js';
+import { LegalTerminosRoute } from './routes/legal-terminos.js';
 import { LoginRoute } from './routes/login.js';
 import { OfertasRoute } from './routes/ofertas.js';
 import { OnboardingRoute } from './routes/onboarding.js';
@@ -143,6 +144,12 @@ const publicTrackingRoute = createRoute({
   component: PublicTrackingRoute,
 });
 
+const legalTerminosRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/legal/terminos',
+  component: LegalTerminosRoute,
+});
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
@@ -162,6 +169,7 @@ const routeTree = rootRoute.addChildren([
   certificadosRoute,
   asignacionDetalleRoute,
   publicTrackingRoute,
+  legalTerminosRoute,
 ]);
 
 export const router = createRouter({

--- a/apps/web/src/routes/legal-terminos.tsx
+++ b/apps/web/src/routes/legal-terminos.tsx
@@ -1,0 +1,253 @@
+import { Link } from '@tanstack/react-router';
+import { ArrowLeft, CheckCircle2, Loader2 } from 'lucide-react';
+import { useAuth } from '../hooks/use-auth.js';
+import { useAcceptTermsV2Mutation, useConsentTermsV2 } from '../hooks/use-consent-terms-v2.js';
+
+/**
+ * /legal/terminos — Página pública con los Términos de Servicio v2
+ * (ADR-031 §4). Si el user está logueado y es carrier sin consent,
+ * muestra botón "Acepto"; si ya aceptó, muestra confirmación.
+ *
+ * No requiere ProtectedRoute: es pública. Pero usa useAuth() para
+ * decidir si renderiza el botón de aceptación.
+ */
+export function LegalTerminosRoute() {
+  const { user, loading } = useAuth();
+  const consentQ = useConsentTermsV2({ enabled: !!user });
+  const acceptM = useAcceptTermsV2Mutation();
+
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <header className="border-neutral-200 border-b bg-white">
+        <div className="mx-auto flex max-w-3xl items-center gap-3 px-4 py-3 sm:px-6">
+          <Link
+            to="/"
+            className="rounded p-1 text-neutral-500 transition hover:bg-neutral-100"
+            aria-label="Volver"
+          >
+            <ArrowLeft className="h-5 w-5" aria-hidden />
+          </Link>
+          <div>
+            <h1 className="font-semibold text-neutral-900 text-lg">Términos de Servicio</h1>
+            <p className="text-neutral-500 text-xs">Versión 2 · Vigente desde 2026-05-10</p>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6">
+        {user &&
+          !loading &&
+          consentQ.data?.accepted === false &&
+          consentQ.data?.reason === 'pending' && (
+            <AcceptanceCard
+              onAccept={() => acceptM.mutate()}
+              isPending={acceptM.isPending}
+              isSuccess={acceptM.isSuccess}
+              isError={acceptM.isError}
+            />
+          )}
+
+        {user && !loading && consentQ.data?.accepted && consentQ.data?.accepted_at && (
+          <AlreadyAcceptedCard acceptedAt={consentQ.data.accepted_at} />
+        )}
+
+        <article className="prose prose-neutral mt-6 max-w-none rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+          <TermsContent />
+        </article>
+      </main>
+    </div>
+  );
+}
+
+function AcceptanceCard(props: {
+  onAccept: () => void;
+  isPending: boolean;
+  isSuccess: boolean;
+  isError: boolean;
+}) {
+  return (
+    <section
+      aria-label="Aceptación de Términos"
+      className="rounded-lg border border-primary-200 bg-primary-50 p-4 shadow-sm"
+    >
+      <h2 className="font-semibold text-neutral-900">Aún no aceptaste estos Términos</h2>
+      <p className="mt-1 text-neutral-700 text-sm">
+        Para recibir liquidaciones de tus viajes en Booster, necesitamos que aceptes los Términos de
+        Servicio v2. Tu aceptación queda registrada con fecha, IP y agente de usuario para fines de
+        auditoría.
+      </p>
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={props.onAccept}
+          disabled={props.isPending || props.isSuccess}
+          className="inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white shadow-xs transition hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {props.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          ) : (
+            <CheckCircle2 className="h-4 w-4" aria-hidden />
+          )}
+          {props.isPending ? 'Registrando aceptación…' : 'Acepto los Términos de Servicio v2'}
+        </button>
+        {props.isError && (
+          <span role="alert" className="text-danger-700 text-sm">
+            No pudimos registrar tu aceptación. Intenta de nuevo.
+          </span>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function AlreadyAcceptedCard(props: { acceptedAt: string }) {
+  const date = new Date(props.acceptedAt);
+  const localized = date.toLocaleString('es-CL', {
+    dateStyle: 'long',
+    timeStyle: 'short',
+    timeZone: 'America/Santiago',
+  });
+  return (
+    <section
+      aria-label="Términos aceptados"
+      className="rounded-lg border border-success-500/30 bg-success-50 p-4 shadow-sm"
+    >
+      <div className="flex items-start gap-3">
+        <CheckCircle2 className="h-5 w-5 shrink-0 text-success-700" aria-hidden />
+        <div>
+          <h2 className="font-semibold text-neutral-900">Aceptaste estos Términos</h2>
+          <p className="mt-1 text-neutral-700 text-sm">
+            Fecha de aceptación: <strong>{localized}</strong>. Esta versión seguirá vigente hasta
+            una próxima actualización (te avisaremos con 30 días de antelación si afecta cobros).
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TermsContent() {
+  return (
+    <>
+      <h2>1. Quiénes somos</h2>
+      <p>
+        Booster AI (en adelante, <strong>"Booster"</strong>) es operado por Booster Chile SpA, RUT
+        XX.XXX.XXX-X, con domicilio en Chile. Para consultas legales escribe a{' '}
+        <a href="mailto:soporte@boosterchile.com">soporte@boosterchile.com</a>.
+      </p>
+      <p>
+        Booster opera un marketplace digital B2B que conecta <strong>generadores de carga</strong>{' '}
+        con <strong>transportistas</strong>. Estos Términos aplican principalmente a los
+        Transportistas que aceptan ofertas y reciben remuneración a través de la plataforma.
+      </p>
+
+      <h2>2. Aceptación</h2>
+      <p>
+        Al hacer click en "Acepto los Términos de Servicio v2" desde tu cuenta, declaras haber
+        leído, comprendido y aceptado este documento en su integridad. La aceptación se registra con
+        marca temporal, dirección IP y agente de usuario para auditoría.
+      </p>
+
+      <h2>3. Operación del marketplace</h2>
+      <p>
+        El generador publica una solicitud de transporte con precio en pesos chilenos. El algoritmo
+        de matching de Booster selecciona transportistas candidatos. Tras la aceptación se genera un
+        compromiso vinculante por el monto acordado. El transportista ejecuta el viaje, registra
+        recogida y entrega; Booster persiste evidencia, telemetría (si hay Teltonika) y certifica la
+        huella de carbono.
+      </p>
+      <h3>Tiers de membresía</h3>
+      <ul>
+        <li>
+          <strong>Free</strong>: $0/mes · comisión 12% · acceso al marketplace y certificación ESG.
+        </li>
+        <li>
+          <strong>Standard</strong>: $15.000/mes · comisión 9% · badge verificado, soporte humano.
+        </li>
+        <li>
+          <strong>Pro</strong>: $45.000/mes · comisión 7% · prioridad alta, dashboards.
+        </li>
+        <li>
+          <strong>Premium</strong>: $120.000/mes · comisión 5% · Teltonika incluido, prioridad
+          máxima.
+        </li>
+      </ul>
+      <p>
+        Al registrarte entras automáticamente al tier <strong>Free</strong>.
+      </p>
+
+      <h2>4. Modelo de cobro</h2>
+      <p>
+        Cuando un viaje queda <strong>entregado</strong>, Booster calcula automáticamente la
+        comisión sobre el monto bruto del viaje según el tier, aplica IVA 19% y emite DTE Tipo 33
+        (Factura Electrónica) al transportista. El transportista emite DTE Tipo 52 (Guía de
+        Despacho) al generador por el monto bruto.
+      </p>
+      <p>Ejemplo: viaje de $200.000 con tier Free (12%):</p>
+      <ul>
+        <li>Monto bruto: $200.000</li>
+        <li>Comisión Booster: $24.000</li>
+        <li>IVA: $4.560</li>
+        <li>
+          <strong>Factura Booster al carrier:</strong> $28.560
+        </li>
+        <li>
+          <strong>Neto al carrier:</strong> $176.000
+        </li>
+      </ul>
+
+      <h2>5. Obligaciones del Transportista</h2>
+      <ol>
+        <li>Ejecutar los viajes aceptados con vehículos, conductores y permisos al día.</li>
+        <li>Mantener actualizada su información tributaria y de contacto.</li>
+        <li>Reportar incidentes a la brevedad por canales oficiales.</li>
+        <li>No usar la plataforma para evadir obligaciones laborales con sus conductores.</li>
+        <li>Permitir telemetría cuando aplique (tier Premium con device subsidiado).</li>
+        <li>Aceptar el cargo de la comisión dentro de los plazos del DTE.</li>
+      </ol>
+
+      <h2>6. Obligaciones de Booster</h2>
+      <ol>
+        <li>SLA objetivo del 99% mensual (excluyendo mantenimientos comunicados).</li>
+        <li>
+          Procesar liquidaciones con la metodología publicada, auditablemente y sin alteración
+          retroactiva.
+        </li>
+        <li>Emitir DTE conforme al SII chileno vía proveedor certificado.</li>
+        <li>Proteger datos personales conforme a la Ley 19.628.</li>
+        <li>Comunicar cambios materiales con 30 días de anticipación.</li>
+      </ol>
+
+      <h2>7. Disputas</h2>
+      <p>
+        Si consideras que una liquidación tiene errores, puedes abrir disputa dentro de los 30 días
+        corridos desde la emisión. Booster revisa en máximo 10 días hábiles.
+      </p>
+
+      <h2>8. Datos personales</h2>
+      <p>
+        Aplicable la Política de Privacidad vigente. Booster <strong>no vende</strong> datos a
+        terceros. Comparte solo lo estrictamente necesario con proveedores tecnológicos (Google
+        Cloud, Twilio, Sovos) bajo confidencialidad.
+      </p>
+
+      <h2>9. Modificaciones</h2>
+      <p>
+        Booster puede modificar estos Términos. Cambios materiales y adversos se notifican con 30
+        días de anticipación; puedes dar de baja tu cuenta sin penalidad antes de la entrada en
+        vigor.
+      </p>
+
+      <h2>10. Ley aplicable</h2>
+      <p>
+        Estos Términos se rigen por las leyes de Chile. Disputas no resueltas amistosamente se
+        someten a tribunales ordinarios de Santiago.
+      </p>
+
+      <p className="text-neutral-500 text-xs">
+        Versión completa con todas las cláusulas legales: ver{' '}
+        <code>docs/legal/terminos-de-servicio-v2.md</code> en el repositorio público de Booster.
+      </p>
+    </>
+  );
+}

--- a/docs/adr/031-pricing-v2-activacion-escala-minima.md
+++ b/docs/adr/031-pricing-v2-activacion-escala-minima.md
@@ -1,0 +1,190 @@
+# ADR-031 — Activación de pricing v2 con escala mínima (1 cliente, 1 vehículo)
+
+**Status**: Accepted
+**Date**: 2026-05-10
+**Decider**: Felipe Vicencio (Product Owner)
+**Technical contributor**: Claude (Cowork) actuando como arquitecto de software
+**Supersedes parcialmente**: [ADR-030 §"Activación en producción"](./030-pricing-v2-activation-commission-and-billing.md)
+**Related**:
+- [ADR-027 Pricing v1](./027-pricing-model-uniform-shipper-set-with-tier-commission-roadmap.md) (superseded por ADR-030)
+- [ADR-030 Pricing v2 — foundation](./030-pricing-v2-activation-commission-and-billing.md)
+- [ADR-024 SII provider Sovos](./024-sii-provider-sovos-with-multi-vendor-strategy.md)
+- [ADR-026 Carrier membership tiers](./026-carrier-membership-tiers-and-revenue-model.md)
+
+---
+
+## Contexto
+
+ADR-030 definió la foundation técnica de pricing v2 detrás del feature flag `PRICING_V2_ACTIVATED` y estableció **6 criterios duros** para prender el flag en producción:
+
+1. ≥30 carriers activos con ≥1 trip/mes
+2. ≥3 meses de operación sin incidentes
+3. T&Cs v2 firmadas por ≥80% carriers
+4. Sovos sandbox: 100% trips piloto sin rechazo SII durante 30 días
+5. Migration aplicada en staging con dataset real
+6. Comunicación a carriers 30 días antes del primer cobro
+
+El Product Owner aprobó el **2026-05-10** una **flexibilización del criterio de escala**: el código de pricing v2 debe operar en producción **desde el primer carrier**, incluso si hay un solo cliente con un solo vehículo. La razón es estratégica:
+
+- **Validación temprana del modelo en condiciones reales** (vs sandbox/staging) sin riesgo material — un carrier x un trip x 12% de comisión es revenue marginal pero datos operativos críticos.
+- **Evitar el "limbo de no-monetización indefinida"** que el propio ADR-027 advertía como riesgo ("se quedó así para siempre").
+- **El consent firmado por el carrier es prerequisito legal individualizado**, no agregado: con consent firmado por 1 sólo carrier ya hay base contractual para emitirle factura.
+- **Sovos integration es bloqueante para emisión DTE**, pero NO para cálculo + persistencia. Las liquidaciones pueden quedar en `lista_para_dte` sin emitir; el carrier ve su monto neto, Booster ve la comisión devengada, y cuando Sovos esté integrado se emite el DTE retroactivo.
+
+Este ADR redefine los criterios de activación para alinear con esa decisión.
+
+---
+
+## Decisión
+
+### 1. Criterios de activación productiva (revisados)
+
+Reemplaza la lista del ADR-030 §"Activación en producción" por:
+
+**Bloqueantes** (sin esto, el flag NO se prende):
+
+- [ ] **Migration aplicada en producción**: tablas creadas, seed cargado.
+- [ ] **Onboarding empresa transportista crea automáticamente carrier_memberships tier free + status='activa'**: sin esto, el primer trip entregado no se liquida (`skipped_no_membership`).
+- [ ] **T&Cs v2 publicadas en `/legal/terminos`** y accesibles públicamente.
+- [ ] **Endpoint `POST /me/consent/terms-v2` implementado y testeado**: registra `consent_terms_v2_aceptado_en`, IP y user-agent.
+- [ ] **UI de aceptación** funcional en `apps/web` (banner persistente hasta que el carrier acepte).
+
+**No bloqueantes** (el flag puede prenderse sin esto; Sovos se integra después):
+
+- ⏸ **Sovos integration real**: mientras tanto, liquidaciones quedan `lista_para_dte` sin emisión DTE. Job `emitir-dte-pendientes` se implementa cuando Sovos esté listo y procesa el backlog acumulado retroactivamente.
+- ⏸ **Cobro automático mensual de membership fees**: tier `free` no factura mensual, así que para 1 cliente tier free esto no aplica. Se activa cuando haya el primer carrier en tier Standard/Pro/Premium.
+- ⏸ **Comunicación masiva pre-cobro**: con 1-10 carriers el contacto es individual, no requiere campaña.
+
+**Removidos** (el criterio agregado ya no aplica):
+
+- ~~≥30 carriers activos con ≥1 trip/mes~~ → reemplazado por "carrier_memberships poblado en onboarding".
+- ~~≥3 meses sin incidentes~~ → estabilidad se valida con el primer trip real; cualquier incidente surface inmediatamente, no se espera 3 meses.
+- ~~≥80% carriers consent firmado~~ → el consent es per-carrier; el flag puede prenderse antes de tener ningún consent (las liquidaciones quedan en `pending_consent` hasta que el carrier acepte).
+
+### 2. Default del flag por entorno
+
+Cambia el default de `PRICING_V2_ACTIVATED` para que **prod tenga `true` automáticamente** sin requerir setear env var explícito:
+
+```typescript
+// apps/api/src/config.ts
+PRICING_V2_ACTIVATED: z.coerce.boolean().default(
+  process.env.NODE_ENV === 'production',  // true en prod, false else
+),
+```
+
+Razones:
+
+- **Producción**: `NODE_ENV=production` está garantizado por Cloud Run → flag automáticamente `true` desde el primer deploy posterior a este ADR.
+- **Dev/test/staging**: `NODE_ENV` distinto a `'production'` → flag `false`; los tests existentes que dependen del comportamiento legacy no se rompen.
+- **Override explícito**: setear `PRICING_V2_ACTIVATED=false` en Cloud Run revierte la activación en segundos sin tocar BD ni código.
+
+### 3. Auto-creación de membership al onboarding
+
+`apps/api/src/services/onboarding.ts` debe, además del INSERT actual de `users` + `empresas` + `memberships`, hacer **INSERT condicional**:
+
+```typescript
+if (empresa.isTransportista) {
+  INSERT INTO carrier_memberships (
+    empresa_id, tier_slug, status, activada_en
+  ) VALUES (
+    new_empresa.id, 'free', 'activa', now()
+  );
+}
+```
+
+Esto garantiza que **todo carrier nuevo arranca con tier `free`** (comisión 12%, fee mensual $0). El upgrade a tiers superiores ocurre via UI futura (no en este ADR).
+
+### 4. Flow de consent T&Cs v2
+
+Cuando el carrier:
+1. Entra a `/app` y NO tiene `consent_terms_v2_aceptado_en` populado → banner persistente "Para recibir tu liquidación necesitas aceptar los Términos de Servicio v2" con link a `/legal/terminos`.
+2. Lee los términos y click "Acepto" → POST `/me/consent/terms-v2` → backend hace `UPDATE carrier_memberships SET consent_terms_v2_aceptado_en = now(), consent_terms_v2_ip = $ip, consent_terms_v2_user_agent = $ua WHERE empresa_id = $activeEmpresa AND status = 'activa'`.
+3. Banner desaparece. Liquidaciones futuras se crean con `status='lista_para_dte'`. Las que ya estaban `pending_consent` quedan así (un job manual de "reactivar pending consent" puede transicionarlas; out-of-scope hoy).
+
+### 5. Trigger de liquidación: confirmación de entrega
+
+`apps/api/src/services/confirmar-entrega-viaje.ts` (existente) llama `liquidarTrip()` **después** del UPDATE de `deliveredAt`. Es **fire-and-forget**: si falla, log error pero NO revierte el `deliveredAt` — el trip ya está entregado, la liquidación se puede reintentar manualmente desde un endpoint de soporte (out-of-scope).
+
+```typescript
+// pseudo-code
+await db.transaction((tx) => {
+  // ... UPDATE assignment SET deliveredAt = now() ...
+});
+
+// Post-commit, fire-and-forget.
+void liquidarTrip({
+  db, logger, assignmentId,
+  pricingV2Activated: config.PRICING_V2_ACTIVATED,
+}).catch((err) => {
+  logger.error({ err, assignmentId }, 'liquidarTrip fallo post-entrega — revisar manualmente');
+});
+```
+
+### 6. Validación de impacto bajo el modelo "1 cliente"
+
+Para un caso real con 1 carrier tier free + 1 trip entregado mensual a $200.000 CLP:
+
+- Comisión Booster: `200.000 × 12% = $24.000`
+- IVA: `24.000 × 19% = $4.560`
+- Factura Booster→carrier: `$28.560`
+- Neto al carrier: `$176.000` (lo que paga el shipper menos comisión)
+- DTE: queda en `lista_para_dte` hasta que Sovos esté integrado. El monto **es real y está devengado** desde el punto de vista contable de Booster.
+
+Con 0 carriers, el código está dormido (no se ejecuta nada). Con 1 carrier sin consent, las liquidaciones quedan `pending_consent` y el carrier ve un banner pidiéndole aceptar.
+
+---
+
+## Consecuencias
+
+### Positivas
+
+- **Activación real con riesgo controlado**: el primer cliente es ground truth operativo, no piloto sintético.
+- **Sin "limbo de no-monetización"**: el modelo de revenue está vivo desde el primer trip, evita el riesgo identificado en ADR-027.
+- **Reversibilidad mantenida**: `PRICING_V2_ACTIVATED=false` en Cloud Run revierte en segundos.
+- **DTE retroactivo cuando Sovos esté listo**: las liquidaciones acumuladas en `lista_para_dte` se procesan en batch; el cliente recibe sus facturas con la fecha de servicio original.
+- **Auditoría intacta**: cada liquidación captura `pricing_methodology_version` + `tier_slug_aplicado` + montos + timestamps; sin importar cuándo se emita el DTE, los datos son consistentes.
+
+### Negativas / costos
+
+- **Riesgo de calcular comisiones sin poder facturar inmediatamente**: si Sovos tarda meses, hay backlog. Mitigación: implementar `emitir-dte-pendientes` como prioridad post-activación.
+- **Asimetría temporal carrier↔Booster**: el carrier puede percibir que Booster "le retiene" comisión sin emitir factura. Mitigación: comunicación explícita 1:1 con el primer cliente sobre el cronograma de DTE.
+- **No hay cobro real al carrier hasta que DTE se emite + se transfiere**: la comisión está **devengada** (en BD) pero **no cobrada** (en banco) hasta el proceso completo. Esto es un timing accounting, no un problema contable.
+
+### Acciones derivadas (este PR)
+
+1. **T&Cs v2 documento** en `docs/legal/terminos-de-servicio-v2.md` y página pública `/legal/terminos` en `apps/web`.
+2. **Endpoint** `POST /me/consent/terms-v2` en `apps/api`.
+3. **UI consent** en `apps/web` (banner + página dedicada de aceptación).
+4. **Auto-membership** en `services/onboarding.ts`.
+5. **Wire trigger** en `services/confirmar-entrega-viaje.ts`.
+6. **Default flag** por `NODE_ENV` en `config.ts`.
+7. **Tests** para todos los anteriores.
+
+### Acciones diferidas explícitamente
+
+- **Sovos integration** (`apps/document-service`): se implementa cuando el primer carrier reciba >5 liquidaciones acumuladas y la urgencia de emitir DTE sea real. Mientras tanto, las liquidaciones se persisten correctamente y `emitir-dte-pendientes` queda como TODO documentado.
+- **Cron mensual de membership fees**: se implementa cuando exista el primer carrier tier Standard/Pro/Premium.
+- **UI de upgrade de tier**: cuando un carrier free quiera pasar a Standard. Mientras tanto, upgrade manual vía SQL + comunicación 1:1.
+- **Runbook de disputa** `docs/runbooks/liquidacion-disputa.md`: cuando ocurra la primera disputa.
+
+---
+
+## Validación (este PR)
+
+- [x] T&Cs v2 redactadas (jurídicamente coherentes para escala mínima — revisión legal formal antes del primer DTE real).
+- [x] Endpoint `/me/consent/terms-v2` implementado + tests.
+- [x] UI consent banner en `apps/web` + página `/legal/terminos`.
+- [x] `services/onboarding.ts` crea `carrier_memberships` para empresas transportistas.
+- [x] `services/confirmar-entrega-viaje.ts` invoca `liquidarTrip()` fire-and-forget post-commit.
+- [x] `config.ts` default flag por `NODE_ENV`.
+- [x] Coverage api ≥80% lines mantenido.
+- [ ] (Externo / no este PR) Sovos integration real.
+- [ ] (Externo / no este PR) Comunicación con el primer carrier sobre el cronograma de DTE.
+
+---
+
+## Notas
+
+- El cambio de "≥30 carriers" a "1 cliente OK" no relaja la **rigurosidad del cálculo** — el pricing-engine sigue siendo 100% testeado y el service de liquidación sigue siendo idempotente. Lo que se relaja es el criterio de **escala temporal** para activar, no el criterio de **corrección técnica**.
+- Si la operación real revela inconsistencias entre el cálculo y la realidad del negocio (ej. necesidad de un cargo adicional, descuento por volumen), se documenta en nuevo ADR + bump de `pricing_methodology_version`. Liquidaciones ya emitidas no se re-emiten.
+- Este ADR no toca terraform/infra. La activación es por `NODE_ENV=production` que Cloud Run ya tiene seteado.

--- a/docs/legal/terminos-de-servicio-v2.md
+++ b/docs/legal/terminos-de-servicio-v2.md
@@ -1,0 +1,277 @@
+# Términos de Servicio Booster AI — v2
+
+**Versión**: 2.0
+**Vigente desde**: 2026-05-10
+**Última actualización**: 2026-05-10
+
+> Estos Términos reemplazan cualquier versión anterior. El uso continuado
+> de Booster AI tras la aceptación de esta versión implica la aceptación
+> íntegra del documento.
+
+---
+
+## 1. Quiénes somos
+
+Booster AI (en adelante, **"Booster"**) es operado por Booster Chile SpA,
+RUT XX.XXX.XXX-X, con domicilio en [dirección Chile]. Cualquier
+comunicación legal o consulta sobre estos Términos puede dirigirse a
+[soporte@boosterchile.com](mailto:soporte@boosterchile.com).
+
+Booster opera un marketplace digital B2B que conecta:
+
+- **Generadores de carga** (en adelante, **"Generadores"**): empresas con
+  necesidad de transportar mercaderías en territorio chileno.
+- **Transportistas** (en adelante, **"Transportistas"**): empresas con
+  flota propia y conductores que ejecutan los viajes.
+
+Estos Términos aplican principalmente a los **Transportistas** que
+acepten ofertas y reciban remuneración a través de la plataforma. Los
+términos para Generadores se rigen por un acuerdo separado.
+
+## 2. Aceptación
+
+Al hacer click en "Acepto los Términos de Servicio v2" desde
+[app.boosterchile.com](https://app.boosterchile.com), el Transportista
+declara haber leído, comprendido y aceptado este documento en su
+integridad. La aceptación se registra técnicamente con marca temporal,
+dirección IP y agente de usuario para fines de auditoría.
+
+El Transportista declara estar facultado legalmente para vincular a su
+empresa (cargo de representante legal, dueño, administrador o
+mandatario expreso). Booster puede solicitar validación adicional de
+dicha facultad cuando el monto operado lo justifique.
+
+## 3. Operación del marketplace
+
+### 3.1 Cómo funciona
+
+1. El Generador publica una solicitud de transporte con precio sugerido
+   en pesos chilenos (CLP).
+2. El algoritmo de matching de Booster (descrito en términos técnicos en
+   nuestra documentación pública) selecciona Transportistas candidatos.
+3. El Transportista recibe ofertas y puede aceptarlas o rechazarlas.
+4. La aceptación genera un compromiso vinculante de transporte por el
+   monto acordado (`agreedPriceClp`).
+5. El Transportista ejecuta el viaje, registra recogida y entrega.
+6. Booster persiste evidencia, telemetría (si el vehículo tiene
+   Teltonika) y certifica la huella de carbono del viaje.
+
+### 3.2 Tier de membresía
+
+Cada Transportista pertenece a un **tier** que determina:
+
+- **Comisión** que Booster cobra sobre el monto bruto del viaje.
+- **Fee mensual** de membresía (si aplica).
+- **Beneficios** adicionales (prioridad de matching, dispositivo
+  Teltonika subsidiado, etc.).
+
+| Tier | Fee mensual | Comisión | Beneficios principales |
+|---|---|---|---|
+| Free | $0 | 12% | Acceso al marketplace, certificación ESG |
+| Standard | $15.000 | 9% | Badge verificado, soporte humano |
+| Pro | $45.000 | 7% | Prioridad alta, dashboards, integración contable |
+| Premium | $120.000 | 5% | Teltonika incluido, prioridad máxima |
+
+Al registrarte como Transportista entras automáticamente al tier
+**Free**. El upgrade o downgrade se gestiona desde tu perfil. Los
+fees mensuales se facturan el primer día hábil de cada mes con
+vencimiento a 14 días.
+
+## 4. Modelo de cobro
+
+### 4.1 Comisión sobre viajes ("liquidación")
+
+Cuando un viaje queda **entregado** (estado `entregado` en la
+plataforma), Booster calcula automáticamente:
+
+```
+comisión        = monto_bruto × comisión_pct_tier
+IVA comisión    = comisión × 19%
+factura Booster = comisión + IVA
+neto carrier    = monto_bruto − comisión
+```
+
+**Ejemplo**: viaje de $200.000 con tier Free (12%):
+
+- Monto bruto: $200.000
+- Comisión Booster: $24.000
+- IVA: $4.560
+- **Factura Booster al carrier**: $28.560 (DTE Tipo 33)
+- **Neto al carrier**: $176.000 (lo que paga el Generador)
+
+### 4.2 Emisión de documentos tributarios (DTE)
+
+- **Booster emite DTE Tipo 33 (Factura Electrónica)** al Transportista
+  por el monto `factura Booster` (comisión + IVA). Esta es la
+  contraprestación por el servicio de marketplace y telemetría.
+- **El Transportista emite DTE Tipo 52 (Guía de Despacho electrónica)**
+  al Generador por el monto bruto, en tanto persona obligada a la
+  facturación del servicio de transporte. Booster puede emitir el
+  Tipo 52 "en nombre de" el Transportista, previo mandato expreso y
+  certificado digital cargado, conforme a las normas del Servicio de
+  Impuestos Internos (SII).
+
+### 4.3 Flujo de dinero
+
+El pago del monto bruto del viaje fluye **directamente del Generador al
+Transportista** (mecanismo: transferencia bancaria coordinada
+externamente, o pago intermediado por Booster cuando se active el
+módulo "pronto pago" — opcional).
+
+Booster cobra su comisión **al Transportista** vía la factura Tipo 33
+emitida, con vencimiento a 30 días corridos desde la emisión.
+
+### 4.4 Versión de la metodología de cálculo
+
+Cada liquidación captura el `pricing_methodology_version` vigente al
+momento del cierre del viaje (por ejemplo, `pricing-v2.0-cl-2026.06`).
+Los cambios futuros a tasas de comisión, IVA o reglas de redondeo
+**no se aplican retroactivamente** a liquidaciones ya emitidas.
+
+## 5. Obligaciones del Transportista
+
+El Transportista se compromete a:
+
+1. **Ejecutar los viajes aceptados** con sus propios vehículos,
+   conductores con licencia vigente, seguros al día y permisos
+   correspondientes (carga peligrosa, internacional, etc. cuando aplique).
+2. **Mantener al día su información tributaria** (RUT vigente, dirección
+   actualizada, datos bancarios para coordinación de pagos).
+3. **Reportar incidentes** (atrasos, accidentes, daños, robos) a la
+   brevedad por los canales oficiales (in-app o
+   soporte@boosterchile.com).
+4. **No utilizar la plataforma para evadir** obligaciones laborales con
+   sus conductores. Booster no actúa como empleador del personal del
+   Transportista bajo ninguna circunstancia.
+5. **Permitir telemetría** (cuando aplique al tier Premium con dispositivo
+   subsidiado) durante la vigencia del beneficio.
+6. **Aceptar el cargo de la comisión** dentro de los plazos de la DTE
+   emitida. Mora en el pago puede resultar en suspensión del acceso al
+   marketplace.
+
+## 6. Obligaciones de Booster
+
+Booster se compromete a:
+
+1. **Mantener disponible** la plataforma con un SLA objetivo del 99% de
+   uptime mensual (excluyendo mantenimientos comunicados con 24h de
+   anticipación).
+2. **Procesar liquidaciones** con la metodología publicada,
+   auditablemente y sin alteración retroactiva.
+3. **Emitir DTE Tipo 33** con la oportunidad y formato que exige el SII
+   chileno, vía proveedor certificado (Sovos u otro de capacidad
+   equivalente). Los plazos de emisión pueden tener desfase justificado
+   por integración con el SII; en ningún caso supera 60 días desde la
+   entrega del viaje.
+4. **Proteger datos personales** del Transportista, sus conductores y
+   contactos conforme a la Ley 19.628 y normas posteriores. Detalles en
+   la Política de Privacidad publicada.
+5. **Comunicar cambios materiales** a estos Términos con al menos 30
+   días de anticipación cuando el cambio afecte adversamente al
+   Transportista (subida de comisión, eliminación de beneficios, etc.).
+
+## 7. Disputas, contracargos y cancelaciones
+
+### 7.1 Disputa de liquidación
+
+Si el Transportista considera que una liquidación tiene errores
+(monto, comisión aplicada, tier incorrecto), puede abrirla en disputa
+desde la plataforma o vía soporte@boosterchile.com dentro de los **30
+días corridos** desde la emisión. Booster revisa en máximo 10 días
+hábiles. Resolución posible:
+
+- **Procedente**: Booster anula el DTE original y emite uno nuevo
+  corregido (sin costo para el Transportista).
+- **Improcedente**: Booster mantiene el monto. El Transportista mantiene
+  el derecho de escalar a SERNAC o tribunales civiles según corresponda.
+
+### 7.2 Cancelación de viajes
+
+El comportamiento de cancelaciones (penalty, reembolso, indemnización)
+se rige por las reglas operativas vigentes al momento del incidente.
+Estas reglas se mantienen públicas y separadas de este documento por
+ser de mayor frecuencia de actualización.
+
+### 7.3 Suspensión
+
+Booster puede **suspender** la cuenta del Transportista cuando:
+
+- Acumule 30+ días de mora en facturas de comisión.
+- Reciba múltiples reportes verificados de mala praxis (cargas no
+  entregadas, daños sistemáticos, comportamiento abusivo).
+- Incumpla obligaciones tributarias verificables (RUT inhabilitado).
+- Esté involucrado en investigación judicial que comprometa la
+  reputación del marketplace.
+
+La suspensión es notificada con 48h de anticipación cuando es por mora
+o inactividad. Es inmediata cuando es por fraude o riesgo material a
+otros usuarios.
+
+## 8. Datos personales y privacidad
+
+El procesamiento de datos personales se rige por la **Política de
+Privacidad** vigente. Resumen de los puntos críticos para este contrato:
+
+- Booster recolecta datos del Transportista (RUT, datos de contacto),
+  sus conductores (nombre, licencia) y de los viajes (ubicación GPS si
+  hay telemetría, evidencia fotográfica).
+- Los datos se procesan en Chile y en regiones GCP autorizadas.
+- Booster **no vende** datos a terceros. Comparte datos con:
+  - Proveedores tecnológicos esenciales (Google Cloud, Twilio, Sovos)
+    bajo acuerdos de confidencialidad.
+  - Autoridades cuando es legalmente requerido.
+  - Generadores **estrictamente** los datos necesarios para la
+    ejecución del viaje aceptado (placa, contacto del conductor durante
+    el viaje, ubicación en tiempo real).
+
+## 9. Propiedad intelectual
+
+- La plataforma, marcas, logos y código de Booster son propiedad de
+  Booster Chile SpA. El Transportista recibe una licencia limitada,
+  revocable y no exclusiva para usar la plataforma según estos
+  Términos.
+- Los datos generados por el Transportista (descripciones de carga,
+  fotos de evidencia, etc.) **permanecen propiedad del Transportista**.
+  Booster recibe licencia para usarlos exclusivamente para operar la
+  plataforma, generar certificados ESG y reportes anonimizados.
+
+## 10. Modificaciones
+
+Booster puede modificar estos Términos. Las modificaciones se notifican:
+
+- **Materiales y adversas** al Transportista: con 30 días de
+  anticipación, vía email y banner persistente en la app. El
+  Transportista puede dar de baja su cuenta sin penalidad antes de que
+  entren en vigor.
+- **No materiales** (correcciones, aclaraciones, modificaciones que
+  benefician al Transportista): se publican y entran en vigor
+  inmediatamente.
+
+El uso continuado tras la entrada en vigor implica aceptación.
+
+## 11. Ley aplicable y jurisdicción
+
+Estos Términos se rigen por las leyes de la República de Chile.
+Cualquier disputa que no pueda resolverse amistosamente se somete a la
+jurisdicción de los tribunales ordinarios de Santiago, salvo que las
+normas de protección al consumidor exijan otra cosa.
+
+## 12. Disposiciones finales
+
+- **Independencia de cláusulas**: si una cláusula resulta inválida, las
+  demás permanecen vigentes.
+- **No renuncia**: el no ejercicio de un derecho por parte de Booster
+  no implica renuncia futura.
+- **Comunicaciones**: por defecto a la dirección de email registrada en
+  la cuenta. El Transportista debe mantenerla actualizada.
+
+---
+
+**Aceptación**
+
+Al hacer click en **"Acepto"** desde tu cuenta Booster, manifiestas
+voluntad expresa de quedar vinculado a este contrato. Tu aceptación
+queda registrada con marca temporal, dirección IP y agente de usuario.
+
+Puedes descargar una copia firmada digitalmente (PDF) desde tu perfil
+después de aceptar.


### PR DESCRIPTION
## Resumen

Cierra **ADR-031**: activa pricing v2 en producción desde el primer carrier (no espera ≥30). El default del feature flag pasa a `true` cuando `NODE_ENV=production`. Implementa todo lo faltante para operar end-to-end excepto Sovos (diferido explícitamente).

## Componentes nuevos

### 1. [ADR-031](docs/adr/031-pricing-v2-activacion-escala-minima.md)
Supersede §"Activación en producción" del ADR-030. Reemplaza los 6 criterios duros por bloqueantes operacionales realistas. Default del flag por \`NODE_ENV\`.

### 2. T&Cs v2 — documento legal y página pública
- [\`docs/legal/terminos-de-servicio-v2.md\`](docs/legal/terminos-de-servicio-v2.md) (12 secciones, Chile/CLP, modelo comisión + tiers + DTE + disputas)
- Página pública [\`/legal/terminos\`](apps/web/src/routes/legal-terminos.tsx) con texto renderizado + botón "Acepto" para carriers sin consent

### 3. Backend
- \`POST /me/consent/terms-v2\` — registra consent con IP + UA + timestamp; idempotente
- \`GET /me/consent/terms-v2\` — consulta estado (\`accepted\`/\`pending\`/\`not_a_carrier\`)
- **11 tests** cubriendo cada branch

### 4. Auto-membership al onboarding
\`apps/api/src/services/onboarding.ts\` inserta condicionalmente:
\`\`\`sql
INSERT INTO carrier_memberships (empresa_id, tier_slug, status)
VALUES (\$1, 'free', 'activa')
WHERE empresa.is_transportista = true
\`\`\`

### 5. Wire trigger fire-and-forget
\`apps/api/src/services/confirmar-entrega-viaje.ts\` invoca \`liquidarTrip()\` post-commit después de setear \`deliveredAt\`.

### 6. Frontend
- \`ConsentTermsBanner\` component — banner persistente con link a \`/legal/terminos\`; solo visible si carrier sin consent
- Integrado en \`Layout\` justo bajo el header
- Hooks \`useConsentTermsV2\` + \`useAcceptTermsV2Mutation\`
- **11 tests**

### 7. Config flag por NODE_ENV
\`\`\`ts
PRICING_V2_ACTIVATED: z.coerce
  .boolean()
  .default(process.env.NODE_ENV === 'production'),
\`\`\`

## Coverage final

| Workspace | Lines | Branches | Functions |
|-----------|-------|----------|-----------|
| api | 83.90% | 76.05% | 85.46% |
| web | 88.83% | 78.51% | 86.81% |

Ambos sobre threshold 80/75/75/80.

## Diferido (OK por ADR-031)

- ⏸ **Sovos integration** — \`apps/document-service\` queda esqueleto. Las liquidaciones se acumulan en \`lista_para_dte\` (auditables) hasta que Sovos esté listo y se procesen retroactivamente.
- ⏸ **Cron mensual membership fees** — no aplica para tier Free; se activa con el primer carrier Standard/Pro/Premium.
- ⏸ **UI upgrade de tier** — manual vía SQL + comunicación 1:1 mientras tanto.

## Test plan

- [x] \`pnpm lint\` verde
- [x] \`pnpm typecheck\` verde
- [x] \`pnpm --filter @booster-ai/api test\` 497/497 verde
- [x] \`pnpm --filter @booster-ai/web test\` 724/724 verde
- [x] Coverage api y web sobre threshold
- [ ] CI: 14 checks SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)