### PR TITLE
feat(web): onboarding del Modo Conductor (Phase 4 PR-K8) — cierra ciclo voice-first

### DIFF
--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,6 +8,7 @@ import { CargaTrackRoute } from './routes/carga-track.js';
 import { CargasDetalleRoute, CargasListRoute, CargasNuevoRoute } from './routes/cargas.js';
 import { CertificadosRoute } from './routes/certificados.js';
 import { CobraHoyHistorialRoute } from './routes/cobra-hoy-historial.js';
+import { ConductorModoRoute } from './routes/conductor-modo.js';
 import { IndexRoute } from './routes/index.js';
 import { LegalCobraHoyRoute } from './routes/legal-cobra-hoy.js';
 import { LegalTerminosRoute } from './routes/legal-terminos.js';
@@ -69,6 +70,16 @@ const perfilRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/app/perfil',
   component: PerfilRoute,
+});
+
+// Phase 4 PR-K8 — onboarding del Modo Conductor. Una sola pantalla con
+// 4 cards (autoplay coaching, permisos mic+GPS, comandos de voz,
+// explainer). Hub centralizado para que el conductor habilite y entienda
+// las features voice-first de K1-K7. Layout `/app/*` autenticado.
+const conductorModoRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/app/conductor/modo',
+  component: ConductorModoRoute,
 });
 
 const adminDispositivosRoute = createRoute({
@@ -186,6 +197,7 @@ const routeTree = rootRoute.addChildren([
   appRoute,
   ofertasRoute,
   perfilRoute,
+  conductorModoRoute,
   adminDispositivosRoute,
   vehiculosListRoute,
   vehiculosNuevoRoute,

--- a/apps/web/src/routes/conductor-modo.test.tsx
+++ b/apps/web/src/routes/conductor-modo.test.tsx
@@ -1,0 +1,176 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type ProtectedContext =
+  | { kind: 'onboarded'; me: MeOnboarded }
+  | { kind: 'pre-onboarding'; me: Extract<MeResponse, { needs_onboarding: true }> }
+  | { kind: 'unmanaged' };
+
+let providedContext: ProtectedContext = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: ProtectedContext) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children, title }: { children: ReactNode; title: string }) => (
+    <div data-testid="layout" data-title={title}>
+      {children}
+    </div>
+  ),
+}));
+
+const queryDriverPermissionsSpy = vi.fn();
+const requestMicrophonePermissionSpy = vi.fn();
+const requestGeolocationPermissionSpy = vi.fn();
+
+vi.mock('../services/driver-mode-permissions.js', () => ({
+  queryDriverPermissions: (...args: unknown[]) => queryDriverPermissionsSpy(...args),
+  requestMicrophonePermission: (...args: unknown[]) => requestMicrophonePermissionSpy(...args),
+  requestGeolocationPermission: (...args: unknown[]) => requestGeolocationPermissionSpy(...args),
+}));
+
+const loadAutoplayPreferenceSpy = vi.fn();
+const saveAutoplayPreferenceSpy = vi.fn();
+
+vi.mock('../services/coaching-voice.js', () => ({
+  loadAutoplayPreference: () => loadAutoplayPreferenceSpy(),
+  saveAutoplayPreference: (v: boolean) => saveAutoplayPreferenceSpy(v),
+}));
+
+const { ConductorModoRoute } = await import('./conductor-modo.js');
+
+function makeMe(): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: {
+      id: 'u',
+      email: 'felipe@boosterchile.com',
+      full_name: 'Felipe Vicencio',
+      phone: '+56912345678',
+      whatsapp_e164: '+56912345678',
+      rut: '12.345.678-9',
+      is_platform_admin: false,
+      status: 'activo',
+    },
+    memberships: [],
+    active_membership: null,
+  } as unknown as MeOnboarded;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  loadAutoplayPreferenceSpy.mockReturnValue(false);
+  queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ConductorModoRoute', () => {
+  it('contexto no onboarded → no renderiza', () => {
+    providedContext = { kind: 'unmanaged' };
+    const { container } = render(<ConductorModoRoute />);
+    expect(container.querySelector('[data-testid="autoplay-card"]')).toBeNull();
+  });
+
+  it('contexto onboarded → renderiza las 4 cards', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorModoRoute />);
+    expect(screen.getByTestId('layout')).toHaveAttribute('data-title', 'Modo Conductor');
+    expect(screen.getByTestId('autoplay-card')).toBeInTheDocument();
+    expect(screen.getByTestId('permissions-card')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-commands-card')).toBeInTheDocument();
+    expect(screen.getByTestId('how-it-works-card')).toBeInTheDocument();
+    await waitFor(() => expect(queryDriverPermissionsSpy).toHaveBeenCalled());
+  });
+
+  it('autoplay toggle persiste vía saveAutoplayPreference', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    loadAutoplayPreferenceSpy.mockReturnValue(false);
+    render(<ConductorModoRoute />);
+    const toggle = screen.getByTestId('autoplay-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    fireEvent.click(toggle);
+    expect(saveAutoplayPreferenceSpy).toHaveBeenCalledWith(true);
+    expect(toggle.checked).toBe(true);
+  });
+
+  it('estado inicial granted muestra pill "Activado" sin botón Permitir', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    queryDriverPermissionsSpy.mockResolvedValue({ mic: 'granted', geo: 'granted' });
+    render(<ConductorModoRoute />);
+    await waitFor(() => expect(screen.getByTestId('mic-granted-pill')).toBeInTheDocument());
+    expect(screen.getByTestId('geo-granted-pill')).toBeInTheDocument();
+    expect(screen.queryByTestId('mic-request-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('geo-request-btn')).not.toBeInTheDocument();
+  });
+
+  it('estado denied muestra instrucción de habilitar en settings', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    queryDriverPermissionsSpy.mockResolvedValue({ mic: 'denied', geo: 'denied' });
+    render(<ConductorModoRoute />);
+    await waitFor(() => expect(screen.getByTestId('mic-denied-help')).toBeInTheDocument());
+    expect(screen.getByTestId('geo-denied-help')).toBeInTheDocument();
+  });
+
+  it('click "Permitir" del mic dispara requestMicrophonePermission y actualiza estado', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
+    requestMicrophonePermissionSpy.mockResolvedValue('granted');
+    render(<ConductorModoRoute />);
+    await waitFor(() => expect(screen.getByTestId('mic-request-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('mic-request-btn'));
+    await waitFor(() => expect(requestMicrophonePermissionSpy).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByTestId('mic-granted-pill')).toBeInTheDocument());
+  });
+
+  it('click "Permitir" del GPS dispara requestGeolocationPermission y actualiza estado', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
+    requestGeolocationPermissionSpy.mockResolvedValue('granted');
+    render(<ConductorModoRoute />);
+    await waitFor(() => expect(screen.getByTestId('geo-request-btn')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('geo-request-btn'));
+    await waitFor(() => expect(requestGeolocationPermissionSpy).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByTestId('geo-granted-pill')).toBeInTheDocument());
+  });
+
+  it('muestra los 4 comandos de voz con sus frases', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorModoRoute />);
+    expect(screen.getByTestId('voice-cmd-aceptar_oferta')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-cmd-confirmar_entrega')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-cmd-marcar_incidente')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-cmd-cancelar')).toBeInTheDocument();
+    // Phrase wrapper actually contains the canonical phrase.
+    expect(screen.getAllByText(/"aceptar oferta"/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('muestra explainer del flujo en how-it-works card', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorModoRoute />);
+    expect(screen.getByTestId('how-it-works-card')).toBeInTheDocument();
+    expect(screen.getByText(/detección de vehículo parado/i)).toBeInTheDocument();
+    expect(screen.getByText(/doble confirmación/i)).toBeInTheDocument();
+    expect(screen.getByText(/Ley 18\.290/i)).toBeInTheDocument();
+  });
+
+  it('autoplay inicial cargado desde localStorage refleja en toggle', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    loadAutoplayPreferenceSpy.mockReturnValue(true);
+    render(<ConductorModoRoute />);
+    const toggle = screen.getByTestId('autoplay-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+});

--- a/apps/web/src/routes/conductor-modo.tsx
+++ b/apps/web/src/routes/conductor-modo.tsx
@@ -1,0 +1,528 @@
+import { Link } from '@tanstack/react-router';
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  HelpCircle,
+  Info,
+  Mic,
+  MicOff,
+  Navigation,
+  NavigationOff,
+  Volume2,
+} from 'lucide-react';
+import { type ReactNode, useEffect, useState } from 'react';
+import { Layout } from '../components/Layout.js';
+import { ProtectedRoute } from '../components/ProtectedRoute.js';
+import type { MeResponse } from '../hooks/use-me.js';
+import { loadAutoplayPreference, saveAutoplayPreference } from '../services/coaching-voice.js';
+import {
+  type PermissionState,
+  type PermissionStatus,
+  queryDriverPermissions,
+  requestGeolocationPermission,
+  requestMicrophonePermission,
+} from '../services/driver-mode-permissions.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+
+/**
+ * /app/conductor/modo — onboarding y configuración del **Modo Conductor**
+ * (Phase 4 PR-K8).
+ *
+ * Cierre del ciclo Phase 4 voice-first: K1-K7 implementaron features
+ * voice (auto-play coaching, comandos para confirmar entrega, marcar
+ * incidente, aceptar oferta, cancelar). Sin esta pantalla, todas esas
+ * features eran "descoberables solo por accidente" — el conductor no
+ * sabía que existían, no había explicación, y no había forma centralizada
+ * de habilitar/probar los permisos del browser.
+ *
+ * **Una sola pantalla** con 4 cards:
+ *
+ *   1. **Audio coaching automático** — toggle único persistido en
+ *      localStorage. ON = al terminar viaje se reproduce el coaching IA
+ *      en voz alta sin que el conductor toque nada (gated por vehículo
+ *      parado). OFF = mute, requiere tap manual del play.
+ *
+ *   2. **Permisos del navegador** — estado actual de mic + GPS con
+ *      botones "Permitir" cuando están en `prompt`. Si están `denied`,
+ *      muestra instrucción de habilitarlo en settings del browser.
+ *
+ *   3. **Comandos de voz disponibles** — lista de los 4 intents con
+ *      las frases que disparan cada uno. Lectura — el "probar mic" real
+ *      vive dentro de cada feature card (DeliveryConfirmCard,
+ *      IncidentReportCard, VoiceAcceptOfferControl).
+ *
+ *   4. **Cómo funciona** — explainer breve del flujo: detección de
+ *      vehículo parado (histeresis 3/8 km/h, HOLD_MS=4000ms), doble
+ *      confirmación, comando "cancelar" como abort universal.
+ *
+ * **No bloquea ninguna feature**: si el conductor entra a `/app/ofertas`
+ * sin haber visitado esta página, las features voice siguen funcionando
+ * (con prompts de permiso ad-hoc del browser). Esta pantalla es para
+ * onboarding + troubleshooting + transparencia de qué requiere Booster.
+ */
+
+export function ConductorModoRoute() {
+  return (
+    <ProtectedRoute meRequirement="require-onboarded">
+      {(ctx) => {
+        if (ctx.kind !== 'onboarded') {
+          return null;
+        }
+        return <ConductorModoPage me={ctx.me} />;
+      }}
+    </ProtectedRoute>
+  );
+}
+
+function ConductorModoPage({ me }: { me: MeOnboarded }) {
+  const [autoplayEnabled, setAutoplayEnabled] = useState(() => loadAutoplayPreference());
+  const [permissions, setPermissions] = useState<PermissionState>({
+    mic: 'unknown',
+    geo: 'unknown',
+  });
+  const [requestingMic, setRequestingMic] = useState(false);
+  const [requestingGeo, setRequestingGeo] = useState(false);
+
+  // Initial query de permisos al montar. No dispara prompts — solo lee
+  // el estado actual del browser.
+  useEffect(() => {
+    let cancelled = false;
+    queryDriverPermissions()
+      .then((state) => {
+        if (!cancelled) {
+          setPermissions(state);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setPermissions({ mic: 'unknown', geo: 'unknown' });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function handleAutoplayToggle(checked: boolean) {
+    setAutoplayEnabled(checked);
+    saveAutoplayPreference(checked);
+  }
+
+  async function handleRequestMic() {
+    setRequestingMic(true);
+    try {
+      const newStatus = await requestMicrophonePermission();
+      setPermissions((prev) => ({ ...prev, mic: newStatus }));
+    } finally {
+      setRequestingMic(false);
+    }
+  }
+
+  async function handleRequestGeo() {
+    setRequestingGeo(true);
+    try {
+      const newStatus = await requestGeolocationPermission();
+      setPermissions((prev) => ({ ...prev, geo: newStatus }));
+    } finally {
+      setRequestingGeo(false);
+    }
+  }
+
+  return (
+    <Layout me={me} title="Modo Conductor">
+      <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6">
+        <Link
+          to="/app"
+          className="mb-4 inline-flex items-center gap-1 text-neutral-600 text-sm transition hover:text-neutral-900"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Volver al inicio
+        </Link>
+
+        <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">Modo Conductor</h1>
+        <p className="mt-2 max-w-xl text-neutral-600 text-sm">
+          Configura una sola vez antes de manejar. Activamos audio, voz y GPS para que puedas operar
+          la app sin tocar la pantalla mientras conduces.
+        </p>
+
+        <div className="mt-8 space-y-4">
+          <AutoplayCard enabled={autoplayEnabled} onChange={handleAutoplayToggle} />
+          <PermissionsCard
+            permissions={permissions}
+            onRequestMic={handleRequestMic}
+            onRequestGeo={handleRequestGeo}
+            requestingMic={requestingMic}
+            requestingGeo={requestingGeo}
+          />
+          <VoiceCommandsReferenceCard />
+          <HowItWorksCard />
+        </div>
+      </div>
+    </Layout>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card: Audio coaching automático
+// ---------------------------------------------------------------------------
+
+interface AutoplayCardProps {
+  enabled: boolean;
+  onChange: (enabled: boolean) => void;
+}
+
+function AutoplayCard({ enabled, onChange }: AutoplayCardProps) {
+  return (
+    <section
+      aria-label="Audio coaching automático"
+      className="rounded-lg border border-neutral-200 bg-white p-5"
+      data-testid="autoplay-card"
+    >
+      <div className="flex items-start gap-3">
+        <Volume2 className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
+        <div className="flex-1">
+          <h2 className="font-semibold text-base text-neutral-900">Audio coaching automático</h2>
+          <p className="mt-1 text-neutral-600 text-sm">
+            Cuando termines una entrega y el vehículo esté detenido, Booster te dice por voz cómo
+            mejoraste tu manejo eco-eficiente en ese viaje. Sin tocar la pantalla.
+          </p>
+
+          <label className="mt-3 flex items-center gap-3 text-neutral-800 text-sm">
+            <input
+              type="checkbox"
+              checked={enabled}
+              onChange={(e) => onChange(e.target.checked)}
+              className="h-5 w-5 rounded border-neutral-300 text-primary-600 focus:ring-primary-500"
+              data-testid="autoplay-toggle"
+            />
+            <span className="font-medium">
+              {enabled
+                ? 'Activado · escucharás coaching al terminar viajes'
+                : 'Desactivado · botón manual de play en cada coaching'}
+            </span>
+          </label>
+
+          <p className="mt-2 flex items-start gap-1.5 text-[11px] text-neutral-500">
+            <Info className="mt-px h-3 w-3 shrink-0" aria-hidden />
+            Por seguridad, solo arranca cuando el vehículo está detenido (≤3 km/h por 4 s). Si
+            comienzas a moverte se pausa.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card: Permisos del navegador
+// ---------------------------------------------------------------------------
+
+interface PermissionsCardProps {
+  permissions: PermissionState;
+  onRequestMic: () => void;
+  onRequestGeo: () => void;
+  requestingMic: boolean;
+  requestingGeo: boolean;
+}
+
+function PermissionsCard({
+  permissions,
+  onRequestMic,
+  onRequestGeo,
+  requestingMic,
+  requestingGeo,
+}: PermissionsCardProps) {
+  return (
+    <section
+      aria-label="Permisos del navegador"
+      className="rounded-lg border border-neutral-200 bg-white p-5"
+      data-testid="permissions-card"
+    >
+      <h2 className="font-semibold text-base text-neutral-900">Permisos del navegador</h2>
+      <p className="mt-1 text-neutral-600 text-sm">
+        Booster necesita acceso al micrófono (para los comandos de voz) y al GPS (para detectar
+        cuándo estás detenido y reproducir audio de forma segura).
+      </p>
+
+      <div className="mt-4 space-y-3">
+        <PermissionRow
+          icon={
+            permissions.mic === 'granted' ? (
+              <Mic className="h-5 w-5 text-success-700" aria-hidden />
+            ) : (
+              <MicOff className="h-5 w-5 text-neutral-500" aria-hidden />
+            )
+          }
+          name="Micrófono"
+          status={permissions.mic}
+          purpose='Para decir "aceptar oferta", "confirmar entrega", "marcar incidente".'
+          onRequest={onRequestMic}
+          requesting={requestingMic}
+          testIdPrefix="mic"
+        />
+        <PermissionRow
+          icon={
+            permissions.geo === 'granted' ? (
+              <Navigation className="h-5 w-5 text-success-700" aria-hidden />
+            ) : (
+              <NavigationOff className="h-5 w-5 text-neutral-500" aria-hidden />
+            )
+          }
+          name="GPS / Ubicación"
+          status={permissions.geo}
+          purpose="Para detectar cuándo el vehículo está detenido y reproducir audio sin distraer."
+          onRequest={onRequestGeo}
+          requesting={requestingGeo}
+          testIdPrefix="geo"
+        />
+      </div>
+    </section>
+  );
+}
+
+interface PermissionRowProps {
+  icon: ReactNode;
+  name: string;
+  status: PermissionStatus;
+  purpose: string;
+  onRequest: () => void;
+  requesting: boolean;
+  testIdPrefix: string;
+}
+
+function PermissionRow({
+  icon,
+  name,
+  status,
+  purpose,
+  onRequest,
+  requesting,
+  testIdPrefix,
+}: PermissionRowProps) {
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-md bg-neutral-50 p-3 sm:flex-row sm:items-center"
+      data-testid={`${testIdPrefix}-permission-row`}
+    >
+      <div className="flex items-start gap-3 sm:flex-1">
+        <div className="mt-0.5 shrink-0">{icon}</div>
+        <div className="flex-1">
+          <p className="font-medium text-neutral-900 text-sm">{name}</p>
+          <p className="text-neutral-600 text-xs">{purpose}</p>
+          <p className="mt-1 text-[11px]" data-testid={`${testIdPrefix}-status`}>
+            <StatusBadge status={status} />
+          </p>
+        </div>
+      </div>
+      <div className="sm:shrink-0">
+        {(status === 'prompt' || status === 'unknown') && (
+          <button
+            type="button"
+            onClick={onRequest}
+            disabled={requesting}
+            className="inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white shadow-xs transition hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-60"
+            data-testid={`${testIdPrefix}-request-btn`}
+          >
+            {requesting ? 'Solicitando…' : 'Permitir'}
+          </button>
+        )}
+        {status === 'denied' && (
+          <p
+            className="max-w-[16rem] text-amber-700 text-xs"
+            data-testid={`${testIdPrefix}-denied-help`}
+          >
+            Activa este permiso en la configuración del navegador y vuelve a esta pantalla.
+          </p>
+        )}
+        {status === 'granted' && (
+          <span
+            className="inline-flex items-center gap-1 rounded-md bg-success-50 px-2 py-1 font-medium text-success-800 text-xs"
+            data-testid={`${testIdPrefix}-granted-pill`}
+          >
+            <CheckCircle2 className="h-3.5 w-3.5" aria-hidden />
+            Activado
+          </span>
+        )}
+        {status === 'unsupported' && (
+          <p className="max-w-[16rem] text-neutral-500 text-xs">
+            Tu navegador no soporta este permiso. Prueba con Chrome o Safari recientes.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: PermissionStatus }) {
+  switch (status) {
+    case 'granted':
+      return <span className="text-success-700">Concedido</span>;
+    case 'denied':
+      return <span className="text-amber-700">Bloqueado</span>;
+    case 'prompt':
+      return <span className="text-neutral-600">Pendiente</span>;
+    case 'unsupported':
+      return <span className="text-neutral-500">No soportado</span>;
+    default:
+      return <span className="text-neutral-500">Estado desconocido</span>;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Card: Comandos de voz disponibles
+// ---------------------------------------------------------------------------
+
+interface VoiceCommandEntry {
+  intent: string;
+  title: string;
+  phrases: string[];
+  context: string;
+}
+
+const VOICE_COMMANDS: VoiceCommandEntry[] = [
+  {
+    intent: 'aceptar_oferta',
+    title: 'Aceptar oferta',
+    phrases: ['aceptar oferta', 'tomar oferta', 'acepto la oferta'],
+    context: 'En la pantalla de Ofertas, cuando hay una sola oferta pendiente.',
+  },
+  {
+    intent: 'confirmar_entrega',
+    title: 'Confirmar entrega',
+    phrases: ['confirmar entrega', 'ya entregué', 'entrega confirmada'],
+    context: 'En el detalle de la asignación, después de descargar la mercadería.',
+  },
+  {
+    intent: 'marcar_incidente',
+    title: 'Marcar incidente',
+    phrases: ['incidente', 'reportar problema', 'tengo un problema'],
+    context: 'Cualquier momento del viaje. Luego eliges el tipo (accidente, demora, etc.).',
+  },
+  {
+    intent: 'cancelar',
+    title: 'Cancelar',
+    phrases: ['cancelar', 'detente', 'olvídalo'],
+    context: 'Si dijiste algo por error y aún no se procesó, abortas la acción.',
+  },
+];
+
+function VoiceCommandsReferenceCard() {
+  return (
+    <section
+      aria-label="Comandos de voz disponibles"
+      className="rounded-lg border border-neutral-200 bg-white p-5"
+      data-testid="voice-commands-card"
+    >
+      <div className="flex items-start gap-3">
+        <Mic className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
+        <div className="flex-1">
+          <h2 className="font-semibold text-base text-neutral-900">Comandos de voz disponibles</h2>
+          <p className="mt-1 text-neutral-600 text-sm">
+            Cada acción crítica del viaje se puede ejecutar diciéndola en voz alta. Mantén
+            presionado el botón del micrófono en la card correspondiente y dí la frase.
+          </p>
+
+          <ul className="mt-4 space-y-3">
+            {VOICE_COMMANDS.map((cmd) => (
+              <li
+                key={cmd.intent}
+                className="rounded-md border border-neutral-100 bg-neutral-50 p-3"
+                data-testid={`voice-cmd-${cmd.intent}`}
+              >
+                <p className="font-medium text-neutral-900 text-sm">{cmd.title}</p>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {cmd.phrases.map((p) => (
+                    <span
+                      key={p}
+                      className="inline-flex rounded-md bg-white px-2 py-0.5 font-mono text-[11px] text-neutral-700 ring-1 ring-neutral-200"
+                    >
+                      "{p}"
+                    </span>
+                  ))}
+                </div>
+                <p className="mt-2 text-neutral-600 text-xs">{cmd.context}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card: Cómo funciona
+// ---------------------------------------------------------------------------
+
+function HowItWorksCard() {
+  return (
+    <section
+      aria-label="Cómo funciona el modo conductor"
+      className="rounded-lg border border-primary-200 bg-primary-50/40 p-5"
+      data-testid="how-it-works-card"
+    >
+      <div className="flex items-start gap-3">
+        <HelpCircle className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
+        <div className="flex-1">
+          <h2 className="font-semibold text-base text-primary-900">Cómo funciona</h2>
+          <ul className="mt-3 space-y-2 text-neutral-700 text-sm">
+            <li className="flex items-start gap-2">
+              <span
+                className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary-600"
+                aria-hidden
+              />
+              <span>
+                <strong>Detección de vehículo parado</strong>: el GPS reporta velocidad. Cuando cae
+                a ≤3 km/h por al menos 4 segundos, te consideramos "detenido" y habilitamos audio +
+                comandos seguros.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span
+                className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary-600"
+                aria-hidden
+              />
+              <span>
+                <strong>Doble confirmación</strong>: para acciones críticas (aceptar oferta,
+                confirmar entrega) pedimos repetir la frase o tocar un botón grande verde. Esto
+                evita falsos positivos si dices la palabra en una conversación casual.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span
+                className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary-600"
+                aria-hidden
+              />
+              <span>
+                <strong>"Cancelar" siempre funciona</strong>: si te equivocaste, di "cancelar"
+                dentro de los 4 segundos siguientes y la acción se descarta.
+              </span>
+            </li>
+            <li className="flex items-start gap-2">
+              <span
+                className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-primary-600"
+                aria-hidden
+              />
+              <span>
+                <strong>Toques al volante son ilegales</strong> (Ley 18.290 art. 199 letra C).
+                Booster está diseñado para minimizar toques: voz primero, botones grandes segundos.
+                Si tu pasajero/copiloto va contigo, también puede operar la app.
+              </span>
+            </li>
+          </ul>
+
+          <div className="mt-4 flex items-start gap-2 rounded-md bg-white p-3 text-neutral-700 text-xs ring-1 ring-primary-200">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" aria-hidden />
+            <span>
+              <strong>No usar WhatsApp manejando.</strong> El coaching y los avisos críticos te
+              llegan por audio dentro de Booster. WhatsApp queda solo para coordinar con el
+              destinatario o el generador de la carga antes y después del viaje.
+            </span>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/routes/ofertas.tsx
+++ b/apps/web/src/routes/ofertas.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { Inbox, LogOut, RefreshCw, Settings, User as UserIcon } from 'lucide-react';
+import { Headphones, Inbox, LogOut, RefreshCw, Settings, User as UserIcon } from 'lucide-react';
 import { EmptyState } from '../components/EmptyState.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { OfferCard } from '../components/offers/OfferCard.js';
@@ -86,18 +86,28 @@ function OfertasPage({ me }: { me: MeOnboarded }) {
                 Cargas disponibles para tu empresa. Las ofertas expiran en 1 hora.
               </p>
             </div>
-            <button
-              type="button"
-              onClick={() => offersQuery.refetch()}
-              disabled={offersQuery.isFetching}
-              className="flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm shadow-xs transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <RefreshCw
-                className={`h-4 w-4 ${offersQuery.isFetching ? 'animate-spin' : ''}`}
-                aria-hidden
-              />
-              {offersQuery.isFetching ? 'Actualizando…' : 'Actualizar'}
-            </button>
+            <div className="flex items-center gap-2">
+              <Link
+                to="/app/conductor/modo"
+                className="flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm shadow-xs transition hover:bg-neutral-100"
+                data-testid="link-modo-conductor"
+              >
+                <Headphones className="h-4 w-4" aria-hidden />
+                Modo Conductor
+              </Link>
+              <button
+                type="button"
+                onClick={() => offersQuery.refetch()}
+                disabled={offersQuery.isFetching}
+                className="flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm shadow-xs transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                <RefreshCw
+                  className={`h-4 w-4 ${offersQuery.isFetching ? 'animate-spin' : ''}`}
+                  aria-hidden
+                />
+                {offersQuery.isFetching ? 'Actualizando…' : 'Actualizar'}
+              </button>
+            </div>
           </div>
 
           {!isCarrier && (

--- a/apps/web/src/routes/perfil.tsx
+++ b/apps/web/src/routes/perfil.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Headphones } from 'lucide-react';
 import { Layout } from '../components/Layout.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { AuthProvidersSection } from '../components/profile/AuthProvidersSection.js';
@@ -58,6 +58,30 @@ function PerfilPage({ me }: { me: MeOnboarded }) {
         <AuthProvidersSection />
 
         <TwoFactorSection initialPhoneE164={me.user.whatsapp_e164 ?? me.user.phone ?? null} />
+
+        <section
+          aria-label="Modo Conductor"
+          className="mt-8 rounded-lg border border-neutral-200 bg-white p-5"
+          data-testid="perfil-modo-conductor-section"
+        >
+          <div className="flex items-start gap-3">
+            <Headphones className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
+            <div className="flex-1">
+              <h2 className="font-semibold text-base text-neutral-900">Modo Conductor</h2>
+              <p className="mt-1 text-neutral-600 text-sm">
+                Activa audio coaching automático, gestiona permisos de micrófono y GPS, y revisa los
+                comandos de voz para operar sin tocar la pantalla mientras conduces.
+              </p>
+              <Link
+                to="/app/conductor/modo"
+                className="mt-3 inline-flex items-center gap-2 rounded-md bg-primary-600 px-3 py-2 font-medium text-sm text-white shadow-xs transition hover:bg-primary-700"
+                data-testid="link-modo-conductor-perfil"
+              >
+                Configurar modo conductor
+              </Link>
+            </div>
+          </div>
+        </section>
       </div>
     </Layout>
   );

--- a/apps/web/src/services/driver-mode-permissions.test.ts
+++ b/apps/web/src/services/driver-mode-permissions.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  queryDriverPermissions,
+  requestGeolocationPermission,
+  requestMicrophonePermission,
+} from './driver-mode-permissions.js';
+
+describe('queryDriverPermissions', () => {
+  it('returns unsupported when Permissions API missing', async () => {
+    const nav = {} as Navigator;
+    const res = await queryDriverPermissions({ navigatorOverride: nav });
+    expect(res).toEqual({ mic: 'unsupported', geo: 'unsupported' });
+  });
+
+  it('returns granted/granted when both grants', async () => {
+    const permissions = {
+      query: vi.fn().mockResolvedValue({ state: 'granted' }),
+    } as unknown as Permissions;
+    const nav = { permissions } as Navigator;
+    const res = await queryDriverPermissions({ navigatorOverride: nav });
+    expect(res).toEqual({ mic: 'granted', geo: 'granted' });
+    expect(permissions.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns denied when Permissions API reports denied', async () => {
+    const permissions = {
+      query: vi.fn().mockResolvedValue({ state: 'denied' }),
+    } as unknown as Permissions;
+    const res = await queryDriverPermissions({
+      navigatorOverride: { permissions } as Navigator,
+    });
+    expect(res).toEqual({ mic: 'denied', geo: 'denied' });
+  });
+
+  it('returns unknown when query rejects (Safari TypeError simulation)', async () => {
+    const permissions = {
+      query: vi.fn().mockRejectedValue(new TypeError('not supported')),
+    } as unknown as Permissions;
+    const res = await queryDriverPermissions({
+      navigatorOverride: { permissions } as Navigator,
+    });
+    expect(res).toEqual({ mic: 'unknown', geo: 'unknown' });
+  });
+
+  it('returns prompt independently for mic and geo', async () => {
+    const permissions = {
+      query: vi.fn().mockImplementation(({ name }: { name: string }) => {
+        if (name === 'microphone') {
+          return Promise.resolve({ state: 'prompt' });
+        }
+        return Promise.resolve({ state: 'granted' });
+      }),
+    } as unknown as Permissions;
+    const res = await queryDriverPermissions({
+      navigatorOverride: { permissions } as Navigator,
+    });
+    expect(res).toEqual({ mic: 'prompt', geo: 'granted' });
+  });
+});
+
+describe('requestMicrophonePermission', () => {
+  it('returns unsupported when mediaDevices missing', async () => {
+    const res = await requestMicrophonePermission({
+      mediaDevices: undefined as unknown as MediaDevices,
+    });
+    expect(res).toBe('unsupported');
+  });
+
+  it('returns granted and stops tracks on success', async () => {
+    const stopSpy = vi.fn();
+    const stream = {
+      getTracks: () => [{ stop: stopSpy }, { stop: stopSpy }],
+    } as unknown as MediaStream;
+    const md = {
+      getUserMedia: vi.fn().mockResolvedValue(stream),
+    } as unknown as MediaDevices;
+    const res = await requestMicrophonePermission({ mediaDevices: md });
+    expect(res).toBe('granted');
+    expect(stopSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns denied on NotAllowedError', async () => {
+    const err = new Error('blocked');
+    err.name = 'NotAllowedError';
+    const md = {
+      getUserMedia: vi.fn().mockRejectedValue(err),
+    } as unknown as MediaDevices;
+    const res = await requestMicrophonePermission({ mediaDevices: md });
+    expect(res).toBe('denied');
+  });
+
+  it('returns unknown on other errors', async () => {
+    const md = {
+      getUserMedia: vi.fn().mockRejectedValue(new Error('hardware busted')),
+    } as unknown as MediaDevices;
+    const res = await requestMicrophonePermission({ mediaDevices: md });
+    expect(res).toBe('unknown');
+  });
+});
+
+describe('requestGeolocationPermission', () => {
+  it('returns unsupported when geolocation missing', async () => {
+    const res = await requestGeolocationPermission({
+      geolocation: undefined as unknown as Geolocation,
+    });
+    expect(res).toBe('unsupported');
+  });
+
+  it('returns granted on successful position', async () => {
+    const geo = {
+      getCurrentPosition: vi.fn().mockImplementation((onOk: PositionCallback) => {
+        onOk({
+          coords: { latitude: -33, longitude: -70 },
+          timestamp: Date.now(),
+        } as unknown as GeolocationPosition);
+      }),
+    } as unknown as Geolocation;
+    const res = await requestGeolocationPermission({ geolocation: geo });
+    expect(res).toBe('granted');
+  });
+
+  it('returns denied when code=1 (PERMISSION_DENIED)', async () => {
+    const geo = {
+      getCurrentPosition: vi
+        .fn()
+        .mockImplementation((_onOk: PositionCallback, onErr: PositionErrorCallback) => {
+          onErr({ code: 1, message: 'denied' } as GeolocationPositionError);
+        }),
+    } as unknown as Geolocation;
+    const res = await requestGeolocationPermission({ geolocation: geo });
+    expect(res).toBe('denied');
+  });
+
+  it('returns unknown on other geolocation error codes', async () => {
+    const geo = {
+      getCurrentPosition: vi
+        .fn()
+        .mockImplementation((_onOk: PositionCallback, onErr: PositionErrorCallback) => {
+          onErr({ code: 3, message: 'timeout' } as GeolocationPositionError);
+        }),
+    } as unknown as Geolocation;
+    const res = await requestGeolocationPermission({ geolocation: geo });
+    expect(res).toBe('unknown');
+  });
+});

--- a/apps/web/src/services/driver-mode-permissions.ts
+++ b/apps/web/src/services/driver-mode-permissions.ts
@@ -1,0 +1,153 @@
+/**
+ * Driver mode browser permissions (Phase 4 PR-K8 — onboarding driver-mode).
+ *
+ * El "modo conductor" de Booster combina varias features que requieren
+ * permisos del browser:
+ *
+ *   - **Geolocation** (GPS): necesario para `stopped-detector`
+ *     (auto-play coaching solo con vehículo parado) y para que la
+ *     telemetría del teléfono complemente al Teltonika si está apagado.
+ *   - **Microphone**: necesario para `voice-commands` (push-to-talk
+ *     "aceptar oferta", "confirmar entrega", "marcar incidente",
+ *     "cancelar"). Sin mic, los flujos hands-free no funcionan — solo
+ *     queda el camino visual de botones.
+ *
+ * Este módulo encapsula la query del estado actual (`navigator.permissions`
+ * cuando está disponible) + el side effect de "pedir" el permiso
+ * (`getUserMedia` para mic, `getCurrentPosition` para geo). Devuelve
+ * shapes simples consumibles por React sin importar `Permissions` types.
+ *
+ * **Diseño defensivo**:
+ *   - `navigator.permissions.query` con `name: 'microphone'` no existe en
+ *     todos los browsers (Safari < 16). El query() puede rechazar con
+ *     `TypeError`. En ese caso devolvemos `'unknown'` — el usuario solo
+ *     puede saber el estado real intentando obtener el stream.
+ *   - `getUserMedia({ audio: true })` y `getCurrentPosition` ambos abren
+ *     el prompt del browser si el state es `prompt`. Si está `denied`,
+ *     fallan inmediatamente sin volver a preguntar — el usuario debe
+ *     habilitarlo en settings del browser (instrucción mostrada en la UI).
+ *   - Tras solicitar mic, **se cortan los tracks inmediatamente** — no
+ *     mantenemos el mic abierto. La recognition real lo abrirá luego
+ *     vía Web Speech API.
+ */
+
+export type PermissionStatus = 'granted' | 'denied' | 'prompt' | 'unsupported' | 'unknown';
+
+export interface PermissionState {
+  mic: PermissionStatus;
+  geo: PermissionStatus;
+}
+
+/**
+ * Lee el estado actual de los permisos. NO dispara prompts — solo
+ * consulta. Útil para el render inicial de la pantalla.
+ *
+ * Devuelve `'unsupported'` si la Permissions API no existe.
+ * Devuelve `'unknown'` si la API existe pero rechaza el query del nombre
+ * (típicamente Safari con `'microphone'`).
+ */
+export async function queryDriverPermissions(opts?: {
+  navigatorOverride?: Navigator;
+}): Promise<PermissionState> {
+  const nav = opts?.navigatorOverride ?? (typeof navigator !== 'undefined' ? navigator : null);
+  if (!nav || typeof nav.permissions === 'undefined') {
+    return { mic: 'unsupported', geo: 'unsupported' };
+  }
+  const mic = await safeQuery(nav.permissions, 'microphone');
+  const geo = await safeQuery(nav.permissions, 'geolocation');
+  return { mic, geo };
+}
+
+async function safeQuery(
+  permissions: Permissions,
+  name: 'microphone' | 'geolocation',
+): Promise<PermissionStatus> {
+  try {
+    // Algunos browsers (Safari ≤16) tiran TypeError aquí para 'microphone'.
+    // PermissionName es un tipo abierto en otros, así que casting puntual.
+    const status = await permissions.query({ name: name as PermissionName });
+    const s = status.state;
+    if (s === 'granted' || s === 'denied' || s === 'prompt') {
+      return s;
+    }
+    return 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Pide el permiso de micrófono. Si está `granted`, resuelve sin prompt.
+ * Si está `denied`, falla — el usuario debe habilitarlo en settings.
+ * Si está `prompt`, dispara el prompt nativo del browser.
+ *
+ * Tras éxito, **cierra inmediatamente** los tracks del stream —
+ * no mantenemos el mic abierto.
+ *
+ * Devuelve el nuevo estado, derivado del resultado:
+ *   - Si getUserMedia resolvió → 'granted'
+ *   - Si rechazó con NotAllowedError → 'denied'
+ *   - Cualquier otro error → 'unknown'
+ */
+export async function requestMicrophonePermission(opts?: {
+  mediaDevices?: MediaDevices;
+}): Promise<PermissionStatus> {
+  const md =
+    opts?.mediaDevices ??
+    (typeof navigator !== 'undefined' && typeof navigator.mediaDevices !== 'undefined'
+      ? navigator.mediaDevices
+      : null);
+  if (!md || typeof md.getUserMedia !== 'function') {
+    return 'unsupported';
+  }
+  try {
+    const stream = await md.getUserMedia({ audio: true });
+    // Stop tracks ASAP — solo queremos el handshake de permiso.
+    for (const track of stream.getTracks()) {
+      track.stop();
+    }
+    return 'granted';
+  } catch (err) {
+    if (err instanceof Error && err.name === 'NotAllowedError') {
+      return 'denied';
+    }
+    return 'unknown';
+  }
+}
+
+/**
+ * Pide el permiso de geolocation. Llama `getCurrentPosition` una sola vez
+ * — Maps API / stopped-detector usarán `watchPosition` después.
+ *
+ * Devuelve nuevo estado:
+ *   - Resolved → 'granted'
+ *   - PERMISSION_DENIED (1) → 'denied'
+ *   - Cualquier otro error → 'unknown'
+ */
+export async function requestGeolocationPermission(opts?: {
+  geolocation?: Geolocation;
+}): Promise<PermissionStatus> {
+  const geo =
+    opts?.geolocation ??
+    (typeof navigator !== 'undefined' && typeof navigator.geolocation !== 'undefined'
+      ? navigator.geolocation
+      : null);
+  if (!geo || typeof geo.getCurrentPosition !== 'function') {
+    return 'unsupported';
+  }
+  return new Promise<PermissionStatus>((resolve) => {
+    geo.getCurrentPosition(
+      () => resolve('granted'),
+      (err) => {
+        // GeolocationPositionError.PERMISSION_DENIED === 1
+        if (err && err.code === 1) {
+          resolve('denied');
+        } else {
+          resolve('unknown');
+        }
+      },
+      // No options — query rápida; el watch real lo configura stopped-detector.
+      { timeout: 8000, maximumAge: 60_000 },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- **Cierra el ciclo Phase 4 voice-first driver UX**. K1-K7 implementaron las features (auto-play coaching, comandos confirmar entrega, marcar incidente, aceptar oferta, cancelar). Sin esta pantalla, todas esas features eran "descubribles solo por accidente".
- Nueva ruta `/app/conductor/modo` con 4 cards: autoplay coaching toggle, permisos mic+GPS, referencia de comandos de voz, explainer del flujo.
- Nuevo service `driver-mode-permissions.ts` que encapsula `navigator.permissions.query` + side-effects de request (`getUserMedia` y `getCurrentPosition`), con fallback para Safari y dependency injection para tests.
- Entrypoints: link "Modo Conductor" en header de `/app/ofertas` y sección "Modo Conductor" en `/app/perfil`.

## UX

Una sola pantalla mobile-first con 4 cards. **Sin bloqueos**: las features voice siguen funcionando si el conductor no visita esta página (prompts ad-hoc del browser). Esta pantalla es para onboarding, troubleshooting y transparencia de qué requiere Booster.

### Card 1 — Audio coaching automático
Toggle único persistido en localStorage (reusa `coaching-voice.ts` existente). Microcopy explica el guard de vehículo parado (≤3 km/h por 4 s).

### Card 2 — Permisos del navegador
Estado actual de mic + GPS con botones "Permitir" cuando están en `prompt`. Si están `denied`, instrucción de habilitarlo en settings. Si están `granted`, pill verde "Activado".

### Card 3 — Comandos de voz disponibles
Referencia de los 4 intents con frases canónicas y contexto donde aplican.

### Card 4 — Cómo funciona
Explainer breve del flujo: detección de vehículo parado, doble confirmación anti-falso-positivo, "cancelar" como abort universal, referencia a Ley 18.290 art. 199 letra C.

## Service: driver-mode-permissions.ts

```ts
queryDriverPermissions() → { mic: PermissionStatus, geo: PermissionStatus }
requestMicrophonePermission() → 'granted' | 'denied' | 'unknown' | 'unsupported'
requestGeolocationPermission() → 'granted' | 'denied' | 'unknown' | 'unsupported'
```

- Defensivo contra Safari ≤16 (TypeError en `permissions.query({ name: 'microphone' })` → devuelve `'unknown'`)
- Tras `getUserMedia` exitoso, **stop() de tracks inmediatamente** — no mantenemos mic abierto
- Dependency injection (`navigatorOverride`, `mediaDevices`, `geolocation`) para tests sin tocar globals

## Tests (23 nuevos)

- `driver-mode-permissions.test.ts`: 13 tests (query granted/denied/prompt/unsupported/unknown × mic+geo combos, request mic stop-tracks + NotAllowedError, request geo PERMISSION_DENIED vs other codes)
- `conductor-modo.test.tsx`: 10 tests (protected guard, 4-card render, autoplay toggle persistence + initial state from localStorage, granted/denied/prompt rendering, mic+geo request click flow, voice commands list, how-it-works explainer)

Suite web total: **765 → 788 tests** (+23).

## No bloquea ninguna feature

Si el conductor entra a `/app/ofertas` sin haber visitado esta página, las features voice siguen funcionando (con prompts de permiso ad-hoc del browser al primer uso). Esta pantalla es onboarding + troubleshooting + transparencia.

## Test plan

- [x] Unit tests pass (23/23 nuevos)
- [x] Lint clean (Biome)
- [x] Typecheck clean
- [ ] CI verde
- [ ] Manual staging: visitar `/app/conductor/modo`, verificar permisos en estado `prompt`, click "Permitir" mic + GPS, verificar pill verde
- [ ] Manual staging: activar autoplay toggle, navegar a una asignación entregada, verificar auto-play coaching gated por vehículo detenido

🤖 Generated with [Claude Code](https://claude.com/claude-code)