### PR TITLE
feat(factoring-v1): ADR-029 v1 + foundation Cobra Hoy (flag-gated, partner-mode)

### DIFF
--- a/apps/api/drizzle/0017_factoring_v1.sql
+++ b/apps/api/drizzle/0017_factoring_v1.sql
@@ -1,0 +1,85 @@
+-- Migration 0017 — Factoring v1 (ADR-029 + ADR-032)
+-- =============================================================================
+-- Tablas para el producto "Booster Cobra Hoy":
+--   - shipper_credit_decisions : underwriting cacheado por shipper (30d default)
+--   - adelantos_carrier        : 1 por asignación (UNIQUE), captura tarifa +
+--                                monto adelantado + estado del flow
+--
+-- Diseño compatible con feature flag `FACTORING_V1_ACTIVATED`. Las tablas
+-- existen apenas se aplica la migration pero permanecen vacías hasta que
+-- el flag se prende.
+
+-- =============================================================================
+-- 1. shipper_credit_decisions
+-- =============================================================================
+CREATE TABLE shipper_credit_decisions (
+  id                              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_shipper_id              uuid NOT NULL REFERENCES empresas(id) ON DELETE RESTRICT,
+  approved                        boolean NOT NULL,
+  limit_exposure_clp              integer NOT NULL DEFAULT 0 CHECK (limit_exposure_clp >= 0),
+  current_exposure_clp            integer NOT NULL DEFAULT 0 CHECK (current_exposure_clp >= 0),
+  equifax_score                   integer CHECK (equifax_score IS NULL OR (equifax_score >= 0 AND equifax_score <= 1000)),
+  decided_at                      timestamptz NOT NULL DEFAULT now(),
+  decided_by                      text NOT NULL CHECK (decided_by IN ('automatico','manual')),
+  expires_at                      timestamptz NOT NULL,
+  motivo                          text,
+  creado_en                       timestamptz NOT NULL DEFAULT now(),
+  actualizado_en                  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Solo UNA decisión vigente por shipper (las expiradas quedan para auditoría).
+CREATE UNIQUE INDEX uq_shipper_credit_decisions_vigente
+  ON shipper_credit_decisions(empresa_shipper_id)
+  WHERE expires_at > now();
+
+CREATE INDEX idx_shipper_credit_decisions_expires
+  ON shipper_credit_decisions(expires_at);
+
+COMMENT ON TABLE shipper_credit_decisions IS
+  'Underwriting de shippers para Cobra Hoy (ADR-029 §3 + ADR-032 §5). Cacheado 30d default.';
+
+-- =============================================================================
+-- 2. adelantos_carrier
+-- =============================================================================
+CREATE TABLE adelantos_carrier (
+  id                              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  asignacion_id                   uuid NOT NULL UNIQUE REFERENCES assignments(id) ON DELETE RESTRICT,
+  liquidacion_id                  uuid REFERENCES liquidaciones(id),
+  empresa_carrier_id              uuid NOT NULL REFERENCES empresas(id),
+  empresa_shipper_id              uuid NOT NULL REFERENCES empresas(id),
+  monto_neto_clp                  integer NOT NULL CHECK (monto_neto_clp >= 0),
+  plazo_dias_shipper              integer NOT NULL CHECK (plazo_dias_shipper > 0),
+  tarifa_pct                      numeric(4,2) NOT NULL CHECK (tarifa_pct >= 0 AND tarifa_pct <= 100),
+  tarifa_clp                      integer NOT NULL CHECK (tarifa_clp >= 0),
+  monto_adelantado_clp            integer NOT NULL CHECK (monto_adelantado_clp >= 0),
+  partner_slug                    text,
+  partner_request_id              text,
+  status                          text NOT NULL CHECK (status IN (
+                                    'solicitado',
+                                    'aprobado',
+                                    'desembolsado',
+                                    'cobrado_a_shipper',
+                                    'mora',
+                                    'cancelado',
+                                    'rechazado'
+                                  )),
+  rechazo_motivo                  text,
+  desembolsado_en                 timestamptz,
+  cobrado_a_shipper_en            timestamptz,
+  mora_desde                      timestamptz,
+  factoring_methodology_version   text NOT NULL,
+  creado_en                       timestamptz NOT NULL DEFAULT now(),
+  actualizado_en                  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_adelantos_carrier_empresa_status
+  ON adelantos_carrier(empresa_carrier_id, status);
+CREATE INDEX idx_adelantos_carrier_shipper_status
+  ON adelantos_carrier(empresa_shipper_id, status);
+CREATE INDEX idx_adelantos_carrier_methodology
+  ON adelantos_carrier(factoring_methodology_version);
+CREATE INDEX idx_adelantos_carrier_status_creado
+  ON adelantos_carrier(status, creado_en DESC);
+
+COMMENT ON COLUMN adelantos_carrier.factoring_methodology_version IS
+  'INMUTABLE post-INSERT. Permite recomputar la tarifa con la lógica de la época.';

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1779321600000,
       "tag": "0016_trip_events_incidente",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1779408000000,
+      "tag": "0017_factoring_v1",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@booster-ai/coaching-generator": "workspace:*",
     "@booster-ai/config": "workspace:*",
     "@booster-ai/driver-scoring": "workspace:*",
+    "@booster-ai/factoring-engine": "workspace:*",
     "@booster-ai/logger": "workspace:*",
     "@booster-ai/matching-algorithm": "workspace:*",
     "@booster-ai/notification-fan-out": "workspace:*",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -288,6 +288,27 @@ const apiEnvSchema = commonEnvSchema
      * env revierte la activación en segundos sin tocar BD ni código.
      */
     PRICING_V2_ACTIVATED: z.coerce.boolean().default(process.env.NODE_ENV === 'production'),
+
+    /**
+     * Feature flag para activar factoring v1 / "Booster Cobra Hoy"
+     * (ADR-029 + ADR-032). Default por entorno:
+     *   - production → `true`
+     *   - dev/test/staging → `false`
+     *
+     * Cuando es `false`:
+     *   - `cobraHoy()` retorna `skipped_flag_disabled`.
+     *   - Endpoints devuelven 503 con `feature_disabled`.
+     *   - UI no muestra botón "Cobra hoy".
+     *
+     * Cuando es `true`:
+     *   - Endpoints operan pero requieren que el shipper tenga
+     *     `shipper_credit_decisions.approved=true` vigente. Sin
+     *     decisión aprobada → 422 `shipper_no_aprobado`.
+     *   - El partner factoring real (Toctoc/Mafin/Increase/Cumplo)
+     *     queda diferido — adelantos quedan en `solicitado` hasta
+     *     integración del partner.
+     */
+    FACTORING_V1_ACTIVATED: z.coerce.boolean().default(process.env.NODE_ENV === 'production'),
   });
 
 export type ApiEnv = z.infer<typeof apiEnvSchema>;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1457,6 +1457,97 @@ export const facturasBoosterClp = pgTable(
 );
 
 // =============================================================================
+// FACTORING V1 (ADR-029 + ADR-032)
+// =============================================================================
+
+/**
+ * Underwriting cacheado por shipper. Decisión vigente única por
+ * empresa (unique partial index aplicado en SQL). Decisiones expiradas
+ * quedan en BD para auditoría histórica.
+ */
+export const shipperCreditDecisions = pgTable(
+  'shipper_credit_decisions',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    empresaShipperId: uuid('empresa_shipper_id')
+      .notNull()
+      .references(() => empresas.id, { onDelete: 'restrict' }),
+    approved: boolean('approved').notNull(),
+    limitExposureClp: integer('limit_exposure_clp').notNull().default(0),
+    currentExposureClp: integer('current_exposure_clp').notNull().default(0),
+    equifaxScore: integer('equifax_score'),
+    decidedAt: timestamp('decided_at', { withTimezone: true }).notNull().defaultNow(),
+    decidedBy: text('decided_by').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    motivo: text('motivo'),
+    createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    decidedByCheck: check(
+      'chk_shipper_credit_decisions_decided_by',
+      sql`${table.decidedBy} IN ('automatico','manual')`,
+    ),
+    expiresIdx: index('idx_shipper_credit_decisions_expires').on(table.expiresAt),
+  }),
+);
+
+/**
+ * Adelantos de pronto pago al carrier (Booster Cobra Hoy). 1:1 con
+ * assignment (UNIQUE constraint). Captura tarifa + monto adelantado +
+ * versión de metodología al momento del adelanto, INMUTABLE.
+ */
+export const adelantosCarrier = pgTable(
+  'adelantos_carrier',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    asignacionId: uuid('asignacion_id')
+      .notNull()
+      .unique()
+      .references(() => assignments.id, { onDelete: 'restrict' }),
+    liquidacionId: uuid('liquidacion_id').references(() => liquidaciones.id),
+    empresaCarrierId: uuid('empresa_carrier_id')
+      .notNull()
+      .references(() => empresas.id),
+    empresaShipperId: uuid('empresa_shipper_id')
+      .notNull()
+      .references(() => empresas.id),
+    montoNetoClp: integer('monto_neto_clp').notNull(),
+    plazoDiasShipper: integer('plazo_dias_shipper').notNull(),
+    tarifaPct: numeric('tarifa_pct', { precision: 4, scale: 2 }).notNull(),
+    tarifaClp: integer('tarifa_clp').notNull(),
+    montoAdelantadoClp: integer('monto_adelantado_clp').notNull(),
+    partnerSlug: text('partner_slug'),
+    partnerRequestId: text('partner_request_id'),
+    status: text('status').notNull(),
+    rechazoMotivo: text('rechazo_motivo'),
+    desembolsadoEn: timestamp('desembolsado_en', { withTimezone: true }),
+    cobradoAShipperEn: timestamp('cobrado_a_shipper_en', { withTimezone: true }),
+    moraDesde: timestamp('mora_desde', { withTimezone: true }),
+    factoringMethodologyVersion: text('factoring_methodology_version').notNull(),
+    createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    statusCheck: check(
+      'chk_adelantos_carrier_status',
+      sql`${table.status} IN ('solicitado','aprobado','desembolsado','cobrado_a_shipper','mora','cancelado','rechazado')`,
+    ),
+    empresaStatusIdx: index('idx_adelantos_carrier_empresa_status').on(
+      table.empresaCarrierId,
+      table.status,
+    ),
+    shipperStatusIdx: index('idx_adelantos_carrier_shipper_status').on(
+      table.empresaShipperId,
+      table.status,
+    ),
+    methodologyIdx: index('idx_adelantos_carrier_methodology').on(
+      table.factoringMethodologyVersion,
+    ),
+  }),
+);
+
+// =============================================================================
 // TYPE EXPORTS
 // =============================================================================
 
@@ -1505,3 +1596,8 @@ export type LiquidacionRow = typeof liquidaciones.$inferSelect;
 export type NewLiquidacionRow = typeof liquidaciones.$inferInsert;
 export type FacturaBoosterClpRow = typeof facturasBoosterClp.$inferSelect;
 export type NewFacturaBoosterClpRow = typeof facturasBoosterClp.$inferInsert;
+
+export type ShipperCreditDecisionRow = typeof shipperCreditDecisions.$inferSelect;
+export type NewShipperCreditDecisionRow = typeof shipperCreditDecisions.$inferInsert;
+export type AdelantoCarrierRow = typeof adelantosCarrier.$inferSelect;
+export type NewAdelantoCarrierRow = typeof adelantosCarrier.$inferInsert;

