### PR TITLE
feat(cobra-hoy): expone nota_visible al carrier en historial

### DIFF
--- a/apps/api/src/routes/cobra-hoy.ts
+++ b/apps/api/src/routes/cobra-hoy.ts
@@ -136,6 +136,44 @@ export function createCobraHoyAssignmentsRoutes(opts: { db: Db; logger: Logger }
   return app;
 }
 
+/**
+ * Decide qué mensaje del admin se expone al carrier en el historial,
+ * según el estado del adelanto. Pure: facilita test unitario sin BD.
+ *
+ *   - `rechazado` / `cancelado` → primero `rechazoMotivo` (campo
+ *     semánticamente acotado), si no hay → última línea de `notas_admin`.
+ *   - `mora` → última línea de `notas_admin` (típicamente la
+ *     auto-mora del cron).
+ *   - Otros estados → null (no surfaced para preservar privacidad
+ *     operativa: admins pueden dejar notas internas que el carrier
+ *     no debería ver hasta que se "cierre" su solicitud).
+ */
+export function buildNotaVisible(
+  status: string,
+  rechazoMotivo: string | null,
+  notasAdmin: string | null,
+): string | null {
+  if (status !== 'rechazado' && status !== 'cancelado' && status !== 'mora') {
+    return null;
+  }
+  if (rechazoMotivo && (status === 'rechazado' || status === 'cancelado')) {
+    return rechazoMotivo;
+  }
+  if (!notasAdmin) {
+    return null;
+  }
+  // Última línea no vacía (las notas se appenden con \n al final).
+  const lines = notasAdmin.split('\n').filter((l) => l.trim() !== '');
+  const last = lines[lines.length - 1];
+  if (!last) {
+    return null;
+  }
+  // Strip tag `[ISO email]` del prefijo: el carrier no necesita ver el
+  // email del operador ni la marca temporal — esa info queda en logs
+  // para auditoría.
+  return last.replace(/^\[[^\]]+\]\s*/, '').trim() || null;
+}
+
 export function createCobraHoyMeRoutes(opts: { db: Db; logger: Logger }) {
   const app = new Hono();
 
@@ -159,6 +197,8 @@ export function createCobraHoyMeRoutes(opts: { db: Db; logger: Logger }) {
         montoAdelantadoClp: adelantosCarrier.montoAdelantadoClp,
         status: adelantosCarrier.status,
         desembolsadoEn: adelantosCarrier.desembolsadoEn,
+        rechazoMotivo: adelantosCarrier.rechazoMotivo,
+        notasAdmin: adelantosCarrier.notasAdmin,
         createdAt: adelantosCarrier.createdAt,
       })
       .from(adelantosCarrier)
@@ -178,6 +218,11 @@ export function createCobraHoyMeRoutes(opts: { db: Db; logger: Logger }) {
         status: r.status,
         desembolsado_en: r.desembolsadoEn?.toISOString() ?? null,
         creado_en: r.createdAt.toISOString(),
+        // ADR-032 — el carrier solo ve mensajes para estados donde la
+        // explicación cierra el loop UX: rechazado, cancelado, mora.
+        // Para otros estados, los admins pueden dejar notas internas que
+        // NO deben filtrarse al carrier (privacidad operativa).
+        nota_visible: buildNotaVisible(r.status, r.rechazoMotivo, r.notasAdmin),
       })),
     });
   });

--- a/apps/api/test/unit/cobra-hoy-routes.test.ts
+++ b/apps/api/test/unit/cobra-hoy-routes.test.ts
@@ -305,6 +305,8 @@ describe('GET /me/cobra-hoy/historial', () => {
         montoAdelantadoClp: 173360,
         status: 'desembolsado',
         desembolsadoEn: desembolsadoAt,
+        rechazoMotivo: null,
+        notasAdmin: null,
         createdAt,
       },
     ]);
@@ -323,6 +325,123 @@ describe('GET /me/cobra-hoy/historial', () => {
       status: 'desembolsado',
       desembolsado_en: desembolsadoAt.toISOString(),
       creado_en: createdAt.toISOString(),
+      // `desembolsado` no expone notas al carrier (privacidad operativa).
+      nota_visible: null,
     });
