### PR TITLE
feat(empty-backhaul): wire end-to-end del cálculo GLEC v3.0 §6.4

### DIFF
--- a/apps/api/src/routes/certificates.ts
+++ b/apps/api/src/routes/certificates.ts
@@ -99,6 +99,9 @@ export function createCertificatesRoutes(opts: {
         certificateSha256: tripMetrics.certificateSha256,
         certificateKmsKeyVersion: tripMetrics.certificateKmsKeyVersion,
         certificateIssuedAt: tripMetrics.certificateIssuedAt,
+        // ADR-021 §6.4 — empty backhaul.
+        factorMatchingAplicado: tripMetrics.factorMatchingAplicado,
+        ahorroCo2eVsSinMatchingKgco2e: tripMetrics.ahorroCo2eVsSinMatchingKgco2e,
       })
       .from(tripMetrics)
       .innerJoin(trips, eq(trips.id, tripMetrics.tripId))
@@ -128,6 +131,11 @@ export function createCertificatesRoutes(opts: {
         certificate_sha256: r.certificateSha256,
         certificate_kms_key_version: r.certificateKmsKeyVersion,
         certificate_issued_at: r.certificateIssuedAt,
+        // ADR-021 §6.4 — null si el cert es legacy pre-empty-backhaul o
+        // si el vehículo no tiene perfil energético. La UI esconde el badge
+        // cuando es null.
+        factor_matching_aplicado: r.factorMatchingAplicado,
+        ahorro_co2e_vs_sin_matching_kgco2e: r.ahorroCo2eVsSinMatchingKgco2e,
       })),
       pagination: { limit, offset, returned: rows.length },
     });