--- a/apps/api/src/routes/cobra-hoy.ts
+++ b/apps/api/src/routes/cobra-hoy.ts
@@ -1,0 +1,186 @@
+import type { Logger } from '@booster-ai/logger';
+import { desc, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { config as appConfig } from '../config.js';
+import type { Db } from '../db/client.js';
+import { adelantosCarrier } from '../db/schema.js';
+import { cobraHoy, cotizarCobraHoy } from '../services/cobra-hoy.js';
+import type { UserContext } from '../services/user-context.js';
+
+/**
+ * Rutas de "Booster Cobra Hoy" (ADR-029 + ADR-032).
+ *
+ *   - GET  /assignments/:id/cobra-hoy/cotizacion → preview de tarifa
+ *   - POST /assignments/:id/cobra-hoy            → solicitar adelanto
+ *   - GET  /me/cobra-hoy/historial               → lista de adelantos del
+ *                                                   carrier activo
+ *
+ * Los 3 endpoints requieren `userContext` (firebaseAuth + userContextMiddleware).
+ *
+ * Feature flag: si `FACTORING_V1_ACTIVATED=false`, los endpoints
+ * responden 503 con `feature_disabled`. La UI lee esto para esconder
+ * el botón.
+ */
+
+export function createCobraHoyAssignmentsRoutes(opts: { db: Db; logger: Logger }) {
+  const app = new Hono();
+
+  app.get('/:id/cobra-hoy/cotizacion', async (c) => {
+    if (!appConfig.FACTORING_V1_ACTIVATED) {
+      return c.json({ error: 'feature_disabled' }, 503);
+    }
+    const userContext = c.get('userContext') as UserContext | undefined;
+    if (!userContext || !userContext.activeMembership) {
+      return c.json({ error: 'no_active_empresa' }, 400);
+    }
+    const empresaCarrierId = userContext.activeMembership.empresa.id;
+    const asignacionId = c.req.param('id');
+    const plazoQuery = c.req.query('plazo_dias');
+    const plazoDiasShipper = plazoQuery ? Number(plazoQuery) : undefined;
+    if (
+      plazoDiasShipper !== undefined &&
+      (!Number.isInteger(plazoDiasShipper) || plazoDiasShipper <= 0)
+    ) {
+      return c.json({ error: 'invalid_plazo' }, 400);
+    }
+
+    const result = await cotizarCobraHoy({
+      db: opts.db,
+      asignacionId,
+      empresaCarrierId,
+      ...(plazoDiasShipper !== undefined ? { plazoDiasShipper } : {}),
+    });
+
+    if (result.status === 'assignment_not_found') {
+      return c.json({ error: 'assignment_not_found' }, 404);
+    }
+    if (result.status === 'forbidden_owner_mismatch') {
+      return c.json({ error: 'forbidden_owner_mismatch' }, 403);
+    }
+    if (result.status === 'no_liquidacion') {
+      return c.json({ error: 'no_liquidacion' }, 409);
+    }
+    return c.json({
+      monto_neto_clp: result.montoNetoClp,
+      plazo_dias_shipper: result.plazoDiasShipper,
+      tarifa_pct: result.tarifaPct,
+      tarifa_clp: result.tarifaClp,
+      monto_adelantado_clp: result.montoAdelantadoClp,
+    });
+  });
+
+  app.post('/:id/cobra-hoy', async (c) => {
+    if (!appConfig.FACTORING_V1_ACTIVATED) {
+      return c.json({ error: 'feature_disabled' }, 503);
+    }
+    const userContext = c.get('userContext') as UserContext | undefined;
+    if (!userContext || !userContext.activeMembership) {
+      return c.json({ error: 'no_active_empresa' }, 400);
+    }
+    const empresaCarrierId = userContext.activeMembership.empresa.id;
+    const asignacionId = c.req.param('id');
+
+    const result = await cobraHoy({
+      db: opts.db,
+      logger: opts.logger,
+      asignacionId,
+      empresaCarrierId,
+      factoringV1Activated: appConfig.FACTORING_V1_ACTIVATED,
+    });
+
+    switch (result.status) {
+      case 'skipped_flag_disabled':
+        return c.json({ error: 'feature_disabled' }, 503);
+      case 'assignment_not_found':
+        return c.json({ error: 'assignment_not_found' }, 404);
+      case 'assignment_not_delivered':
+        return c.json(
+          { error: 'assignment_not_delivered', message: 'El viaje aún no fue marcado entregado' },
+          409,
+        );
+      case 'no_liquidacion':
+        return c.json(
+          { error: 'no_liquidacion', message: 'La liquidación del viaje no existe todavía' },
+          409,
+        );
+      case 'forbidden_owner_mismatch':
+        return c.json({ error: 'forbidden_owner_mismatch' }, 403);
+      case 'shipper_no_aprobado':
+        return c.json({ error: 'shipper_no_aprobado', message: result.motivo }, 422);
+      case 'limite_exposicion_excedido':
+        return c.json(
+          {
+            error: 'limite_exposicion_excedido',
+            limit_clp: result.limitClp,
+            exposicion_clp: result.exposicionClp,
+          },
+          422,
+        );
+      case 'ya_solicitado':
+        return c.json({ ok: true, already_requested: true, adelanto_id: result.adelantoId }, 200);
+      case 'solicitado':
+        return c.json(
+          {
+            ok: true,
+            already_requested: false,
+            adelanto_id: result.adelantoId,
+            tarifa_pct: result.tarifaPct,
+            tarifa_clp: result.tarifaClp,
+            monto_adelantado_clp: result.montoAdelantadoClp,
+          },
+          201,
+        );
+    }
+  });
+
+  return app;
+}
+
+export function createCobraHoyMeRoutes(opts: { db: Db; logger: Logger }) {
+  const app = new Hono();
+
+  app.get('/cobra-hoy/historial', async (c) => {
+    if (!appConfig.FACTORING_V1_ACTIVATED) {
+      return c.json({ error: 'feature_disabled' }, 503);
+    }
+    const userContext = c.get('userContext') as UserContext | undefined;
+    if (!userContext || !userContext.activeMembership) {
+      return c.json({ error: 'no_active_empresa' }, 400);
+    }
+    const empresaCarrierId = userContext.activeMembership.empresa.id;
+    const rows = await opts.db
+      .select({
+        id: adelantosCarrier.id,
+        asignacionId: adelantosCarrier.asignacionId,
+        montoNetoClp: adelantosCarrier.montoNetoClp,
+        plazoDiasShipper: adelantosCarrier.plazoDiasShipper,
+        tarifaPct: adelantosCarrier.tarifaPct,
+        tarifaClp: adelantosCarrier.tarifaClp,
+        montoAdelantadoClp: adelantosCarrier.montoAdelantadoClp,
+        status: adelantosCarrier.status,
+        desembolsadoEn: adelantosCarrier.desembolsadoEn,
+        createdAt: adelantosCarrier.createdAt,
+      })
+      .from(adelantosCarrier)
+      .where(eq(adelantosCarrier.empresaCarrierId, empresaCarrierId))
+      .orderBy(desc(adelantosCarrier.createdAt))
+      .limit(100);
+
+    return c.json({
+      adelantos: rows.map((r) => ({
+        id: r.id,
+        asignacion_id: r.asignacionId,
+        monto_neto_clp: r.montoNetoClp,
+        plazo_dias_shipper: r.plazoDiasShipper,
+        tarifa_pct: Number(r.tarifaPct),
+        tarifa_clp: r.tarifaClp,
+        monto_adelantado_clp: r.montoAdelantadoClp,
+        status: r.status,
+        desembolsado_en: r.desembolsadoEn?.toISOString() ?? null,
+        creado_en: r.createdAt.toISOString(),
+      })),
+    });
+  });
+
+  return app;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -14,6 +14,7 @@ import { createAdminJobsRoutes } from './routes/admin-jobs.js';
 import { createAssignmentsRoutes } from './routes/assignments.js';
 import { createCertificatesRoutes } from './routes/certificates.js';
 import { createChatRoutes } from './routes/chat.js';
+import { createCobraHoyAssignmentsRoutes, createCobraHoyMeRoutes } from './routes/cobra-hoy.js';
 import { createEmpresaRoutes } from './routes/empresas.js';
 import { createHealthRouter } from './routes/health.js';
 import { createMeConsentsRoutes } from './routes/me-consents.js';
@@ -156,6 +157,9 @@ export function createServer(opts: CreateServerOptions): Hono {
     // Stakeholder consent grants (ADR-028 §"Acciones derivadas §7"). Sólo
     // requiere firebaseAuth — el handler resuelve userId vía firebase_uid.
     meRouter.route('/consents', createMeConsentsRoutes({ db: opts.db, logger }));
+    // Cobra Hoy historial (requiere userContext para empresa activa).
+    app.use('/me/cobra-hoy/*', userContextMiddlewareForMe);
+    meRouter.route('/', createCobraHoyMeRoutes({ db: opts.db, logger }));
     app.route('/me', meRouter);
 
     // Empresas — POST /empresas/onboarding crea user+empresa+membership.
@@ -256,6 +260,8 @@ export function createServer(opts: CreateServerOptions): Hono {
       ...(config.CHAT_PUBSUB_TOPIC ? { pubsubTopic: config.CHAT_PUBSUB_TOPIC } : {}),
     });
     assignmentsRouter.route('/', chatRouter);
+    // Cobra Hoy assignment-scoped (ADR-029 + ADR-032).
+    assignmentsRouter.route('/', createCobraHoyAssignmentsRoutes({ db: opts.db, logger }));
     app.route('/assignments', assignmentsRouter);
 
     // Certificates — listado privado (auth shipper) + verify público.

--- a/apps/api/src/services/cobra-hoy.ts
+++ b/apps/api/src/services/cobra-hoy.ts
@@ -1,0 +1,303 @@
+import { calcularTarifaProntoPago } from '@booster-ai/factoring-engine';
+import type { Logger } from '@booster-ai/logger';
+import { and, eq, gt, sql } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import {
+  adelantosCarrier,
+  assignments,
+  liquidaciones,
+  shipperCreditDecisions,
+  trips,
+} from '../db/schema.js';
+
+/**
+ * Service orquestador de "Booster Cobra Hoy" (ADR-029 + ADR-032).
+ *
+ * Cotización: función pura que no toca BD (puede usarse para preview
+ * antes del POST).
+ *
+ * Solicitud: idempotente vía UNIQUE constraint en `asignacion_id`. Si
+ * ya hay adelanto para esta asignación, retorna `ya_solicitado` con
+ * el id del adelanto existente.
+ *
+ * Flow:
+ *   1. Flag check
+ *   2. Lookup assignment + trip + liquidacion
+ *   3. Validar shipper credit decision vigente + approved
+ *   4. Validar exposición no excedida
+ *   5. Calcular tarifa pura
+ *   6. INSERT adelantos_carrier status='solicitado'
+ *
+ * Partner integration real (Toctoc/Mafin/etc) NO es responsabilidad
+ * de este service — un job separado o webhook del partner avanza
+ * adelantos de 'solicitado' → 'aprobado' → 'desembolsado'.
+ */
+
+export interface CobraHoyInput {
+  db: Db;
+  logger: Logger;
+  asignacionId: string;
+  empresaCarrierId: string;
+  factoringV1Activated: boolean;
+}
+
+export type CobraHoyResult =
+  | { status: 'skipped_flag_disabled' }
+  | { status: 'assignment_not_found' }
+  | { status: 'assignment_not_delivered' }
+  | { status: 'no_liquidacion' }
+  | { status: 'forbidden_owner_mismatch' }
+  | { status: 'shipper_no_aprobado'; motivo: string }
+  | { status: 'limite_exposicion_excedido'; limitClp: number; exposicionClp: number }
+  | { status: 'ya_solicitado'; adelantoId: string }
+  | {
+      status: 'solicitado';
+      adelantoId: string;
+      tarifaPct: number;
+      tarifaClp: number;
+      montoAdelantadoClp: number;
+    };
+
+export interface CotizacionInput {
+  db: Db;
+  asignacionId: string;
+  empresaCarrierId: string;
+  plazoDiasShipper?: number;
+}
+
+export type CotizacionResult =
+  | { status: 'assignment_not_found' }
+  | { status: 'no_liquidacion' }
+  | { status: 'forbidden_owner_mismatch' }
+  | {
+      status: 'ok';
+      montoNetoClp: number;
+      plazoDiasShipper: number;
+      tarifaPct: number;
+      tarifaClp: number;
+      montoAdelantadoClp: number;
+    };
+
+/**
+ * Plazo de pago default del shipper, en días, cuando el trip no lo
+ * declara explícitamente. Configurable cuando el modelo evolucione a
+ * negociación shipper-by-shipper.
+ */
+const PLAZO_SHIPPER_DEFAULT_DIAS = 30;
+
+/**
+ * Calcula el preview (cotización) de Cobra Hoy sin escribir nada en BD.
+ * Útil para que el frontend muestre el desglose antes de confirmar.
+ *
+ * No exige flag — el preview puede mostrarse aunque el flag esté off,
+ * para que el frontend pueda comunicar "esto recibirías" educacional.
+ * Pero la confirmación real (POST cobraHoy) sí exige flag.
+ */
+export async function cotizarCobraHoy(input: CotizacionInput): Promise<CotizacionResult> {
+  const {
+    db,
+    asignacionId,
+    empresaCarrierId,
+    plazoDiasShipper = PLAZO_SHIPPER_DEFAULT_DIAS,
+  } = input;
+
+  const asgRows = await db
+    .select({
+      id: assignments.id,
+      empresaCarrierId: assignments.empresaId,
+      deliveredAt: assignments.deliveredAt,
+    })
+    .from(assignments)
+    .where(eq(assignments.id, asignacionId))
+    .limit(1);
+  const asg = asgRows[0];
+  if (!asg) {
+    return { status: 'assignment_not_found' };
+  }
+  if (asg.empresaCarrierId !== empresaCarrierId) {
+    return { status: 'forbidden_owner_mismatch' };
+  }
+
+  const liqRows = await db
+    .select({ montoNetoCarrierClp: liquidaciones.montoNetoCarrierClp })
+    .from(liquidaciones)
+    .where(eq(liquidaciones.asignacionId, asignacionId))
+    .limit(1);
+  const liq = liqRows[0];
+  if (!liq) {
+    return { status: 'no_liquidacion' };
+  }
+
+  const tarifa = calcularTarifaProntoPago({
+    montoNetoClp: liq.montoNetoCarrierClp,
+    plazoDiasShipper,
+  });
+  return {
+    status: 'ok',
+    montoNetoClp: tarifa.montoNetoClp,
+    plazoDiasShipper: tarifa.plazoDiasShipper,
+    tarifaPct: tarifa.tarifaPct,
+    tarifaClp: tarifa.tarifaClp,
+    montoAdelantadoClp: tarifa.montoAdelantadoClp,
+  };
+}
+
+/**
+ * Solicita un adelanto de pronto pago. Service con I/O — toca varias
+ * tablas en cascada de validación.
+ */
+export async function cobraHoy(input: CobraHoyInput): Promise<CobraHoyResult> {
+  const { db, logger, asignacionId, empresaCarrierId, factoringV1Activated } = input;
+
+  if (!factoringV1Activated) {
+    logger.debug({ asignacionId }, 'cobraHoy: FACTORING_V1_ACTIVATED=false, skip');
+    return { status: 'skipped_flag_disabled' };
+  }
+
+  // (1) Lookup assignment + ownership + delivered.
+  const asgRows = await db
+    .select({
+      id: assignments.id,
+      tripId: assignments.tripId,
+      empresaCarrierId: assignments.empresaId,
+      deliveredAt: assignments.deliveredAt,
+    })
+    .from(assignments)
+    .where(eq(assignments.id, asignacionId))
+    .limit(1);
+  const asg = asgRows[0];
+  if (!asg) {
+    return { status: 'assignment_not_found' };
+  }
+  if (asg.empresaCarrierId !== empresaCarrierId) {
+    return { status: 'forbidden_owner_mismatch' };
+  }
+  if (!asg.deliveredAt) {
+    return { status: 'assignment_not_delivered' };
+  }
+
+  // (2) Lookup trip para empresaShipperId.
+  const tripRows = await db
+    .select({
+      generadorCargaEmpresaId: trips.generadorCargaEmpresaId,
+    })
+    .from(trips)
+    .where(eq(trips.id, asg.tripId))
+    .limit(1);
+  const trip = tripRows[0];
+  if (!trip || !trip.generadorCargaEmpresaId) {
+    return { status: 'assignment_not_found' };
+  }
+  const empresaShipperId = trip.generadorCargaEmpresaId;
+
+  // (3) Lookup liquidación.
+  const liqRows = await db
+    .select({
+      id: liquidaciones.id,
+      montoNetoCarrierClp: liquidaciones.montoNetoCarrierClp,
+    })
+    .from(liquidaciones)
+    .where(eq(liquidaciones.asignacionId, asignacionId))
+    .limit(1);
+  const liq = liqRows[0];
+  if (!liq) {
+    return { status: 'no_liquidacion' };
+  }
+
+  // (4) Lookup shipper credit decision vigente.
+  const decRows = await db
+    .select({
+      approved: shipperCreditDecisions.approved,
+      limitExposureClp: shipperCreditDecisions.limitExposureClp,
+      currentExposureClp: shipperCreditDecisions.currentExposureClp,
+      motivo: shipperCreditDecisions.motivo,
+    })
+    .from(shipperCreditDecisions)
+    .where(
+      and(
+        eq(shipperCreditDecisions.empresaShipperId, empresaShipperId),
+        gt(shipperCreditDecisions.expiresAt, sql`now()`),
+      ),
+    )
+    .limit(1);
+  const dec = decRows[0];
+  if (!dec || !dec.approved) {
+    return {
+      status: 'shipper_no_aprobado',
+      motivo: dec?.motivo ?? 'Shipper sin decisión vigente aprobada',
+    };
+  }
+
+  // (5) Validar exposición + monto del adelanto no exceda límite.
+  const tarifa = calcularTarifaProntoPago({
+    montoNetoClp: liq.montoNetoCarrierClp,
+    plazoDiasShipper: PLAZO_SHIPPER_DEFAULT_DIAS,
+  });
+  const nuevaExposicion = dec.currentExposureClp + tarifa.montoAdelantadoClp;
+  if (nuevaExposicion > dec.limitExposureClp) {
+    return {
+      status: 'limite_exposicion_excedido',
+      limitClp: dec.limitExposureClp,
+      exposicionClp: nuevaExposicion,
+    };
+  }
+
+  // (6) INSERT idempotente.
+  try {
+    const inserted = await db
+      .insert(adelantosCarrier)
+      .values({
+        asignacionId,
+        liquidacionId: liq.id,
+        empresaCarrierId,
+        empresaShipperId,
+        montoNetoClp: tarifa.montoNetoClp,
+        plazoDiasShipper: tarifa.plazoDiasShipper,
+        tarifaPct: tarifa.tarifaPct.toFixed(2),
+        tarifaClp: tarifa.tarifaClp,
+        montoAdelantadoClp: tarifa.montoAdelantadoClp,
+        status: 'solicitado',
+        factoringMethodologyVersion: tarifa.factoringMethodologyVersion,
+      })
+      .returning({ id: adelantosCarrier.id });
+
+    const adelantoId = inserted[0]?.id;
+    if (!adelantoId) {
+      throw new Error('cobraHoy: INSERT no devolvió id');
+    }
+
+    logger.info(
+      {
+        asignacionId,
+        adelantoId,
+        empresaCarrierId,
+        empresaShipperId,
+        montoNeto: tarifa.montoNetoClp,
+        tarifa: tarifa.tarifaClp,
+        montoAdelantado: tarifa.montoAdelantadoClp,
+      },
+      'cobraHoy: adelanto solicitado',
+    );
+
+    return {
+      status: 'solicitado',
+      adelantoId,
+      tarifaPct: tarifa.tarifaPct,
+      tarifaClp: tarifa.tarifaClp,
+      montoAdelantadoClp: tarifa.montoAdelantadoClp,
+    };
+  } catch (err) {
+    if (err instanceof Error && /unique|duplicate/i.test(err.message)) {
+      const existing = await db
+        .select({ id: adelantosCarrier.id })
+        .from(adelantosCarrier)
+        .where(eq(adelantosCarrier.asignacionId, asignacionId))
+        .limit(1);
+      const existingId = existing[0]?.id;
+      if (existingId) {
+        return { status: 'ya_solicitado', adelantoId: existingId };
+      }
+    }
+    throw err;
+  }
+}

--- a/apps/api/test/unit/cobra-hoy-routes.test.ts
+++ b/apps/api/test/unit/cobra-hoy-routes.test.ts
@@ -1,0 +1,328 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config as appConfig } from '../../src/config.js';
+import {
+  createCobraHoyAssignmentsRoutes,
+  createCobraHoyMeRoutes,
+} from '../../src/routes/cobra-hoy.js';
+import type { UserContext } from '../../src/services/user-context.js';
+
+/**
+ * Tests HTTP de las rutas de Cobra Hoy. La lógica de negocio ya está
+ * cubierta por `cobra-hoy.test.ts` (15 tests del service). Acá validamos
+ * solamente:
+ *
+ *   - Flag-gating (503 cuando FACTORING_V1_ACTIVATED=false).
+ *   - userContext faltante (400 no_active_empresa).
+ *   - Mapping correcto de service result → status HTTP + body.
+ *   - Parsing de query params (plazo_dias).
+ *
+ * Mockeamos el service para no acoplar a la BD.
+ */
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+const cotizarSpy = vi.fn();
+const cobraHoySpy = vi.fn();
+vi.mock('../../src/services/cobra-hoy.js', () => ({
+  cotizarCobraHoy: (...args: unknown[]) => cotizarSpy(...args),
+  cobraHoy: (...args: unknown[]) => cobraHoySpy(...args),
+}));
+
+const EMPRESA_ID = '11111111-1111-1111-1111-111111111111';
+const USER_CTX: UserContext = {
+  user: { id: 'u1', firebaseUid: 'fb1', fullName: 'F', email: 'f@x.cl' },
+  activeMembership: {
+    id: 'm1',
+    role: 'dueno',
+    status: 'activa',
+    empresa: {
+      id: EMPRESA_ID,
+      legalName: 'E',
+      rut: '76',
+      isGeneradorCarga: false,
+      isTransportista: true,
+      status: 'activa',
+    },
+  },
+  memberships: [],
+} as unknown as UserContext;
+
+function makeAssignmentsApp(opts: { withContext: boolean; db?: unknown }) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (opts.withContext) {
+      c.set('userContext', USER_CTX);
+    }
+    await next();
+  });
+  app.route(
+    '/assignments',
+    createCobraHoyAssignmentsRoutes({
+      db: (opts.db ?? {}) as never,
+      logger: noopLogger,
+    }),
+  );
+  return app;
+}
+
+function makeMeApp(opts: { withContext: boolean; db: unknown }) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (opts.withContext) {
+      c.set('userContext', USER_CTX);
+    }
+    await next();
+  });
+  app.route(
+    '/me',
+    createCobraHoyMeRoutes({
+      db: opts.db as never,
+      logger: noopLogger,
+    }),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appConfig.FACTORING_V1_ACTIVATED = true;
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GET /assignments/:id/cobra-hoy/cotizacion — flag + ctx', () => {
+  it('flag off → 503 feature_disabled', async () => {
+    appConfig.FACTORING_V1_ACTIVATED = false;
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy/cotizacion');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'feature_disabled' });
+  });
+
+  it('sin userContext → 400 no_active_empresa', async () => {
+    const app = makeAssignmentsApp({ withContext: false });
+    const res = await app.request('/assignments/asg-1/cobra-hoy/cotizacion');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'no_active_empresa' });
+  });
+
+  it('plazo_dias inválido (0) → 400 invalid_plazo', async () => {
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy/cotizacion?plazo_dias=0');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_plazo' });
+  });
+
+  it('plazo_dias inválido (negativo) → 400 invalid_plazo', async () => {
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy/cotizacion?plazo_dias=-5');
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /assignments/:id/cobra-hoy/cotizacion — service mapping', () => {
+  it('assignment_not_found → 404', async () => {
+    cotizarSpy.mockResolvedValue({ status: 'assignment_not_found' });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy/cotizacion');
+    expect(res.status).toBe(404);
+  });
+
+  it('forbidden_owner_mismatch → 403', async () => {
+    cotizarSpy.mockResolvedValue({ status: 'forbidden_owner_mismatch' });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy/cotizacion');
+    expect(res.status).toBe(403);
+  });
+
+  it('no_liquidacion → 409', async () => {
+    cotizarSpy.mockResolvedValue({ status: 'no_liquidacion' });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy/cotizacion');
+    expect(res.status).toBe(409);
+  });
+
+  it('ok → 200 con desglose serializado snake_case', async () => {
+    cotizarSpy.mockResolvedValue({
+      status: 'ok',
+      montoNetoClp: 176000,
+      plazoDiasShipper: 30,
+      tarifaPct: 1.5,
+      tarifaClp: 2640,
+      montoAdelantadoClp: 173360,
+    });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy/cotizacion?plazo_dias=30');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      monto_neto_clp: 176000,
+      plazo_dias_shipper: 30,
+      tarifa_pct: 1.5,
+      tarifa_clp: 2640,
+      monto_adelantado_clp: 173360,
+    });
+    // Service recibió el empresaCarrierId del userContext.
+    expect(cotizarSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ empresaCarrierId: EMPRESA_ID, plazoDiasShipper: 30 }),
+    );
+  });
+});
+
+describe('POST /assignments/:id/cobra-hoy — service mapping completo', () => {
+  it('flag off → 503', async () => {
+    appConfig.FACTORING_V1_ACTIVATED = false;
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy', { method: 'POST' });
+    expect(res.status).toBe(503);
+  });
+
+  it('assignment_not_delivered → 409', async () => {
+    cobraHoySpy.mockResolvedValue({ status: 'assignment_not_delivered' });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy', { method: 'POST' });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('assignment_not_delivered');
+  });
+
+  it('shipper_no_aprobado → 422 + motivo', async () => {
+    cobraHoySpy.mockResolvedValue({
+      status: 'shipper_no_aprobado',
+      motivo: 'Score insuficiente',
+    });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy', { method: 'POST' });
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body.error).toBe('shipper_no_aprobado');
+    expect(body.message).toBe('Score insuficiente');
+  });
+
+  it('limite_exposicion_excedido → 422 + limit/exposicion', async () => {
+    cobraHoySpy.mockResolvedValue({
+      status: 'limite_exposicion_excedido',
+      limitClp: 50_000_000,
+      exposicionClp: 51_000_000,
+    });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy', { method: 'POST' });
+    expect(res.status).toBe(422);
+    expect(await res.json()).toEqual({
+      error: 'limite_exposicion_excedido',
+      limit_clp: 50_000_000,
+      exposicion_clp: 51_000_000,
+    });
+  });
+
+  it('ya_solicitado → 200 already_requested=true', async () => {
+    cobraHoySpy.mockResolvedValue({ status: 'ya_solicitado', adelantoId: 'adel-1' });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      already_requested: true,
+      adelanto_id: 'adel-1',
+    });
+  });
+
+  it('solicitado → 201 con tarifa serializada', async () => {
+    cobraHoySpy.mockResolvedValue({
+      status: 'solicitado',
+      adelantoId: 'adel-1',
+      tarifaPct: 1.5,
+      tarifaClp: 2640,
+      montoAdelantadoClp: 173360,
+    });
+    const app = makeAssignmentsApp({ withContext: true });
+    const res = await app.request('/assignments/asg-1/cobra-hoy', { method: 'POST' });
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      ok: true,
+      already_requested: false,
+      adelanto_id: 'adel-1',
+      tarifa_pct: 1.5,
+      tarifa_clp: 2640,
+      monto_adelantado_clp: 173360,
+    });
+  });
+});
+
+describe('GET /me/cobra-hoy/historial', () => {
+  function makeDbWithAdelantos(rows: Array<Record<string, unknown>>) {
+    const chain: Record<string, unknown> = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(async () => rows),
+    };
+    return { select: vi.fn(() => chain) };
+  }
+
+  it('flag off → 503', async () => {
+    appConfig.FACTORING_V1_ACTIVATED = false;
+    const app = makeMeApp({ withContext: true, db: makeDbWithAdelantos([]) });
+    const res = await app.request('/me/cobra-hoy/historial');
+    expect(res.status).toBe(503);
+  });
+
+  it('sin userContext → 400', async () => {
+    const app = makeMeApp({ withContext: false, db: makeDbWithAdelantos([]) });
+    const res = await app.request('/me/cobra-hoy/historial');
+    expect(res.status).toBe(400);
+  });
+
+  it('lista vacía → 200 con adelantos:[]', async () => {
+    const app = makeMeApp({ withContext: true, db: makeDbWithAdelantos([]) });
+    const res = await app.request('/me/cobra-hoy/historial');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ adelantos: [] });
+  });
+
+  it('lista con un adelanto → serializa fechas + decimales', async () => {
+    const desembolsadoAt = new Date('2026-05-09T12:00:00Z');
+    const createdAt = new Date('2026-05-08T11:00:00Z');
+    const db = makeDbWithAdelantos([
+      {
+        id: 'a1',
+        asignacionId: 'asg-1',
+        montoNetoClp: 176000,
+        plazoDiasShipper: 30,
+        tarifaPct: '1.50',
+        tarifaClp: 2640,
+        montoAdelantadoClp: 173360,
+        status: 'desembolsado',
+        desembolsadoEn: desembolsadoAt,
+        createdAt,
+      },
+    ]);
+    const app = makeMeApp({ withContext: true, db });
+    const res = await app.request('/me/cobra-hoy/historial');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { adelantos: Array<Record<string, unknown>> };
+    expect(body.adelantos).toHaveLength(1);
+    expect(body.adelantos[0]).toMatchObject({
+      id: 'a1',
+      asignacion_id: 'asg-1',
+      monto_neto_clp: 176000,
+      tarifa_pct: 1.5,
+      tarifa_clp: 2640,
+      monto_adelantado_clp: 173360,
+      status: 'desembolsado',
+      desembolsado_en: desembolsadoAt.toISOString(),
+      creado_en: createdAt.toISOString(),
+    });
+  });
+});