+  });
+
+  it('adelanto rechazado con motivo → nota_visible = rechazoMotivo', async () => {
+    const db = makeDbWithAdelantos([
+      {
+        id: 'a1',
+        asignacionId: 'asg-1',
+        montoNetoClp: 176000,
+        plazoDiasShipper: 30,
+        tarifaPct: '1.50',
+        tarifaClp: 2640,
+        montoAdelantadoClp: 173360,
+        status: 'rechazado',
+        desembolsadoEn: null,
+        rechazoMotivo: 'Score insuficiente del shipper',
+        notasAdmin: null,
+        createdAt: new Date('2026-05-08T11:00:00Z'),
+      },
+    ]);
+    const app = makeMeApp({ withContext: true, db });
+    const res = await app.request('/me/cobra-hoy/historial');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { adelantos: Array<Record<string, unknown>> };
+    expect(body.adelantos[0]?.nota_visible).toBe('Score insuficiente del shipper');
+  });
+
+  it('adelanto mora con notas_admin → nota_visible = última línea sin tag', async () => {
+    const db = makeDbWithAdelantos([
+      {
+        id: 'a1',
+        asignacionId: 'asg-1',
+        montoNetoClp: 176000,
+        plazoDiasShipper: 30,
+        tarifaPct: '1.50',
+        tarifaClp: 2640,
+        montoAdelantadoClp: 173360,
+        status: 'mora',
+        desembolsadoEn: new Date('2026-04-01T12:00:00Z'),
+        rechazoMotivo: null,
+        notasAdmin:
+          '[2026-05-01T09:00:00.000Z admin@boosterchile.com] approval ok\n[2026-05-10T09:00:00.000Z cron@boosterchile.com] auto-mora: shipper no pagó en plazo (10 días vencidos sobre 30).',
+        createdAt: new Date('2026-04-01T11:00:00Z'),
+      },
+    ]);
+    const app = makeMeApp({ withContext: true, db });
+    const res = await app.request('/me/cobra-hoy/historial');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { adelantos: Array<Record<string, unknown>> };
+    expect(body.adelantos[0]?.nota_visible).toBe(
+      'auto-mora: shipper no pagó en plazo (10 días vencidos sobre 30).',
+    );
+  });
+});
+
+describe('buildNotaVisible (helper puro)', () => {
+  it('estado solicitado → null aunque tenga notas', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(buildNotaVisible('solicitado', null, '[2026-05-01 admin@x] nota interna')).toBeNull();
+  });
+
+  it('estado aprobado → null', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(buildNotaVisible('aprobado', null, '[2026 admin@x] nota')).toBeNull();
+  });
+
+  it('estado desembolsado → null', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(buildNotaVisible('desembolsado', null, '[t admin@x] x')).toBeNull();
+  });
+
+  it('estado cobrado_a_shipper → null', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(buildNotaVisible('cobrado_a_shipper', null, '[t a@x] y')).toBeNull();
+  });
+
+  it('rechazado con rechazoMotivo → usa el motivo', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(buildNotaVisible('rechazado', 'Sin antigüedad', null)).toBe('Sin antigüedad');
+  });
+
+  it('rechazado sin rechazoMotivo + notas_admin → última línea limpia', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(
+      buildNotaVisible(
+        'rechazado',
+        null,
+        '[2026-05-01T09:00:00.000Z admin@boosterchile.com] revisión inicial\n[2026-05-02T09:00:00.000Z admin@boosterchile.com] rechazado: límite excedido',
+      ),
+    ).toBe('rechazado: límite excedido');
+  });
+
+  it('cancelado sin motivo y sin notas → null', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(buildNotaVisible('cancelado', null, null)).toBeNull();
+  });
+
+  it('mora sin notas → null', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(buildNotaVisible('mora', null, null)).toBeNull();
+  });
+
+  it('mora con notas con varias líneas → última línea sin tag', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(
+      buildNotaVisible(
+        'mora',
+        null,
+        '[2026-05-01T09:00:00.000Z cron@boosterchile.com] auto-mora: shipper no pagó en plazo (5 días vencidos sobre 30).',
+      ),
+    ).toBe('auto-mora: shipper no pagó en plazo (5 días vencidos sobre 30).');
+  });
+
+  it('línea con tag pero sin contenido → null', async () => {
+    const { buildNotaVisible } = await import('../../src/routes/cobra-hoy.js');
+    expect(buildNotaVisible('rechazado', null, '[2026-05-01T09:00:00.000Z admin@x]')).toBeNull();
   });
 });