--- a/apps/api/src/services/actualizar-factor-matching.ts
+++ b/apps/api/src/services/actualizar-factor-matching.ts
@@ -1,0 +1,189 @@
+import { type TipoCombustible, calcularEmptyBackhaul } from '@booster-ai/carbon-calculator';
+import type { Logger } from '@booster-ai/logger';
+import { and, asc, eq, gt, lt, ne, sql } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { assignments, tripMetrics, trips, vehicles } from '../db/schema.js';
+
+/**
+ * ADR-021 §6.4 — recalcular `factor_matching_aplicado` post-entrega del
+ * viaje, usando una heurística geo del próximo trip del mismo vehículo.
+ *
+ * **Heurística v1 (honest-default)**:
+ *
+ *   - Buscar el próximo trip *cargado* del mismo vehículo cuya ventana
+ *     de pickup arranca dentro de los **7 días corridos** posteriores a
+ *     `deliveredAt` del trip actual.
+ *   - Si **el origen del next trip está en la misma región chilena** que
+ *     el destino del trip actual → `factorMatching = 1` (matching pleno).
+ *   - Si no hay next trip en la ventana o arranca lejos →
+ *     `factorMatching = 0` (peor caso, vuelve vacío).
+ *
+ * Esto NO mide kilómetros exactos del retorno cargado — es una
+ * aproximación binaria conservadora. Sigue siendo GLEC §6.4 compliant
+ * (la regla obliga a *atribuir empty backhaul al loaded leg*; nuestra
+ * heurística decide cuánto atribuir).
+ *
+ * Una versión futura (out of scope acá) puede:
+ *   - Pedir Routes API el km loaded vs km total del retorno.
+ *   - Considerar trips parciales (un trip que arranca a 50km del
+ *     destino actual → factorMatching = (km_total − 50) / km_total).
+ *
+ * **Idempotente**: re-llamar el service con el mismo tripId recalcula
+ * con los datos vigentes (útil si después del primer recálculo aparece
+ * un trip de retorno).
+ *
+ * **No-op si**:
+ *   - El vehículo no tiene perfil energético (consumo + capacidad)
+ *     → `factor_matching_aplicado` queda null.
+ *   - No hay métricas previas del trip (calcularMetricasEstimadas
+ *     debería haber corrido antes).
+ *   - El trip no tiene assignment cerrado.
+ */
+export async function actualizarFactorMatchingViaje(opts: {
+  db: Db;
+  logger: Logger;
+  tripId: string;
+}): Promise<{
+  recomputed: boolean;
+  factorMatching?: number;
+  ahorroCo2eKgWtw?: number;
+}> {
+  const { db, logger, tripId } = opts;
+
+  const tripRows = await db
+    .select({
+      id: trips.id,
+      destinationRegionCode: trips.destinationRegionCode,
+      destinationAddressRaw: trips.destinationAddressRaw,
+    })
+    .from(trips)
+    .where(eq(trips.id, tripId))
+    .limit(1);
+  const trip = tripRows[0];
+  if (!trip) {
+    logger.warn({ tripId }, 'actualizarFactorMatchingViaje: trip no existe');
+    return { recomputed: false };
+  }
+
+  const asgRows = await db
+    .select({
+      vehicleId: assignments.vehicleId,
+      deliveredAt: assignments.deliveredAt,
+    })
+    .from(assignments)
+    .where(eq(assignments.tripId, tripId))
+    .limit(1);
+  const assignment = asgRows[0];
+  if (!assignment?.vehicleId || !assignment.deliveredAt) {
+    logger.debug(
+      { tripId, hasAssignment: !!assignment },
+      'actualizarFactorMatchingViaje: skip — sin assignment con vehicle + deliveredAt',
+    );
+    return { recomputed: false };
+  }
+
+  const vehRows = await db
+    .select({
+      fuelType: vehicles.fuelType,
+      consumptionLPer100kmBaseline: vehicles.consumptionLPer100kmBaseline,
+      capacityKg: vehicles.capacityKg,
+    })
+    .from(vehicles)
+    .where(eq(vehicles.id, assignment.vehicleId))
+    .limit(1);
+  const veh = vehRows[0];
+  if (!veh?.fuelType || !veh.consumptionLPer100kmBaseline || !veh.capacityKg) {
+    logger.debug(
+      { tripId, vehicleId: assignment.vehicleId },
+      'actualizarFactorMatchingViaje: skip — vehículo sin perfil energético completo',
+    );
+    return { recomputed: false };
+  }
+
+  const metricsRows = await db
+    .select({
+      distanceKmEstimated: tripMetrics.distanceKmEstimated,
+    })
+    .from(tripMetrics)
+    .where(eq(tripMetrics.tripId, tripId))
+    .limit(1);
+  const metrics = metricsRows[0];
+  if (!metrics?.distanceKmEstimated) {
+    logger.warn(
+      { tripId },
+      'actualizarFactorMatchingViaje: trip sin metricas_viaje (corrió calcularMetricasEstimadas?)',
+    );
+    return { recomputed: false };
+  }
+
+  // Ventana de 7 días post deliveredAt para considerar el próximo trip.
+  const ventanaFinDate = new Date(assignment.deliveredAt.getTime() + 7 * 24 * 60 * 60 * 1000);
+
+  // Buscar el próximo trip del mismo vehículo: assignment.vehicleId
+  // coincide, pickup_window_start > deliveredAt y dentro de la ventana.
+  // Orden por pickup_window_start asc → el más cercano cronológicamente.
+  const nextRows = await db
+    .select({
+      tripId: trips.id,
+      originRegionCode: trips.originRegionCode,
+    })
+    .from(trips)
+    .innerJoin(assignments, eq(assignments.tripId, trips.id))
+    .where(
+      and(
+        eq(assignments.vehicleId, assignment.vehicleId),
+        ne(trips.id, tripId),
+        gt(trips.pickupWindowStart, assignment.deliveredAt),
+        lt(trips.pickupWindowStart, ventanaFinDate),
+      ),
+    )
+    .orderBy(asc(trips.pickupWindowStart))
+    .limit(1);
+  const nextTrip = nextRows[0];
+
+  // Heurística: matching pleno si la región del próximo origen == región
+  // del destino actual. Si no hay next trip → factorMatching = 0.
+  let factorMatching = 0;
+  if (
+    nextTrip?.originRegionCode &&
+    trip.destinationRegionCode &&
+    nextTrip.originRegionCode === trip.destinationRegionCode
+  ) {
+    factorMatching = 1;
+  }
+
+  const empty = calcularEmptyBackhaul({
+    distanciaRetornoKm: Number(metrics.distanceKmEstimated),
+    factorMatching,
+    consumoBasePor100km: Number(veh.consumptionLPer100kmBaseline),
+    combustible: veh.fuelType as TipoCombustible,
+    capacidadKg: veh.capacityKg,
+  });
+
+  await db
+    .update(tripMetrics)
+    .set({
+      factorMatchingAplicado: factorMatching.toFixed(2),
+      emisionesEmptyBackhaulKgco2eWtw: empty.emisionesKgco2eWtw.toString(),
+      ahorroCo2eVsSinMatchingKgco2e: empty.ahorroVsSinMatchingKgco2e.toString(),
+      updatedAt: sql`now()`,
+    })
+    .where(eq(tripMetrics.tripId, tripId));
+
+  logger.info(
+    {
+      tripId,
+      vehicleId: assignment.vehicleId,
+      nextTripId: nextTrip?.tripId ?? null,
+      factorMatching,
+      ahorroCo2eKgWtw: empty.ahorroVsSinMatchingKgco2e,
+    },
+    'factor matching actualizado post-entrega',
+  );
+
+  return {
+    recomputed: true,
+    factorMatching,
+    ahorroCo2eKgWtw: empty.ahorroVsSinMatchingKgco2e,
+  };
+}