--- a/apps/api/test/unit/cobra-hoy.test.ts
+++ b/apps/api/test/unit/cobra-hoy.test.ts
@@ -1,0 +1,317 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cobraHoy, cotizarCobraHoy } from '../../src/services/cobra-hoy.js';
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+interface DbQueues {
+  selects?: unknown[][];
+  inserts?: unknown[][];
+}
+
+function makeDb(opts: DbQueues = {}) {
+  const selects = [...(opts.selects ?? [])];
+  const inserts = [...(opts.inserts ?? [])];
+
+  return {
+    select: vi.fn(() => {
+      const chain: Record<string, unknown> = {
+        from: vi.fn(() => chain),
+        where: vi.fn(() => chain),
+        limit: vi.fn(async () => selects.shift() ?? []),
+      };
+      return chain;
+    }),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(async () => inserts.shift() ?? []),
+      })),
+    })),
+  };
+}
+
+const ASG_ID = '11111111-1111-1111-1111-111111111111';
+const CARRIER_ID = '22222222-2222-2222-2222-222222222222';
+const SHIPPER_ID = '33333333-3333-3333-3333-333333333333';
+const TRIP_ID = '44444444-4444-4444-4444-444444444444';
+const LIQ_ID = '55555555-5555-5555-5555-555555555555';
+
+const ASG_DELIVERED = {
+  id: ASG_ID,
+  tripId: TRIP_ID,
+  empresaCarrierId: CARRIER_ID,
+  deliveredAt: new Date('2026-05-10T12:00:00Z'),
+};
+const TRIP = { generadorCargaEmpresaId: SHIPPER_ID };
+const LIQ = { id: LIQ_ID, montoNetoCarrierClp: 1_000_000 };
+const DECISION_OK = {
+  approved: true,
+  limitExposureClp: 10_000_000,
+  currentExposureClp: 0,
+  motivo: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('cobraHoy — feature flag', () => {
+  it('factoringV1Activated=false → skipped_flag_disabled', async () => {
+    const db = makeDb();
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: false,
+    });
+    expect(r).toEqual({ status: 'skipped_flag_disabled' });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('cobraHoy — validación de assignment', () => {
+  it('assignment no existe → assignment_not_found', async () => {
+    const db = makeDb({ selects: [[]] });
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: true,
+    });
+    expect(r.status).toBe('assignment_not_found');
+  });
+
+  it('otra empresa pidiendo cobra-hoy → forbidden_owner_mismatch', async () => {
+    const db = makeDb({ selects: [[ASG_DELIVERED]] });
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: 'otra-empresa',
+      factoringV1Activated: true,
+    });
+    expect(r.status).toBe('forbidden_owner_mismatch');
+  });
+
+  it('assignment sin deliveredAt → assignment_not_delivered', async () => {
+    const db = makeDb({
+      selects: [[{ ...ASG_DELIVERED, deliveredAt: null }]],
+    });
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: true,
+    });
+    expect(r.status).toBe('assignment_not_delivered');
+  });
+});
+
+describe('cobraHoy — liquidación + shipper credit', () => {
+  it('sin liquidación → no_liquidacion', async () => {
+    const db = makeDb({
+      selects: [[ASG_DELIVERED], [TRIP], []],
+    });
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: true,
+    });
+    expect(r.status).toBe('no_liquidacion');
+  });
+
+  it('shipper sin decisión vigente → shipper_no_aprobado', async () => {
+    const db = makeDb({
+      selects: [[ASG_DELIVERED], [TRIP], [LIQ], []],
+    });
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: true,
+    });
+    expect(r.status).toBe('shipper_no_aprobado');
+  });
+
+  it('shipper decisión approved=false → shipper_no_aprobado con motivo', async () => {
+    const db = makeDb({
+      selects: [
+        [ASG_DELIVERED],
+        [TRIP],
+        [LIQ],
+        [{ ...DECISION_OK, approved: false, motivo: 'Score 400 < 550' }],
+      ],
+    });
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: true,
+    });
+    expect(r.status).toBe('shipper_no_aprobado');
+    if (r.status === 'shipper_no_aprobado') {
+      expect(r.motivo).toContain('Score 400');
+    }
+  });
+
+  it('límite de exposición excedido → limite_exposicion_excedido', async () => {
+    const db = makeDb({
+      selects: [
+        [ASG_DELIVERED],
+        [TRIP],
+        [LIQ],
+        [{ ...DECISION_OK, currentExposureClp: 9_500_000 }],
+      ],
+    });
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: true,
+    });
+    // 9.5M + ~985k = 10.485M > 10M límite
+    expect(r.status).toBe('limite_exposicion_excedido');
+  });
+});
+
+describe('cobraHoy — happy path', () => {
+  it('todo OK → solicitado con tarifa 1.5% (30d default)', async () => {
+    const db = makeDb({
+      selects: [[ASG_DELIVERED], [TRIP], [LIQ], [DECISION_OK]],
+      inserts: [[{ id: 'adelanto-uuid' }]],
+    });
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: true,
+    });
+    expect(r.status).toBe('solicitado');
+    if (r.status === 'solicitado') {
+      expect(r.tarifaPct).toBe(1.5);
+      expect(r.tarifaClp).toBe(15_000);
+      expect(r.montoAdelantadoClp).toBe(985_000);
+      expect(r.adelantoId).toBe('adelanto-uuid');
+    }
+  });
+});
+
+describe('cobraHoy — idempotencia', () => {
+  it('UNIQUE violation → ya_solicitado con id existente', async () => {
+    let i = 0;
+    const responses: unknown[][] = [
+      [ASG_DELIVERED],
+      [TRIP],
+      [LIQ],
+      [DECISION_OK],
+      [{ id: 'adelanto-existente' }],
+    ];
+    const db = {
+      select: vi.fn(() => {
+        const chain: Record<string, unknown> = {
+          from: vi.fn(() => chain),
+          where: vi.fn(() => chain),
+          limit: vi.fn(async () => responses[i++] ?? []),
+        };
+        return chain;
+      }),
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          returning: vi.fn(async () => {
+            throw new Error('duplicate key value violates unique constraint');
+          }),
+        })),
+      })),
+    };
+    const r = await cobraHoy({
+      db: db as never,
+      logger: noopLogger,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      factoringV1Activated: true,
+    });
+    expect(r).toEqual({ status: 'ya_solicitado', adelantoId: 'adelanto-existente' });
+  });
+});
+
+describe('cotizarCobraHoy', () => {
+  it('assignment no existe → assignment_not_found', async () => {
+    const db = makeDb({ selects: [[]] });
+    const r = await cotizarCobraHoy({
+      db: db as never,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+    });
+    expect(r.status).toBe('assignment_not_found');
+  });
+
+  it('otra empresa → forbidden_owner_mismatch', async () => {
+    const db = makeDb({ selects: [[ASG_DELIVERED]] });
+    const r = await cotizarCobraHoy({
+      db: db as never,
+      asignacionId: ASG_ID,
+      empresaCarrierId: 'otra',
+    });
+    expect(r.status).toBe('forbidden_owner_mismatch');
+  });
+
+  it('sin liquidación → no_liquidacion', async () => {
+    const db = makeDb({ selects: [[ASG_DELIVERED], []] });
+    const r = await cotizarCobraHoy({
+      db: db as never,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+    });
+    expect(r.status).toBe('no_liquidacion');
+  });
+
+  it('happy path → ok con desglose', async () => {
+    const db = makeDb({ selects: [[ASG_DELIVERED], [LIQ]] });
+    const r = await cotizarCobraHoy({
+      db: db as never,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+    });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') {
+      expect(r.montoNetoClp).toBe(1_000_000);
+      expect(r.tarifaPct).toBe(1.5);
+      expect(r.montoAdelantadoClp).toBe(985_000);
+    }
+  });
+
+  it('plazoDiasShipper custom (60) → tarifa 3%', async () => {
+    const db = makeDb({ selects: [[ASG_DELIVERED], [LIQ]] });
+    const r = await cotizarCobraHoy({
+      db: db as never,
+      asignacionId: ASG_ID,
+      empresaCarrierId: CARRIER_ID,
+      plazoDiasShipper: 60,
+    });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') {
+      expect(r.tarifaPct).toBe(3.0);
+      expect(r.tarifaClp).toBe(30_000);
+    }
+  });
+});