--- a/apps/web/src/hooks/use-cobra-hoy.ts
+++ b/apps/web/src/hooks/use-cobra-hoy.ts
@@ -76,6 +76,12 @@ export interface AdelantoHistorial {
     | 'rechazado';
   desembolsado_en: string | null;
   creado_en: string;
+  /**
+   * Mensaje del admin visible al carrier. Solo presente para estados
+   * `rechazado`, `cancelado` o `mora` (privacidad operativa). Para otros
+   * estados es `null` aunque el admin haya dejado notas internas.
+   */
+  nota_visible: string | null;
 }
 
 export function useHistorialCobraHoy(opts: { enabled?: boolean } = {}) {

--- a/apps/web/src/routes/cobra-hoy-historial.test.tsx
+++ b/apps/web/src/routes/cobra-hoy-historial.test.tsx
@@ -125,6 +125,7 @@ describe('CobraHoyHistorialRoute — estados de datos', () => {
           status: 'desembolsado' as const,
           desembolsado_en: '2026-05-08T12:00:00Z',
           creado_en: '2026-05-08T11:00:00Z',
+          nota_visible: null,
         },
       ],
     });
@@ -135,5 +136,78 @@ describe('CobraHoyHistorialRoute — estados de datos', () => {
     expect(screen.getByText('Desembolsado')).toBeInTheDocument();
     // Tarifa formateada con porcentaje.
     expect(screen.getByText(/\(1\.50%\)/)).toBeInTheDocument();
+    // Sin nota visible: el bloque NotaCarrier no debe aparecer.
+    expect(screen.queryByText(/Nota del equipo Booster/)).not.toBeInTheDocument();
+  });
+
+  it('rechazado con nota_visible → muestra NotaCarrier con AlertTriangle', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      adelantos: [
+        {
+          id: 'a1',
+          asignacion_id: 'asg-1',
+          monto_neto_clp: 176000,
+          plazo_dias_shipper: 30,
+          tarifa_pct: 1.5,
+          tarifa_clp: 2640,
+          monto_adelantado_clp: 173360,
+          status: 'rechazado' as const,
+          desembolsado_en: null,
+          creado_en: '2026-05-08T11:00:00Z',
+          nota_visible: 'Score insuficiente del shipper',
+        },
+      ],
+    });
+    renderRoute();
+    expect(await screen.findByText('Rechazado')).toBeInTheDocument();
+    expect(screen.getByText(/Nota del equipo Booster/)).toBeInTheDocument();
+    expect(screen.getByText(/Score insuficiente del shipper/)).toBeInTheDocument();
+  });
+
+  it('mora con nota_visible → muestra NotaCarrier en tono amber', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      adelantos: [
+        {
+          id: 'a1',
+          asignacion_id: 'asg-1',
+          monto_neto_clp: 176000,
+          plazo_dias_shipper: 30,
+          tarifa_pct: 1.5,
+          tarifa_clp: 2640,
+          monto_adelantado_clp: 173360,
+          status: 'mora' as const,
+          desembolsado_en: '2026-04-01T12:00:00Z',
+          creado_en: '2026-04-01T11:00:00Z',
+          nota_visible: 'auto-mora: shipper no pagó en plazo (10 días vencidos sobre 30).',
+        },
+      ],
+    });
+    renderRoute();
+    expect(await screen.findByText('En mora')).toBeInTheDocument();
+    expect(screen.getByText(/auto-mora: shipper no pagó en plazo/)).toBeInTheDocument();
+  });
+
+  it('adelanto con status sin nota_visible → no muestra panel de nota', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      adelantos: [
+        {
+          id: 'a1',
+          asignacion_id: 'asg-1',
+          monto_neto_clp: 176000,
+          plazo_dias_shipper: 30,
+          tarifa_pct: 1.5,
+          tarifa_clp: 2640,
+          monto_adelantado_clp: 173360,
+          status: 'rechazado' as const,
+          desembolsado_en: null,
+          creado_en: '2026-05-08T11:00:00Z',
+          // nota_visible null (admin no dejó motivo)
+          nota_visible: null,
+        },
+      ],
+    });
+    renderRoute();
+    expect(await screen.findByText('Rechazado')).toBeInTheDocument();
+    expect(screen.queryByText(/Nota del equipo Booster/)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/cobra-hoy-historial.tsx
+++ b/apps/web/src/routes/cobra-hoy-historial.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { ArrowLeft, Banknote, Clock3 } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, Banknote, Clock3, MessageSquare } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { EmptyState, emptyStateActionClass } from '../components/EmptyState.js';
 import { Layout } from '../components/Layout.js';
