### PR TITLE
feat(factoring-admin): UI platform-admin para gestión de adelantos Cobra Hoy

### DIFF
--- a/apps/api/drizzle/0018_factoring_admin_notas.sql
+++ b/apps/api/drizzle/0018_factoring_admin_notas.sql
@@ -1,0 +1,8 @@
+-- Admin platform-wide UI para Cobra Hoy (ADR-029 v1 / ADR-032).
+--
+-- Agrega `notas_admin` (texto append-only construido en API con tag
+-- [ts admin_email]) al adelanto para registrar comentarios libres del
+-- operador en cada transición. No reemplaza `rechazo_motivo` (campo
+-- semánticamente acotado a 'rechazado'/'cancelado').
+
+ALTER TABLE adelantos_carrier ADD COLUMN notas_admin text;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1779408000000,
       "tag": "0017_factoring_v1",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1779494400000,
+      "tag": "0018_factoring_admin_notas",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -309,6 +309,32 @@ const apiEnvSchema = commonEnvSchema
      *     integración del partner.
      */
     FACTORING_V1_ACTIVATED: z.coerce.boolean().default(process.env.NODE_ENV === 'production'),
+
+    /**
+     * Allowlist de emails con acceso a endpoints `/admin/cobra-hoy/*`
+     * (operadores de Booster Chile SpA, no admins de empresa carrier).
+     *
+     * Formato CSV: `dev@boosterchile.com,contacto@boosterchile.com`. El
+     * helper `requirePlatformAdmin` compara `userContext.user.email` ∈
+     * lista; sin match → 403 `forbidden_platform_admin`.
+     *
+     * Alineado con el Workspace group `admins@boosterchile.com` creado
+     * en el sprint IaC hardening (handoff 2026-05-09). Por simpleza
+     * mantenemos la fuente de verdad en config (ENV), no en BD ni en
+     * custom claims Firebase — son 1-2 humanos hasta TRL 10.
+     *
+     * Default vacío para que ningún entorno tenga acceso accidental.
+     * Cloud Run prod debe setear esta var explícitamente.
+     */
+    BOOSTER_PLATFORM_ADMIN_EMAILS: z
+      .string()
+      .default('')
+      .transform((s) =>
+        s
+          .split(',')
+          .map((x) => x.trim().toLowerCase())
+          .filter(Boolean),
+      ),
   });
 
 export type ApiEnv = z.infer<typeof apiEnvSchema>;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1525,6 +1525,10 @@ export const adelantosCarrier = pgTable(
     cobradoAShipperEn: timestamp('cobrado_a_shipper_en', { withTimezone: true }),
     moraDesde: timestamp('mora_desde', { withTimezone: true }),
     factoringMethodologyVersion: text('factoring_methodology_version').notNull(),
+    // ADR-032 / admin UI: notas append-only del operador platform-admin
+    // en cada transición. Formato libre con tag [ISO8601 admin_email] al
+    // inicio de cada línea.
+    notasAdmin: text('notas_admin'),
     createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/apps/api/src/routes/admin-cobra-hoy.ts
+++ b/apps/api/src/routes/admin-cobra-hoy.ts
@@ -1,0 +1,257 @@
+import type { Logger } from '@booster-ai/logger';
+import { and, desc, eq, sql } from 'drizzle-orm';
+import type { Context } from 'hono';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { config as appConfig } from '../config.js';
+import type { Db } from '../db/client.js';
+import { adelantosCarrier } from '../db/schema.js';
+import type { UserContext } from '../services/user-context.js';
+
+/**
+ * Endpoints admin de "Booster Cobra Hoy" (ADR-029 + ADR-032).
+ *
+ * Audiencia: operadores de Booster Chile SpA, NO admins de empresa
+ * carrier. Auth se hace contra `BOOSTER_PLATFORM_ADMIN_EMAILS` (allowlist
+ * por email — ver config.ts).
+ *
+ *   GET  /admin/cobra-hoy/adelantos?status=...&empresa_carrier_id=...
+ *   POST /admin/cobra-hoy/adelantos/:id/transicionar
+ *        body { target_status, notas? }
+ *
+ * Las transiciones soportadas modelan el flujo manual mientras el
+ * partner real (Toctoc/Mafin/etc) no esté integrado:
+ *   - solicitado    → aprobado | rechazado | cancelado
+ *   - aprobado      → desembolsado | cancelado | rechazado
+ *   - desembolsado  → cobrado_a_shipper | mora
+ *   - mora          → cobrado_a_shipper | cancelado
+ *
+ * `desembolsado` y `cobrado_a_shipper` capturan timestamp automático
+ * (`desembolsado_en`, `cobrado_a_shipper_en`).
+ */
+
+type AdelantoStatus =
+  | 'solicitado'
+  | 'aprobado'
+  | 'desembolsado'
+  | 'cobrado_a_shipper'
+  | 'mora'
+  | 'cancelado'
+  | 'rechazado';
+
+const TRANSICIONES_VALIDAS: Record<AdelantoStatus, AdelantoStatus[]> = {
+  solicitado: ['aprobado', 'rechazado', 'cancelado'],
+  aprobado: ['desembolsado', 'cancelado', 'rechazado'],
+  desembolsado: ['cobrado_a_shipper', 'mora'],
+  cobrado_a_shipper: [],
+  mora: ['cobrado_a_shipper', 'cancelado'],
+  cancelado: [],
+  rechazado: [],
+};
+
+const transicionarBodySchema = z.object({
+  target_status: z.enum([
+    'aprobado',
+    'desembolsado',
+    'cobrado_a_shipper',
+    'mora',
+    'cancelado',
+    'rechazado',
+  ]),
+  notas: z.string().min(1).max(1000).optional(),
+});
+
+const statusQuerySchema = z.enum([
+  'solicitado',
+  'aprobado',
+  'desembolsado',
+  'cobrado_a_shipper',
+  'mora',
+  'cancelado',
+  'rechazado',
+]);
+
+export function createAdminCobraHoyRoutes(opts: { db: Db; logger: Logger }) {
+  const app = new Hono();
+
+  // biome-ignore lint/suspicious/noExplicitAny: hono Context genéricos.
+  function requirePlatformAdmin(c: Context<any, any, any>) {
+    if (!appConfig.FACTORING_V1_ACTIVATED) {
+      return {
+        ok: false as const,
+        response: c.json({ error: 'feature_disabled' }, 503),
+      };
+    }
+    const userContext = c.get('userContext') as UserContext | undefined;
+    if (!userContext) {
+      return { ok: false as const, response: c.json({ error: 'unauthorized' }, 401) };
+    }
+    const email = userContext.user.email?.toLowerCase();
+    const allowlist = appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS;
+    if (!email || !allowlist.includes(email)) {
+      return {
+        ok: false as const,
+        response: c.json({ error: 'forbidden_platform_admin' }, 403),
+      };
+    }
+    return { ok: true as const, userContext, adminEmail: email };
+  }
+
+  // GET /admin/cobra-hoy/adelantos
+  app.get('/adelantos', async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+
+    const statusParam = c.req.query('status');
+    const empresaCarrierIdParam = c.req.query('empresa_carrier_id');
+    const empresaShipperIdParam = c.req.query('empresa_shipper_id');
+
+    let statusFilter: AdelantoStatus | undefined;
+    if (statusParam) {
+      const parsed = statusQuerySchema.safeParse(statusParam);
+      if (!parsed.success) {
+        return c.json({ error: 'invalid_status' }, 400);
+      }
+      statusFilter = parsed.data;
+    }
+
+    const conditions = [] as ReturnType<typeof eq>[];
+    if (statusFilter) {
+      conditions.push(eq(adelantosCarrier.status, statusFilter));
+    }
+    if (empresaCarrierIdParam) {
+      conditions.push(eq(adelantosCarrier.empresaCarrierId, empresaCarrierIdParam));
+    }
+    if (empresaShipperIdParam) {
+      conditions.push(eq(adelantosCarrier.empresaShipperId, empresaShipperIdParam));
+    }
+
+    // rls-allowlist: admin platform-wide query — solo accesible vía requirePlatformAdmin allowlist.
+    const baseQuery = opts.db.select().from(adelantosCarrier);
+    const filteredQuery = conditions.length > 0 ? baseQuery.where(and(...conditions)) : baseQuery;
+    const rows = await filteredQuery.orderBy(desc(adelantosCarrier.createdAt)).limit(500);
+
+    return c.json({
+      adelantos: rows.map((r) => ({
+        id: r.id,
+        asignacion_id: r.asignacionId,
+        liquidacion_id: r.liquidacionId,
+        empresa_carrier_id: r.empresaCarrierId,
+        empresa_shipper_id: r.empresaShipperId,
+        monto_neto_clp: r.montoNetoClp,
+        plazo_dias_shipper: r.plazoDiasShipper,
+        tarifa_pct: Number(r.tarifaPct),
+        tarifa_clp: r.tarifaClp,
+        monto_adelantado_clp: r.montoAdelantadoClp,
+        status: r.status,
+        factoring_methodology_version: r.factoringMethodologyVersion,
+        desembolsado_en: r.desembolsadoEn?.toISOString() ?? null,
+        cobrado_a_shipper_en: r.cobradoAShipperEn?.toISOString() ?? null,
+        notas_admin: r.notasAdmin,
+        creado_en: r.createdAt.toISOString(),
+      })),
+    });
+  });
+
+  // POST /admin/cobra-hoy/adelantos/:id/transicionar
+  app.post('/adelantos/:id/transicionar', async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const adelantoId = c.req.param('id');
+    let body: z.infer<typeof transicionarBodySchema>;
+    try {
+      const json = await c.req.json();
+      const parsed = transicionarBodySchema.safeParse(json);
+      if (!parsed.success) {
+        return c.json({ error: 'invalid_body', details: parsed.error.format() }, 400);
+      }
+      body = parsed.data;
+    } catch {
+      return c.json({ error: 'invalid_json' }, 400);
+    }
+
+    const rows = await opts.db
+      .select({
+        id: adelantosCarrier.id,
+        status: adelantosCarrier.status,
+      })
+      // rls-allowlist: admin platform-wide query — protegido por requirePlatformAdmin.
+      .from(adelantosCarrier)
+      .where(eq(adelantosCarrier.id, adelantoId))
+      .limit(1);
+    const current = rows[0];
+    if (!current) {
+      return c.json({ error: 'adelanto_not_found' }, 404);
+    }
+
+    const currentStatus = current.status as AdelantoStatus;
+    const allowedTargets = TRANSICIONES_VALIDAS[currentStatus];
+    if (!allowedTargets.includes(body.target_status)) {
+      return c.json(
+        {
+          error: 'transicion_invalida',
+          current_status: currentStatus,
+          target_status: body.target_status,
+          allowed_targets: allowedTargets,
+        },
+        409,
+      );
+    }
+
+    const now = new Date();
+    const updates: Record<string, unknown> = {
+      status: body.target_status,
+      updatedAt: now,
+    };
+    if (body.target_status === 'desembolsado') {
+      updates.desembolsadoEn = now;
+    }
+    if (body.target_status === 'cobrado_a_shipper') {
+      updates.cobradoAShipperEn = now;
+    }
+    if (body.notas !== undefined) {
+      const tag = `[${now.toISOString()} ${auth.adminEmail}]`;
+      updates.notasAdmin = sql`coalesce(${adelantosCarrier.notasAdmin} || E'\n', '') || ${`${tag} ${body.notas}`}`;
+    }
+
+    // rls-allowlist: admin platform-wide update — protegido por requirePlatformAdmin.
+    const updated = await opts.db
+      .update(adelantosCarrier)
+      .set(updates)
+      .where(eq(adelantosCarrier.id, adelantoId))
+      .returning({
+        id: adelantosCarrier.id,
+        status: adelantosCarrier.status,
+        desembolsadoEn: adelantosCarrier.desembolsadoEn,
+        cobradoAShipperEn: adelantosCarrier.cobradoAShipperEn,
+      });
+    const after = updated[0];
+    if (!after) {
+      return c.json({ error: 'update_failed' }, 500);
+    }
+
+    opts.logger.info(
+      {
+        adelantoId,
+        from: currentStatus,
+        to: after.status,
+        adminEmail: auth.adminEmail,
+      },
+      'admin cobra-hoy: transición aplicada',
+    );
+
+    return c.json({
+      ok: true,
+      adelanto_id: after.id,
+      status: after.status,
+      desembolsado_en: after.desembolsadoEn?.toISOString() ?? null,
+      cobrado_a_shipper_en: after.cobradoAShipperEn?.toISOString() ?? null,
+    });
+  });
+
+  return app;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -9,6 +9,7 @@ import type { Db } from './db/client.js';
 import { createAuthMiddleware } from './middleware/auth.js';
 import { createFirebaseAuthMiddleware } from './middleware/firebase-auth.js';
 import { createUserContextMiddleware } from './middleware/user-context.js';
