### PR TITLE
docs(wave-3): smoke-test script + handoff código listo

### DIFF
--- a/docs/handoff/2026-05-10-wave-3-tls-ready.md
+++ b/docs/handoff/2026-05-10-wave-3-tls-ready.md
@@ -1,0 +1,139 @@
+# Handoff — Wave 3 TLS dual-endpoint listo para rollout (2026-05-10)
+
+Estado del proyecto Wave 3 (TLS + DR backup) al cierre de la sesión
+2026-05-10. **Toda la capa de código está mergeada**. Pendiente: pasos
+operacionales del operador cuando se cumplan las pre-conditions del
+runbook `wave-2-3-deploy.md` §5.2.
+
+## TL;DR
+
+- ✅ **Código 100%**: Terraform (`wave-3-tls.tf`, `dr-region.tf`), manifests K8s (`telemetry-tcp-gateway.yaml`, `-dr.yaml`, `cert-primary.yaml`, `cert-dr.yaml`, `cert-manager-issuers.yaml`), gateway Node (`main.ts` con dual server 5027 + 5061).
+- ✅ **Smoke test script**: `scripts/smoke-test-wave-3-tls.sh` valida DNS → IP drift vs TF → TCP → TLS handshake → cert chain + CN + vigencia, opcionalmente handshake IMEI Teltonika.
+- ⏳ **Bloqueado operacionalmente** por las pre-conditions del runbook:
+  1. G2.3 — Capacity load test PASS (Wave 2 estable).
+  2. G3.4 — DR failover test PASS.
+  3. Wave 2 estable >7 días en prod sin alertas P0/P1 críticas.
+
+## Inventario del código Wave 3
+
+### Terraform
+- `infrastructure/wave-3-tls.tf` — IP estática `booster-telemetry-tls-lb-ip` + DNS `telemetry-tls.boosterchile.com` + SA `cert-manager-cloud-dns` + Workload Identity binding + Cloud NAT (primary + DR).
+- `infrastructure/dr-region.tf` — IP estática `telemetry_dr_lb` + DNS `telemetry-dr.boosterchile.com` + cluster DR `booster-ai-telemetry-dr` us-central1.
+- **Outputs disponibles**: `telemetry_tls_lb_ip` (primary), `dr_lb_ip` (DR), `cert_manager_gcp_sa_email`.
+
+### K8s manifests
+- `infrastructure/k8s/telemetry-tcp-gateway.yaml` — Deployment + 2 Services (`telemetry-tcp-gateway` plain 5027, `telemetry-tcp-gateway-tls` TLS 5061) + HPA. Hardened (non-root UID 10001, readOnlyRootFilesystem, cap drop ALL).
+- `infrastructure/k8s/telemetry-tcp-gateway-dr.yaml` — Mirror en cluster DR. Service único TLS 5061 (sin plain en DR).
+- `infrastructure/k8s/cert-manager-issuers.yaml` — ClusterIssuer `letsencrypt-prod` con DNS-01 solver via Cloud DNS SA.
+- `infrastructure/k8s/cert-primary.yaml` — Certificate Let's Encrypt para `telemetry-tls.boosterchile.com`.
+- `infrastructure/k8s/cert-dr.yaml` — Certificate para `telemetry-dr.boosterchile.com`.
+
+### Gateway code
+- `apps/telemetry-tcp-gateway/src/main.ts` — dual server pattern: `net.createServer` en 5027 + `tls.createServer` en 5061 (conditional, requiere TLS_CERT_PATH + TLS_KEY_PATH). Ambos invocan el mismo `handleConnection`, mismas dependencias.
+- Si los paths no se montan (cert-manager aún no resolvió ACME), el listener TLS skipea con warn — el plain sigue funcionando.
+
+## Procedimiento operacional (cuando las pre-conditions se cumplan)
+
+Sigue el runbook completo `docs/runbooks/wave-2-3-deploy.md` §3.2 + §5.2. Resumen:
+
+### 1. Terraform apply (primary + DR networking)
+```bash
+cd infrastructure
+terraform plan -var-file=terraform.tfvars.local -out=/tmp/plan-wave-3
+terraform apply /tmp/plan-wave-3
+```
+
+Recursos esperados: `google_compute_address.telemetry_tls_lb`, `google_dns_record_set.telemetry_tls`, `google_service_account.cert_manager_cloud_dns`, `google_compute_router_nat.primary_nat`, `google_compute_router_nat.dr_nat`.
+
+### 2. Verificar IPs reservadas
+```bash
+terraform output telemetry_tls_lb_ip   # primary
+terraform output dr_lb_ip              # DR
+```
+
+Si los valores difieren del `loadBalancerIP` hardcoded en los manifests, **actualizar antes del `kubectl apply`**:
+- `infrastructure/k8s/telemetry-tcp-gateway.yaml` → service `telemetry-tcp-gateway-tls` → `loadBalancerIP`.
+- `infrastructure/k8s/telemetry-tcp-gateway-dr.yaml` → service `telemetry-tcp-gateway-tls` → `loadBalancerIP`.
+
+### 3. cert-manager en cluster primary
+```bash
+gcloud container clusters get-credentials booster-ai-telemetry --region=southamerica-west1
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --version v1.16.0 --set crds.enabled=true
+
+# Anotar K8s SA cert-manager para Workload Identity
+kubectl annotate serviceaccount cert-manager -n cert-manager \
+  iam.gke.io/gcp-service-account="$(cd ../infrastructure && terraform output -raw cert_manager_gcp_sa_email)"
+
+kubectl apply -f infrastructure/k8s/cert-manager-issuers.yaml
+kubectl apply -f infrastructure/k8s/cert-primary.yaml
+```
+
+Esperar a que el Certificate esté Ready (~2-5 min con DNS-01):
+```bash
+kubectl get certificate telemetry-tls-cert -n telemetry -w
+```
+
+### 4. cert-manager en cluster DR
+Idéntico al paso 3 pero contra cluster DR + `cert-dr.yaml`.
+
+### 5. Deploy gateway con TLS habilitado
+```bash
+./scripts/deploy-telemetry-gateway.sh $(git rev-parse HEAD)
+```
+
+El manifest ya monta el Secret `telemetry-tls-cert` como volumen optional — si cert-manager terminó, el pod arranca con listener TLS automáticamente.
+
+### 6. Smoke test desde laptop operador
+```bash
+./scripts/smoke-test-wave-3-tls.sh                              # primary
+./scripts/smoke-test-wave-3-tls.sh --dr                         # DR
+./scripts/smoke-test-wave-3-tls.sh --imei 863238075489155       # con handshake IMEI
+```
+
+Valida en orden:
+1. DNS → IP coincide con `terraform output`.
+2. TCP open en `:5061`.
+3. TLS handshake TLSv1.2+ con cert válido Let's Encrypt.
+4. CN del cert incluye el dominio.
+5. Cert vigente con >7 días.
+6. (Opcional) handshake IMEI → ACK 0x01.
+
+### 7. Migración devices Wave 3
+Por device en Teltonika Configurator:
+- **Server Mode (primary)**: TLS, Domain `telemetry-tls.boosterchile.com`, Port 5061.
+- **Server Mode (backup)**: Backup, Domain `telemetry-dr.boosterchile.com`, Port 5061, TLS Enable.
+- Push config.
+- Verificar `kubectl logs -n telemetry deployment/telemetry-tcp-gateway --tail=100 --context=booster-primary | grep "handshake IMEI completado"`.
+
+### 8. Documentar en ADR-005
+Update sección "Status post-Wave 3":
+- Devices migrados a TLS: N/total.
+- DR failover testado: fecha, pass.
+
+## Rollback
+
+Si algo falla en el rollout TLS pero Wave 2 sigue OK:
+- **Devices**: revertir cfg al endpoint plain `telemetry.boosterchile.com:5027`. Los devices Wave 1/2 ya estaban acá.
+- **K8s**: el Service `telemetry-tcp-gateway-tls` puede borrarse sin afectar el Service plain `telemetry-tcp-gateway`. `kubectl delete svc telemetry-tcp-gateway-tls -n telemetry`.
+- **Terraform**: las IPs estáticas tienen `prevent_destroy=false` por default — `terraform destroy -target=google_compute_address.telemetry_tls_lb` las libera. Lo mismo con el DNS A record.
+
+## Próximos pasos cuando esto se merge
+
+1. **Confirmar pre-conditions**:
+   - `kubectl get pods -n telemetry --context=booster-primary` estable.
+   - Cloud Monitoring → no alertas P0/P1 en últimos 7d.
+   - `scripts/load-test` ejecutado con resultados PASS documentados.
+   - `docs/runbooks/dr-failover-test.md` ejecutado con resultados PASS.
+
+2. **Programar ventana de rollout TLS** (1-2h, no requiere downtime — los devices migran 1×1).
+
+3. **Comunicar a flota Wave 1/2** que recibirán nueva config TLS via push remoto.
+
+## Referencias
+
+- ADR-005 — Stack telemetría IoT.
+- Runbook `docs/runbooks/wave-2-3-deploy.md` §3.2 + §5.2.
+- Brief `Booster-FMC150-Wave2-Wave3-Brief-2026-05-06.pdf` (D3 + D4).
+- Handoffs previos: `2026-05-07-wave-2-3-deploy-progress.md`, `2026-05-09-iac-hardening-sprint.md`.