@@ -123,7 +123,7 @@ function HistorialPage({ me }: { me: MeOnboarded }) {
                 </tr>
               </thead>
               <tbody className="divide-y divide-neutral-100 bg-white">
-                {histQ.data.adelantos.map((a) => (
+                {histQ.data.adelantos.flatMap((a) => [
                   <tr key={a.id} className="hover:bg-neutral-50">
                     <Td className="text-neutral-600 text-xs">{formatDate(a.creado_en)}</Td>
                     <Td>
@@ -145,8 +145,15 @@ function HistorialPage({ me }: { me: MeOnboarded }) {
                     <Td>
                       <StatusBadge status={a.status} />
                     </Td>
-                  </tr>
-                ))}
+                  </tr>,
+                  a.nota_visible ? (
+                    <tr key={`${a.id}-nota`} className="bg-neutral-50/50">
+                      <td colSpan={6} className="px-4 pt-0 pb-3">
+                        <NotaCarrier status={a.status} message={a.nota_visible} />
+                      </td>
+                    </tr>
+                  ) : null,
+                ])}
               </tbody>
             </table>
           </div>
@@ -220,6 +227,32 @@ function StatusBadge({ status }: { status: AdelantoHistorial['status'] }) {
     >
       {v.label}
     </span>
+  );
+}
+
+/**
+ * Mensaje del admin al carrier — solo para estados rechazado / cancelado / mora.
+ * Color y icono varían según severidad: rechazado/cancelado en danger, mora en amber.
+ */
+function NotaCarrier({
+  status,
+  message,
+}: {
+  status: AdelantoHistorial['status'];
+  message: string;
+}) {
+  const isDanger = status === 'rechazado' || status === 'cancelado';
+  const tone = isDanger
+    ? 'border-danger-500/30 bg-danger-50 text-danger-700'
+    : 'border-amber-500/30 bg-amber-50 text-amber-700';
+  const Icon = isDanger ? AlertTriangle : MessageSquare;
+  return (
+    <output className={`flex items-start gap-2 rounded-md border px-3 py-2 text-xs ${tone}`}>
+      <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden />
+      <span>
+        <strong className="font-medium">Nota del equipo Booster:</strong> {message}
+      </span>
+    </output>
   );
 }
 


### PR DESCRIPTION
## Summary

Cierra el loop UX para los estados \`rechazado\` / \`cancelado\` / \`mora\` del módulo Cobra Hoy: el carrier ahora ve el motivo del admin en su historial sin filtrar notas internas de estados intermedios (privacidad operativa).

Hoy: el carrier veía solo el badge \"Rechazado\" sin entender por qué. Con este PR, ve el mensaje del admin debajo del estado.

## Helper puro \`buildNotaVisible\`

Decisión deterministica por estado:

| Estado | Salida |
|---|---|
| \`solicitado\`, \`aprobado\`, \`desembolsado\`, \`cobrado_a_shipper\` | \`null\` |
| \`rechazado\` o \`cancelado\` | \`rechazo_motivo\` si existe, sino última línea de \`notas_admin\` sin el tag \`[ISO email]\` |
| \`mora\` | última línea de \`notas_admin\` sin el tag (típicamente la auto-mora del cron #139) |

Strip del tag preserva info de auditoría en BD/logs pero no la filtra al carrier.

## Componentes

### Backend
- \`routes/cobra-hoy.ts\` (\`GET /me/cobra-hoy/historial\`):
  - SELECT incluye \`rechazo_motivo\` y \`notas_admin\`.
  - Response añade \`nota_visible: string | null\` calculada con \`buildNotaVisible\`.
- Helper exportado para testear sin BD.

### Web
- \`use-cobra-hoy.ts\`: \`AdelantoHistorial.nota_visible: string | null\`.
- \`cobra-hoy-historial.tsx\`: nuevo \`NotaCarrier\` que renderiza como fila adicional cuando \`nota_visible != null\`. Tone:
  - \`rechazado\` / \`cancelado\` → danger (rosa, \`AlertTriangle\`).
  - \`mora\` → amber (\`MessageSquare\`).

## Evidencia

\`\`\`
API: 595 tests pass (+13: 10 unit del helper + 3 integration historial)
Web: 768 tests pass (+3: nota rechazado, mora, ausente cuando null)
lint: 0 errors
typecheck api+web: clean
\`\`\`

## Test plan

- [ ] Adelanto \`rechazado\` con \`rechazo_motivo='Score insuficiente'\` → carrier ve banner danger con el motivo.
- [ ] Adelanto \`mora\` por auto-cron → carrier ve banner amber con \"auto-mora: shipper no pagó en plazo (X días vencidos sobre Y).\"
- [ ] Adelanto \`desembolsado\` con notas internas → carrier NO ve las notas (privacidad).
- [ ] Adelanto \`rechazado\` sin motivo ni notas → no se renderiza la fila (nota_visible=null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)