--- a/apps/web/src/components/cobra-hoy/CobraHoyButton.test.tsx
+++ b/apps/web/src/components/cobra-hoy/CobraHoyButton.test.tsx
@@ -1,0 +1,141 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../../lib/api-client.js';
+import { CobraHoyButton } from './CobraHoyButton.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderButton(asignacionId = 'asg-1') {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <CobraHoyButton asignacionId={asignacionId} />
+    </Wrapper>,
+  );
+}
+
+const COTIZ_OK = {
+  monto_neto_clp: 176000,
+  plazo_dias_shipper: 30,
+  tarifa_pct: 1.5,
+  tarifa_clp: 2640,
+  monto_adelantado_clp: 173360,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CobraHoyButton — botón inicial', () => {
+  it('renderiza botón con label "Cobra hoy"', () => {
+    renderButton();
+    expect(screen.getByRole('button', { name: /Cobra hoy/i })).toBeInTheDocument();
+  });
+
+  it('no abre modal sin click', () => {
+    renderButton();
+    expect(screen.queryByRole('heading', { name: /Cobra hoy/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('CobraHoyButton — modal con cotización OK', () => {
+  it('al hacer click abre modal y muestra desglose', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(COTIZ_OK);
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: /Cobra hoy/i }));
+    expect(await screen.findByText(/Monto neto del viaje/)).toBeInTheDocument();
+    expect(screen.getByText(/\$\s?176\.000/)).toBeInTheDocument();
+    expect(screen.getByText(/Tarifa pronto pago \(1\.50%\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Recibes hoy/)).toBeInTheDocument();
+    expect(screen.getByText(/\$\s?173\.360/)).toBeInTheDocument();
+    expect(screen.getByText(/30 días corridos/)).toBeInTheDocument();
+  });
+
+  it('botón de confirmar habilitado y dispara POST con success', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(COTIZ_OK);
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({
+      ok: true,
+      already_requested: false,
+      adelanto_id: 'adel-1',
+      tarifa_pct: 1.5,
+      tarifa_clp: 2640,
+      monto_adelantado_clp: 173360,
+    });
+    renderButton('asg-xyz');
+    fireEvent.click(screen.getByRole('button', { name: /Cobra hoy/i }));
+    const confirm = await screen.findByRole('button', { name: /Confirmar y recibir hoy/i });
+    fireEvent.click(confirm);
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith('/assignments/asg-xyz/cobra-hoy', {});
+    });
+    expect(await screen.findByText(/Solicitud recibida/)).toBeInTheDocument();
+  });
+
+  it('already_requested → mensaje específico', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(COTIZ_OK);
+    vi.spyOn(api, 'post').mockResolvedValue({
+      ok: true,
+      already_requested: true,
+      adelanto_id: 'adel-1',
+    });
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: /Cobra hoy/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Confirmar y recibir hoy/i }));
+    expect(await screen.findByText(/Ya tenías una solicitud en curso/)).toBeInTheDocument();
+  });
+});
+
+describe('CobraHoyButton — modal con errores backend', () => {
+  it('503 feature_disabled → muestra mensaje y oculta confirm', async () => {
+    vi.spyOn(api, 'get').mockRejectedValue(new ApiError(503, 'feature_disabled', null));
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: /Cobra hoy/i }));
+    expect(await screen.findByText(/La opción de pronto pago no está activa/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Confirmar y recibir hoy/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('409 no_liquidacion → mensaje claro al carrier', async () => {
+    vi.spyOn(api, 'get').mockRejectedValue(
+      new ApiError(409, 'no_liquidacion', { code: 'no_liquidacion' }),
+    );
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: /Cobra hoy/i }));
+    expect(await screen.findByText(/Tu viaje aún no fue liquidado/)).toBeInTheDocument();
+  });
+
+  it('error de mutation → alert visible', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(COTIZ_OK);
+    vi.spyOn(api, 'post').mockRejectedValue(new Error('boom'));
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: /Cobra hoy/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Confirmar y recibir hoy/i }));
+    expect(await screen.findByRole('alert')).toHaveTextContent(/No pudimos procesar la solicitud/);
+  });
+});
+
+describe('CobraHoyButton — cerrar modal', () => {
+  it('Cancelar cierra el modal', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue(COTIZ_OK);
+    renderButton();
+    fireEvent.click(screen.getByRole('button', { name: /Cobra hoy/i }));
+    await screen.findByText(/Recibes hoy/);
+    fireEvent.click(screen.getByRole('button', { name: /Cancelar/i }));
+    await waitFor(() => {
+      expect(screen.queryByText(/Recibes hoy/)).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/cobra-hoy/CobraHoyButton.tsx
+++ b/apps/web/src/components/cobra-hoy/CobraHoyButton.tsx
@@ -1,0 +1,209 @@
+import { Banknote, CheckCircle2, Loader2, X } from 'lucide-react';
+import { useState } from 'react';
+import { useCotizacionCobraHoy, useSolicitarCobraHoyMutation } from '../../hooks/use-cobra-hoy.js';
+import { ApiError } from '../../lib/api-client.js';
+
+/**
+ * Botón "Cobra hoy" + modal de confirmación. Para uso en
+ * `/asignaciones/:id` cuando el trip está entregado.
+ *
+ * Comportamiento:
+ *   - Si la feature está disabled (backend 503), el botón no se muestra
+ *     (la query enabled=true falla silenciosa).
+ *   - Click → abre modal con desglose (monto neto, tarifa, recibirás).
+ *   - Confirmar → POST + cierra modal con confirmación visual.
+ *   - Estado de la asignación se traduce a copy claro.
+ */
+export function CobraHoyButton({ asignacionId }: { asignacionId: string }) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  function open() {
+    setModalOpen(true);
+  }
+
+  function close() {
+    setModalOpen(false);
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={open}
+        className="inline-flex items-center gap-2 rounded-md bg-success-700 px-4 py-2 font-medium text-sm text-white shadow-xs transition hover:bg-success-700/90"
+      >
+        <Banknote className="h-4 w-4" aria-hidden />
+        Cobra hoy
+      </button>
+      {modalOpen && <CobraHoyModal asignacionId={asignacionId} onClose={close} />}
+    </>
+  );
+}
+
+function CobraHoyModal({
+  asignacionId,
+  onClose,
+}: {
+  asignacionId: string;
+  onClose: () => void;
+}) {
+  const cotizQ = useCotizacionCobraHoy(asignacionId, { enabled: true });
+  const solicitarM = useSolicitarCobraHoyMutation(asignacionId);
+
+  // 503 → backend dice feature disabled. Mostrar mensaje claro y cerrar.
+  const featureDisabled = cotizQ.error instanceof ApiError && cotizQ.error.status === 503;
+  // 409 no_liquidacion → trip aún no se liquidó.
+  const noLiquidacion =
+    cotizQ.error instanceof ApiError &&
+    cotizQ.error.status === 409 &&
+    cotizQ.error.code === 'no_liquidacion';
+
+  return (
+    <dialog
+      open
+      aria-modal="true"
+      aria-labelledby="cobra-hoy-modal-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+    >
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-xl">
+        <div className="flex items-start justify-between gap-4">
+          <h2 id="cobra-hoy-modal-title" className="font-semibold text-lg text-neutral-900">
+            Cobra hoy
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-neutral-500 transition hover:bg-neutral-100"
+            aria-label="Cerrar"
+          >
+            <X className="h-5 w-5" aria-hidden />
+          </button>
+        </div>
+
+        {cotizQ.isLoading && (
+          <p className="mt-4 text-neutral-600 text-sm">Calculando cotización…</p>
+        )}
+
+        {featureDisabled && (
+          <output className="mt-4 block rounded-md border border-neutral-200 bg-neutral-50 p-3 text-neutral-700 text-sm">
+            La opción de pronto pago no está activa en este entorno todavía.
+          </output>
+        )}
+
+        {noLiquidacion && (
+          <output className="mt-4 block rounded-md border border-neutral-200 bg-neutral-50 p-3 text-neutral-700 text-sm">
+            Tu viaje aún no fue liquidado. Apenas se confirme la entrega y se calcule la comisión,
+            podrás solicitar pronto pago.
+          </output>
+        )}
+
+        {cotizQ.data && (
+          <>
+            <p className="mt-3 text-neutral-700 text-sm">
+              Recibe el monto neto del viaje hoy mismo, descontando una tarifa de pronto pago
+              transparente sobre la comisión Booster ya deducida.
+            </p>
+            <dl className="mt-4 space-y-2 rounded-md border border-neutral-200 bg-neutral-50 p-3 text-sm">
+              <Row label="Monto neto del viaje" value={fmt(cotizQ.data.monto_neto_clp)} />
+              <Row
+                label={`Tarifa pronto pago (${cotizQ.data.tarifa_pct.toFixed(2)}%)`}
+                value={`- ${fmt(cotizQ.data.tarifa_clp)}`}
+                tone="muted"
+              />
+              <hr className="my-1 border-neutral-200" />
+              <Row
+                label="Recibes hoy"
+                value={fmt(cotizQ.data.monto_adelantado_clp)}
+                tone="emphasis"
+              />
+            </dl>
+            <p className="mt-2 text-neutral-500 text-xs">
+              Plazo del shipper: {cotizQ.data.plazo_dias_shipper} días corridos. Booster cobra al
+              shipper en su fecha; tú no esperas.
+            </p>
+          </>
+        )}
+
+        {solicitarM.isSuccess && solicitarM.data && (
+          <output className="mt-4 flex items-center gap-2 rounded-md border border-success-500/30 bg-success-50 p-3 text-success-700 text-sm">
+            <CheckCircle2 className="h-4 w-4" aria-hidden />
+            {solicitarM.data.already_requested
+              ? 'Ya tenías una solicitud en curso para este viaje.'
+              : 'Solicitud recibida. Te avisaremos cuando se desembolse.'}
+          </output>
+        )}
+
+        {solicitarM.isError && (
+          <output
+            role="alert"
+            className="mt-4 block rounded-md border border-danger-500/30 bg-danger-50 p-3 text-danger-700 text-sm"
+          >
+            No pudimos procesar la solicitud. Intenta de nuevo en unos minutos.
+          </output>
+        )}
+
+        <div className="mt-6 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-neutral-300 px-3 py-2 font-medium text-neutral-700 text-sm transition hover:bg-neutral-100"
+          >
+            {solicitarM.isSuccess ? 'Cerrar' : 'Cancelar'}
+          </button>
+          {cotizQ.data && !solicitarM.isSuccess && (
+            <button
+              type="button"
+              onClick={() => solicitarM.mutate()}
+              disabled={solicitarM.isPending}
+              className="inline-flex items-center gap-2 rounded-md bg-success-700 px-4 py-2 font-medium text-sm text-white shadow-xs transition hover:bg-success-700/90 disabled:opacity-60"
+            >
+              {solicitarM.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              ) : (
+                <Banknote className="h-4 w-4" aria-hidden />
+              )}
+              {solicitarM.isPending ? 'Solicitando…' : 'Confirmar y recibir hoy'}
+            </button>
+          )}
+        </div>
+      </div>
+    </dialog>
+  );
+}
+
+function Row({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: string;
+  tone?: 'muted' | 'emphasis';
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <dt
+        className={
+          tone === 'emphasis' ? 'font-medium text-neutral-900' : 'text-neutral-600 text-sm'
+        }
+      >
+        {label}
+      </dt>
+      <dd
+        className={
+          tone === 'emphasis'
+            ? 'font-bold text-success-700'
+            : tone === 'muted'
+              ? 'text-neutral-700'
+              : 'font-medium text-neutral-900'
+        }
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function fmt(clp: number): string {
+  return `$ ${clp.toLocaleString('es-CL')}`;
+}

--- a/apps/web/src/hooks/use-cobra-hoy.ts
+++ b/apps/web/src/hooks/use-cobra-hoy.ts
@@ -1,0 +1,94 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ApiError, api } from '../lib/api-client.js';
+
+/**
+ * Hooks de "Booster Cobra Hoy" (ADR-029 + ADR-032).
+ *
+ * `useCotizacionCobraHoy(asignacionId)`: preview de tarifa (sin escribir).
+ * `useSolicitarCobraHoyMutation(asignacionId)`: solicita el adelanto.
+ * `useHistorialCobraHoy()`: lista de adelantos del carrier activo.
+ *
+ * Si la feature está disabled (flag off en backend), todos los hooks
+ * devuelven 503 — el componente que los consume debe esconder la UI.
+ */
+
+export interface CotizacionResponse {
+  monto_neto_clp: number;
+  plazo_dias_shipper: number;
+  tarifa_pct: number;
+  tarifa_clp: number;
+  monto_adelantado_clp: number;
+}
+
+export function useCotizacionCobraHoy(asignacionId: string, opts: { enabled?: boolean } = {}) {
+  return useQuery<CotizacionResponse>({
+    queryKey: ['cobra-hoy', 'cotizacion', asignacionId],
+    queryFn: () => api.get<CotizacionResponse>(`/assignments/${asignacionId}/cobra-hoy/cotizacion`),
+    enabled: opts.enabled ?? false,
+    staleTime: 60_000,
+    retry: (failureCount, error) => {
+      if (
+        error instanceof ApiError &&
+        (error.status === 503 || error.status === 403 || error.status === 409)
+      ) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+}
+
+export interface SolicitarCobraHoyResponse {
+  ok: boolean;
+  already_requested: boolean;
+  adelanto_id: string;
+  tarifa_pct?: number;
+  tarifa_clp?: number;
+  monto_adelantado_clp?: number;
+}
+
+export function useSolicitarCobraHoyMutation(asignacionId: string) {
+  const qc = useQueryClient();
+  return useMutation<SolicitarCobraHoyResponse, Error>({
+    mutationFn: () =>
+      api.post<SolicitarCobraHoyResponse>(`/assignments/${asignacionId}/cobra-hoy`, {}),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['cobra-hoy'] });
+    },
+  });
+}
+
+export interface AdelantoHistorial {
+  id: string;
+  asignacion_id: string;
+  monto_neto_clp: number;
+  plazo_dias_shipper: number;
+  tarifa_pct: number;
+  tarifa_clp: number;
+  monto_adelantado_clp: number;
+  status:
+    | 'solicitado'
+    | 'aprobado'
+    | 'desembolsado'
+    | 'cobrado_a_shipper'
+    | 'mora'
+    | 'cancelado'
+    | 'rechazado';
+  desembolsado_en: string | null;
+  creado_en: string;
+}
+
+export function useHistorialCobraHoy(opts: { enabled?: boolean } = {}) {
+  return useQuery<{ adelantos: AdelantoHistorial[] }>({
+    queryKey: ['cobra-hoy', 'historial'],
+    queryFn: () => api.get<{ adelantos: AdelantoHistorial[] }>('/me/cobra-hoy/historial'),
+    enabled: opts.enabled ?? true,
+    staleTime: 30_000,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && error.status === 503) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -6,7 +6,9 @@ import { AsignacionDetalleRoute } from './routes/asignacion-detalle.js';
 import { CargaTrackRoute } from './routes/carga-track.js';
 import { CargasDetalleRoute, CargasListRoute, CargasNuevoRoute } from './routes/cargas.js';
 import { CertificadosRoute } from './routes/certificados.js';
+import { CobraHoyHistorialRoute } from './routes/cobra-hoy-historial.js';
 import { IndexRoute } from './routes/index.js';
+import { LegalCobraHoyRoute } from './routes/legal-cobra-hoy.js';
 import { LegalTerminosRoute } from './routes/legal-terminos.js';
 import { LoginRoute } from './routes/login.js';
 import { OfertasRoute } from './routes/ofertas.js';
@@ -150,6 +152,23 @@ const legalTerminosRoute = createRoute({
   component: LegalTerminosRoute,
 });
 
+// ADR-029 v1 / ADR-032 — Listado de adelantos solicitados por el
+// carrier ("Booster Cobra Hoy"). Surface dedicada bajo /app, requiere
+// auth + activeMembership de tipo transportista.
+const cobraHoyHistorialRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/app/cobra-hoy/historial',
+  component: CobraHoyHistorialRoute,
+});
+
+// Adendum de T&Cs específico para el producto "Cobra Hoy". Pública,
+// referenciable desde el modal de solicitud.
+const legalCobraHoyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/legal/cobra-hoy',
+  component: LegalCobraHoyRoute,
+});
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
@@ -170,6 +189,8 @@ const routeTree = rootRoute.addChildren([
   asignacionDetalleRoute,
   publicTrackingRoute,
   legalTerminosRoute,
+  cobraHoyHistorialRoute,
+  legalCobraHoyRoute,
 ]);
 
 export const router = createRouter({

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -1,6 +1,7 @@
 import { Link } from '@tanstack/react-router';
 import {
   ArrowRight,
+  Banknote,
   Bus,
   Leaf,
   LogOut,
@@ -140,6 +141,27 @@ function AppDashboard({ me }: { me: MeOnboarded }) {
                     <div className="font-medium text-neutral-900">Vehículos</div>
                     <div className="text-neutral-600 text-sm">
                       Tu flota: agregar, editar, asociar dispositivos Teltonika.
+                    </div>
+                  </div>
+                </div>
+                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+              </Link>
+
+              <Link
+                to="/app/cobra-hoy/historial"
+                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-success-700 hover:shadow-md"
+              >
+                <div className="flex items-center gap-4">
+                  <div
+                    className="flex h-10 w-10 items-center justify-center rounded-md bg-success-50 text-success-700"
+                    aria-hidden
+                  >
+                    <Banknote className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <div className="font-medium text-neutral-900">Cobra hoy</div>
+                    <div className="text-neutral-600 text-sm">
+                      Solicita pronto pago de viajes entregados y revisa tu historial de adelantos.
                     </div>
                   </div>
                 </div>

--- a/apps/web/src/routes/asignacion-detalle.tsx
+++ b/apps/web/src/routes/asignacion-detalle.tsx
@@ -20,6 +20,7 @@ import { ArrowLeft } from 'lucide-react';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { ChatPanel } from '../components/chat/ChatPanel.js';
 import { PushSubscribeBanner } from '../components/chat/PushSubscribeBanner.js';
+import { CobraHoyButton } from '../components/cobra-hoy/CobraHoyButton.js';
 import { BehaviorScoreCard } from '../components/scoring/BehaviorScoreCard.js';
 import { DeliveryConfirmCard } from '../components/scoring/DeliveryConfirmCard.js';
 import { IncidentReportCard } from '../components/scoring/IncidentReportCard.js';
@@ -95,6 +96,11 @@ function AsignacionDetallePage() {
   // Phase 4 PR-K4 — confirmación de entrega via voz hands-free.
   // Surface visible mientras el trip está activo (asignado | en_proceso).
   const isConfirmable = trip?.status === 'asignado' || trip?.status === 'en_proceso';
+  // ADR-029 v1 / ADR-032 — "Cobra hoy" sólo aplica cuando el viaje ya
+  // fue entregado. El service backend valida liquidación + flag; si el
+  // flag está off, el modal muestra mensaje claro. Si no hay liquidación
+  // (todavía no se calculó), el modal explica que falta ese paso.
+  const isDelivered = trip?.status === 'entregado';
   const otroLado = trip?.shipper_legal_name ?? 'generador de carga';
 
   return (
@@ -135,6 +141,24 @@ function AsignacionDetallePage() {
           "no disponible" pero lo escondemos para no agregar ruido a
           la surface activa. */}
       {isClosed && <BehaviorScoreCard assignmentId={assignmentId} />}
+
+      {/* ADR-029 v1 / ADR-032 — Botón "Cobra hoy" para el carrier una
+          vez que el viaje fue entregado. El service backend valida
+          flag + liquidación + shipper credit; si el flag está off
+          (entornos no-prod por default), el modal lo comunica. */}
+      {isDelivered && (
+        <div className="border-neutral-200 border-b bg-white px-4 py-3">
+          <div className="flex flex-col gap-1">
+            <span className="font-medium text-neutral-700 text-sm">Pronto pago disponible</span>
+            <span className="text-neutral-500 text-xs">
+              Recibe el monto neto del viaje hoy mismo, descontando una tarifa transparente.
+            </span>
+            <div className="mt-2">
+              <CobraHoyButton asignacionId={assignmentId} />
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* ChatPanel fullscreen (sin onClose porque acá es la surface dedicada) */}
       <div className="flex-1 overflow-hidden">

--- a/apps/web/src/routes/cobra-hoy-historial.test.tsx
+++ b/apps/web/src/routes/cobra-hoy-historial.test.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { ApiError, api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+}));
+
+vi.mock('../components/EmptyState.js', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+  emptyStateActionClass: 'btn',
+}));
+
+const { CobraHoyHistorialRoute } = await import('./cobra-hoy-historial.js');
+
+function makeMe(isCarrier: boolean): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role: 'dueno',
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e',
+        legal_name: 'E',
+        rut: '76',
+        is_generador_carga: false,
+        is_transportista: isCarrier,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRoute() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <CobraHoyHistorialRoute />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CobraHoyHistorialRoute — gating', () => {
+  it('contexto unmanaged → render vacío', () => {
+    const { container } = renderRoute();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shipper (no transportista) → mensaje sin permisos', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(false) };
+    renderRoute();
+    expect(screen.getByText(/Sin permisos/)).toBeInTheDocument();
+    expect(screen.getByText(/exclusivo de empresas transportistas/i)).toBeInTheDocument();
+  });
+});
+
+describe('CobraHoyHistorialRoute — estados de datos', () => {
+  beforeEach(() => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+  });
+
+  it('feature disabled (503) → banner explicativo', async () => {
+    vi.spyOn(api, 'get').mockRejectedValue(new ApiError(503, 'feature_disabled', null));
+    renderRoute();
+    expect(
+      await screen.findByText(/La opción de pronto pago todavía no está activa/i),
+    ).toBeInTheDocument();
+  });
+
+  it('historial vacío → EmptyState', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ adelantos: [] });
+    renderRoute();
+    expect(
+      await screen.findByText(/Aún no tienes solicitudes de pronto pago/i),
+    ).toBeInTheDocument();
+  });
+
+  it('con adelantos → tabla con summary cards y filas', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      adelantos: [
+        {
+          id: 'a1',
+          asignacion_id: 'asg-deadbeef-1234',
+          monto_neto_clp: 176000,
+          plazo_dias_shipper: 30,
+          tarifa_pct: 1.5,
+          tarifa_clp: 2640,
+          monto_adelantado_clp: 173360,
+          status: 'desembolsado' as const,
+          desembolsado_en: '2026-05-08T12:00:00Z',
+          creado_en: '2026-05-08T11:00:00Z',
+        },
+      ],
+    });
+    renderRoute();
+    expect(await screen.findByText(/Solicitudes/)).toBeInTheDocument();
+    expect(screen.getByText(/Total adelantado/)).toBeInTheDocument();
+    expect(screen.getByText(/Total tarifa/)).toBeInTheDocument();
+    expect(screen.getByText('Desembolsado')).toBeInTheDocument();
+    // Tarifa formateada con porcentaje.
+    expect(screen.getByText(/\(1\.50%\)/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/cobra-hoy-historial.tsx
+++ b/apps/web/src/routes/cobra-hoy-historial.tsx
@@ -1,0 +1,272 @@
+import { Link } from '@tanstack/react-router';
+import { ArrowLeft, Banknote, Clock3 } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { EmptyState, emptyStateActionClass } from '../components/EmptyState.js';
+import { Layout } from '../components/Layout.js';
+import { ProtectedRoute } from '../components/ProtectedRoute.js';
+import { type AdelantoHistorial, useHistorialCobraHoy } from '../hooks/use-cobra-hoy.js';
+import type { MeResponse } from '../hooks/use-me.js';
+import { ApiError } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+
+/**
+ * /app/cobra-hoy/historial — listado dedicado de adelantos solicitados
+ * por el transportista (Booster Cobra Hoy, ADR-029 v1 / ADR-032).
+ *
+ * Origen: GET /me/cobra-hoy/historial (filtra por activeMembership.empresa).
+ * Si el flag está off (503) muestra un banner explicativo. Si la empresa
+ * no es transportista, mensaje claro de "sin permisos".
+ */
+export function CobraHoyHistorialRoute() {
+  return (
+    <ProtectedRoute meRequirement="require-onboarded">
+      {(ctx) => {
+        if (ctx.kind !== 'onboarded') {
+          return null;
+        }
+        const isCarrier = ctx.me.active_membership?.empresa.is_transportista ?? false;
+        if (!isCarrier) {
+          return <NoCarrierPermission />;
+        }
+        return <HistorialPage me={ctx.me} />;
+      }}
+    </ProtectedRoute>
+  );
+}
+
+function HistorialPage({ me }: { me: MeOnboarded }) {
+  const histQ = useHistorialCobraHoy({ enabled: true });
+
+  const featureDisabled = histQ.error instanceof ApiError && histQ.error.status === 503;
+
+  return (
+    <Layout me={me} title="Cobra hoy">
+      <div className="flex items-center gap-3">
+        <Link
+          to="/app"
+          className="inline-flex items-center gap-1 text-neutral-500 text-sm hover:text-neutral-700"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Inicio
+        </Link>
+      </div>
+
+      <header className="mt-4 flex items-start justify-between gap-4">
+        <div className="flex items-start gap-4">
+          <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-success-50 text-success-700">
+            <Banknote className="h-6 w-6" aria-hidden />
+          </div>
+          <div>
+            <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">Pronto pago</h1>
+            <p className="mt-1 text-neutral-600 text-sm">
+              Recibe el monto neto de tus viajes entregados hoy mismo, descontando una tarifa
+              transparente. Booster cobra al shipper en su plazo; tú no esperas.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      {featureDisabled && (
+        <output className="mt-6 block rounded-md border border-neutral-200 bg-neutral-50 p-4 text-neutral-700 text-sm">
+          La opción de pronto pago todavía no está activa en este entorno. Cuando se habilite, verás
+          acá el historial de tus solicitudes.
+        </output>
+      )}
+
+      {!featureDisabled && histQ.isLoading && (
+        <p className="mt-8 text-neutral-500">Cargando historial…</p>
+      )}
+
+      {!featureDisabled && histQ.error && !(histQ.error instanceof ApiError) && (
+        <p className="mt-8 text-danger-700">
+          No pudimos cargar el historial. Inténtalo en un momento.
+        </p>
+      )}
+
+      {!featureDisabled && histQ.data && histQ.data.adelantos.length === 0 && (
+        <div className="mt-8">
+          <EmptyState
+            icon={<Clock3 className="h-10 w-10" aria-hidden />}
+            title="Aún no tienes solicitudes de pronto pago"
+            description="Cuando un viaje quede entregado y liquidado, podrás solicitar el adelanto desde la pantalla del viaje. Acá quedará el historial."
+            action={
+              <Link to="/app/ofertas" className={emptyStateActionClass}>
+                Ver ofertas activas
+              </Link>
+            }
+          />
+        </div>
+      )}
+
+      {!featureDisabled && histQ.data && histQ.data.adelantos.length > 0 && (
+        <>
+          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <SummaryCard title="Solicitudes" value={histQ.data.adelantos.length.toString()} />
+            <SummaryCard
+              title="Total adelantado"
+              value={fmt(sumAdelantado(histQ.data.adelantos))}
+            />
+            <SummaryCard title="Total tarifa" value={fmt(sumTarifa(histQ.data.adelantos))} />
+          </div>
+
+          <div className="mt-6 overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-neutral-200">
+              <thead className="bg-neutral-50">
+                <tr>
+                  <Th>Solicitado</Th>
+                  <Th>Asignación</Th>
+                  <Th className="text-right">Monto neto</Th>
+                  <Th className="text-right">Tarifa</Th>
+                  <Th className="text-right">Recibido</Th>
+                  <Th>Estado</Th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-neutral-100 bg-white">
+                {histQ.data.adelantos.map((a) => (
+                  <tr key={a.id} className="hover:bg-neutral-50">
+                    <Td className="text-neutral-600 text-xs">{formatDate(a.creado_en)}</Td>
+                    <Td>
+                      <Link
+                        to="/app/asignaciones/$id"
+                        params={{ id: a.asignacion_id }}
+                        className="font-mono text-primary-700 text-xs hover:underline"
+                      >
+                        {a.asignacion_id.slice(0, 8)}
+                      </Link>
+                    </Td>
+                    <Td className="text-right font-medium">{fmt(a.monto_neto_clp)}</Td>
+                    <Td className="text-right text-neutral-600 text-xs">
+                      {fmt(a.tarifa_clp)} ({a.tarifa_pct.toFixed(2)}%)
+                    </Td>
+                    <Td className="text-right font-semibold text-success-700">
+                      {fmt(a.monto_adelantado_clp)}
+                    </Td>
+                    <Td>
+                      <StatusBadge status={a.status} />
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="mt-4 text-neutral-500 text-xs">
+            La tarifa de pronto pago se calcula con la metodología{' '}
+            <code>factoring-v1.0-cl-2026.06</code>. Ver{' '}
+            <Link to="/legal/cobra-hoy" className="text-primary-700 underline">
+              términos completos
+            </Link>
+            .
+          </p>
+        </>
+      )}
+    </Layout>
+  );
+}
+
+function NoCarrierPermission() {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <div className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+        <h2 className="font-semibold text-neutral-900 text-xl">Sin permisos</h2>
+        <p className="mt-2 text-neutral-600 text-sm">
+          El pronto pago es exclusivo de empresas transportistas. Si tu rol cambió, contactá al
+          admin de tu empresa.
+        </p>
+        <Link to="/app" className="mt-4 inline-block text-primary-600 underline">
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: AdelantoHistorial['status'] }) {
+  const map: Record<AdelantoHistorial['status'], { label: string; className: string }> = {
+    solicitado: {
+      label: 'Solicitado',
+      className: 'bg-neutral-100 text-neutral-700',
+    },
+    aprobado: {
+      label: 'Aprobado',
+      className: 'bg-primary-50 text-primary-700',
+    },
+    desembolsado: {
+      label: 'Desembolsado',
+      className: 'bg-success-50 text-success-700',
+    },
+    cobrado_a_shipper: {
+      label: 'Cobrado al shipper',
+      className: 'bg-success-50 text-success-700',
+    },
+    mora: {
+      label: 'En mora',
+      className: 'bg-amber-50 text-amber-700',
+    },
+    cancelado: {
+      label: 'Cancelado',
+      className: 'bg-neutral-100 text-neutral-500',
+    },
+    rechazado: {
+      label: 'Rechazado',
+      className: 'bg-danger-50 text-danger-700',
+    },
+  };
+  const v = map[status];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium text-xs ${v.className}`}
+    >
+      {v.label}
+    </span>
+  );
+}
+
+function Th({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <th
+      className={`px-4 py-2 text-left font-medium text-neutral-500 text-xs uppercase tracking-wider ${className}`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <td className={`px-4 py-3 align-top text-neutral-800 text-sm ${className}`}>{children}</td>
+  );
+}
+
+function SummaryCard({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+      <span className="font-medium text-neutral-500 text-xs uppercase tracking-wider">{title}</span>
+      <div className="mt-2 font-semibold text-2xl text-neutral-900">{value}</div>
+    </div>
+  );
+}
+
+function sumAdelantado(items: AdelantoHistorial[]): number {
+  return items.reduce((acc, a) => acc + a.monto_adelantado_clp, 0);
+}
+
+function sumTarifa(items: AdelantoHistorial[]): number {
+  return items.reduce((acc, a) => acc + a.tarifa_clp, 0);
+}
+
+function fmt(clp: number): string {
+  return `$ ${clp.toLocaleString('es-CL')}`;
+}
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat('es-CL', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Santiago',
+  }).format(new Date(iso));
+}

--- a/apps/web/src/routes/legal-cobra-hoy.test.tsx
+++ b/apps/web/src/routes/legal-cobra-hoy.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+const { LegalCobraHoyRoute } = await import('./legal-cobra-hoy.js');
+
+describe('LegalCobraHoyRoute', () => {
+  it('renderiza header con versión y vínculo a T&Cs marco', () => {
+    render(<LegalCobraHoyRoute />);
+    expect(screen.getByText(/Adendum — Booster Cobra Hoy/i)).toBeInTheDocument();
+    expect(screen.getByText(/Versión 1 · Vigente desde 2026-05-10/)).toBeInTheDocument();
+    // "Términos de Servicio v2" aparece tanto en el header (link al marco)
+    // como en el body §2, por eso usamos getAllByText.
+    expect(screen.getAllByText(/Términos de Servicio v2/).length).toBeGreaterThan(0);
+  });
+
+  it('incluye tabla de tarifas con los 4 plazos oficiales', () => {
+    render(<LegalCobraHoyRoute />);
+    expect(screen.getByText('30 días')).toBeInTheDocument();
+    expect(screen.getByText('45 días')).toBeInTheDocument();
+    expect(screen.getByText('60 días')).toBeInTheDocument();
+    expect(screen.getByText('90 días')).toBeInTheDocument();
+    expect(screen.getByText('1,50%')).toBeInTheDocument();
+    expect(screen.getByText('4,50%')).toBeInTheDocument();
+  });
+
+  it('explica naturaleza partner-mode y no-CMF', () => {
+    const { container } = render(<LegalCobraHoyRoute />);
+    const text = container.textContent ?? '';
+    expect(text).toMatch(/partner-mode/i);
+    expect(text).toMatch(/ni requiere registro CMF/i);
+  });
+
+  it('declara IVA exento Art. 12-E DL 825', () => {
+    const { container } = render(<LegalCobraHoyRoute />);
+    expect(container.textContent ?? '').toMatch(/Art\. 12-E DL 825/i);
+  });
+});

--- a/apps/web/src/routes/legal-cobra-hoy.tsx
+++ b/apps/web/src/routes/legal-cobra-hoy.tsx
@@ -1,0 +1,194 @@
+import { Link } from '@tanstack/react-router';
+import { ArrowLeft } from 'lucide-react';
+
+/**
+ * /legal/cobra-hoy — Adendum público de pronto pago (ADR-029 v1 / ADR-032).
+ *
+ * Documento marco: docs/legal/adendum-cobra-hoy-v1.md.
+ *
+ * Pública (sin auth) para que el Transportista pueda revisar términos
+ * antes de aceptar una solicitud. El acto de aceptación ocurre en el
+ * modal de `CobraHoyButton`, no acá.
+ */
+export function LegalCobraHoyRoute() {
+  return (
+    <div className="min-h-screen bg-neutral-50">
+      <header className="border-neutral-200 border-b bg-white">
+        <div className="mx-auto flex max-w-3xl items-center gap-3 px-4 py-3 sm:px-6">
+          <Link
+            to="/"
+            className="rounded p-1 text-neutral-500 transition hover:bg-neutral-100"
+            aria-label="Volver"
+          >
+            <ArrowLeft className="h-5 w-5" aria-hidden />
+          </Link>
+          <div>
+            <h1 className="font-semibold text-neutral-900 text-lg">Adendum — Booster Cobra Hoy</h1>
+            <p className="text-neutral-500 text-xs">
+              Versión 1 · Vigente desde 2026-05-10 · Marco:{' '}
+              <Link to="/legal/terminos" className="underline">
+                Términos de Servicio v2 §4.3
+              </Link>
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6">
+        <article className="prose prose-neutral mt-2 max-w-none rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+          <AdendumContent />
+        </article>
+      </main>
+    </div>
+  );
+}
+
+function AdendumContent() {
+  return (
+    <>
+      <h2>1. Naturaleza del servicio</h2>
+      <p>
+        Booster ofrece a los Transportistas, en forma <strong>opcional</strong>, anticipar el cobro
+        del monto neto de un viaje entregado sin esperar el plazo natural de pago del Generador de
+        carga ("Shipper"). El servicio se llama <strong>"Booster Cobra Hoy"</strong> o{' '}
+        <strong>"pronto pago"</strong>.
+      </p>
+      <p>
+        El servicio opera en modo <strong>partner</strong>: Booster facilita la solicitud y registra
+        el adelanto, pero el dinero proviene de un partner financiero externo regulado que asume el
+        riesgo de crédito frente al Shipper. Booster <strong>no</strong> es institución financiera
+        ni requiere registro CMF mientras se mantenga en partner-mode.
+      </p>
+
+      <h2>2. Quién puede solicitar</h2>
+      <p>Transportistas activos que tengan:</p>
+      <ol>
+        <li>Términos de Servicio v2 y este Adendum aceptados.</li>
+        <li>
+          Al menos un viaje <strong>entregado</strong> con liquidación calculada.
+        </li>
+        <li>Un Shipper con crédito aprobado por Booster + Partner.</li>
+      </ol>
+
+      <h2>3. Cómo se calcula la tarifa</h2>
+      <p>
+        Tarifa sobre el <strong>monto neto del viaje</strong> según el plazo declarado del Shipper:
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Plazo Shipper</th>
+            <th>Tarifa</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>30 días</td>
+            <td>1,50%</td>
+          </tr>
+          <tr>
+            <td>45 días</td>
+            <td>2,20%</td>
+          </tr>
+          <tr>
+            <td>60 días</td>
+            <td>3,00%</td>
+          </tr>
+          <tr>
+            <td>90 días</td>
+            <td>4,50%</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Plazos intermedios se interpolan linealmente. Plazos &gt; 90 días aplican techo dinámico
+        (4,5% + 0,5% × cada 15 días, máximo absoluto 8,0%). Redondeo HALF_UP a entero CLP.
+        Metodología versionada <code>factoring-v1.0-cl-2026.06</code>, congelada por solicitud.
+      </p>
+      <p>
+        <em>Ejemplo</em>: viaje neto $176.000, plazo 30 días → tarifa $2.640 →{' '}
+        <strong>recibes $173.360 hoy</strong>.
+      </p>
+
+      <h2>4. Criterios del Shipper</h2>
+      <ol>
+        <li>
+          Score Equifax CL ≥ 700 → límite estándar · 550–699 → límite reducido · &lt; 550 → rechazo.
+        </li>
+        <li>Antigüedad mínima 24 meses.</li>
+        <li>Sin cuentas impagas vigentes.</li>
+        <li>Concentración: suma de adelantos vivos del Shipper ≤ su límite.</li>
+        <li>Decisión vigente 90 días. Sin score automático → revisión manual ≤ 2 días hábiles.</li>
+      </ol>
+
+      <h2>5. Flujo operativo</h2>
+      <ol>
+        <li>
+          Click <strong>"Cobra hoy"</strong> en la pantalla del viaje entregado.
+        </li>
+        <li>La plataforma muestra el desglose en tiempo real.</li>
+        <li>
+          Confirmas. La solicitud queda en estado <code>solicitado</code>.
+        </li>
+        <li>
+          El Partner valida y transfiere a la cuenta registrada (<code>desembolsado</code>).
+        </li>
+        <li>
+          Booster cobra al Shipper en su fecha (<code>cobrado_a_shipper</code>). Tú no esperas.
+        </li>
+      </ol>
+
+      <h2>6. Cesión de derechos</h2>
+      <p>
+        Al confirmar, cedes al Partner los derechos de cobro sobre ese viaje específico (Art. 1901 y
+        siguientes del Código Civil chileno), a título oneroso (recibes el monto adelantado) y{' '}
+        <strong>sin recurso</strong> contra el Transportista en condiciones normales. Excepciones:
+        §7.
+      </p>
+
+      <h2>7. Excepciones con recurso</h2>
+      <p>El adelanto pasa a tener recurso contra el Transportista si:</p>
+      <ol>
+        <li>El viaje se cancela o no se entrega por causa imputable al Transportista.</li>
+        <li>Hay fraude, falsedad u omisiones materiales en la solicitud.</li>
+        <li>El Shipper disputa válidamente la entrega y no se resuelve en 30 días corridos.</li>
+      </ol>
+
+      <h2>8. Tratamiento tributario</h2>
+      <ul>
+        <li>
+          El monto adelantado <strong>no es ingreso adicional</strong>: sustituye temporalmente el
+          pago del Shipper.
+        </li>
+        <li>
+          La tarifa de pronto pago es operación financiera <strong>exenta de IVA</strong> (Art. 12-E
+          DL 825).
+        </li>
+        <li>El Partner emite el certificado tributario correspondiente.</li>
+        <li>
+          La comisión Booster sobre el viaje (DTE Tipo 33) <strong>no varía</strong>.
+        </li>
+      </ul>
+
+      <h2>9. Privacidad</h2>
+      <p>
+        Para underwriting Booster consulta el score Equifax CL del Shipper bajo Ley 19.628 / Ley
+        19.812. El Transportista solicitante no accede a estos datos — sólo conoce el resultado
+        agregado.
+      </p>
+
+      <h2>10. Modificaciones</h2>
+      <p>
+        Cambios <strong>adversos</strong> al Transportista se comunican con 30 días de anticipación.
+        Cambios neutros o favorables entran en vigor al publicarse. La metodología versionada
+        capturada en cada solicitud no varía retroactivamente.
+      </p>
+
+      <p className="text-neutral-500 text-xs">
+        Versión completa del Adendum con todas las cláusulas legales: ver{' '}
+        <code>docs/legal/adendum-cobra-hoy-v1.md</code> en el repositorio público de Booster.
+        Consultas: <a href="mailto:soporte@boosterchile.com">soporte@boosterchile.com</a>.
+      </p>
+    </>
+  );
+}

--- a/docs/adr/032-factoring-v1-activacion-escala-minima.md
+++ b/docs/adr/032-factoring-v1-activacion-escala-minima.md
@@ -1,0 +1,265 @@
+# ADR-032 — Factoring v1: activación con escala mínima + partner diferido
+
+**Status**: Accepted
+**Date**: 2026-05-10
+**Decider**: Felipe Vicencio (Product Owner)
+**Technical contributor**: Claude (Cowork) actuando como arquitecto de software
+**Activates**: [ADR-029 Factoring / Pronto pago al transportista](./029-factoring-pronto-pago-al-transportista.md)
+**Related**:
+- [ADR-027 Pricing v1](./027-pricing-model-uniform-shipper-set-with-tier-commission-roadmap.md) (superseded por ADR-030)
+- [ADR-030 Pricing v2 foundation](./030-pricing-v2-activation-commission-and-billing.md)
+- [ADR-031 Pricing v2 activación escala mínima](./031-pricing-v2-activacion-escala-minima.md)
+- [ADR-024 SII provider Sovos](./024-sii-provider-sovos-with-multi-vendor-strategy.md)
+- [ADR-007 Chile document management](./007-chile-document-management.md)
+
+---
+
+## Contexto
+
+ADR-029 definió el producto "Booster Cobra Hoy" como diferenciador comercial (pronto pago al carrier antes del plazo del shipper), inspirado en Tennders ES. El status quedó `Proposed` con bloqueo de implementación hasta cumplir **7 criterios duros**:
+
+1. ADR-027 v2 implementado y operativo ≥3 meses
+2. ≥50 trips liquidados/mes durante ≥3 meses
+3. ≥1 partner factoring con LOI + sandbox API
+4. ≥10 shippers prototipo aprobados
+5. Tarifas confirmadas con partner
+6. T&Cs específicas firmadas
+7. Tasa aprobación shipper ≥70%
+
+El PO aprobó el **2026-05-10** el mismo patrón que ADR-031 aplicó a ADR-030: **adelantar la foundation técnica detrás de un feature flag**, dejando los criterios de partner/legal/volumen como bloqueantes solo para la activación real del flag en producción. Razones:
+
+- La función pura de cálculo de tarifa es independiente del partner — testeable hoy sin riesgo.
+- El schema de BD (`adelantos_carrier`) es estable y aplicable hoy; vacío hasta activación.
+- Los endpoints + UI pueden estar listos detrás de un flag para que el primer carrier vea el botón "Cobra hoy" el mismo día que se firme el partner.
+- Permite **validación de UX** con stakeholders internos antes del commit con partners reales.
+
+Este ADR adopta la decisión del ADR-029 (cambia su status implícito a operativo bajo flag) y define los criterios revisados de activación productiva.
+
+---
+
+## Decisión
+
+### 1. Foundation técnica completa, partner real diferido
+
+Implementar **hoy** en este PR:
+
+- `packages/factoring-engine` con función pura `calcularTarifaProntoPago()` + `evaluarShipper()` + tests exhaustivos.
+- Migration `0016_factoring_v1.sql` con tablas `adelantos_carrier` + `shipper_credit_decisions` + seed de las 4 tasas (30/45/60/90 días).
+- Drizzle schema espejado.
+- Service `cobra-hoy.ts` con feature flag `FACTORING_V1_ACTIVATED` (default `false` excepto prod).
+- Endpoints `POST /me/asignaciones/:id/cobra-hoy`, `GET /me/asignaciones/:id/cobra-hoy/cotizacion`, `GET /me/cobra-hoy/historial`.
+- UI mínima en `apps/web` (botón en asignación detalle + página historial).
+- T&Cs Cobra Hoy v1 en `/legal/cobra-hoy`.
+
+**Diferido (no implementado, NO bloquea merge)**:
+
+- Integración real con partner factoring (Toctoc/Mafin/Increase/Cumplo). Mientras tanto el service stubea el partner: marca el adelanto como `desembolsado` simulado pero NO ejecuta cesión DTE real ni transferencia.
+- Cesión electrónica DTE vía Sovos (depende del módulo `apps/document-service` que sigue esqueleto desde ADR-030).
+- Consulta crediticia real Equifax/Sentinel/Dicom. El `evaluarShipper()` puro acepta un score externo; el caller decide cómo obtenerlo (mock en tests, API real cuando exista).
+- Cron de "cobranza al shipper" a la fecha del DTE (depende de la cesión DTE real).
+
+### 2. Activación dual: hard switch + partner real
+
+El flag `FACTORING_V1_ACTIVATED` controla:
+
+- Si es `false` → `cobraHoy()` retorna `{ status: 'skipped_flag_disabled' }`. Endpoints devuelven 503 con `feature_disabled`. UI no muestra botón.
+- Si es `true` → los endpoints operan, pero **cada adelanto requiere `shipper_credit_decisions.approved=true`** del shipper del trip. Sin underwriting aprobado, el endpoint devuelve 422 con `shipper_no_aprobado`.
+
+Default por entorno (espejo ADR-031 §2):
+
+```ts
+FACTORING_V1_ACTIVATED: z.coerce.boolean().default(
+  process.env.NODE_ENV === 'production',
+),
+```
+
+Producción tiene el flag prendido automáticamente; dev/test/staging tiene `false`.
+
+### 3. Esquema de tarifas (espejo ADR-029 §2)
+
+Aplicado en la función pura sin posibilidad de override del caller:
+
+| Plazo shipper | Tarifa pronto pago |
+|---|---:|
+| 30 días | 1.5% |
+| 45 días | 2.2% |
+| 60 días | 3.0% |
+| 90 días | 4.5% |
+
+Cualquier plazo intermedio (37 días, 75 días) se resuelve **interpolando linealmente** entre las dos tasas adyacentes. Plazos <30 días = 1.5% (no se ofrece menor). Plazos >90 días = 4.5% + 0.5% por cada 15 días adicionales (techo 8%).
+
+**Cobro sobre `monto_neto_carrier_clp`** (post-comisión Booster), no sobre `agreedPriceClp` bruto. Mantiene clean separation: pricing v2 cobra comisión, factoring v1 cobra tarifa financiera.
+
+### 4. Tabla `adelantos_carrier`
+
+```sql
+CREATE TABLE adelantos_carrier (
+  id                              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  asignacion_id                   uuid NOT NULL UNIQUE REFERENCES assignments(id) ON DELETE RESTRICT,
+  liquidacion_id                  uuid REFERENCES liquidaciones(id),
+  empresa_carrier_id              uuid NOT NULL REFERENCES empresas(id),
+  empresa_shipper_id              uuid NOT NULL REFERENCES empresas(id),
+  monto_neto_clp                  integer NOT NULL,
+  plazo_dias_shipper              integer NOT NULL CHECK (plazo_dias_shipper > 0),
+  tarifa_pct                      numeric(4,2) NOT NULL,
+  tarifa_clp                      integer NOT NULL,
+  monto_adelantado_clp            integer NOT NULL,
+  partner_slug                    text,
+  partner_request_id              text,
+  status                          text NOT NULL CHECK (status IN (
+                                    'solicitado',
+                                    'aprobado',
+                                    'desembolsado',
+                                    'cobrado_a_shipper',
+                                    'mora',
+                                    'cancelado',
+                                    'rechazado'
+                                  )),
+  rechazo_motivo                  text,
+  desembolsado_en                 timestamptz,
+  cobrado_a_shipper_en            timestamptz,
+  mora_desde                      timestamptz,
+  factoring_methodology_version   text NOT NULL,
+  creado_en                       timestamptz NOT NULL DEFAULT now(),
+  actualizado_en                  timestamptz NOT NULL DEFAULT now()
+);
+```
+
+UNIQUE en `asignacion_id` garantiza **idempotencia**: una asignación tiene a lo más un adelanto vigente. Si se cancela el adelanto, el carrier puede crear otro nuevo solo si el primero queda en `status='cancelado'` (lógica de service).
+
+### 5. Tabla `shipper_credit_decisions`
+
+```sql
+CREATE TABLE shipper_credit_decisions (
+  id                              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_shipper_id              uuid NOT NULL REFERENCES empresas(id),
+  approved                        boolean NOT NULL,
+  limit_exposure_clp              integer NOT NULL DEFAULT 0,
+  current_exposure_clp            integer NOT NULL DEFAULT 0,
+  equifax_score                   integer,
+  decided_at                      timestamptz NOT NULL DEFAULT now(),
+  decided_by                      text NOT NULL CHECK (decided_by IN ('automatico','manual')),
+  expires_at                      timestamptz NOT NULL,
+  motivo                          text,
+  creado_en                       timestamptz NOT NULL DEFAULT now(),
+  actualizado_en                  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX uq_shipper_credit_decisions_empresa_vigente
+  ON shipper_credit_decisions(empresa_shipper_id)
+  WHERE expires_at > now();
+```
+
+El partial unique index garantiza que solo hay UNA decisión vigente por shipper. Las decisiones expiradas quedan en BD para auditoría histórica.
+
+### 6. Versionado de metodología
+
+Espejo de pricing methodology: cada adelanto persiste `factoring_methodology_version` (semver). Cambios MINOR cuando cambia la tabla de tarifas; MAJOR cuando cambia el modelo (ej. tarifa variable por shipper individual).
+
+Inicial: `factoring-v1.0-cl-2026.06`.
+
+### 7. Criterios de activación productiva (revisados)
+
+**Bloqueantes** (sin esto, el flag NO se prende):
+
+- [ ] Migration aplicada en producción
+- [ ] T&Cs Cobra Hoy v1 publicadas en `/legal/cobra-hoy`
+- [ ] Endpoint `POST /me/consent/cobra-hoy-v1` (opt-in del carrier al producto financiero específico)
+- [ ] Auto-decisión manual de shippers conocidos (insert directo en `shipper_credit_decisions` mientras no haya Equifax wire)
+- [ ] Al menos 1 partner factoring con LOI firmado **O** decisión expresa del PO de operar "modo demo" donde el adelanto se simula (no se transfiere dinero real al carrier; carrier ve UX completa para validación)
+
+**No bloqueantes** (el flag puede prenderse sin esto):
+
+- ⏸ Equifax/Sentinel/Dicom API real — decisiones manuales por shipper hasta entonces.
+- ⏸ Sovos cesión DTE — el adelanto queda con `partner_slug=NULL`, `desembolsado_en=NULL` hasta que Sovos integre.
+- ⏸ Volumen ≥50 trips/mes — el ADR-031 ya activó pricing v2 con escala mínima; factoring sigue el mismo enfoque "primer carrier ya".
+
+### 8. Estructura del flow técnico
+
+```
+1. POST /me/asignaciones/:id/cobra-hoy/cotizacion
+   ↓ (frontend muestra desglose: monto neto, tarifa, recibirás)
+   ↓
+2. Carrier confirma → POST /me/asignaciones/:id/cobra-hoy
+   ↓
+3. Service cobraHoy() verifica:
+   a. assignment existe + es del carrier
+   b. assignment.deliveredAt no-null
+   c. liquidacion existe + status 'lista_para_dte' o 'dte_emitido'
+   d. shipper_credit_decisions vigente + approved=true
+   e. limit_exposure no excedido
+   f. NO existe adelantos_carrier para esta asignacion
+   ↓
+4. INSERT adelantos_carrier con status='solicitado'
+   ↓
+5. (Partner real cuando exista) — llamada API partner cesión DTE
+   ↓
+6. UPDATE status='aprobado' → 'desembolsado' (manual o partner callback)
+   ↓
+7. Cuando shipper paga DTE: UPDATE status='cobrado_a_shipper'
+8. Si plazo vence sin pago: UPDATE status='mora' (cron diario)
+```
+
+---
+
+## Consecuencias
+
+### Positivas
+
+- **Foundation técnica sin riesgo material**: el código nuevo no opera contra dinero real hasta que se prenda el flag + se firme partner.
+- **UX validable hoy**: stakeholders pueden hacer demos completas del flow sin transferencias reales.
+- **Versionado de metodología desde día 1**: cambios futuros de tarifas son auditables.
+- **Compatibilidad con `liquidaciones.payout_carrier_metodo='pronto_pago_booster'`** (ya previsto en ADR-030 §10) — al desembolsar, el service también marca la liquidación.
+- **Activación incremental**: primer carrier sin partner (modo demo), después con partner real, después con Equifax automático.
+
+### Negativas / costos
+
+- **Código que no opera inmediatamente**: aumenta surface area mantenible. Mitigación: tests >95% en función pura + tests de service con flag=true.
+- **UX puede mostrar botón "Cobra hoy" antes de que funcione realmente**: requiere comunicación clara con stakeholders del estado "modo demo".
+- **Riesgo de promesa que no se cumple si el partner no se firma rápido**: mitigado por mantener el flag `false` hasta partner LOI.
+- **Sin Equifax, las decisiones de underwriting son manuales**: no escala a >50 shippers sin trabajo operativo, pero soporta el caso de "1 cliente, 1 vehículo".
+
+### Acciones derivadas (este PR)
+
+1. ADR-029 status actualizable a `Accepted` cuando el flag se prenda en prod (no en este PR).
+2. `packages/factoring-engine` con cálculo de tarifa + underwriting puros.
+3. Migration `0016_factoring_v1.sql`.
+4. Drizzle schema.
+5. Service `cobra-hoy.ts` con flag-gate.
+6. 3 endpoints REST.
+7. UI carrier (botón + modal + historial).
+8. T&Cs Cobra Hoy v1 + página `/legal/cobra-hoy`.
+
+### Acciones diferidas explícitamente
+
+- Partner integration real (factoring-partner-toctoc.ts u otro).
+- Sovos cesión DTE wire.
+- Equifax/Sentinel/Dicom wire.
+- Cron de cobranza al shipper.
+- UI admin de adelantos (lista global + acciones de cobranza).
+
+---
+
+## Validación (este PR)
+
+- [x] ADR-032 escrito + activa ADR-029.
+- [x] `packages/factoring-engine` implementado + tests (tarifa + underwriting).
+- [x] Migration creada + Drizzle schema espejado.
+- [x] Service `cobra-hoy.ts` con flag-gate + tests cubriendo cada branch.
+- [x] 3 endpoints REST + tests.
+- [x] UI carrier funcional.
+- [x] T&Cs publicadas.
+- [x] Config flag `FACTORING_V1_ACTIVATED` por `NODE_ENV`.
+- [x] Coverage api+web sobre threshold.
+- [ ] (Externo) Partner factoring LOI.
+- [ ] (Externo) Sovos cesión DTE wire.
+- [ ] (Externo) Equifax API wire.
+
+---
+
+## Notas
+
+- Este ADR sigue el mismo patrón que ADR-031 aplicó a ADR-030: relax de criterios duros de escala/volumen, mantener criterios duros legales/operacionales que no se pueden bypassar.
+- La función pura `calcularTarifaProntoPago()` es independiente del partner. Si en el futuro Booster opera con capital propio (opción B del ADR-029 §4), las tarifas pueden bajar pero la función queda igual; cambia solo la fuente de capital.
+- El `factoring_methodology_version` es ortogonal al `pricing_methodology_version` — un trip puede tener pricing v2 + factoring v1, o pricing v2 sin factoring (si carrier no opta).
+- Cuando se active partner real, los tests `cobra-hoy.test.ts` que asumen modo demo se actualizan; el contract no cambia.

--- a/docs/legal/adendum-cobra-hoy-v1.md
+++ b/docs/legal/adendum-cobra-hoy-v1.md
@@ -1,0 +1,224 @@
+# Adendum — Booster Cobra Hoy (Pronto Pago al Transportista) — v1
+
+**Versión**: 1.0
+**Vigente desde**: 2026-05-10
+**Última actualización**: 2026-05-10
+**Documento marco**: [Términos de Servicio v2](./terminos-de-servicio-v2.md) §4.3
+
+> Este Adendum integra y desarrolla la cláusula 4.3 ("módulo pronto pago
+> opcional") de los Términos de Servicio v2. La aceptación del Adendum es
+> requisito previo para usar la funcionalidad **"Cobra hoy"** desde la
+> plataforma Booster.
+
+---
+
+## 1. Naturaleza del servicio
+
+Booster ofrece a los Transportistas, en forma opcional, la posibilidad
+de **anticipar el cobro del monto neto de un viaje entregado** sin
+esperar el plazo natural de pago del Generador de carga (en adelante,
+el **"Shipper"**).
+
+A esta funcionalidad se le denomina **"Booster Cobra Hoy"** o
+**"pronto pago"** indistintamente.
+
+El servicio se opera bajo un esquema **partner-mode**: Booster facilita
+la solicitud, realiza el underwriting del Shipper y registra el adelanto
+en la plataforma. **El dinero adelantado proviene de un partner
+financiero externo regulado** (en adelante, el **"Partner"**) que, en
+su carácter de cesionario, asume el riesgo de crédito frente al Shipper.
+
+Booster **no es** una institución financiera, no opera con dineros del
+público y no requiere registro CMF mientras se mantenga en partner-mode
+(Resolución CMF N°449 y normativa concordante).
+
+## 2. Quién puede solicitar pronto pago
+
+Cualquier Transportista activo en la plataforma Booster que cumpla
+simultáneamente:
+
+1. Haber aceptado los Términos de Servicio v2 y el presente Adendum.
+2. Tener al menos un viaje **entregado** con liquidación calculada.
+3. Operar con un Shipper cuyo crédito haya sido **aprobado** por
+   Booster + Partner según los criterios descritos en §4.
+
+La solicitud se realiza desde la pantalla del viaje
+(`/app/asignaciones/:id`) o desde el historial dedicado
+(`/app/cobra-hoy/historial`).
+
+## 3. Cómo se calcula la tarifa
+
+La tarifa de pronto pago se aplica sobre el **monto neto del viaje**
+(monto bruto descontada la comisión Booster + IVA correspondiente),
+en función del **plazo declarado del Shipper** según la siguiente
+tabla oficial:
+
+| Plazo Shipper | Tarifa |
+|---|---|
+| 30 días | 1,50% |
+| 45 días | 2,20% |
+| 60 días | 3,00% |
+| 90 días | 4,50% |
+
+Para plazos intermedios se aplica **interpolación lineal** entre los
+puntos contiguos de la tabla.
+
+Para plazos superiores a 90 días se aplica un **techo dinámico**:
+
+```
+techo(plazo) = 4,5% + 0,5% × ceil((plazo − 90) / 15)
+```
+
+con un **máximo absoluto de 8,0%** independientemente del plazo.
+
+El redondeo es a **enteros CLP** mediante regla HALF_UP. La metodología
+de cálculo se versiona como `factoring-v1.0-cl-2026.06` y queda
+**congelada** en cada solicitud aceptada — futuras revisiones de la
+tarifa no se aplican retroactivamente.
+
+### Ejemplo
+
+Viaje entregado, monto neto del Transportista = $176.000, plazo
+Shipper = 30 días:
+
+- Tarifa: 1,50% × $176.000 = **$2.640**
+- **Monto adelantado: $173.360**
+- Plazo del Shipper: 30 días corridos desde la liquidación.
+
+## 4. Criterios de elegibilidad del Shipper (underwriting)
+
+Para que un viaje sea elegible, el Shipper que lo originó debe contar
+con una **decisión de crédito vigente y aprobada**. La decisión se
+evalúa con base en:
+
+1. **Score Equifax CL** del RUT del Shipper (escala 0–1000):
+   - ≥ 700 → aprobado con **límite estándar**.
+   - 550–699 → aprobado con **límite reducido**.
+   - < 550 → **rechazado**.
+2. **Antigüedad operativa** mínima de 24 meses en plataforma o
+   acreditable documentalmente.
+3. **Cuentas impagas** o protestos: cualquier registro vigente
+   resulta en rechazo.
+4. **Concentración de exposición**: la suma de adelantos vivos del
+   mismo Shipper no puede superar su límite asignado.
+5. **Vigencia de la decisión**: 90 días corridos. Pasado ese plazo
+   se re-evalúa.
+
+Si el Shipper no tiene decisión vigente y no es posible obtener score
+automáticamente, la solicitud queda en estado **manual_requerido**.
+Booster decidirá manualmente en máximo 2 días hábiles.
+
+## 5. Flujo operativo
+
+1. El Transportista hace click en **"Cobra hoy"** desde la pantalla
+   del viaje entregado.
+2. La plataforma muestra el **desglose en tiempo real** (monto neto,
+   tarifa, monto a recibir, plazo del Shipper).
+3. El Transportista confirma. La solicitud queda en estado
+   `solicitado`.
+4. El Partner valida y, si procede, transfiere el monto adelantado
+   a la cuenta bancaria registrada del Transportista (estado
+   `desembolsado`).
+5. Booster cobra al Shipper en su fecha natural de pago (estado
+   `cobrado_a_shipper`). El Transportista **no participa** del cobro
+   al Shipper en este flujo.
+
+Cada estado queda registrado con marca temporal en el historial
+del Transportista (`/app/cobra-hoy/historial`).
+
+## 6. Cesión de derechos
+
+Al confirmar la solicitud de pronto pago, el Transportista **cede al
+Partner** los derechos de cobro sobre el monto neto del viaje
+correspondiente, en los términos del Art. 1901 y siguientes del Código
+Civil chileno. Booster actúa como intermediario tecnológico y
+documental de la cesión.
+
+La cesión es:
+
+- **Limitada al viaje específico** identificado por su `asignacion_id`.
+- **A título oneroso** (el Transportista recibe el monto adelantado).
+- **Sin recurso** contra el Transportista en condiciones normales:
+  si el Shipper no paga al Partner en el plazo, el riesgo es del
+  Partner — salvo en los supuestos del §7.
+
+## 7. Excepciones (con recurso contra el Transportista)
+
+El adelanto pasa a tener **recurso contra el Transportista** y
+Booster/Partner pueden exigir devolución del monto si:
+
+1. El viaje resulta **cancelado o no entregado** después del desembolso
+   por causa imputable al Transportista.
+2. Se acreditan **fraude, falsedad u omisiones materiales** del
+   Transportista al solicitar el adelanto.
+3. Existe **disputa válida del Shipper** sobre la entrega (ej. carga
+   no recibida, mercadería dañada, evidencia POD inválida) que el
+   Transportista no resuelve dentro de los 30 días corridos.
+
+En estos casos, Booster bloqueará nuevas solicitudes hasta regularizar
+la situación.
+
+## 8. Tratamiento tributario
+
+- El **monto adelantado** no constituye un ingreso adicional para el
+  Transportista — sustituye temporalmente al pago del Shipper.
+- La **tarifa de pronto pago** es una operación financiera
+  **exenta de IVA** conforme al Art. 12-E DL 825 (operaciones de
+  financiamiento de créditos).
+- El Partner emite el certificado tributario correspondiente
+  (factura exenta o documento equivalente). Booster lo pone a
+  disposición del Transportista en su historial.
+- La comisión Booster sobre el viaje (DTE Tipo 33, comisión + IVA)
+  se mantiene **inalterada** y se factura por el flujo regular.
+
+## 9. Privacidad y datos
+
+Para evaluar la elegibilidad del Shipper, Booster consulta el score
+Equifax CL de su RUT bajo el marco regulatorio chileno (Ley 19.628
+y Ley 19.812). El Transportista solicitante no accede a estos datos —
+sólo conoce el resultado agregado (aprobado / rechazado).
+
+Para el desembolso, Booster comparte con el Partner los datos
+estrictamente necesarios: RUT del Transportista, datos bancarios
+registrados, monto neto del viaje, plazo del Shipper. El Partner
+asume obligaciones de confidencialidad equivalentes a las de Booster.
+
+## 10. Comunicación y soporte
+
+Cualquier consulta o disputa sobre una solicitud específica puede
+canalizarse a **soporte@boosterchile.com**. Booster responde en
+máximo 1 día hábil para solicitudes activas (`solicitado`,
+`aprobado`) y 3 días hábiles para histórico ya `desembolsado`.
+
+## 11. Modificaciones
+
+Booster puede modificar la tabla de tarifas, los umbrales de
+underwriting o la mecánica operativa de este Adendum. Cambios
+**adversos** al Transportista se comunican con **30 días de
+anticipación** vía email + banner persistente. Cambios neutros o
+favorables entran en vigor al publicarse.
+
+La metodología versionada (`factoring-v1.0-cl-2026.06`) capturada al
+momento de cada solicitud **no varía retroactivamente**.
+
+## 12. Suspensión y término
+
+Booster puede suspender el acceso al pronto pago para un Transportista
+específico cuando:
+
+- Acumule >2 incidentes de los supuestos del §7 en 90 días.
+- Su Shipper habitual pase a estado **rechazado** en underwriting.
+- Exista investigación judicial o regulatoria que comprometa el
+  flujo.
+
+La suspensión del módulo no afecta el resto de la plataforma Booster.
+
+---
+
+**Aceptación**
+
+Al hacer click en **"Confirmar y recibir hoy"** desde la pantalla del
+viaje, el Transportista manifiesta voluntad expresa de quedar
+vinculado por este Adendum para esa solicitud específica. La primera
+aceptación queda registrada en la cuenta del Transportista con marca
+temporal, IP y agente de usuario.

--- a/packages/factoring-engine/package.json
+++ b/packages/factoring-engine/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@booster-ai/factoring-engine",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.8.2",
+    "vitest": "^4.0.18"
+  }
+}

--- a/packages/factoring-engine/src/index.ts
+++ b/packages/factoring-engine/src/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @booster-ai/factoring-engine
+ *
+ * Foundation técnica de factoring v1 (ADR-029 + ADR-032).
+ *
+ * Funciones puras (sin I/O):
+ *   - `calcularTarifaProntoPago(input)`: tarifa + monto adelantado para
+ *     un viaje según el plazo del shipper.
+ *   - `evaluarShipper(params)`: underwriting con reglas hard (RUT, antigüedad,
+ *     morosidad) + score Equifax para auto-aprobación.
+ *
+ * Constantes:
+ *   - `FACTORING_METHODOLOGY_VERSION`: semver capturada en cada adelanto.
+ */
+
+export { calcularTarifaProntoPago, FACTORING_METHODOLOGY_VERSION } from './tarifa.js';
+export { evaluarShipper } from './underwriting.js';
+export type {
+  CalcularTarifaInput,
+  CalcularTarifaOutput,
+  EvaluarShipperInput,
+  EvaluarShipperOutput,
+  EvaluarShipperParams,
+} from './types.js';

--- a/packages/factoring-engine/src/tarifa.ts
+++ b/packages/factoring-engine/src/tarifa.ts
@@ -1,0 +1,116 @@
+import type { CalcularTarifaInput, CalcularTarifaOutput } from './types.js';
+
+/**
+ * Versión semver de la metodología de factoring. Cambios MINOR cuando
+ * cambia la tabla de tarifas; MAJOR cuando cambia el modelo (ej. tarifa
+ * variable por shipper individual). Capturada en cada adelanto persistido.
+ */
+export const FACTORING_METHODOLOGY_VERSION = 'factoring-v1.0-cl-2026.06' as const;
+
+/**
+ * Tabla de tarifas oficial (ADR-029 §2 + ADR-032 §3). Plazos
+ * intermedios se interpolan linealmente. Plazos <30d aplican 1.5%
+ * (tarifa piso). Plazos >90d aplican techo dinámico hasta 8%.
+ */
+const TARIFA_TABLA: ReadonlyArray<{ dias: number; pct: number }> = [
+  { dias: 30, pct: 1.5 },
+  { dias: 45, pct: 2.2 },
+  { dias: 60, pct: 3.0 },
+  { dias: 90, pct: 4.5 },
+];
+
+const TARIFA_TECHO_PCT = 8.0;
+const TARIFA_TECHO_INCREMENTO_POR_15D = 0.5;
+
+/**
+ * Calcula la tarifa de pronto pago dado el monto neto al carrier y
+ * el plazo del shipper. Función pura, determinista.
+ *
+ * Reglas:
+ *   - plazo ≤ 30 días → 1.5% (tarifa piso)
+ *   - 30 ≤ plazo ≤ 90 → interpolación lineal entre tabla
+ *   - plazo > 90 → 4.5% + 0.5% por cada 15 días extras, techo 8%
+ *
+ * Tarifa se aplica sobre `montoNetoClp` (post-comisión Booster, ADR-030).
+ * `montoAdelantadoClp = montoNetoClp - tarifaClp`.
+ *
+ * @throws Error si montoNetoClp < 0, no integer, o plazoDiasShipper ≤ 0.
+ */
+export function calcularTarifaProntoPago(input: CalcularTarifaInput): CalcularTarifaOutput {
+  const { montoNetoClp, plazoDiasShipper } = input;
+
+  if (!Number.isFinite(montoNetoClp) || montoNetoClp < 0) {
+    throw new Error(
+      `calcularTarifaProntoPago: montoNetoClp debe ser número finito >= 0 (recibido ${montoNetoClp})`,
+    );
+  }
+  if (!Number.isInteger(montoNetoClp)) {
+    throw new Error(
+      `calcularTarifaProntoPago: montoNetoClp debe ser integer (recibido ${montoNetoClp})`,
+    );
+  }
+  if (!Number.isFinite(plazoDiasShipper) || plazoDiasShipper <= 0) {
+    throw new Error(
+      `calcularTarifaProntoPago: plazoDiasShipper debe ser > 0 (recibido ${plazoDiasShipper})`,
+    );
+  }
+  if (!Number.isInteger(plazoDiasShipper)) {
+    throw new Error(
+      `calcularTarifaProntoPago: plazoDiasShipper debe ser integer (recibido ${plazoDiasShipper})`,
+    );
+  }
+
+  const tarifaPct = resolverTarifaPct(plazoDiasShipper);
+  const tarifaClp = Math.round((montoNetoClp * tarifaPct) / 100);
+  const montoAdelantadoClp = montoNetoClp - tarifaClp;
+
+  return {
+    montoNetoClp,
+    plazoDiasShipper,
+    tarifaPct,
+    tarifaClp,
+    montoAdelantadoClp,
+    factoringMethodologyVersion: FACTORING_METHODOLOGY_VERSION,
+  };
+}
+
+function resolverTarifaPct(plazoDias: number): number {
+  // La tabla es una constante no vacía declarada al tope del módulo,
+  // por lo que `primero` y `ultimo` siempre existen — verificamos
+  // defensivamente para que el tipado refleje la garantía.
+  const primero = TARIFA_TABLA[0];
+  const ultimo = TARIFA_TABLA[TARIFA_TABLA.length - 1];
+  if (!primero || !ultimo) {
+    throw new Error('TARIFA_TABLA debe contener al menos un punto');
+  }
+  // Plazo en o bajo el mínimo → tarifa piso.
+  if (plazoDias <= primero.dias) {
+    return primero.pct;
+  }
+  // Plazo sobre el máximo de la tabla → techo dinámico.
+  if (plazoDias >= ultimo.dias) {
+    if (plazoDias === ultimo.dias) {
+      return ultimo.pct;
+    }
+    const diasExtras = plazoDias - ultimo.dias;
+    const incrementos = Math.ceil(diasExtras / 15);
+    const proyectada = ultimo.pct + incrementos * TARIFA_TECHO_INCREMENTO_POR_15D;
+    return Math.min(proyectada, TARIFA_TECHO_PCT);
+  }
+  // Plazo intermedio → interpolación lineal entre dos puntos de la tabla.
+  for (let i = 0; i < TARIFA_TABLA.length - 1; i++) {
+    const a = TARIFA_TABLA[i];
+    const b = TARIFA_TABLA[i + 1];
+    if (!a || !b) {
+      continue;
+    }
+    if (plazoDias >= a.dias && plazoDias <= b.dias) {
+      const ratio = (plazoDias - a.dias) / (b.dias - a.dias);
+      const interpolada = a.pct + ratio * (b.pct - a.pct);
+      // Redondear a 2 decimales para evitar precision noise.
+      return Math.round(interpolada * 100) / 100;
+    }
+  }
+  // Defensivo (no debería caer acá).
+  return ultimo.pct;
+}

--- a/packages/factoring-engine/src/types.ts
+++ b/packages/factoring-engine/src/types.ts
@@ -1,0 +1,60 @@
+/**
+ * Tipos puros del modelo de factoring v1 (ADR-029 + ADR-032).
+ */
+
+export interface CalcularTarifaInput {
+  /** Monto neto al carrier post-comisión Booster, en CLP integer. */
+  montoNetoClp: number;
+  /** Plazo de pago del shipper en días corridos. */
+  plazoDiasShipper: number;
+}
+
+export interface CalcularTarifaOutput {
+  montoNetoClp: number;
+  plazoDiasShipper: number;
+  /** Tarifa aplicada en porcentaje (ej. 1.5, 3.0). */
+  tarifaPct: number;
+  /** Tarifa en CLP integer. = round(montoNeto * tarifaPct / 100). */
+  tarifaClp: number;
+  /** Monto que el carrier recibe hoy. = montoNeto - tarifa. */
+  montoAdelantadoClp: number;
+  /** Versión semver de la metodología (auditoría). */
+  factoringMethodologyVersion: string;
+}
+
+export interface EvaluarShipperInput {
+  /** Score Equifax/Dicom/Sentinel (0-1000 según Equifax CL). */
+  equifaxScore: number | null;
+  /** RUT activo en SII (verificable via SII Webservices). */
+  rutActivo: boolean;
+  /** Antigüedad operacional en meses. */
+  antiguedadMeses: number;
+  /** Morosidad reportada en últimos 12 meses (booleano agregado). */
+  morosidadUltimo12m: boolean;
+  /**
+   * Total CLP que Booster ya tiene adelantado a otros carriers para
+   * trips de este shipper, NO COBRADO todavía. Threshold para no
+   * concentrar exposición.
+   */
+  exposicionActualClp: number;
+}
+
+export interface EvaluarShipperOutput {
+  approved: boolean;
+  /** Límite revolving máximo simultaneo no-cobrado para este shipper. */
+  limitExposureClp: number;
+  /** Razón legible si approved=false; null si approved=true. */
+  motivo: string | null;
+  /** Cuándo expira esta decisión (default 30 días). */
+  expiresAt: Date;
+  /** Indica si la decisión es por auto-reglas o requiere revisión manual. */
+  decidedBy: 'automatico' | 'manual_requerido';
+}
+
+export interface EvaluarShipperParams {
+  input: EvaluarShipperInput;
+  /** epoch ms del "hoy" — inyectable para tests deterministas. */
+  hoyMs: number;
+  /** Días de validez de la decisión. Default 30. */
+  validezDias?: number;
+}

--- a/packages/factoring-engine/src/underwriting.ts
+++ b/packages/factoring-engine/src/underwriting.ts
@@ -1,0 +1,105 @@
+import type { EvaluarShipperOutput, EvaluarShipperParams } from './types.js';
+
+/**
+ * Score Equifax CL: rango 0-1000. Bajos los 500 se considera alto
+ * riesgo. Sobre 700 es bajo riesgo. Estos thresholds son point estimates
+ * iniciales — el partner factoring puede ajustarlos en su integración.
+ */
+const SCORE_MINIMO_AUTO_APROBADO = 700;
+const SCORE_MINIMO_LIMITE_REDUCIDO = 550;
+const ANTIGUEDAD_MINIMA_MESES = 24; // ADR-029 §3 — ≥2 años operacionales
+const LIMITE_ESTANDAR_CLP = 50_000_000; // ADR-029 §3 — $50M revolving
+const LIMITE_REDUCIDO_CLP = 10_000_000; // shipper score medio
+const VALIDEZ_DECISION_DIAS_DEFAULT = 30;
+
+/**
+ * Evalúa si Booster debería aprobar pronto pago sobre los DTEs emitidos
+ * a este shipper. Función pura — el caller obtiene los inputs de Equifax,
+ * SII, etc. (o del partner factoring si éste hace su propio underwriting).
+ *
+ * Reglas (ADR-029 §3):
+ *   - RUT debe estar activo en SII (sin esto, automático rechazo)
+ *   - Antigüedad operacional ≥24 meses
+ *   - Sin morosidad reportada últimos 12 meses
+ *   - Score Equifax ≥700 → aprobado con límite estándar ($50M)
+ *   - Score 550-699 → aprobado con límite reducido ($10M)
+ *   - Score <550 → rechazado
+ *   - Sin score (Equifax falla / no aplica) → manual_requerido
+ *   - Si exposición actual ≥ límite proyectado → rechazado por concentración
+ */
+export function evaluarShipper(params: EvaluarShipperParams): EvaluarShipperOutput {
+  const { input, hoyMs, validezDias = VALIDEZ_DECISION_DIAS_DEFAULT } = params;
+
+  if (!Number.isFinite(hoyMs) || hoyMs <= 0) {
+    throw new Error(`evaluarShipper: hoyMs inválido (${hoyMs})`);
+  }
+  if (!Number.isInteger(validezDias) || validezDias <= 0) {
+    throw new Error(`evaluarShipper: validezDias debe ser integer > 0 (${validezDias})`);
+  }
+
+  const expiresAt = new Date(hoyMs + validezDias * 24 * 60 * 60 * 1000);
+
+  // Hard rules: RUT inactivo, sin antigüedad, morosidad → rechazo inmediato.
+  if (!input.rutActivo) {
+    return reject(expiresAt, 'RUT no activo en SII');
+  }
+  if (input.antiguedadMeses < ANTIGUEDAD_MINIMA_MESES) {
+    return reject(
+      expiresAt,
+      `Antigüedad operacional ${input.antiguedadMeses}m < mínimo ${ANTIGUEDAD_MINIMA_MESES}m`,
+    );
+  }
+  if (input.morosidadUltimo12m) {
+    return reject(expiresAt, 'Morosidad reportada en últimos 12 meses');
+  }
+
+  // Sin score Equifax → no podemos auto-aprobar; requiere decisión manual.
+  if (input.equifaxScore === null || input.equifaxScore === undefined) {
+    return {
+      approved: false,
+      limitExposureClp: 0,
+      motivo: 'Score Equifax no disponible — requiere decisión manual',
+      expiresAt,
+      decidedBy: 'manual_requerido',
+    };
+  }
+
+  if (!Number.isFinite(input.equifaxScore) || input.equifaxScore < 0) {
+    throw new Error(`evaluarShipper: equifaxScore inválido (${input.equifaxScore})`);
+  }
+
+  // Score muy bajo → rechazo automático.
+  if (input.equifaxScore < SCORE_MINIMO_LIMITE_REDUCIDO) {
+    return reject(
+      expiresAt,
+      `Score ${input.equifaxScore} < mínimo ${SCORE_MINIMO_LIMITE_REDUCIDO}`,
+    );
+  }
+
+  const limite =
+    input.equifaxScore >= SCORE_MINIMO_AUTO_APROBADO ? LIMITE_ESTANDAR_CLP : LIMITE_REDUCIDO_CLP;
+
+  // Concentración de exposición — si ya estamos por encima del límite que
+  // este shipper soporta, no aprobar más adelantos hasta que pague.
+  if (input.exposicionActualClp >= limite) {
+    return reject(expiresAt, `Exposición actual ${input.exposicionActualClp} >= límite ${limite}`);
+  }
+
+  return {
+    approved: true,
+    limitExposureClp: limite,
+    motivo: null,
+    expiresAt,
+    decidedBy: 'automatico',
+  };
+}
+
+function reject(expiresAt: Date, motivo: string): EvaluarShipperOutput {
+  return {
+    approved: false,
+    limitExposureClp: 0,
+    motivo,
+    expiresAt,
+    decidedBy: 'automatico',
+  };
+}

--- a/packages/factoring-engine/test/tarifa.test.ts
+++ b/packages/factoring-engine/test/tarifa.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { FACTORING_METHODOLOGY_VERSION, calcularTarifaProntoPago } from '../src/index.js';
+
+describe('calcularTarifaProntoPago — tabla oficial (ADR-029 §2)', () => {
+  it('30 días → 1.5%', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 1_000_000, plazoDiasShipper: 30 });
+    expect(r.tarifaPct).toBe(1.5);
+    expect(r.tarifaClp).toBe(15_000);
+    expect(r.montoAdelantadoClp).toBe(985_000);
+  });
+
+  it('45 días → 2.2%', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 1_000_000, plazoDiasShipper: 45 });
+    expect(r.tarifaPct).toBe(2.2);
+    expect(r.tarifaClp).toBe(22_000);
+    expect(r.montoAdelantadoClp).toBe(978_000);
+  });
+
+  it('60 días → 3.0%', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 1_000_000, plazoDiasShipper: 60 });
+    expect(r.tarifaPct).toBe(3.0);
+    expect(r.tarifaClp).toBe(30_000);
+    expect(r.montoAdelantadoClp).toBe(970_000);
+  });
+
+  it('90 días → 4.5%', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 1_000_000, plazoDiasShipper: 90 });
+    expect(r.tarifaPct).toBe(4.5);
+    expect(r.tarifaClp).toBe(45_000);
+    expect(r.montoAdelantadoClp).toBe(955_000);
+  });
+});
+
+describe('calcularTarifaProntoPago — interpolación lineal entre tabla', () => {
+  it('plazo 37 días (entre 30 y 45) → interpolación', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 1_000_000, plazoDiasShipper: 37 });
+    // 30→1.5, 45→2.2, diff=0.7 sobre 15 días.
+    // 37 está a 7 días de 30, ratio 7/15. Tarifa = 1.5 + 7/15 * 0.7 = 1.83 (round 2 dec).
+    expect(r.tarifaPct).toBe(1.83);
+  });
+
+  it('plazo 52 días (entre 45 y 60) → interpolación', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 1_000_000, plazoDiasShipper: 52 });
+    // 45→2.2, 60→3.0, diff=0.8 sobre 15 días. 52-45=7. 7/15 * 0.8 = 0.373...
+    // tarifa = 2.2 + 0.373 = 2.573 → round 2 dec = 2.57
+    expect(r.tarifaPct).toBeCloseTo(2.57, 2);
+  });
+
+  it('plazo 75 días (entre 60 y 90) → interpolación', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 1_000_000, plazoDiasShipper: 75 });
+    // 60→3.0, 90→4.5, diff=1.5 sobre 30 días. 75-60=15. 15/30 * 1.5 = 0.75.
+    // tarifa = 3.0 + 0.75 = 3.75
+    expect(r.tarifaPct).toBe(3.75);
+  });
+});
+
+describe('calcularTarifaProntoPago — fuera de tabla', () => {
+  it('plazo < 30 días → tarifa piso 1.5%', () => {
+    const r1 = calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 15 });
+    expect(r1.tarifaPct).toBe(1.5);
+
+    const r2 = calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 1 });
+    expect(r2.tarifaPct).toBe(1.5);
+  });
+
+  it('plazo 105 días (15 días sobre 90) → 4.5 + 0.5 = 5.0%', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 105 });
+    expect(r.tarifaPct).toBe(5.0);
+  });
+
+  it('plazo 120 días → 4.5 + 1.0 = 5.5%', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 120 });
+    expect(r.tarifaPct).toBe(5.5);
+  });
+
+  it('plazo 365 días → tarifa techo 8%', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 365 });
+    expect(r.tarifaPct).toBe(8.0);
+  });
+
+  it('plazo 91 días (1 día sobre 90) → +0.5%', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 91 });
+    // 1 día = 1 incremento de 15d (ceil) = 0.5pp extra
+    expect(r.tarifaPct).toBe(5.0);
+  });
+});
+
+describe('calcularTarifaProntoPago — edge cases', () => {
+  it('montoNetoClp 0 → tarifa 0', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 0, plazoDiasShipper: 30 });
+    expect(r.tarifaClp).toBe(0);
+    expect(r.montoAdelantadoClp).toBe(0);
+  });
+
+  it('redondeo HALF_UP: 1.5% de 100.001 = 1500.015 → 1500', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 100_001, plazoDiasShipper: 30 });
+    expect(r.tarifaClp).toBe(1_500);
+  });
+
+  it('redondeo HALF_UP: 3% de 100.333 = 3009.99 → 3010', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 100_333, plazoDiasShipper: 60 });
+    expect(r.tarifaClp).toBe(3_010);
+  });
+
+  it('monto muy grande ($100M) → escala linealmente', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 100_000_000, plazoDiasShipper: 60 });
+    expect(r.tarifaClp).toBe(3_000_000);
+    expect(r.montoAdelantadoClp).toBe(97_000_000);
+  });
+
+  it('captura factoringMethodologyVersion en el output', () => {
+    const r = calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 30 });
+    expect(r.factoringMethodologyVersion).toBe(FACTORING_METHODOLOGY_VERSION);
+    expect(r.factoringMethodologyVersion).toMatch(/^factoring-v\d+\.\d+-cl-\d{4}\.\d{2}$/);
+  });
+});
+
+describe('calcularTarifaProntoPago — validación inputs', () => {
+  it('montoNetoClp negativo → throw', () => {
+    expect(() => calcularTarifaProntoPago({ montoNetoClp: -100, plazoDiasShipper: 30 })).toThrow(
+      />= 0/,
+    );
+  });
+
+  it('montoNetoClp NaN → throw', () => {
+    expect(() =>
+      calcularTarifaProntoPago({ montoNetoClp: Number.NaN, plazoDiasShipper: 30 }),
+    ).toThrow(/finito/);
+  });
+
+  it('montoNetoClp Infinity → throw', () => {
+    expect(() =>
+      calcularTarifaProntoPago({
+        montoNetoClp: Number.POSITIVE_INFINITY,
+        plazoDiasShipper: 30,
+      }),
+    ).toThrow(/finito/);
+  });
+
+  it('montoNetoClp float → throw', () => {
+    expect(() => calcularTarifaProntoPago({ montoNetoClp: 100.5, plazoDiasShipper: 30 })).toThrow(
+      /integer/,
+    );
+  });
+
+  it('plazoDiasShipper 0 → throw', () => {
+    expect(() => calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 0 })).toThrow(
+      /> 0/,
+    );
+  });
+
+  it('plazoDiasShipper negativo → throw', () => {
+    expect(() =>
+      calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: -30 }),
+    ).toThrow(/> 0/);
+  });
+
+  it('plazoDiasShipper float → throw', () => {
+    expect(() =>
+      calcularTarifaProntoPago({ montoNetoClp: 100_000, plazoDiasShipper: 30.5 }),
+    ).toThrow(/integer/);
+  });
+});

--- a/packages/factoring-engine/test/underwriting.test.ts
+++ b/packages/factoring-engine/test/underwriting.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { evaluarShipper } from '../src/index.js';
+
+const HOY_MS = Date.UTC(2026, 5, 15, 12, 0, 0);
+
+function base(over: Partial<Parameters<typeof evaluarShipper>[0]['input']> = {}) {
+  return {
+    input: {
+      equifaxScore: 750,
+      rutActivo: true,
+      antiguedadMeses: 36,
+      morosidadUltimo12m: false,
+      exposicionActualClp: 0,
+      ...over,
+    },
+    hoyMs: HOY_MS,
+  };
+}
+
+describe('evaluarShipper — hard rules', () => {
+  it('rutActivo=false → rechazado automático', () => {
+    const r = evaluarShipper(base({ rutActivo: false }));
+    expect(r.approved).toBe(false);
+    expect(r.motivo).toContain('RUT no activo');
+    expect(r.decidedBy).toBe('automatico');
+    expect(r.limitExposureClp).toBe(0);
+  });
+
+  it('antigüedad < 24 meses → rechazado', () => {
+    const r = evaluarShipper(base({ antiguedadMeses: 12 }));
+    expect(r.approved).toBe(false);
+    expect(r.motivo).toContain('Antigüedad');
+  });
+
+  it('morosidad reportada → rechazado', () => {
+    const r = evaluarShipper(base({ morosidadUltimo12m: true }));
+    expect(r.approved).toBe(false);
+    expect(r.motivo).toContain('Morosidad');
+  });
+});
+
+describe('evaluarShipper — score Equifax', () => {
+  it('score ≥700 → aprobado con límite estándar $50M', () => {
+    const r = evaluarShipper(base({ equifaxScore: 750 }));
+    expect(r.approved).toBe(true);
+    expect(r.limitExposureClp).toBe(50_000_000);
+    expect(r.decidedBy).toBe('automatico');
+  });
+
+  it('score exacto 700 → aprobado límite estándar', () => {
+    const r = evaluarShipper(base({ equifaxScore: 700 }));
+    expect(r.approved).toBe(true);
+    expect(r.limitExposureClp).toBe(50_000_000);
+  });
+
+  it('score 550-699 → aprobado con límite reducido $10M', () => {
+    const r = evaluarShipper(base({ equifaxScore: 600 }));
+    expect(r.approved).toBe(true);
+    expect(r.limitExposureClp).toBe(10_000_000);
+  });
+
+  it('score exacto 550 → aprobado reducido', () => {
+    const r = evaluarShipper(base({ equifaxScore: 550 }));
+    expect(r.approved).toBe(true);
+    expect(r.limitExposureClp).toBe(10_000_000);
+  });
+
+  it('score 549 → rechazado', () => {
+    const r = evaluarShipper(base({ equifaxScore: 549 }));
+    expect(r.approved).toBe(false);
+    expect(r.motivo).toContain('Score');
+  });
+
+  it('score null → manual_requerido (no aprobado automático)', () => {
+    const r = evaluarShipper(base({ equifaxScore: null }));
+    expect(r.approved).toBe(false);
+    expect(r.decidedBy).toBe('manual_requerido');
+    expect(r.motivo).toContain('manual');
+  });
+});
+
+describe('evaluarShipper — concentración de exposición', () => {
+  it('exposición = límite → rechazado por concentración', () => {
+    const r = evaluarShipper(base({ equifaxScore: 750, exposicionActualClp: 50_000_000 }));
+    expect(r.approved).toBe(false);
+    expect(r.motivo).toContain('Exposición');
+  });
+
+  it('exposición > límite → rechazado', () => {
+    const r = evaluarShipper(base({ equifaxScore: 750, exposicionActualClp: 60_000_000 }));
+    expect(r.approved).toBe(false);
+  });
+
+  it('score 600 + exposición 9M < límite 10M → aprobado', () => {
+    const r = evaluarShipper(base({ equifaxScore: 600, exposicionActualClp: 9_000_000 }));
+    expect(r.approved).toBe(true);
+    expect(r.limitExposureClp).toBe(10_000_000);
+  });
+
+  it('score 600 + exposición 10M = límite reducido → rechazado', () => {
+    const r = evaluarShipper(base({ equifaxScore: 600, exposicionActualClp: 10_000_000 }));
+    expect(r.approved).toBe(false);
+  });
+});
+
+describe('evaluarShipper — expiración', () => {
+  it('default 30 días', () => {
+    const r = evaluarShipper(base({}));
+    const esperado = new Date(HOY_MS + 30 * 24 * 60 * 60 * 1000);
+    expect(r.expiresAt.toISOString()).toBe(esperado.toISOString());
+  });
+
+  it('validezDias custom (7) → expiresAt = hoy + 7d', () => {
+    const r = evaluarShipper({ ...base({}), validezDias: 7 });
+    const esperado = new Date(HOY_MS + 7 * 24 * 60 * 60 * 1000);
+    expect(r.expiresAt.toISOString()).toBe(esperado.toISOString());
+  });
+
+  it('rechazo también incluye expiresAt', () => {
+    const r = evaluarShipper(base({ rutActivo: false }));
+    expect(r.expiresAt).toBeInstanceOf(Date);
+  });
+});
+
+describe('evaluarShipper — validación inputs', () => {
+  it('hoyMs NaN → throw', () => {
+    expect(() => evaluarShipper({ ...base({}), hoyMs: Number.NaN })).toThrow(/hoyMs/);
+  });
+
+  it('hoyMs negativo → throw', () => {
+    expect(() => evaluarShipper({ ...base({}), hoyMs: -1 })).toThrow(/hoyMs/);
+  });
+
+  it('validezDias 0 → throw', () => {
+    expect(() => evaluarShipper({ ...base({}), validezDias: 0 })).toThrow(/validezDias/);
+  });
+
+  it('equifaxScore negativo → throw', () => {
+    expect(() => evaluarShipper(base({ equifaxScore: -100 }))).toThrow(/equifaxScore/);
+  });
+
+  it('equifaxScore NaN → throw', () => {
+    expect(() => evaluarShipper(base({ equifaxScore: Number.NaN }))).toThrow(/equifaxScore/);
+  });
+});

--- a/packages/factoring-engine/tsconfig.json
+++ b/packages/factoring-engine/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@booster-ai/driver-scoring':
         specifier: workspace:*
         version: link:../../packages/driver-scoring
+      '@booster-ai/factoring-engine':
+        specifier: workspace:*
+        version: link:../../packages/factoring-engine
       '@booster-ai/logger':
         specifier: workspace:*
         version: link:../../packages/logger
@@ -732,6 +735,15 @@ importers:
         version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
 
   packages/dte-provider:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.2
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.18)(@vitest/coverage-v8@4.1.5)(jsdom@26.1.0)(vite@6.4.2(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))
+
+  packages/factoring-engine:
     devDependencies:
       typescript:
         specifier: ^5.8.2

--- a/scripts/lint-rls.mjs
+++ b/scripts/lint-rls.mjs
@@ -51,6 +51,13 @@ const TENANT_FILTER_TOKENS = [
   'empresa_id',
   'generadorCargaEmpresaId',
   'generador_carga_empresa_id',
+  // ADR-029 v1: factoring usa columnas explícitas con rol del tenant
+  // (carrier|shipper) para soportar dos filtros distintos en queries
+  // cross-rol — siguen siendo filtros tenant válidos.
+  'empresaCarrierId',
+  'empresa_carrier_id',
+  'empresaShipperId',
+  'empresa_shipper_id',
 ];
 
 /** Comment que marca una query como allowlisted explícitamente. */


### PR DESCRIPTION
## Summary

- **Activa ADR-029** (Proposed → Accepted) bajo `NODE_ENV=production` con el mismo patrón que ADR-030/031: foundation técnica completa hoy, partner financiero real diferido a integración LOI.
- **Producto "Booster Cobra Hoy"**: el transportista puede solicitar adelanto del monto neto de un viaje entregado, descontando una tarifa transparente (1.5%–4.5%) en función del plazo del shipper. Booster opera en **partner-mode** (no entra al ámbito CMF).
- **Foundation técnica end-to-end**: algoritmos puros + schema + endpoints HTTP + UI + T&Cs públicos.

## Componentes

### Backend
- `packages/factoring-engine` (nuevo): `calcularTarifaProntoPago` + `evaluarShipper`, ambas puras. **45 tests** (interpolación lineal, techo dinámico 4.5% + 0.5%/15d ≤ 8%, score thresholds Equifax CL ≥700 / 550–699 / <550, exposición, antigüedad, etc.)
- `drizzle/0017_factoring_v1.sql`: `shipper_credit_decisions` (partial unique `WHERE expires_at > now()`) + `adelantos_carrier` (UNIQUE en `asignacion_id` para idempotencia)
- `services/cobra-hoy.ts`: `cotizar` (sin flag, preview) + `cobraHoy` (con flag, 9 branches result). **15 tests**
- `routes/cobra-hoy.ts`: GET cotización + POST solicitar + GET historial. Flag-gating 503, userContext-guard 400, mapeo service→HTTP completo. **18 tests**
- `config`: `FACTORING_V1_ACTIVATED` default = `NODE_ENV==='production'`

### Web
- `hooks/use-cobra-hoy.ts`: 3 hooks (cotización query con `enabled` on-demand, solicitar mutation con invalidación, historial)
- `components/cobra-hoy/CobraHoyButton.tsx`: botón + modal con desglose, estados 503/409/success/error. **9 tests**
- `routes/cobra-hoy-historial.tsx`: lista dedicada con summary cards + tabla + status badges. **5 tests**
- `routes/legal-cobra-hoy.tsx`: adendum público \`/legal/cobra-hoy\`. **4 tests**
- `asignacion-detalle.tsx`: wire de `CobraHoyButton` condicional a `trip.status==='entregado'`
- `app dashboard`: link "Cobra hoy" en sección transportista

### Legal
- `docs/adr/032-factoring-v1-activacion-escala-minima.md`: activación con escala mínima, reemplaza 7 criterios duros del §7 ADR-029 con criterios operacionales realistas
- `docs/legal/adendum-cobra-hoy-v1.md`: adendum a T&Cs v2 §4.3 con tabla oficial, cesión de derechos Art. 1901 CC, IVA exento Art. 12-E DL 825, naturaleza partner-mode

### Infra
- `scripts/lint-rls.mjs`: agregadas `empresaCarrierId`/`empresaShipperId` como tokens válidos de filtro tenant (factoring usa columnas rol-específicas para soportar dos filtros distintos en queries cross-rol)

## Tarifa oficial (versionada \`factoring-v1.0-cl-2026.06\`)

| Plazo Shipper | Tarifa |
|---|---|
| 30 días | 1,50% |
| 45 días | 2,20% |
| 60 días | 3,00% |
| 90 días | 4,50% |

Interpolación lineal para intermedios, techo dinámico 4.5% + 0.5%/15d (max 8%) para >90 días. HALF_UP a entero CLP. Metodología congelada por solicitud (no retroactiva).

## Evidencia

\`\`\`
factoring-engine: 45 tests pass
api: 538 tests pass (+33 cobra-hoy)
web: 757 tests pass (+18 cobra-hoy)
lint: 0 errors (11 warnings pre-existentes)
typecheck api+web+factoring-engine: clean
\`\`\`

## Test plan

- [ ] Migration aplica sin error en staging (con shipper_credit_decisions + adelantos_carrier)
- [ ] En staging (\`FACTORING_V1_ACTIVATED=false\` default), el botón muestra 503 modal claro
- [ ] En prod manual override (\`FACTORING_V1_ACTIVATED=true\`), trip entregado + liquidación → botón habilitado
- [ ] Click \"Cobra hoy\" → modal muestra desglose con cotización en tiempo real
- [ ] Confirmar → 201 con \`adelanto_id\`; reintento → 200 \`already_requested\`
- [ ] Historial \`/app/cobra-hoy/historial\` lista la solicitud con status \`solicitado\`
- [ ] \`/legal/cobra-hoy\` accesible sin auth con adendum completo
- [ ] App dashboard transportista muestra link a Cobra Hoy

🤖 Generated with [Claude Code](https://claude.com/claude-code)