--- a/scripts/smoke-test-wave-3-tls.sh
+++ b/scripts/smoke-test-wave-3-tls.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Smoke test del endpoint TLS de telemetry-tcp-gateway (Wave 3).
+#
+# Validaciones que hace este script en orden:
+#
+#   1. DNS resuelve `telemetry-tls.boosterchile.com`.
+#   2. La IP resuelta coincide con `terraform output telemetry_tls_lb_ip`
+#      (detecta drift del manifest K8s vs IP reservada).
+#   3. TCP connect a puerto 5061 (LB acepta conexión).
+#   4. TLS handshake exitoso a TLSv1.2+ con cert de Let's Encrypt.
+#   5. CN/SAN del cert coincide con el dominio esperado.
+#   6. Cert no expirado y tiene >7 días de vigencia (early warning).
+#   7. (Opcional, --imei <IMEI>) handshake IMEI Teltonika contra el gateway:
+#      envía los 17 bytes "IMEI length + IMEI ASCII" y verifica byte 0x01 ACK.
+#
+# Para el endpoint DR (`telemetry-dr.boosterchile.com`) pasar --dr.
+#
+# Pre-requisitos:
+#   - openssl >= 1.1
+#   - dig (BIND tools) o getent
+#   - terraform (opcional, si se quiere validar drift de IP)
+#
+# Usage:
+#   ./scripts/smoke-test-wave-3-tls.sh
+#   ./scripts/smoke-test-wave-3-tls.sh --dr
+#   ./scripts/smoke-test-wave-3-tls.sh --imei 863238075489155
+#   ./scripts/smoke-test-wave-3-tls.sh --skip-ip-drift  # sin terraform local
+
+set -euo pipefail
+
+PRIMARY_HOST="telemetry-tls.boosterchile.com"
+DR_HOST="telemetry-dr.boosterchile.com"
+TLS_PORT="5061"
+
+HOST="$PRIMARY_HOST"
+CHECK_IP_DRIFT="true"
+IMEI=""
+
+# Parse args.
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dr) HOST="$DR_HOST"; shift ;;
+    --imei) IMEI="$2"; shift 2 ;;
+    --skip-ip-drift) CHECK_IP_DRIFT="false"; shift ;;
+    -h|--help)
+      grep '^#' "$0" | head -30
+      exit 0
+      ;;
+    *) echo "Arg desconocido: $1"; exit 2 ;;
+  esac
+done
+
+ok() { printf '\033[32m✓\033[0m %s\n' "$*"; }
+fail() { printf '\033[31m✗\033[0m %s\n' "$*" >&2; exit 1; }
+info() { printf '\033[36mℹ\033[0m %s\n' "$*"; }
+
+# -----------------------------------------------------------------------------
+# 1. DNS
+# -----------------------------------------------------------------------------
+info "Resolviendo $HOST..."
+if command -v dig >/dev/null 2>&1; then
+  RESOLVED_IP=$(dig +short "$HOST" A | head -1)
+elif command -v getent >/dev/null 2>&1; then
+  RESOLVED_IP=$(getent ahostsv4 "$HOST" | head -1 | awk '{print $1}')
+else
+  RESOLVED_IP=$(host "$HOST" | awk '/has address/ { print $4 }' | head -1)
+fi
+
+if [[ -z "$RESOLVED_IP" ]]; then
+  fail "DNS no resolvió $HOST"
+fi
+ok "DNS resolvió a $RESOLVED_IP"
+
+# -----------------------------------------------------------------------------
+# 2. IP drift vs Terraform
+# -----------------------------------------------------------------------------
+if [[ "$CHECK_IP_DRIFT" == "true" && -d infrastructure ]]; then
+  info "Comparando IP DNS con terraform output..."
+  TF_OUTPUT_NAME="telemetry_tls_lb_ip"
+  [[ "$HOST" == "$DR_HOST" ]] && TF_OUTPUT_NAME="dr_lb_ip"
+  TF_IP=$( (cd infrastructure && terraform output -raw "$TF_OUTPUT_NAME" 2>/dev/null) || echo "")
+  if [[ -z "$TF_IP" ]]; then
+    info "No se pudo leer terraform output $TF_OUTPUT_NAME (skipea con --skip-ip-drift si es intencional)"
+  elif [[ "$TF_IP" != "$RESOLVED_IP" ]]; then
+    fail "Drift: DNS=$RESOLVED_IP pero terraform output=$TF_IP. El manifest K8s o el A record están desactualizados."
+  else
+    ok "IP DNS coincide con terraform output ($TF_IP)"
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# 3. TCP connect
+# -----------------------------------------------------------------------------
+info "TCP connect a $HOST:$TLS_PORT (5s timeout)..."
+if ! timeout 5 bash -c "</dev/tcp/$HOST/$TLS_PORT" 2>/dev/null; then
+  fail "No se pudo abrir TCP a $HOST:$TLS_PORT — LB caído o firewall bloqueando"
+fi
+ok "TCP abierto"
+
+# -----------------------------------------------------------------------------
+# 4. TLS handshake
+# -----------------------------------------------------------------------------
+info "TLS handshake a $HOST:$TLS_PORT..."
+TLS_OUTPUT=$(echo | timeout 10 openssl s_client \
+  -connect "$HOST:$TLS_PORT" \
+  -servername "$HOST" \
+  -tls1_2 \
+  -verify_return_error \
+  2>&1 || true)
+
+if ! echo "$TLS_OUTPUT" | grep -q "Verify return code: 0 (ok)"; then
+  echo "$TLS_OUTPUT" | tail -20
+  fail "TLS handshake falló o cert chain inválido"
+fi
+ok "TLS handshake OK (TLSv1.2+, cert chain válido contra raíces públicas)"
+
+# -----------------------------------------------------------------------------
+# 5. CN/SAN check
+# -----------------------------------------------------------------------------
+info "Verificando subject del cert..."
+CERT_SUBJECT=$(echo "$TLS_OUTPUT" | sed -n 's/^subject=//p' | head -1)
+if ! echo "$CERT_SUBJECT" | grep -q "$HOST"; then
+  echo "subject: $CERT_SUBJECT"
+  fail "El subject del cert no contiene $HOST"
+fi
+ok "Subject incluye $HOST"
+
+# -----------------------------------------------------------------------------
+# 6. Vigencia >7 días
+# -----------------------------------------------------------------------------
+info "Verificando vigencia del cert..."
+CERT_PEM=$(echo "$TLS_OUTPUT" | awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/')
+END_DATE=$(echo "$CERT_PEM" | openssl x509 -noout -enddate 2>/dev/null | sed 's/notAfter=//')
+if [[ -z "$END_DATE" ]]; then
+  fail "No se pudo parsear notAfter del cert"
+fi
+
+END_TS=$(date -u -d "$END_DATE" +%s 2>/dev/null || date -u -j -f "%b %e %T %Y %Z" "$END_DATE" +%s 2>/dev/null || echo 0)
+NOW_TS=$(date -u +%s)
+DAYS_REMAINING=$(( (END_TS - NOW_TS) / 86400 ))
+
+if [[ "$END_TS" -le "$NOW_TS" ]]; then
+  fail "Cert ya expirado (notAfter=$END_DATE)"
+elif [[ "$DAYS_REMAINING" -lt 7 ]]; then
+  fail "Cert expira en $DAYS_REMAINING días — cert-manager debería haber renovado, revisar logs"
+fi
+ok "Cert vigente — $DAYS_REMAINING días restantes (renueva @30d)"
+
+# -----------------------------------------------------------------------------
+# 7. (Opcional) handshake IMEI Teltonika
+# -----------------------------------------------------------------------------
+if [[ -n "$IMEI" ]]; then
+  info "Probando handshake IMEI Teltonika con $IMEI..."
+  IMEI_LEN=${#IMEI}
+  # Header: 2 bytes big-endian con la longitud del IMEI, seguido del IMEI ASCII.
+  IMEI_LEN_HEX=$(printf '%04x' "$IMEI_LEN")
+  IMEI_HEX=$(printf '%s' "$IMEI" | xxd -p | tr -d '\n')
+  PACKET_HEX="${IMEI_LEN_HEX}${IMEI_HEX}"
+
+  # openssl s_client en background con stdin del packet IMEI.
+  ACK=$(printf '%s' "$PACKET_HEX" | xxd -r -p | \
+    timeout 10 openssl s_client -connect "$HOST:$TLS_PORT" -servername "$HOST" -tls1_2 -quiet 2>/dev/null | \
+    head -c 1 | xxd -p | tr -d '\n' || true)
+
+  if [[ "$ACK" == "01" ]]; then
+    ok "Gateway respondió ACK 0x01 al handshake IMEI"
+  else
+    fail "Gateway no respondió ACK válido (recibido=0x$ACK, esperado=0x01). Verificar: device aprobado en BD o auto-enrollment habilitado."
+  fi
+fi
+
+echo
+ok "Smoke test Wave 3 TLS PASS contra $HOST"


### PR DESCRIPTION
## Summary

Cierra Wave 3 desde la perspectiva del **repositorio**. Toda la capa técnica ya estaba mergeada en sprints previos (Terraform \`wave-3-tls.tf\` + \`dr-region.tf\`, manifests K8s primary/DR, cert-manager Issuers + Certificates, gateway dual-server). Este PR agrega el último kilómetro: **script de smoke test reusable + handoff doc** que describe el estado actual y el procedimiento operacional cuando se cumplan las pre-conditions.

## Componentes

### \`scripts/smoke-test-wave-3-tls.sh\`
Bash script ejecutable que valida el endpoint TLS en orden:
1. DNS resuelve \`telemetry-tls.boosterchile.com\` (o \`-dr\` con \`--dr\`).
2. IP DNS coincide con \`terraform output telemetry_tls_lb_ip\` (detecta drift).
3. TCP connect a :5061.
4. TLS handshake TLSv1.2+ con cert chain válido contra raíces públicas.
5. CN del cert incluye el dominio.
6. Cert con >7 días de vigencia (early warning).
7. (Opcional con \`--imei <IMEI>\`) handshake IMEI Teltonika contra el gateway → ACK 0x01.

Flags: \`--dr\`, \`--imei <IMEI>\`, \`--skip-ip-drift\`.

### \`docs/handoff/2026-05-10-wave-3-tls-ready.md\`
Handoff doc con:
- Inventario completo del código Wave 3 (Terraform + manifests + gateway code).
- Procedimiento operacional 8-pasos para el día que se ejecute el rollout.
- Pre-conditions bloqueantes:
  - G2.3 — Capacity load test PASS
  - G3.4 — DR failover test PASS
  - Wave 2 estable >7 días sin alertas P0/P1
- Plan de rollback documentado.

## Estado real de Wave 3 (sin este PR)

| Componente | Estado |
|---|---|
| Terraform IPs + DNS + SA cert-manager + Cloud NAT | ✅ Mergeado |
| Manifests K8s primary (`telemetry-tcp-gateway.yaml`) | ✅ Mergeado |
| Manifests K8s DR (`telemetry-tcp-gateway-dr.yaml`) | ✅ Mergeado |
| cert-manager Issuers + Certificates | ✅ Mergeado |
| Gateway dual-server (5027 plain + 5061 TLS) | ✅ Mergeado |
| Smoke test script | ⏳ **Este PR** |
| Handoff doc operacional | ⏳ **Este PR** |
| `terraform apply` Wave 3 IPs | Pendiente operacional |
| `kubectl apply` cert-manager + Certificates | Pendiente operacional |
| Migración devices a TLS | Pendiente operacional (post pre-conditions) |

## Evidencia

\`\`\`
bash -n scripts/smoke-test-wave-3-tls.sh   # syntax OK
biome check pasó en pre-commit (1 archivo .md formateado)
lint: 0 errors (no toca código TS)
\`\`\`

## Test plan

- [ ] El operador puede leer el handoff y ejecutar los 8 pasos sin ambigüedad.
- [ ] Con TF+K8s aplicados en staging, \`./scripts/smoke-test-wave-3-tls.sh\` retorna exit 0.
- [ ] Con un IMEI lab aprobado, \`./scripts/smoke-test-wave-3-tls.sh --imei <IMEI>\` retorna exit 0 + log "Gateway respondió ACK 0x01".

🤖 Generated with [Claude Code](https://claude.com/claude-code)