### PR TITLE
fix(web): detección 404 en ErrorState del tracking público

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,8 @@ __pycache__/
 
 # Claude Code local settings
 .claude/
+
+# Playwright screenshots (UI verification debug artifacts)
+*.png
+!apps/**/*.png
+!packages/**/*.png

--- a/apps/web/src/routes/public-tracking.tsx
+++ b/apps/web/src/routes/public-tracking.tsx
@@ -38,6 +38,7 @@ import {
   type PublicTrackingFoundResponse,
   usePublicTracking,
 } from '../hooks/use-public-tracking.js';
+import { ApiError } from '../lib/api-client.js';
 
 export function PublicTrackingRoute() {
   const { token } = useParams({ strict: false }) as { token: string };
@@ -98,7 +99,10 @@ function LoadingState() {
 }
 
 function ErrorState({ error }: { error: unknown }) {
-  const isNotFound = error instanceof Error && error.message.includes('404');
+  // ApiError pasa el `error` field del response como `message`, así que
+  // `error.message` es típicamente 'not_found' (no contiene '404').
+  // Chequear directamente el status numérico es la forma confiable.
+  const isNotFound = error instanceof ApiError && error.status === 404;
   return (
     <div className="rounded-lg border border-amber-200 bg-amber-50 p-6 shadow-sm">
       <div className="flex items-start gap-3">


### PR DESCRIPTION
## Summary

Bug encontrado durante verificación UI manual con Playwright contra prod.

**Síntoma**: la página \`/tracking/\$token\` con token inválido mostraba el mensaje genérico \"No se pudo cargar el seguimiento — Intenta refrescar la página en unos segundos\" en vez del específico \"Link de seguimiento no válido — verifica que el link sea correcto\".

**Causa**: \`ApiError\` constructor recibe \`errMessage = payload.error\` como 4to argumento. Para 404, el response del API es \`{\"error\": \"not_found\"}\`, así que \`super(message)\` se llama con \"not_found\" → \`error.message = \"not_found\"\` (sin \"404\").

El check anterior:

\`\`\`ts
const isNotFound = error instanceof Error && error.message.includes('404');
\`\`\`

nunca matcheaba en flow real. Los tests pasaban porque pasaban solo 3 args al ApiError constructor, dejando que use el default \`API error 404 (not_found)\` que sí contiene \"404\".

## Fix

\`\`\`ts
const isNotFound = error instanceof ApiError && error.status === 404;
\`\`\`

Confiable en ambos cases (test stub + flow real). Tests siguen verdes.

## Evidencia

Screenshot del bug (mensaje genérico cuando debería ser específico):
- Antes: \"No se pudo cargar el seguimiento\" (genérico)
- Después del fix: \"Link de seguimiento no válido\" (específico, con copy de \"verifica que el link sea correcto\")

\`pnpm test\` ✓ tests existentes verdes (passaban antes y siguen pasando).
\`pnpm typecheck\` ✓
\`pnpm lint\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)