--- a/apps/api/src/services/calcular-metricas-viaje.ts
+++ b/apps/api/src/services/calcular-metricas-viaje.ts
@@ -1,8 +1,10 @@
 import {
   type ResultadoEmisiones,
+  type ResultadoEmptyBackhaul,
   type RouteDataSource,
   type TipoCombustible,
   calcularEmisionesViaje,
+  calcularEmptyBackhaul,
   calcularFactorIncertidumbre,
   derivarNivelCertificacion,
 } from '@booster-ai/carbon-calculator';
@@ -275,6 +277,20 @@ export async function calcularMetricasEstimadas(opts: {
       vehicleTypeMatchesRoutesApi: true,
     });
 
+    // ADR-021 §6.4 — empty backhaul allocation (GLEC v3.0).
+    //
+    // En la fase estimada pre-entrega el matching de retorno todavía no
+    // se conoce — por GLEC default, asumimos factorMatching = 0 (peor
+    // caso: camión vuelve 100% vacío) para no inflar el certificado
+    // con un ahorro especulativo. Post-entrega, `actualizarFactorMatchingViaje`
+    // recalcula con la heurística geo del próximo trip del vehículo.
+    //
+    // Sólo aplicable cuando tenemos perfil completo del vehículo
+    // (consumo + combustible + capacidad). En modo `por_defecto` el
+    // calculator no expone consumo base, así que skipeamos — el
+    // certificate-generator interpreta `null` como "no estimado".
+    const emptyBackhaul = calcularBackhaulSiCorresponde({ emisiones, veh });
+
     const valuesToWrite = {
       distanceKmEstimated: emisiones.distanciaKm.toString(),
       carbonEmissionsKgco2eEstimated: emisiones.emisionesKgco2eWtw.toString(),
@@ -289,6 +305,14 @@ export async function calcularMetricasEstimadas(opts: {
       coveragePct: coveragePct.toString(),
       certificationLevel,
       uncertaintyFactor: uncertaintyFactor.toString(),
+      // ADR-021 — empty backhaul.
+      factorMatchingAplicado: emptyBackhaul ? '0.00' : null,
+      emisionesEmptyBackhaulKgco2eWtw: emptyBackhaul
+        ? emptyBackhaul.emisionesKgco2eWtw.toString()
+        : null,
+      ahorroCo2eVsSinMatchingKgco2e: emptyBackhaul
+        ? emptyBackhaul.ahorroVsSinMatchingKgco2e.toString()
+        : null,
       calculatedAt: new Date(),
     };
 
@@ -478,4 +502,40 @@ export async function recalcularNivelPostEntrega(opts: {
   );
 
   return { recomputed: true, certificationLevel, coveragePct };
+}
+
+/**
+ * Devuelve el cálculo de empty backhaul cuando hay perfil completo del
+ * vehículo. Default: factorMatching = 0 (peor caso conservador, GLEC §6.4.2).
+ * El upgrade post-entrega lo aplica `actualizarFactorMatchingViaje`.
+ *
+ * Vehículo sin perfil energético (modo `por_defecto`) → retorna null:
+ * el calculator no expone consumo base, así que no podemos calcular
+ * empty backhaul honrando GLEC. El certificate-generator interpreta
+ * `null` como "no estimado" en lugar de mostrar 0.
+ */
+function calcularBackhaulSiCorresponde(opts: {
+  emisiones: ResultadoEmisiones;
+  veh:
+    | {
+        fuelType: string | null;
+        consumptionLPer100kmBaseline: string | null;
+        capacityKg: number | null;
+      }
+    | undefined;
+}): ResultadoEmptyBackhaul | null {
+  const { emisiones, veh } = opts;
+  if (!veh?.fuelType || !veh.consumptionLPer100kmBaseline || !veh.capacityKg) {
+    return null;
+  }
+  // ADR-021 §6.4 — la distancia de retorno se asume igual a la del leg
+  // cargado (ida = vuelta) como aproximación honest-default. Una versión
+  // futura podrá pedir el destino del próximo trip al Routes API.
+  return calcularEmptyBackhaul({
+    distanciaRetornoKm: emisiones.distanciaKm,
+    factorMatching: 0,
+    consumoBasePor100km: Number(veh.consumptionLPer100kmBaseline),
+    combustible: veh.fuelType as TipoCombustible,
+    capacidadKg: veh.capacityKg,
+  });
 }

--- a/apps/api/src/services/confirmar-entrega-viaje.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.ts
@@ -35,6 +35,7 @@ import { and, eq } from 'drizzle-orm';
 import { config as appConfig } from '../config.js';
 import type { Db } from '../db/client.js';
 import { assignments, tripEvents, trips } from '../db/schema.js';
+import { actualizarFactorMatchingViaje } from './actualizar-factor-matching.js';
 import { recalcularNivelPostEntrega } from './calcular-metricas-viaje.js';
 import { calcularScoreConduccionViaje } from './calcular-score-conduccion-viaje.js';
 import {
@@ -204,6 +205,19 @@ export async function confirmarEntregaViaje(opts: {
       logger.error(
         { err, tripId },
         'recalcularNivelPostEntrega fallo — emitiendo cert con valores estimados',
+      );
+    }
+
+    // ADR-021 §6.4 — recalcular factor_matching_aplicado post-entrega
+    // con heurística geo del próximo trip del vehículo. Fire-and-forget:
+    // si falla, el cert sale con los valores estimados (factorMatching=0
+    // conservador) — no bloquea la emisión.
+    try {
+      await actualizarFactorMatchingViaje({ db, logger, tripId });
+    } catch (err) {
+      logger.error(
+        { err, tripId },
+        'actualizarFactorMatchingViaje fallo — cert sale con factorMatching=0',
       );
     }
 

--- a/apps/api/src/services/emitir-certificado-viaje.ts
+++ b/apps/api/src/services/emitir-certificado-viaje.ts
@@ -238,6 +238,14 @@ export async function emitirCertificadoViaje(opts: {
       ...(metrics.uncertaintyFactor !== null
         ? { uncertaintyFactor: numOrNull(metrics.uncertaintyFactor) ?? 0 }
         : {}),
+      // ADR-021 §6.4 — empty backhaul allocation. Si los 3 campos están
+      // poblados (trip con perfil energético + matching evaluado post-entrega),
+      // el cert renderiza la sección "Ahorro CO₂e via matching de retorno"
+      // cuando el ahorro > 0. Si están null (legacy pre-ADR-021 o modo
+      // por_defecto), el cert no muestra esa sección.
+      factorMatchingAplicado: numOrNull(metrics.factorMatchingAplicado),
+      emisionesEmptyBackhaulKgco2eWtw: numOrNull(metrics.emisionesEmptyBackhaulKgco2eWtw),
+      ahorroCo2eVsSinMatchingKgco2eWtw: numOrNull(metrics.ahorroCo2eVsSinMatchingKgco2e),
     },
     empresaShipper: {
       id: shipper.id,

--- a/apps/api/test/unit/actualizar-factor-matching.test.ts
+++ b/apps/api/test/unit/actualizar-factor-matching.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { actualizarFactorMatchingViaje } from '../../src/services/actualizar-factor-matching.js';
+
+/**
+ * Tests del recálculo post-entrega de empty backhaul (ADR-021 §6.4).
+ * Heurística v1: factorMatching = 1 si el next trip del vehículo arranca
+ * en la misma región del destino actual, sino 0.
+ */
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+interface DbQueues {
+  selects?: unknown[][];
+  updates?: unknown[][];
+}
+
+function makeDb(opts: DbQueues = {}) {
+  const selects = [...(opts.selects ?? [])];
+  const updates = [...(opts.updates ?? [])];
+
+  const buildSelectChain = () => {
+    const chain: Record<string, unknown> = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(async () => selects.shift() ?? []),
+    };
+    return chain;
+  };
+  const buildUpdateChain = () => ({
+    set: vi.fn(() => ({
+      where: vi.fn(async () => updates.shift() ?? []),
+    })),
+  });
+  return {
+    select: vi.fn(() => buildSelectChain()),
+    update: vi.fn(() => buildUpdateChain()),
+  };
+}
+
+const TRIP_ID = '11111111-1111-1111-1111-111111111111';
+const VEH_ID = '22222222-2222-2222-2222-222222222222';
+
+const TRIP_VALPARAISO_DESTINO = {
+  id: TRIP_ID,
+  destinationRegionCode: 'V',
+  destinationAddressRaw: 'Plaza Sotomayor, Valparaíso',
+};
+
+const ASSIGNMENT_OK = {
+  vehicleId: VEH_ID,
+  deliveredAt: new Date('2026-05-05T18:00:00Z'),
+};
+
+const VEH_COMPLETO = {
+  fuelType: 'diesel',
+  consumptionLPer100kmBaseline: '28.5',
+  capacityKg: 12000,
+};
+
+const METRICS_OK = {
+  distanceKmEstimated: '120',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('actualizarFactorMatchingViaje — no-op branches', () => {
+  it('trip no existe → recomputed:false', async () => {
+    const db = makeDb({ selects: [[]] });
+    const result = await actualizarFactorMatchingViaje({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+    });
+    expect(result.recomputed).toBe(false);
+  });
+
+  it('sin assignment con vehicle+deliveredAt → recomputed:false', async () => {
+    const db = makeDb({
+      selects: [[TRIP_VALPARAISO_DESTINO], [{ vehicleId: null, deliveredAt: null }]],
+    });
+    const result = await actualizarFactorMatchingViaje({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+    });
+    expect(result.recomputed).toBe(false);
+  });
+
+  it('vehículo sin perfil energético completo → recomputed:false', async () => {
+    const db = makeDb({
+      selects: [
+        [TRIP_VALPARAISO_DESTINO],
+        [ASSIGNMENT_OK],
+        [{ fuelType: null, consumptionLPer100kmBaseline: null, capacityKg: null }],
+      ],
+    });
+    const result = await actualizarFactorMatchingViaje({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+    });
+    expect(result.recomputed).toBe(false);
+  });
+
+  it('trip sin métricas previas → warn + recomputed:false', async () => {
+    const db = makeDb({
+      selects: [
+        [TRIP_VALPARAISO_DESTINO],
+        [ASSIGNMENT_OK],
+        [VEH_COMPLETO],
+        [], // tripMetrics vacío
+      ],
+    });
+    const result = await actualizarFactorMatchingViaje({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+    });
+    expect(result.recomputed).toBe(false);
+  });
+});
+
+describe('actualizarFactorMatchingViaje — heurística geo', () => {
+  it('next trip arranca en MISMA región del destino → factorMatching=1, ahorro>0', async () => {
+    const db = makeDb({
+      selects: [
+        [TRIP_VALPARAISO_DESTINO],
+        [ASSIGNMENT_OK],
+        [VEH_COMPLETO],
+        [METRICS_OK],
+        [
+          // Next trip arranca en Valparaíso (región V) → match pleno.
+          { tripId: 'next-trip', originRegionCode: 'V' },
+        ],
+      ],
+      updates: [[]],
+    });
+    const result = await actualizarFactorMatchingViaje({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+    });
+    expect(result.recomputed).toBe(true);
+    expect(result.factorMatching).toBe(1);
+    expect(result.ahorroCo2eKgWtw).toBeGreaterThan(0);
+  });
+
+  it('next trip arranca en OTRA región → factorMatching=0', async () => {
+    const db = makeDb({
+      selects: [
+        [TRIP_VALPARAISO_DESTINO],
+        [ASSIGNMENT_OK],
+        [VEH_COMPLETO],
+        [METRICS_OK],
+        [
+          // Next trip arranca en Concepción (región VIII) ≠ Valparaíso (V).
+          { tripId: 'next-trip', originRegionCode: 'VIII' },
+        ],
+      ],
+      updates: [[]],
+    });
+    const result = await actualizarFactorMatchingViaje({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+    });
+    expect(result.recomputed).toBe(true);
+    expect(result.factorMatching).toBe(0);
+    expect(result.ahorroCo2eKgWtw).toBe(0);
+  });
+
+  it('sin next trip en la ventana de 7d → factorMatching=0, igual persiste', async () => {
+    const db = makeDb({
+      selects: [
+        [TRIP_VALPARAISO_DESTINO],
+        [ASSIGNMENT_OK],
+        [VEH_COMPLETO],
+        [METRICS_OK],
+        [], // no next trips
+      ],
+      updates: [[]],
+    });
+    const result = await actualizarFactorMatchingViaje({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+    });
+    expect(result.recomputed).toBe(true);
+    expect(result.factorMatching).toBe(0);
+  });
+});
+
+describe('actualizarFactorMatchingViaje — persistencia', () => {
+  it('persiste los 3 campos con factorMatching=1', async () => {
+    const setMock = vi.fn(() => ({ where: vi.fn(async () => []) }));
+    const db = {
+      select: vi.fn(() => {
+        const chain: Record<string, unknown> = {
+          from: vi.fn(() => chain),
+          innerJoin: vi.fn(() => chain),
+          where: vi.fn(() => chain),
+          orderBy: vi.fn(() => chain),
+          limit: vi.fn(async () => {
+            const queue: unknown[][] = [
+              [TRIP_VALPARAISO_DESTINO],
+              [ASSIGNMENT_OK],
+              [VEH_COMPLETO],
+              [METRICS_OK],
+              [{ tripId: 'next', originRegionCode: 'V' }],
+            ];
+            return queue[(db.select as ReturnType<typeof vi.fn>).mock.calls.length - 1] ?? [];
+          }),
+        };
+        return chain;
+      }),
+      update: vi.fn(() => ({ set: setMock })),
+    };
+    await actualizarFactorMatchingViaje({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+    });
+    expect(setMock).toHaveBeenCalledTimes(1);
+    const setArg = setMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArg.factorMatchingAplicado).toBe('1.00');
+    expect(Number(setArg.emisionesEmptyBackhaulKgco2eWtw)).toBe(0); // factor 1 → 0 attribution
+    expect(Number(setArg.ahorroCo2eVsSinMatchingKgco2e)).toBeGreaterThan(0);
+  });
+});

--- a/apps/api/test/unit/calcular-metricas-viaje.test.ts
+++ b/apps/api/test/unit/calcular-metricas-viaje.test.ts
@@ -159,6 +159,79 @@ describe('calcularMetricasEstimadas', () => {
     expect(result.isInitialCalculation).toBe(true);
   });
 
+  it('vehículo con perfil completo + carga → persiste empty backhaul fields (ADR-021)', async () => {
+    const db = makeDb({
+      selects: [
+        [TRIP_BASE],
+        [
+          {
+            id: VEH_ID,
+            // 'diesel' es TipoCombustible válido del carbon-calculator.
+            fuelType: 'diesel',
+            consumptionLPer100kmBaseline: '28.5',
+            curbWeightKg: 7000,
+            capacityKg: 12000,
+            vehicleType: 'camion_pequeno',
+          },
+        ],
+        [],
+      ],
+      inserts: [[]],
+    });
+
+    await calcularMetricasEstimadas({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+      vehicleId: VEH_ID,
+    });
+
+    // El INSERT debió recibir los 3 campos backhaul con valores ≥ 0.
+    const insertCall = (db.insert as ReturnType<typeof vi.fn>).mock.results.find((r) => r.value);
+    expect(insertCall).toBeDefined();
+    const values = (insertCall?.value as { values: ReturnType<typeof vi.fn> }).values.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(values.factorMatchingAplicado).toBe('0.00');
+    expect(typeof values.emisionesEmptyBackhaulKgco2eWtw).toBe('string');
+    expect(Number(values.emisionesEmptyBackhaulKgco2eWtw)).toBeGreaterThan(0);
+    // Con factorMatching=0 el ahorro vs sin-matching es 0 (peor caso).
+    expect(values.ahorroCo2eVsSinMatchingKgco2e).toBe('0');
+  });
+
+  it('vehículo en modo por_defecto → backhaul fields quedan null', async () => {
+    const db = makeDb({
+      selects: [
+        [TRIP_BASE],
+        [
+          {
+            id: VEH_ID,
+            fuelType: null,
+            consumptionLPer100kmBaseline: null,
+            curbWeightKg: null,
+            capacityKg: null,
+            vehicleType: 'camion_pequeno',
+          },
+        ],
+        [],
+      ],
+      inserts: [[]],
+    });
+
+    await calcularMetricasEstimadas({
+      db: db as never,
+      logger: noopLogger,
+      tripId: TRIP_ID,
+      vehicleId: VEH_ID,
+    });
+
+    const insertCall = (db.insert as ReturnType<typeof vi.fn>).mock.results.find((r) => r.value);
+    const values = (insertCall?.value as { values: ReturnType<typeof vi.fn> }).values.mock
+      .calls[0]?.[0] as Record<string, unknown>;
+    expect(values.factorMatchingAplicado).toBeNull();
+    expect(values.emisionesEmptyBackhaulKgco2eWtw).toBeNull();
+    expect(values.ahorroCo2eVsSinMatchingKgco2e).toBeNull();
+  });
+
   it('vehículo SIN perfil completo (falta consumo) → cae a modo por_defecto', async () => {
     const db = makeDb({
       selects: [

--- a/apps/web/src/routes/certificados.tsx
+++ b/apps/web/src/routes/certificados.tsx
@@ -39,6 +39,10 @@ interface CertificadoListItem {
   certificate_sha256: string | null;
   certificate_kms_key_version: string | null;
   certificate_issued_at: string | null;
+  // ADR-021 §6.4 — empty backhaul allocation. Null para certs legacy
+  // o trips sin perfil energético del vehículo.
+  factor_matching_aplicado: string | null;
+  ahorro_co2e_vs_sin_matching_kgco2e: string | null;
 }
 
 interface CertificadosResponse {
@@ -140,7 +144,7 @@ function CertificadosPage({ me }: { me: MeOnboarded }) {
 
       {certsQ.data && certsQ.data.certificates.length > 0 && (
         <>
-          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-4">
             <SummaryCard
               title="Certificados emitidos"
               value={certsQ.data.certificates.length.toString()}
@@ -150,6 +154,11 @@ function CertificadosPage({ me }: { me: MeOnboarded }) {
               title="Total CO₂e certificado"
               value={`${formatKg(sumKg(certsQ.data.certificates))} kg`}
               icon={<Leaf className="h-5 w-5 text-emerald-600" aria-hidden />}
+            />
+            <SummaryCard
+              title="Ahorro CO₂e via matching"
+              value={`${formatKg(sumAhorroBackhaul(certsQ.data.certificates))} kg`}
+              icon={<Leaf className="h-5 w-5 text-emerald-700" aria-hidden />}
             />
             <SummaryCard
               title="Estándar"
@@ -166,6 +175,7 @@ function CertificadosPage({ me }: { me: MeOnboarded }) {
                   <Th>Trayecto</Th>
                   <Th>Carga</Th>
                   <Th className="text-right">CO₂e</Th>
+                  <Th className="text-right">Ahorro matching</Th>
                   <Th>Emitido</Th>
                   <Th className="text-right">Acción</Th>
                 </tr>
@@ -183,6 +193,16 @@ function CertificadosPage({ me }: { me: MeOnboarded }) {
                     <Td className="text-xs">{formatCargoType(c.cargo_type)}</Td>
                     <Td className="text-right font-semibold text-emerald-700">
                       {c.kg_co2e ? `${formatKg(Number(c.kg_co2e))} kg` : '—'}
+                    </Td>
+                    <Td className="text-right">
+                      {c.ahorro_co2e_vs_sin_matching_kgco2e &&
+                      Number(c.ahorro_co2e_vs_sin_matching_kgco2e) > 0 ? (
+                        <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 font-medium text-emerald-700 text-xs">
+                          −{formatKg(Number(c.ahorro_co2e_vs_sin_matching_kgco2e))} kg
+                        </span>
+                      ) : (
+                        <span className="text-neutral-400 text-xs">—</span>
+                      )}
                     </Td>
                     <Td className="text-neutral-600 text-xs">
                       {c.certificate_issued_at ? formatDate(c.certificate_issued_at) : '—'}
@@ -274,6 +294,15 @@ function SummaryCard({ title, value, icon }: { title: string; value: string; ico
 
 function sumKg(items: CertificadoListItem[]): number {
   return items.reduce((acc, c) => acc + (c.kg_co2e ? Number(c.kg_co2e) : 0), 0);
+}
+
+function sumAhorroBackhaul(items: CertificadoListItem[]): number {
+  return items.reduce(
+    (acc, c) =>
+      acc +
+      (c.ahorro_co2e_vs_sin_matching_kgco2e ? Number(c.ahorro_co2e_vs_sin_matching_kgco2e) : 0),
+    0,
+  );
 }
 
 function formatKg(n: number): string {

--- a/packages/certificate-generator/src/generar-pdf-base.ts
+++ b/packages/certificate-generator/src/generar-pdf-base.ts
@@ -306,6 +306,48 @@ export async function generarPdfBase(params: ParametrosGenerarPdf): Promise<Uint
   cursorY -= 150;
 
   // ============================================================
+  // Bloque 3.5 — Ahorro CO₂e via matching de retorno (ADR-021 §6.4)
+  // ============================================================
+  // Solo renderizamos si el cálculo se realizó (factorMatchingAplicado
+  // != null) Y hubo ahorro real (> 0). Esto evita ruido visual en certs
+  // donde el viaje no tuvo medición de backhaul, o donde el retorno fue
+  // 100% vacío (peor caso GLEC §6.4.2).
+  const factorMatching = params.metricas.factorMatchingAplicado;
+  const ahorroBackhaul = params.metricas.ahorroCo2eVsSinMatchingKgco2eWtw;
+  if (factorMatching != null && ahorroBackhaul != null && ahorroBackhaul > 0) {
+    drawSectionTitle(
+      page,
+      'Ahorro CO₂e via matching de retorno (GLEC v3.0 §6.4)',
+      40,
+      cursorY,
+      fontBold,
+      colorPrimary,
+    );
+    cursorY -= 22;
+    drawLabelValue(
+      page,
+      'Factor de matching aplicado',
+      `${(factorMatching * 100).toFixed(0)}%`,
+      40,
+      cursorY,
+      fontRegular,
+      fontBold,
+      colorMuted,
+    );
+    drawLabelValue(
+      page,
+      'Ahorro vs sin matching',
+      `${ahorroBackhaul.toFixed(2)} kg CO2e`,
+      width / 2,
+      cursorY,
+      fontRegular,
+      fontBold,
+      colorMuted,
+    );
+    cursorY -= 35;
+  }
+
+  // ============================================================
   // Bloque 4 — Metodología (auditoría)
   // ============================================================
   drawSectionTitle(page, 'Metodología', 40, cursorY, fontBold, colorPrimary);

--- a/packages/certificate-generator/src/tipos.ts
+++ b/packages/certificate-generator/src/tipos.ts
@@ -76,6 +76,17 @@ export interface DatosMetricasCertificado {
    * principal. Decimal en [0, 1].
    */
   uncertaintyFactor?: number;
+  /**
+   * ADR-021 §6.4 — Empty backhaul allocation (GLEC v3.0). Si están
+   * presentes Y `ahorroCo2eVsSinMatchingKgco2eWtw > 0`, el cert renderiza
+   * una sección "Ahorro CO₂e via matching de retorno" con el factor de
+   * matching aplicado y el ahorro absoluto. Si `factorMatchingAplicado`
+   * es null, asumimos que el viaje no tuvo medición de backhaul (modo
+   * por_defecto, o cálculo legacy pre-ADR-021).
+   */
+  factorMatchingAplicado?: number | null;
+  emisionesEmptyBackhaulKgco2eWtw?: number | null;
+  ahorroCo2eVsSinMatchingKgco2eWtw?: number | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Cierra el plan **T+1..T+3 de ADR-021**. El calculator de empty backhaul ya estaba implementado en \`packages/carbon-calculator\` con 44 tests verde; este PR lo **conecta end-to-end**: servicio orquestador → recálculo post-entrega → certificado PDF → UI shipper.

- **Pre-entrega**: \`calcularMetricasEstimadas\` invoca \`calcularEmptyBackhaul(factorMatching=0)\` cuando el vehículo tiene perfil energético completo (peor caso conservador GLEC §6.4.2). Modo \`por_defecto\` deja los 3 campos null.
- **Post-entrega**: nuevo servicio \`actualizarFactorMatchingViaje\` con heurística geo binaria — \`factorMatching=1\` si el próximo trip del vehículo arranca en la misma región del destino actual dentro de 7d, sino 0. Fire-and-forget desde \`confirmar-entrega-viaje\`.
- **PDF**: bloque 3.5 \"Ahorro CO₂e via matching de retorno (GLEC v3.0 §6.4)\" que solo se renderiza si \`factorMatching != null\` y \`ahorro > 0\`.
- **UI**: SummaryCard + columna \"Ahorro matching\" con badge emerald en \`/app/certificados\`.

## Componentes

### Backend
- \`services/calcular-metricas-viaje.ts\`: wire pre-entrega + helper \`calcularBackhaulSiCorresponde\`.
- \`services/actualizar-factor-matching.ts\` (nuevo): heurística geo + recálculo idempotente. **8 tests**.
- \`services/confirmar-entrega-viaje.ts\`: invoca el recálculo post-entrega.
- \`services/emitir-certificado-viaje.ts\`: pasa los 3 campos al cert-generator.
- \`routes/certificates.ts\`: incluye \`factor_matching_aplicado\` y \`ahorro_co2e_vs_sin_matching_kgco2e\` en la response.
- Tests metricas: +2 (vehículo completo → persiste 3 campos backhaul, modo por_defecto → null).

### Certificate generator
- \`tipos.ts\`: 3 campos opcionales en \`DatosMetricasCertificado\`.
- \`generar-pdf-base.ts\`: nuevo bloque 3.5 con factor de matching aplicado (%) + ahorro absoluto (kg CO2e). Conservador con certs legacy.

### Web
- \`routes/certificados.tsx\`: nueva SummaryCard, nueva columna en tabla, badge emerald cuando ahorro > 0, \"—\" cuando null.

## Heurística v1 (honest-default)

Binaria por región chilena (XV, I, II, ..., XII). Sigue siendo GLEC §6.4 compliant: la regla obliga a *atribuir empty backhaul al loaded leg*; nuestra heurística decide cuánto atribuir (0% o 100%). Una versión futura puede:
- Usar Routes API para km exactos del retorno cargado.
- Considerar trips parciales con solapamiento geográfico.

## Evidencia

\`\`\`
api: 564 tests pass (+2 metricas backhaul, +8 actualizar-factor-matching)
web: 765 tests pass (sin nuevos, no rompe los 4 tests pre-existentes de certificados)
certificate-generator: 35 tests pass
lint: 0 errors
typecheck api+web+certificate-generator: clean
\`\`\`

## Plan de despliegue (ADR-021)

- ✅ T+0 — Calculator + ADR (mergeado abril 2026).
- ✅ T+1 — Schema migration (cols ya existían).
- ✅ T+2 — **Este PR**: matching engine reportando factorMatching real (heurística v1).
- ✅ T+3 — **Este PR**: certificado PDF + UI shipper.
- ⏳ T+4 — Nota técnica en \`boosterchile.com/transparencia\` con cita a GLEC v3.0 §6.4 e ISO 14083 (fuera de scope, requiere CMS publicación).

## Test plan

- [ ] Trip nuevo con vehículo perfil completo + 1 trip de retorno mismo región → cert muestra ahorro > 0
- [ ] Trip nuevo con vehículo modo por_defecto → cert NO muestra sección backhaul (factorMatching null)
- [ ] Trip legacy pre-ADR-021 sin recalcular → cert NO muestra sección
- [ ] UI /app/certificados muestra SummaryCard \"Ahorro CO₂e via matching\" con sumatoria
- [ ] Columna \"Ahorro matching\" muestra badge cuando hay ahorro, \"—\" cuando null

🤖 Generated with [Claude Code](https://claude.com/claude-code)