+import { createAdminCobraHoyRoutes } from './routes/admin-cobra-hoy.js';
 import { createAdminDispositivosRoutes } from './routes/admin-dispositivos.js';
 import { createAdminJobsRoutes } from './routes/admin-jobs.js';
 import { createAssignmentsRoutes } from './routes/assignments.js';
@@ -297,6 +298,13 @@ export function createServer(opts: CreateServerOptions): Hono {
       '/admin/dispositivos-pendientes',
       createAdminDispositivosRoutes({ db: opts.db, logger }),
     );
+
+    // Admin platform-wide: gestión de adelantos Cobra Hoy (ADR-029 v1 /
+    // ADR-032). Auth via BOOSTER_PLATFORM_ADMIN_EMAILS allowlist dentro
+    // del handler (no por role de empresa).
+    app.use('/admin/cobra-hoy/*', firebaseAuthMiddleware);
+    app.use('/admin/cobra-hoy/*', userContextMiddleware);
+    app.route('/admin/cobra-hoy', createAdminCobraHoyRoutes({ db: opts.db, logger }));
 
     // Vehículos de la empresa activa.
     app.use('/vehiculos/*', firebaseAuthMiddleware);

--- a/apps/api/test/unit/admin-cobra-hoy.test.ts
+++ b/apps/api/test/unit/admin-cobra-hoy.test.ts
@@ -1,0 +1,332 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config as appConfig } from '../../src/config.js';
+import { createAdminCobraHoyRoutes } from '../../src/routes/admin-cobra-hoy.js';
+import type { UserContext } from '../../src/services/user-context.js';
+
+/**
+ * Tests HTTP de admin-cobra-hoy. Mockean Drizzle chain (select / update)
+ * y validan: flag gating, allowlist por email, transiciones legales/
+ * ilegales, mapeo de timestamps `desembolsado_en` / `cobrado_a_shipper_en`.
+ */
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+const ADMIN_EMAIL = 'dev@boosterchile.com';
+const NON_ADMIN_EMAIL = 'random@example.com';
+
+function makeUserCtx(email: string): UserContext {
+  return {
+    user: { id: 'u1', firebaseUid: 'fb1', fullName: 'Felipe', email },
+    activeMembership: {
+      id: 'm1',
+      role: 'dueno',
+      status: 'activa',
+      empresa: {
+        id: 'e1',
+        legalName: 'E',
+        rut: '76',
+        isGeneradorCarga: false,
+        isTransportista: true,
+        status: 'activa',
+      },
+    },
+    memberships: [],
+  } as unknown as UserContext;
+}
+
+function makeApp(opts: {
+  withContext: boolean;
+  email?: string;
+  selectRows?: Array<Record<string, unknown>>;
+  updateRows?: Array<Record<string, unknown>>;
+}) {
+  const selectQueue: Array<Array<Record<string, unknown>>> = [];
+  if (opts.selectRows) {
+    selectQueue.push(opts.selectRows);
+  }
+  const updateQueue: Array<Array<Record<string, unknown>>> = [];
+  if (opts.updateRows) {
+    updateQueue.push(opts.updateRows);
+  }
+
+  const selectChain: Record<string, unknown> = {
+    from: vi.fn(() => selectChain),
+    where: vi.fn(() => selectChain),
+    orderBy: vi.fn(() => selectChain),
+    limit: vi.fn(async () => selectQueue.shift() ?? []),
+  };
+  const updateChain = {
+    set: vi.fn(() => ({
+      where: vi.fn(() => ({
+        returning: vi.fn(async () => updateQueue.shift() ?? []),
+      })),
+    })),
+  };
+  const db = {
+    select: vi.fn(() => selectChain),
+    update: vi.fn(() => updateChain),
+  };
+
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (opts.withContext) {
+      c.set('userContext', makeUserCtx(opts.email ?? ADMIN_EMAIL));
+    }
+    await next();
+  });
+  app.route('/admin/cobra-hoy', createAdminCobraHoyRoutes({ db: db as never, logger: noopLogger }));
+  return { app, db };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appConfig.FACTORING_V1_ACTIVATED = true;
+  appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS = [ADMIN_EMAIL];
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GET /admin/cobra-hoy/adelantos — gating', () => {
+  it('flag off → 503', async () => {
+    appConfig.FACTORING_V1_ACTIVATED = false;
+    const { app } = makeApp({ withContext: true });
+    const res = await app.request('/admin/cobra-hoy/adelantos');
+    expect(res.status).toBe(503);
+  });
+
+  it('sin userContext → 401', async () => {
+    const { app } = makeApp({ withContext: false });
+    const res = await app.request('/admin/cobra-hoy/adelantos');
+    expect(res.status).toBe(401);
+  });
+
+  it('email no en allowlist → 403 forbidden_platform_admin', async () => {
+    const { app } = makeApp({ withContext: true, email: NON_ADMIN_EMAIL });
+    const res = await app.request('/admin/cobra-hoy/adelantos');
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'forbidden_platform_admin' });
+  });
+
+  it('email en allowlist + lista vacía → 200', async () => {
+    const { app } = makeApp({ withContext: true, selectRows: [] });
+    const res = await app.request('/admin/cobra-hoy/adelantos');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ adelantos: [] });
+  });
+});
+
+describe('GET /admin/cobra-hoy/adelantos — filtros', () => {
+  it('status inválido → 400 invalid_status', async () => {
+    const { app } = makeApp({ withContext: true });
+    const res = await app.request('/admin/cobra-hoy/adelantos?status=basura');
+    expect(res.status).toBe(400);
+  });
+
+  it('status válido + carrier_id → invoca select con filtros + serializa', async () => {
+    const created = new Date('2026-05-10T10:00:00Z');
+    const { app } = makeApp({
+      withContext: true,
+      selectRows: [
+        {
+          id: 'a1',
+          asignacionId: 'asg-1',
+          liquidacionId: 'liq-1',
+          empresaCarrierId: 'car-1',
+          empresaShipperId: 'shi-1',
+          montoNetoClp: 176000,
+          plazoDiasShipper: 30,
+          tarifaPct: '1.50',
+          tarifaClp: 2640,
+          montoAdelantadoClp: 173360,
+          status: 'solicitado',
+          factoringMethodologyVersion: 'factoring-v1.0-cl-2026.06',
+          desembolsadoEn: null,
+          cobradoAShipperEn: null,
+          notasAdmin: null,
+          createdAt: created,
+        },
+      ],
+    });
+    const res = await app.request(
+      '/admin/cobra-hoy/adelantos?status=solicitado&empresa_carrier_id=car-1',
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { adelantos: Array<Record<string, unknown>> };
+    expect(body.adelantos).toHaveLength(1);
+    expect(body.adelantos[0]).toMatchObject({
+      id: 'a1',
+      asignacion_id: 'asg-1',
+      tarifa_pct: 1.5,
+      status: 'solicitado',
+      creado_en: created.toISOString(),
+      desembolsado_en: null,
+      cobrado_a_shipper_en: null,
+    });
+  });
+});
+
+describe('POST /admin/cobra-hoy/adelantos/:id/transicionar', () => {
+  it('flag off → 503', async () => {
+    appConfig.FACTORING_V1_ACTIVATED = false;
+    const { app } = makeApp({ withContext: true });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'aprobado' }),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it('non-admin → 403', async () => {
+    const { app } = makeApp({ withContext: true, email: NON_ADMIN_EMAIL });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'aprobado' }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('JSON inválido → 400', async () => {
+    const { app } = makeApp({ withContext: true });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not json',
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('target_status no soportado por enum → 400 invalid_body', async () => {
+    const { app } = makeApp({ withContext: true });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'solicitado' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('adelanto inexistente → 404', async () => {
+    const { app } = makeApp({ withContext: true, selectRows: [] });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'aprobado' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('transición ilegal (solicitado → desembolsado) → 409 transicion_invalida', async () => {
+    const { app } = makeApp({
+      withContext: true,
+      selectRows: [{ id: 'a1', status: 'solicitado' }],
+    });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'desembolsado' }),
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { error: string; allowed_targets: string[] };
+    expect(body.error).toBe('transicion_invalida');
+    expect(body.allowed_targets).toContain('aprobado');
+  });
+
+  it('terminal status (cancelado) no permite transiciones → 409', async () => {
+    const { app } = makeApp({
+      withContext: true,
+      selectRows: [{ id: 'a1', status: 'cancelado' }],
+    });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'aprobado' }),
+    });
+    expect(res.status).toBe(409);
+  });
+
+  it('transición legal aprobado → desembolsado captura desembolsado_en', async () => {
+    const now = new Date('2026-05-10T12:00:00Z');
+    const { app } = makeApp({
+      withContext: true,
+      selectRows: [{ id: 'a1', status: 'aprobado' }],
+      updateRows: [
+        { id: 'a1', status: 'desembolsado', desembolsadoEn: now, cobradoAShipperEn: null },
+      ],
+    });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'desembolsado', notas: 'transfer ok' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      ok: boolean;
+      status: string;
+      desembolsado_en: string | null;
+      cobrado_a_shipper_en: string | null;
+    };
+    expect(body.ok).toBe(true);
+    expect(body.status).toBe('desembolsado');
+    expect(body.desembolsado_en).toBe(now.toISOString());
+    expect(body.cobrado_a_shipper_en).toBeNull();
+  });
+
+  it('transición legal desembolsado → cobrado_a_shipper captura cobrado_a_shipper_en', async () => {
+    const now = new Date('2026-06-10T12:00:00Z');
+    const { app } = makeApp({
+      withContext: true,
+      selectRows: [{ id: 'a1', status: 'desembolsado' }],
+      updateRows: [
+        {
+          id: 'a1',
+          status: 'cobrado_a_shipper',
+          desembolsadoEn: null,
+          cobradoAShipperEn: now,
+        },
+      ],
+    });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'cobrado_a_shipper' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { cobrado_a_shipper_en: string | null };
+    expect(body.cobrado_a_shipper_en).toBe(now.toISOString());
+  });
+
+  it('transición legal mora → cobrado_a_shipper (rescate)', async () => {
+    const now = new Date('2026-07-10T12:00:00Z');
+    const { app } = makeApp({
+      withContext: true,
+      selectRows: [{ id: 'a1', status: 'mora' }],
+      updateRows: [
+        {
+          id: 'a1',
+          status: 'cobrado_a_shipper',
+          desembolsadoEn: null,
+          cobradoAShipperEn: now,
+        },
+      ],
+    });
+    const res = await app.request('/admin/cobra-hoy/adelantos/a1/transicionar', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_status: 'cobrado_a_shipper' }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/web/src/hooks/use-admin-cobra-hoy.ts
+++ b/apps/web/src/hooks/use-admin-cobra-hoy.ts
@@ -1,0 +1,112 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ApiError, api } from '../lib/api-client.js';
+
+/**
+ * Hooks de admin "Booster Cobra Hoy" (ADR-029 v1 / ADR-032).
+ *
+ * Endpoint backend protegido por allowlist `BOOSTER_PLATFORM_ADMIN_EMAILS`.
+ * Si el usuario no está en la allowlist, los hooks devuelven 403 y la UI
+ * muestra mensaje claro.
+ */
+
+export type AdelantoStatus =
+  | 'solicitado'
+  | 'aprobado'
+  | 'desembolsado'
+  | 'cobrado_a_shipper'
+  | 'mora'
+  | 'cancelado'
+  | 'rechazado';
+
+export interface AdelantoAdminRow {
+  id: string;
+  asignacion_id: string;
+  liquidacion_id: string | null;
+  empresa_carrier_id: string;
+  empresa_shipper_id: string;
+  monto_neto_clp: number;
+  plazo_dias_shipper: number;
+  tarifa_pct: number;
+  tarifa_clp: number;
+  monto_adelantado_clp: number;
+  status: AdelantoStatus;
+  factoring_methodology_version: string;
+  desembolsado_en: string | null;
+  cobrado_a_shipper_en: string | null;
+  notas_admin: string | null;
+  creado_en: string;
+}
+
+export interface AdminAdelantosFilters {
+  status?: AdelantoStatus;
+  empresaCarrierId?: string;
+  empresaShipperId?: string;
+}
+
+export function useAdminAdelantos(
+  filters: AdminAdelantosFilters,
+  opts: { enabled?: boolean } = {},
+) {
+  const params = new URLSearchParams();
+  if (filters.status) {
+    params.set('status', filters.status);
+  }
+  if (filters.empresaCarrierId) {
+    params.set('empresa_carrier_id', filters.empresaCarrierId);
+  }
+  if (filters.empresaShipperId) {
+    params.set('empresa_shipper_id', filters.empresaShipperId);
+  }
+  const qs = params.toString();
+  return useQuery<{ adelantos: AdelantoAdminRow[] }>({
+    queryKey: ['admin-cobra-hoy', 'adelantos', filters],
+    queryFn: () =>
+      api.get<{ adelantos: AdelantoAdminRow[] }>(`/admin/cobra-hoy/adelantos${qs ? `?${qs}` : ''}`),
+    enabled: opts.enabled ?? true,
+    staleTime: 15_000,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && (error.status === 503 || error.status === 403)) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+}
+
+export type TargetTransicion =
+  | 'aprobado'
+  | 'desembolsado'
+  | 'cobrado_a_shipper'
+  | 'mora'
+  | 'cancelado'
+  | 'rechazado';
+
+export interface TransicionarResponse {
+  ok: boolean;
+  adelanto_id: string;
+  status: AdelantoStatus;
+  desembolsado_en: string | null;
+  cobrado_a_shipper_en: string | null;
+}
+
+export interface TransicionarInput {
+  adelantoId: string;
+  targetStatus: TargetTransicion;
+  notas?: string;
+}
+
+export function useTransicionarAdelantoMutation() {
+  const qc = useQueryClient();
+  return useMutation<TransicionarResponse, Error, TransicionarInput>({
+    mutationFn: ({ adelantoId, targetStatus, notas }) =>
+      api.post<TransicionarResponse>(
+        `/admin/cobra-hoy/adelantos/${adelantoId}/transicionar`,
+        notas ? { target_status: targetStatus, notas } : { target_status: targetStatus },
+      ),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['admin-cobra-hoy'] });
+      // También invalida el historial del carrier para que vea el nuevo status.
+      void qc.invalidateQueries({ queryKey: ['cobra-hoy'] });
+    },
+  });
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRootRoute, createRoute, createRouter } from '@tanstack/react-router';
 import { RootComponent } from './routes/__root.js';
+import { AdminCobraHoyRoute } from './routes/admin-cobra-hoy.js';
 import { AdminDispositivosRoute } from './routes/admin-dispositivos.js';
 import { AppRoute } from './routes/app.js';
 import { AsignacionDetalleRoute } from './routes/asignacion-detalle.js';
@@ -74,6 +75,15 @@ const adminDispositivosRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/app/admin/dispositivos',
   component: AdminDispositivosRoute,
+});
+
+// ADR-029 v1 / ADR-032 — admin platform-wide Cobra Hoy. Auth real está
+// en backend (BOOSTER_PLATFORM_ADMIN_EMAILS allowlist); la ruta queda
+// bajo /app para mantener la auth de Firebase y el layout.
+const adminCobraHoyRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/app/admin/cobra-hoy',
+  component: AdminCobraHoyRoute,
 });
 
 const vehiculosListRoute = createRoute({
@@ -191,6 +201,7 @@ const routeTree = rootRoute.addChildren([
   legalTerminosRoute,
   cobraHoyHistorialRoute,
   legalCobraHoyRoute,
+  adminCobraHoyRoute,
 ]);
 
 export const router = createRouter({

--- a/apps/web/src/routes/admin-cobra-hoy.test.tsx
+++ b/apps/web/src/routes/admin-cobra-hoy.test.tsx
@@ -1,0 +1,193 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { ApiError, api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+}));
+
+vi.mock('../components/EmptyState.js', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+  emptyStateActionClass: 'btn',
+}));
+
+const { AdminCobraHoyRoute } = await import('./admin-cobra-hoy.js');
+
+function makeMe(): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role: 'dueno',
+      status: 'activa',
+      empresa: {
+        id: 'e',
+        legal_name: 'E',
+        rut: '76',
+        is_generador_carga: false,
+        is_transportista: true,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRoute() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <AdminCobraHoyRoute />
+    </Wrapper>,
+  );
+}
+
+const ADELANTO_SOLICITADO = {
+  id: 'a1',
+  asignacion_id: 'asg-deadbeef',
+  liquidacion_id: 'liq-1',
+  empresa_carrier_id: 'car-abcdef12',
+  empresa_shipper_id: 'shi-12345678',
+  monto_neto_clp: 176000,
+  plazo_dias_shipper: 30,
+  tarifa_pct: 1.5,
+  tarifa_clp: 2640,
+  monto_adelantado_clp: 173360,
+  status: 'solicitado' as const,
+  factoring_methodology_version: 'factoring-v1.0-cl-2026.06',
+  desembolsado_en: null,
+  cobrado_a_shipper_en: null,
+  notas_admin: null,
+  creado_en: '2026-05-10T11:00:00Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AdminCobraHoyRoute — gating UX', () => {
+  it('contexto unmanaged → render vacío', () => {
+    const { container } = renderRoute();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('403 forbidden → mensaje claro de allowlist', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    vi.spyOn(api, 'get').mockRejectedValue(new ApiError(403, 'forbidden_platform_admin', null));
+    renderRoute();
+    expect(await screen.findByText(/Tu cuenta no está en la allowlist/i)).toBeInTheDocument();
+  });
+
+  it('503 feature_disabled → banner', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    vi.spyOn(api, 'get').mockRejectedValue(new ApiError(503, 'feature_disabled', null));
+    renderRoute();
+    expect(await screen.findByText(/no está activo en este entorno/i)).toBeInTheDocument();
+  });
+});
+
+describe('AdminCobraHoyRoute — lista + filtros', () => {
+  beforeEach(() => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+  });
+
+  it('lista vacía → EmptyState', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ adelantos: [] });
+    renderRoute();
+    expect(await screen.findByText(/No hay adelantos con este filtro/i)).toBeInTheDocument();
+  });
+
+  it('lista con adelanto solicitado → muestra fila + acciones disponibles', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ adelantos: [ADELANTO_SOLICITADO] });
+    renderRoute();
+    // Esperamos por contenido único de la fila (no "Solicitado" porque
+    // colisiona con el botón del filtro).
+    expect(await screen.findByText(/30d · 1\.50%/)).toBeInTheDocument();
+    // Botones de transición legales desde 'solicitado'.
+    expect(screen.getByRole('button', { name: /Aprobar/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Rechazar/i })).toBeInTheDocument();
+    // "Cancelar" aparece como botón de transición — y todavía no hay panel abierto.
+    expect(screen.getAllByRole('button', { name: 'Cancelar' }).length).toBeGreaterThan(0);
+    // Transición no permitida desde 'solicitado' no debe aparecer.
+    expect(screen.queryByRole('button', { name: /Marcar desembolsado/i })).not.toBeInTheDocument();
+  });
+
+  it('cambiar filtro por status → re-query con param', async () => {
+    const getSpy = vi.spyOn(api, 'get').mockResolvedValue({ adelantos: [] });
+    renderRoute();
+    await screen.findByText(/No hay adelantos con este filtro/i);
+    fireEvent.click(screen.getByRole('button', { name: 'Desembolsado' }));
+    await waitFor(() => {
+      const calls = getSpy.mock.calls.map((c) => c[0] as string);
+      expect(calls.some((url) => url.includes('status=desembolsado'))).toBe(true);
+    });
+  });
+});
+
+describe('AdminCobraHoyRoute — transicionar', () => {
+  beforeEach(() => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+  });
+
+  it('click Aprobar abre panel de confirmación con notas y dispara POST', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ adelantos: [ADELANTO_SOLICITADO] });
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({
+      ok: true,
+      adelanto_id: 'a1',
+      status: 'aprobado',
+      desembolsado_en: null,
+      cobrado_a_shipper_en: null,
+    });
+    renderRoute();
+    fireEvent.click(await screen.findByRole('button', { name: /Aprobar/i }));
+    expect(await screen.findByText(/Confirmar transición/)).toBeInTheDocument();
+    fireEvent.change(screen.getByPlaceholderText(/Notas opcionales/i), {
+      target: { value: 'score OK' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirmar' }));
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith(
+        '/admin/cobra-hoy/adelantos/a1/transicionar',
+        expect.objectContaining({ target_status: 'aprobado', notas: 'score OK' }),
+      );
+    });
+  });
+
+  it('estado final cancelado → muestra "Estado final" sin botones', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      adelantos: [{ ...ADELANTO_SOLICITADO, status: 'cancelado' as const }],
+    });
+    renderRoute();
+    expect(await screen.findByText(/Estado final/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Aprobar/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/admin-cobra-hoy.tsx
+++ b/apps/web/src/routes/admin-cobra-hoy.tsx
@@ -1,0 +1,340 @@
+import { Link } from '@tanstack/react-router';
+import { ArrowLeft, Banknote, Loader2 } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+import { EmptyState } from '../components/EmptyState.js';
+import { Layout } from '../components/Layout.js';
+import { ProtectedRoute } from '../components/ProtectedRoute.js';
+import {
+  type AdelantoAdminRow,
+  type AdelantoStatus,
+  type TargetTransicion,
+  useAdminAdelantos,
+  useTransicionarAdelantoMutation,
+} from '../hooks/use-admin-cobra-hoy.js';
+import type { MeResponse } from '../hooks/use-me.js';
+import { ApiError } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+
+const STATUS_FILTERS: Array<{ value: AdelantoStatus | 'todos'; label: string }> = [
+  { value: 'todos', label: 'Todos' },
+  { value: 'solicitado', label: 'Solicitado' },
+  { value: 'aprobado', label: 'Aprobado' },
+  { value: 'desembolsado', label: 'Desembolsado' },
+  { value: 'cobrado_a_shipper', label: 'Cobrado al shipper' },
+  { value: 'mora', label: 'En mora' },
+  { value: 'cancelado', label: 'Cancelado' },
+  { value: 'rechazado', label: 'Rechazado' },
+];
+
+const TRANSICIONES_POR_STATUS: Record<AdelantoStatus, TargetTransicion[]> = {
+  solicitado: ['aprobado', 'rechazado', 'cancelado'],
+  aprobado: ['desembolsado', 'cancelado', 'rechazado'],
+  desembolsado: ['cobrado_a_shipper', 'mora'],
+  cobrado_a_shipper: [],
+  mora: ['cobrado_a_shipper', 'cancelado'],
+  cancelado: [],
+  rechazado: [],
+};
+
+const LABEL_TRANSICION: Record<TargetTransicion, string> = {
+  aprobado: 'Aprobar',
+  desembolsado: 'Marcar desembolsado',
+  cobrado_a_shipper: 'Marcar cobrado',
+  mora: 'Marcar en mora',
+  cancelado: 'Cancelar',
+  rechazado: 'Rechazar',
+};
+
+/**
+ * /app/admin/cobra-hoy — surface platform-admin (Booster Chile SpA) para
+ * gestionar adelantos de pronto pago. Auth real está en backend (allowlist
+ * por email), acá solo damos respuesta UX para usuarios no autorizados.
+ */
+export function AdminCobraHoyRoute() {
+  return (
+    <ProtectedRoute meRequirement="require-onboarded">
+      {(ctx) => {
+        if (ctx.kind !== 'onboarded') {
+          return null;
+        }
+        return <AdminCobraHoyPage me={ctx.me} />;
+      }}
+    </ProtectedRoute>
+  );
+}
+
+function AdminCobraHoyPage({ me }: { me: MeOnboarded }) {
+  const [statusFilter, setStatusFilter] = useState<AdelantoStatus | 'todos'>('todos');
+  const adelantosQ = useAdminAdelantos(statusFilter === 'todos' ? {} : { status: statusFilter });
+
+  const featureDisabled = adelantosQ.error instanceof ApiError && adelantosQ.error.status === 503;
+  const forbidden = adelantosQ.error instanceof ApiError && adelantosQ.error.status === 403;
+
+  return (
+    <Layout me={me} title="Admin Cobra Hoy">
+      <div className="flex items-center gap-3">
+        <Link
+          to="/app"
+          className="inline-flex items-center gap-1 text-neutral-500 text-sm hover:text-neutral-700"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Inicio
+        </Link>
+      </div>
+
+      <header className="mt-4 flex items-start gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary-50 text-primary-700">
+          <Banknote className="h-6 w-6" aria-hidden />
+        </div>
+        <div>
+          <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">Admin · Cobra Hoy</h1>
+          <p className="mt-1 text-neutral-600 text-sm">
+            Gestión platform-wide de adelantos solicitados por transportistas. Solo accesible para
+            operadores de Booster Chile SpA listados en <code>BOOSTER_PLATFORM_ADMIN_EMAILS</code>.
+          </p>
+        </div>
+      </header>
+
+      {forbidden && (
+        <output className="mt-6 block rounded-md border border-danger-500/30 bg-danger-50 p-4 text-danger-700 text-sm">
+          Tu cuenta no está en la allowlist de admins platform-wide. Si necesitás acceso, escribí a
+          soporte@boosterchile.com.
+        </output>
+      )}
+
+      {featureDisabled && (
+        <output className="mt-6 block rounded-md border border-neutral-200 bg-neutral-50 p-4 text-neutral-700 text-sm">
+          El módulo Cobra Hoy no está activo en este entorno.
+        </output>
+      )}
+
+      {!forbidden && !featureDisabled && (
+        <>
+          <div className="mt-6 flex flex-wrap items-center gap-2">
+            {STATUS_FILTERS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setStatusFilter(opt.value)}
+                className={`rounded-full px-3 py-1 font-medium text-xs transition ${
+                  statusFilter === opt.value
+                    ? 'bg-primary-600 text-white'
+                    : 'border border-neutral-300 bg-white text-neutral-700 hover:bg-neutral-100'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          {adelantosQ.isLoading && <p className="mt-8 text-neutral-500">Cargando adelantos…</p>}
+
+          {adelantosQ.data && adelantosQ.data.adelantos.length === 0 && (
+            <div className="mt-8">
+              <EmptyState
+                icon={<Banknote className="h-10 w-10" aria-hidden />}
+                title="No hay adelantos con este filtro"
+                description="Cuando los transportistas soliciten pronto pago verás las solicitudes acá para aprobar, desembolsar o cobrar."
+              />
+            </div>
+          )}
+
+          {adelantosQ.data && adelantosQ.data.adelantos.length > 0 && (
+            <div className="mt-6 overflow-x-auto rounded-lg border border-neutral-200 bg-white shadow-sm">
+              <table className="min-w-full divide-y divide-neutral-200">
+                <thead className="bg-neutral-50">
+                  <tr>
+                    <Th>Solicitado</Th>
+                    <Th>Carrier / Shipper</Th>
+                    <Th className="text-right">Neto / Adelanto</Th>
+                    <Th>Plazo · Tarifa</Th>
+                    <Th>Estado</Th>
+                    <Th className="text-right">Acciones</Th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-neutral-100 bg-white">
+                  {adelantosQ.data.adelantos.map((a) => (
+                    <AdelantoRow key={a.id} adelanto={a} />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </>
+      )}
+    </Layout>
+  );
+}
+
+function AdelantoRow({ adelanto }: { adelanto: AdelantoAdminRow }) {
+  const transicionM = useTransicionarAdelantoMutation();
+  const [confirming, setConfirming] = useState<TargetTransicion | null>(null);
+  const [notas, setNotas] = useState('');
+  const allowed = TRANSICIONES_POR_STATUS[adelanto.status];
+
+  function confirmTransition(target: TargetTransicion) {
+    transicionM.mutate(
+      {
+        adelantoId: adelanto.id,
+        targetStatus: target,
+        ...(notas.trim() ? { notas: notas.trim() } : {}),
+      },
+      {
+        onSuccess: () => {
+          setConfirming(null);
+          setNotas('');
+        },
+      },
+    );
+  }
+
+  return (
+    <>
+      <tr className="hover:bg-neutral-50">
+        <Td className="text-neutral-600 text-xs">{formatDate(adelanto.creado_en)}</Td>
+        <Td>
+          <div className="flex flex-col gap-0.5 font-mono text-xs">
+            <span title="Carrier">C: {adelanto.empresa_carrier_id.slice(0, 8)}</span>
+            <span className="text-neutral-500" title="Shipper">
+              S: {adelanto.empresa_shipper_id.slice(0, 8)}
+            </span>
+          </div>
+        </Td>
+        <Td className="text-right">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-neutral-600 text-xs">{fmt(adelanto.monto_neto_clp)}</span>
+            <span className="font-semibold text-success-700">
+              {fmt(adelanto.monto_adelantado_clp)}
+            </span>
+          </div>
+        </Td>
+        <Td className="text-neutral-600 text-xs">
+          {adelanto.plazo_dias_shipper}d · {adelanto.tarifa_pct.toFixed(2)}%
+        </Td>
+        <Td>
+          <StatusBadge status={adelanto.status} />
+        </Td>
+        <Td className="text-right">
+          {allowed.length === 0 && <span className="text-neutral-400 text-xs">Estado final</span>}
+          {allowed.length > 0 && (
+            <div className="flex flex-wrap justify-end gap-1">
+              {allowed.map((target) => (
+                <button
+                  key={target}
+                  type="button"
+                  onClick={() => setConfirming(target)}
+                  disabled={transicionM.isPending}
+                  className="rounded-md border border-neutral-300 px-2 py-1 font-medium text-neutral-700 text-xs transition hover:bg-neutral-100 disabled:opacity-60"
+                >
+                  {LABEL_TRANSICION[target]}
+                </button>
+              ))}
+            </div>
+          )}
+        </Td>
+      </tr>
+      {confirming && (
+        <tr className="bg-primary-50/50">
+          <td colSpan={6} className="px-4 py-4">
+            <div className="flex flex-col gap-3">
+              <span className="font-medium text-neutral-800 text-sm">
+                Confirmar transición: <strong>{adelanto.status}</strong> →{' '}
+                <strong>{confirming}</strong>
+              </span>
+              <textarea
+                value={notas}
+                onChange={(e) => setNotas(e.target.value)}
+                placeholder="Notas opcionales (visibles solo a admins)"
+                rows={2}
+                className="w-full rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none"
+              />
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => confirmTransition(confirming)}
+                  disabled={transicionM.isPending}
+                  className="inline-flex items-center gap-2 rounded-md bg-primary-600 px-3 py-2 font-medium text-sm text-white transition hover:bg-primary-700 disabled:opacity-60"
+                >
+                  {transicionM.isPending && (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                  )}
+                  Confirmar
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setConfirming(null);
+                    setNotas('');
+                  }}
+                  className="rounded-md border border-neutral-300 px-3 py-2 font-medium text-neutral-700 text-sm hover:bg-neutral-100"
+                >
+                  Cancelar
+                </button>
+                {transicionM.isError && (
+                  <span role="alert" className="text-danger-700 text-sm">
+                    No pudimos aplicar la transición. Revisá los logs.
+                  </span>
+                )}
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}
+
+function StatusBadge({ status }: { status: AdelantoStatus }) {
+  const map: Record<AdelantoStatus, { label: string; className: string }> = {
+    solicitado: { label: 'Solicitado', className: 'bg-neutral-100 text-neutral-700' },
+    aprobado: { label: 'Aprobado', className: 'bg-primary-50 text-primary-700' },
+    desembolsado: { label: 'Desembolsado', className: 'bg-success-50 text-success-700' },
+    cobrado_a_shipper: {
+      label: 'Cobrado al shipper',
+      className: 'bg-success-50 text-success-700',
+    },
+    mora: { label: 'En mora', className: 'bg-amber-50 text-amber-700' },
+    cancelado: { label: 'Cancelado', className: 'bg-neutral-100 text-neutral-500' },
+    rechazado: { label: 'Rechazado', className: 'bg-danger-50 text-danger-700' },
+  };
+  const v = map[status];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium text-xs ${v.className}`}
+    >
+      {v.label}
+    </span>
+  );
+}
+
+function Th({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <th
+      className={`px-4 py-2 text-left font-medium text-neutral-500 text-xs uppercase tracking-wider ${className}`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <td className={`px-4 py-3 align-top text-neutral-800 text-sm ${className}`}>{children}</td>
+  );
+}
+
+function fmt(clp: number): string {
+  return `$ ${clp.toLocaleString('es-CL')}`;
+}
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat('es-CL', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Santiago',
+  }).format(new Date(iso));
+}


### PR DESCRIPTION
## Summary

- **Primer diferido de ADR-032 cerrado**: UI platform-admin para gestionar adelantos manualmente mientras el partner financiero real no esté integrado.
- **Surface**: \`/app/admin/cobra-hoy\` con tabla filtrable por status, panel de confirmación inline con notas, badges por estado.
- **Auth**: allowlist por email (\`BOOSTER_PLATFORM_ADMIN_EMAILS\`) — alineado con \`admins@boosterchile.com\` workspace group del IaC sprint. Sin DB ni custom claims Firebase — apropiado para 1-2 humanos hasta TRL 10.

## Componentes

### Backend
- \`config\`: \`BOOSTER_PLATFORM_ADMIN_EMAILS\` (CSV, default vacío — Cloud Run prod debe setear explícito)
- \`routes/admin-cobra-hoy.ts\`:
  - GET \`/admin/cobra-hoy/adelantos?status&empresa_carrier_id&empresa_shipper_id\` (lista platform-wide, max 500)
  - POST \`/admin/cobra-hoy/adelantos/:id/transicionar\` body \`{target_status, notas?}\`
- **Máquina de estados estricta** (espejo del flujo real del partner):
  - \`solicitado\` → \`aprobado\` | \`rechazado\` | \`cancelado\`
  - \`aprobado\` → \`desembolsado\` | \`cancelado\` | \`rechazado\`
  - \`desembolsado\` → \`cobrado_a_shipper\` | \`mora\`
  - \`mora\` → \`cobrado_a_shipper\` | \`cancelado\`
  - \`cobrado_a_shipper\` / \`cancelado\` / \`rechazado\` → terminales
- Timestamps automáticos en \`desembolsado\` (\`desembolsado_en\`) y \`cobrado_a_shipper\` (\`cobrado_a_shipper_en\`).
- Notas append-only con tag \`[ISO8601 admin_email]\` por línea.
- Migration 0018: agrega \`notas_admin TEXT\` a \`adelantos_carrier\`.
- **16 tests** (gating, filtros, todas las transiciones legales e ilegales, mapeo de timestamps).

### Web
- \`hooks/use-admin-cobra-hoy.ts\`: \`useAdminAdelantos\` (filtros) + \`useTransicionarAdelantoMutation\` (invalida cache admin + historial carrier).
- \`routes/admin-cobra-hoy.tsx\` (\`/app/admin/cobra-hoy\`):
  - Filtros como chips (todos + 7 estados)
  - Tabla con summary por fila: solicitado / carrier·shipper / neto·adelanto / plazo·tarifa / status badge / acciones legales
  - Panel inline de confirmación con textarea de notas
  - Branch UX para 403 (allowlist) y 503 (flag off)
- **8 tests** (gating, lista vacía, transiciones legales, panel de confirmación, estados terminales).

## Evidencia

\`\`\`
api: 554 tests pass (+16 admin-cobra-hoy)
web: 765 tests pass (+8 admin-cobra-hoy)
lint: 0 errors (lint-rls verde con allowlist comment)
typecheck api+web: clean
\`\`\`

## Test plan

- [ ] Configurar \`BOOSTER_PLATFORM_ADMIN_EMAILS=dev@boosterchile.com\` en Cloud Run prod
- [ ] Migration 0018 aplica sin error
- [ ] Login con email en allowlist → \`/app/admin/cobra-hoy\` muestra tabla
- [ ] Login con email NO en allowlist → mensaje 403 claro
- [ ] Filtros funcionan (chip "Desembolsado" → solo desembolsados)
- [ ] Aprobar adelanto solicitado → status cambia, panel se cierra
- [ ] Marcar desembolsado → captura timestamp visible en historial del carrier
- [ ] Transición inválida vía API directa → 409 con \`allowed_targets\`
- [ ] Notas con tag aparecen en \`notas_admin\` de la BD

## Próximos diferidos de ADR-032

Tras este merge quedan:
- Partner factoring real (Toctoc/Mafin/Increase/Cumplo) — wire de \`solicitado\` → desembolso automático
- Sovos cesión DTE wire al desembolsar
- Equifax/Sentinel/Dicom wire para \`evaluarShipper\` automático
- Cron de cobranza al shipper en fecha del plazo

🤖 Generated with [Claude Code](https://claude.com/claude-code)