### PR TITLE
feat(web): aceptar oferta por voz (Phase 4 PR-K7) — cierra voice command framework

### DIFF
--- a/apps/web/src/components/offers/VoiceAcceptOfferControl.test.tsx
+++ b/apps/web/src/components/offers/VoiceAcceptOfferControl.test.tsx
@@ -1,0 +1,269 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../../lib/api-client.js';
+import type {
+  RecognitionState,
+  RecognizedCommand,
+  VoiceCommandController,
+} from '../../services/voice-commands.js';
+import { VoiceAcceptOfferControl } from './VoiceAcceptOfferControl.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function makeRecognizer(initial: RecognitionState = 'idle') {
+  let state: RecognitionState = initial;
+  const stateListeners = new Set<(s: RecognitionState) => void>();
+  const cmdListeners = new Set<(c: RecognizedCommand) => void>();
+  const ctrl: VoiceCommandController = {
+    start: vi.fn(),
+    stop: vi.fn(),
+    abort: vi.fn(),
+    getState: () => state,
+    subscribe: (l) => {
+      stateListeners.add(l);
+      l(state);
+      return () => {
+        stateListeners.delete(l);
+      };
+    },
+    onCommand: (l) => {
+      cmdListeners.add(l);
+      return () => {
+        cmdListeners.delete(l);
+      };
+    },
+    onUnrecognized: () => () => undefined,
+  };
+  return {
+    ctrl,
+    emit: (s: RecognitionState) => {
+      state = s;
+      for (const l of stateListeners) {
+        l(s);
+      }
+    },
+    emitCommand: (cmd: RecognizedCommand) => {
+      for (const l of cmdListeners) {
+        l(cmd);
+      }
+    },
+  };
+}
+
+const OFFER_ID = 'o-1';
+const TRACKING_CODE = 'BOO-XYZ987';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('VoiceAcceptOfferControl', () => {
+  it('renderiza idle: hint con tracking code + voice button + nota single-offer', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <VoiceAcceptOfferControl
+          offerId={OFFER_ID}
+          trackingCode={TRACKING_CODE}
+          recognizer={r.ctrl}
+        />
+      </Wrapper>,
+    );
+    expect(screen.getByText(/aceptar por voz/i)).toBeInTheDocument();
+    expect(screen.getByText(/solo aparece cuando hay una sola oferta/i)).toBeInTheDocument();
+    expect(screen.getByTestId('voice-command-button')).toBeInTheDocument();
+  });
+
+  it('voz 1ra "aceptar oferta" → confirming + botón verde con tracking_code', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <VoiceAcceptOfferControl
+          offerId={OFFER_ID}
+          trackingCode={TRACKING_CODE}
+          recognizer={r.ctrl}
+        />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar oferta', confidence: 1 });
+    });
+    expect(screen.getByText(/confirma diciendo "aceptar" otra vez/i)).toBeInTheDocument();
+    expect(screen.getByTestId('voice-accept-confirm')).toHaveTextContent(new RegExp(TRACKING_CODE));
+  });
+
+  it('voz 2da "aceptar" en confirming → POST /offers/:id/accept', async () => {
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({});
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    const onAccepted = vi.fn();
+    render(
+      <Wrapper>
+        <VoiceAcceptOfferControl
+          offerId={OFFER_ID}
+          trackingCode={TRACKING_CODE}
+          recognizer={r.ctrl}
+          onAccepted={onAccepted}
+        />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar oferta', confidence: 1 });
+    });
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar', confidence: 1 });
+    });
+    await waitFor(() => expect(postSpy).toHaveBeenCalledWith('/offers/o-1/accept', {}));
+    await waitFor(() => expect(onAccepted).toHaveBeenCalled());
+    expect(screen.getByTestId('voice-accept-success')).toBeInTheDocument();
+  });
+
+  it('click visual "Confirmar aceptación" → POST', async () => {
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({});
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <VoiceAcceptOfferControl
+          offerId={OFFER_ID}
+          trackingCode={TRACKING_CODE}
+          recognizer={r.ctrl}
+        />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar oferta', confidence: 1 });
+    });
+    fireEvent.click(screen.getByTestId('voice-accept-confirm'));
+    await waitFor(() => expect(postSpy).toHaveBeenCalledWith('/offers/o-1/accept', {}));
+  });
+
+  it('voz "cancelar" en confirming → vuelve a idle', () => {
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <VoiceAcceptOfferControl
+          offerId={OFFER_ID}
+          trackingCode={TRACKING_CODE}
+          recognizer={r.ctrl}
+        />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar oferta', confidence: 1 });
+    });
+    expect(screen.queryByTestId('voice-accept-confirm')).toBeInTheDocument();
+
+    act(() => {
+      r.emitCommand({ intent: 'cancelar', transcript: 'cancelar', confidence: 1 });
+    });
+    expect(screen.queryByTestId('voice-accept-confirm')).not.toBeInTheDocument();
+    expect(screen.getByText(/solo aparece cuando hay una sola oferta/i)).toBeInTheDocument();
+  });
+
+  it('auto-cancel tras 4s en confirming sin ratificar', () => {
+    vi.useFakeTimers();
+    try {
+      const Wrapper = makeWrapper();
+      const r = makeRecognizer();
+      render(
+        <Wrapper>
+          <VoiceAcceptOfferControl
+            offerId={OFFER_ID}
+            trackingCode={TRACKING_CODE}
+            recognizer={r.ctrl}
+          />
+        </Wrapper>,
+      );
+      act(() => {
+        r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar oferta', confidence: 1 });
+      });
+      expect(screen.queryByTestId('voice-accept-confirm')).toBeInTheDocument();
+      act(() => {
+        vi.advanceTimersByTime(5000);
+      });
+      expect(screen.queryByTestId('voice-accept-confirm')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('error 409 (oferta ya no disponible) → mensaje específico', async () => {
+    vi.spyOn(api, 'post').mockRejectedValue(
+      new ApiError(409, 'offer_not_pending', { code: 'offer_not_pending' }),
+    );
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <VoiceAcceptOfferControl
+          offerId={OFFER_ID}
+          trackingCode={TRACKING_CODE}
+          recognizer={r.ctrl}
+        />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar oferta', confidence: 1 });
+    });
+    fireEvent.click(screen.getByTestId('voice-accept-confirm'));
+    await waitFor(() => expect(screen.getByText(/ya no está disponible/i)).toBeInTheDocument());
+  });
+
+  it('error 410 (expirada) → mensaje específico', async () => {
+    vi.spyOn(api, 'post').mockRejectedValue(
+      new ApiError(410, 'offer_expired', { code: 'offer_expired' }),
+    );
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <VoiceAcceptOfferControl
+          offerId={OFFER_ID}
+          trackingCode={TRACKING_CODE}
+          recognizer={r.ctrl}
+        />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar oferta', confidence: 1 });
+    });
+    fireEvent.click(screen.getByTestId('voice-accept-confirm'));
+    await waitFor(() => expect(screen.getByText(/la oferta expiró/i)).toBeInTheDocument());
+  });
+
+  it('error de red (no ApiError) → mensaje genérico de conexión', async () => {
+    vi.spyOn(api, 'post').mockRejectedValue(new Error('network down'));
+    const Wrapper = makeWrapper();
+    const r = makeRecognizer();
+    render(
+      <Wrapper>
+        <VoiceAcceptOfferControl
+          offerId={OFFER_ID}
+          trackingCode={TRACKING_CODE}
+          recognizer={r.ctrl}
+        />
+      </Wrapper>,
+    );
+    act(() => {
+      r.emitCommand({ intent: 'aceptar_oferta', transcript: 'aceptar oferta', confidence: 1 });
+    });
+    fireEvent.click(screen.getByTestId('voice-accept-confirm'));
+    await waitFor(() => expect(screen.getByText(/sin conexión/i)).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/components/offers/VoiceAcceptOfferControl.tsx
+++ b/apps/web/src/components/offers/VoiceAcceptOfferControl.tsx
@@ -1,0 +1,239 @@
+import { CheckCircle2, Info, Loader2, Mic } from 'lucide-react';
+import { useState } from 'react';
+import { useAcceptOfferMutation } from '../../hooks/use-offers.js';
+import { useVoiceCommand } from '../../hooks/use-voice-command.js';
+import { ApiError } from '../../lib/api-client.js';
+import type { RecognizedCommand, VoiceCommandController } from '../../services/voice-commands.js';
+import { VoiceCommandButton } from '../voice/VoiceCommandButton.js';
+
+/**
+ * Control hands-free para aceptar oferta por voz (Phase 4 PR-K7).
+ *
+ * Cierra el último intent del voice command framework: `aceptar_oferta`.
+ *
+ * **UX deliberadamente conservadora**: aceptar oferta es contrato — un
+ * falso positivo de voz puede comprometer al carrier a un viaje no
+ * deseado. Por eso:
+ *
+ *   1. **Solo se renderiza cuando hay EXACTAMENTE 1 oferta pendiente**.
+ *      Con ≥2 ofertas, el conductor debe tocar la que quiere aceptar
+ *      manualmente — el comando de voz se vuelve ambiguo y peligroso.
+ *      Cuando offerCount=0, tampoco se monta (no hay caller).
+ *
+ *   2. **Doble confirmación**. Voice "aceptar oferta" → estado
+ *      `confirming` con timer 4s + botón verde grande. Para ratificar,
+ *      el conductor debe decir "aceptar" otra vez O tocar el botón.
+ *      Si una conversación incluye "aceptar" como verbo casual, NO
+ *      cierra la oferta.
+ *
+ *   3. **Cancel reverter**. Comando "cancelar" en cualquier estado
+ *      vuelve a idle.
+ *
+ * Mismo patrón que DeliveryConfirmCard (PR-K4): la primera UX
+ * voice-first crítica de Booster.
+ */
+
+const CONFIRM_TIMEOUT_MS = 4000;
+
+export interface VoiceAcceptOfferControlProps {
+  /** ID de la oferta única pendiente. Required — la card se monta solo cuando offerCount=1. */
+  offerId: string;
+  /** Tracking code legible para mostrar en la pregunta. */
+  trackingCode: string;
+  /** Inyectable para tests. */
+  recognizer?: VoiceCommandController;
+  /** Callback opcional post-success (e.g. para navegar al detalle). */
+  onAccepted?: () => void;
+}
+
+type LocalState = 'idle' | 'confirming' | 'submitting' | 'success' | 'error';
+
+export function VoiceAcceptOfferControl({
+  offerId,
+  trackingCode,
+  recognizer,
+  onAccepted,
+}: VoiceAcceptOfferControlProps) {
+  const [localState, setLocalState] = useState<LocalState>('idle');
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [confirmTimer, setConfirmTimer] = useState<ReturnType<typeof setTimeout> | null>(null);
+  const mutation = useAcceptOfferMutation();
+
+  const cancelConfirmTimer = (): void => {
+    if (confirmTimer !== null) {
+      clearTimeout(confirmTimer);
+      setConfirmTimer(null);
+    }
+  };
+
+  const enterConfirming = (): void => {
+    if (localState !== 'idle') {
+      return;
+    }
+    setLocalState('confirming');
+    const t = setTimeout(() => {
+      setLocalState('idle');
+      setConfirmTimer(null);
+    }, CONFIRM_TIMEOUT_MS);
+    setConfirmTimer(t);
+  };
+
+  const ratify = (): void => {
+    if (localState !== 'confirming') {
+      return;
+    }
+    cancelConfirmTimer();
+    setLocalState('submitting');
+    setErrorMsg(null);
+    mutation.mutate(
+      { offerId },
+      {
+        onSuccess: () => {
+          setLocalState('success');
+          onAccepted?.();
+        },
+        onError: (err) => {
+          setLocalState('error');
+          if (err instanceof ApiError && err.status === 409) {
+            setErrorMsg('Esta oferta ya no está disponible. Se actualizó la lista.');
+          } else if (err instanceof ApiError && err.status === 410) {
+            setErrorMsg('La oferta expiró antes de que la aceptaras.');
+          } else if (err instanceof ApiError) {
+            setErrorMsg('No se pudo aceptar la oferta. Intenta otra vez.');
+          } else {
+            setErrorMsg('Sin conexión. Verifica tu red e intenta otra vez.');
+          }
+        },
+      },
+    );
+  };
+
+  const cancel = (): void => {
+    cancelConfirmTimer();
+    setLocalState('idle');
+    setErrorMsg(null);
+  };
+
+  // Voice listener a nivel de control (no solo dentro del
+  // VoiceCommandButton). Patrón establecido en IncidentReportCard
+  // (PR-K6b) y DeliveryConfirmCard (PR-K4).
+  //
+  // useVoiceCommand mantiene `onCommandRef.current` actualizado en cada
+  // render, así que el closure sobre `localState` captura el valor
+  // fresco al momento del comando (no el stale de cuando se subscribió).
+  const onVoiceCommand = (cmd: RecognizedCommand): void => {
+    if (cmd.intent === 'cancelar') {
+      cancel();
+      return;
+    }
+    if (cmd.intent === 'aceptar_oferta') {
+      if (localState === 'idle') {
+        enterConfirming();
+      } else if (localState === 'confirming') {
+        ratify();
+      }
+    }
+  };
+
+  useVoiceCommand({
+    acceptedIntents: new Set(['aceptar_oferta', 'cancelar']),
+    onCommand: onVoiceCommand,
+    ...(recognizer ? { recognizer } : {}),
+  });
+
+  if (localState === 'success') {
+    return (
+      <section
+        aria-label="Oferta aceptada"
+        className="rounded-lg border border-success-200 bg-success-50 p-4"
+        data-testid="voice-accept-success"
+      >
+        <div className="flex items-center gap-3">
+          <CheckCircle2 className="h-5 w-5 text-success-700" aria-hidden />
+          <p className="font-medium text-sm text-success-800">
+            Oferta {trackingCode} aceptada. Procesando asignación…
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  if (localState === 'submitting') {
+    return (
+      <section
+        aria-label="Procesando aceptación"
+        className="rounded-lg border border-neutral-200 bg-white p-4"
+      >
+        <div className="flex items-center gap-3 text-neutral-600 text-sm">
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+          Aceptando oferta {trackingCode}…
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Aceptar oferta por voz"
+      className="rounded-lg border border-primary-200 bg-primary-50/40 p-4"
+      data-testid="voice-accept-control"
+    >
+      <div className="flex items-start gap-3">
+        <Mic className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
+        <div className="flex-1">
+          <p className="font-semibold text-primary-900 text-sm">Aceptar por voz</p>
+          <p className="mt-0.5 text-neutral-600 text-xs">
+            {localState === 'idle' &&
+              `Di "aceptar oferta" o usa el botón Aceptar de abajo. Pedimos confirmar antes de cerrar el contrato.`}
+            {localState === 'confirming' &&
+              `Confirma diciendo "aceptar" otra vez o tocando el botón verde.`}
+            {localState === 'error' && (errorMsg ?? 'No se pudo aceptar.')}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-3">
+        <VoiceCommandButton
+          acceptedIntents={new Set(['aceptar_oferta', 'cancelar'])}
+          onCommand={() => undefined /* no-op: listener vive en useVoiceCommand arriba */}
+          {...(recognizer ? { recognizer } : {})}
+          idleLabel='Di "aceptar oferta"'
+        />
+
+        {localState === 'confirming' && (
+          <>
+            <button
+              type="button"
+              onClick={ratify}
+              className="inline-flex items-center gap-2 rounded-md bg-success-700 px-4 py-3 font-semibold text-sm text-white shadow hover:bg-success-800"
+              data-testid="voice-accept-confirm"
+            >
+              <CheckCircle2 className="h-4 w-4" aria-hidden />
+              Confirmar aceptación · {trackingCode}
+            </button>
+            <button type="button" onClick={cancel} className="text-neutral-500 text-xs underline">
+              Cancelar
+            </button>
+          </>
+        )}
+
+        {localState === 'error' && (
+          <button
+            type="button"
+            onClick={cancel}
+            className="inline-flex items-center gap-2 rounded-md bg-amber-50 px-4 py-3 font-medium text-amber-800 text-sm ring-1 ring-amber-500 hover:bg-amber-100"
+          >
+            Volver
+          </button>
+        )}
+      </div>
+
+      {localState === 'idle' && (
+        <p className="mt-2 flex items-start gap-1.5 text-[11px] text-neutral-500">
+          <Info className="mt-px h-3 w-3 shrink-0" aria-hidden />
+          Solo aparece cuando hay una sola oferta pendiente — si hay más, tócala manualmente.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/routes/ofertas.tsx
+++ b/apps/web/src/routes/ofertas.tsx
@@ -3,6 +3,7 @@ import { Inbox, LogOut, RefreshCw, Settings, User as UserIcon } from 'lucide-rea
 import { EmptyState } from '../components/EmptyState.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { OfferCard } from '../components/offers/OfferCard.js';
+import { VoiceAcceptOfferControl } from '../components/offers/VoiceAcceptOfferControl.js';
 import { signOutUser } from '../hooks/use-auth.js';
 import type { MeResponse } from '../hooks/use-me.js';
 import { useOffersMine } from '../hooks/use-offers.js';
@@ -136,6 +137,17 @@ function OfertasPage({ me }: { me: MeOnboarded }) {
 
           {isCarrier && offersQuery.data && offersQuery.data.offers.length > 0 && (
             <div className="mt-6 space-y-4">
+              {/* Phase 4 PR-K7 — control de aceptación por voz. Solo se
+                  renderiza cuando hay EXACTAMENTE 1 oferta pendiente —
+                  para >1 sería ambiguo qué oferta el comando "aceptar"
+                  refiere. Doble confirmación protege contra falsos
+                  positivos (aceptar oferta es contrato). */}
+              {offersQuery.data.offers.length === 1 && offersQuery.data.offers[0] && (
+                <VoiceAcceptOfferControl
+                  offerId={offersQuery.data.offers[0].id}
+                  trackingCode={offersQuery.data.offers[0].trip_request.tracking_code}
+                />
+              )}
               {offersQuery.data.offers.map((o) => (
                 <OfferCard key={o.id} offer={o} />
               ))}


### PR DESCRIPTION
## Summary

- **Cierra el último intent del voice command framework**: `aceptar_oferta`. Phase 4 voice-first driver UX (K1..K7) ahora completa end-to-end con caller real.
- Nuevo `VoiceAcceptOfferControl` con UX deliberadamente conservadora — aceptar oferta es contrato, falso positivo de voz compromete carrier a viaje no deseado.
- Wire en `/app/ofertas` cuando hay **exactamente 1 oferta pendiente** (con ≥2 ofertas el comando "aceptar" es ambiguo y peligroso → el conductor toca manualmente).

## UX (mismo patrón establecido en PR-K4 DeliveryConfirmCard / PR-K6b IncidentReportCard)

1. **Solo se renderiza con offerCount=1**. Con offerCount=0 no se monta; con ≥2 el conductor decide manualmente.
2. **Doble confirmación con timer 4s**:
   - Voice "aceptar oferta" → `confirming` + botón verde grande con tracking code visible
   - Para ratificar: voice "aceptar" otra vez **O** tap al botón verde
   - Si pasan 4s sin ratificar → auto-cancel a `idle`
3. **Comando "cancelar"** revierte desde cualquier estado.
4. **Errores 409/410/red** con mensajes específicos en español:
   - 409 `offer_not_pending`: "Esta oferta ya no está disponible. Se actualizó la lista."
   - 410 `offer_expired`: "La oferta expiró antes de que la aceptaras."
   - Network: "Sin conexión. Verifica tu red e intenta otra vez."

## Arquitectura

- Voice listener vive en el **control (parent)** vía `useVoiceCommand`, no solo dentro del `VoiceCommandButton`. Razón: el botón se desmonta/cambia de estado durante `confirming`, pero "cancelar" debe seguir capturándose.
- `useVoiceCommand` mantiene `onCommandRef.current` actualizado cada render → closure sobre `localState` siempre fresh.
- `useAcceptOfferMutation` reusado (mismo del flujo visual de OfferCard) → state machine de aceptación servidor inalterada.

## Tests (9 nuevos)

- `renderiza idle: hint con tracking code + voice button + nota single-offer`
- `voz 1ra "aceptar oferta" → confirming + botón verde con tracking_code`
- `voz 2da "aceptar" en confirming → POST /offers/:id/accept`
- `click visual "Confirmar aceptación" → POST`
- `voz "cancelar" en confirming → vuelve a idle`
- `auto-cancel tras 4s en confirming sin ratificar` (vi.useFakeTimers surgical)
- `error 409 (oferta ya no disponible) → mensaje específico`
- `error 410 (expirada) → mensaje específico`
- `error de red (no ApiError) → mensaje genérico de conexión`

Suite web: 765 → **774** tests.

## Test plan

- [x] Unit tests pass (9/9)
- [x] Lint clean (Biome)
- [x] Typecheck clean
- [ ] CI verde
- [ ] Manual: en staging con 1 oferta pendiente, decir "aceptar oferta" → ver confirming → decir "aceptar" → POST exitoso → UI success
- [ ] Manual: con ≥2 ofertas, verificar que el control NO se monta (solo OfferCard manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)