### PR TITLE
feat(api): ETA tracking público vía Routes API on-demand (Phase 5 PR-L2c)

### DIFF
--- a/apps/api/src/routes/public-tracking.ts
+++ b/apps/api/src/routes/public-tracking.ts
@@ -21,7 +21,17 @@ import { Hono } from 'hono';
 import type { Db } from '../db/client.js';
 import { getPublicTracking } from '../services/get-public-tracking.js';
 
-export function createPublicTrackingRoutes(opts: { db: Db; logger: Logger }) {
+export function createPublicTrackingRoutes(opts: {
+  db: Db;
+  logger: Logger;
+  /**
+   * Phase 5 PR-L2c — Routes API key opcional. Si presente, el ETA del
+   * tracking público se calcula con distancia por carretera real al
+   * destino exacto (vs centroide regional). Si ausente o el call falla,
+   * fallback transparente al método de PR-L2b.
+   */
+  routesApiKey?: string | undefined;
+}) {
   const app = new Hono();
 
   app.get('/:token', async (c) => {
@@ -31,6 +41,7 @@ export function createPublicTrackingRoutes(opts: { db: Db; logger: Logger }) {
       db: opts.db,
       logger: opts.logger,
       token,
+      ...(opts.routesApiKey ? { routesApiKey: opts.routesApiKey } : {}),
     });
 
     if (result.status === 'not_found') {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -123,7 +123,19 @@ export function createServer(opts: CreateServerOptions): Hono {
   // la defensa es la opacidad del token UUID v4 (122 bits, no enumerable).
   // El handler restringe los datos expuestos (plate parcial, sin
   // driver name, telemetría sólo <30min).
-  app.route('/public/tracking', createPublicTrackingRoutes({ db: opts.db, logger }));
+  //
+  // Phase 5 PR-L2c — si GOOGLE_ROUTES_API_KEY está configurada, el ETA
+  // del tracking se calcula con Routes API (distancia real por carretera
+  // al destino exacto). Sin la key, fallback transparente al ETA al
+  // centroide regional (PR-L2b).
+  app.route(
+    '/public/tracking',
+    createPublicTrackingRoutes({
+      db: opts.db,
+      logger,
+      ...(config.GOOGLE_ROUTES_API_KEY ? { routesApiKey: config.GOOGLE_ROUTES_API_KEY } : {}),
+    }),
+  );
 
   // Protected routes — OIDC token from allowed Cloud Run SA required
   const authMiddleware = createAuthMiddleware({

--- a/apps/api/src/services/compute-route-eta.ts
+++ b/apps/api/src/services/compute-route-eta.ts
@@ -1,0 +1,257 @@
+/**
+ * Compute ETA for public tracking using Routes API on-demand (Phase 5 PR-L2c).
+ *
+ * **Upgrade sobre PR-L2b**: el ETA al centroide regional con
+ * `haversine × 1.3` tiene error potencial ±20-30% (centroide es la
+ * capital regional, no el destino exacto; factor 1.3 es aproximación
+ * burda de la sinuosidad de carreteras chilenas). Este PR llama al
+ * **Routes API** para obtener la distancia por carretera real al
+ * destino real, manteniendo la velocidad promedio del vehículo
+ * (avgSpeedKmh, medida en los últimos 15min) como el factor de tiempo
+ * — porque Routes API asume velocidades genéricas que no reflejan el
+ * comportamiento actual del transportista.
+ *
+ * **Fórmula**:
+ *   `etaMins = (roadDistKm_routes_api / avgSpeedKmh) × 60`
+ *
+ * vs PR-L2b:
+ *   `etaMins = (haversine(current → centroid) × 1.3 / avgSpeedKmh) × 60`
+ *
+ * Donde solo cambia el numerador: distancia real (Routes API) vs
+ * proxy (haversine × factor).
+ *
+ * **Caching**: Routes API factura ~$5 USD por 1000 requests. La página
+ * pública de tracking puede pollear cada 30s × N consignees abiertos en
+ * un viaje. Sin cache, un viaje de 4h con 5 consignees abiertos generaría
+ * 4×60×5/0.5 = 2,400 calls. Cacheamos por (tripId, currentLat~0.01°,
+ * currentLng~0.01°) con TTL 5min — el vehículo se mueve ~1.1km por 0.01°
+ * en Chile, así que la cache invalida naturalmente al avanzar.
+ *
+ * **Fallback**: si la API key no está configurada, o la llamada falla,
+ * o el destinationAddress está vacío → devolvemos el ETA del fallback
+ * (centroide regional, PR-L2b). Nunca rompe la respuesta del tracking.
+ *
+ * **NO cambia la API pública**: el campo `eta_minutes` del response sigue
+ * siendo `number | null`. La precisión mejorada es transparente al cliente.
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import { RoutesApiError, computeRoutes } from './routes-api.js';
+
+/**
+ * Entrada a `computeRouteEta`. Recibe el ETA fallback ya calculado por
+ * `computeEtaMinutes` (centroide regional). Si Routes API falla o no
+ * está disponible, devolvemos ese fallback sin tocarlo.
+ */
+export interface ComputeRouteEtaInput {
+  /** Logger para warns en fallback. */
+  logger: Logger;
+  /** ID del trip — usado para cache key. */
+  tripId: string;
+  /** Lat actual del vehículo (de telemetría reciente). null = no posicionado. */
+  currentLat: number | null;
+  /** Lng actual del vehículo. null = no posicionado. */
+  currentLng: number | null;
+  /** Dirección textual del destino (Routes API la geocodifica). */
+  destinationAddress: string;
+  /** Velocidad promedio últimos 15min en km/h. null = parado/sin pings. */
+  avgSpeedKmh: number | null;
+  /** ETA en minutos del fallback (PR-L2b centroide). Devolvemos esto si Routes API no aplica. */
+  fallbackEtaMinutes: number | null;
+  /** API key del Routes API. Si undefined/empty, usamos fallback directo. */
+  routesApiKey: string | undefined;
+  /** Inyectable para tests. Default: import dinámico de fetch global. */
+  fetchImpl?: typeof fetch | undefined;
+  /** Inyectable para tests. Default: in-memory module singleton. */
+  cacheStore?: RouteEtaCacheStore | undefined;
+  /** Override Date.now() en tests. Default: Date.now. */
+  nowMs?: number | undefined;
+}
+
+export interface ComputeRouteEtaResult {
+  /** ETA en minutos, o null si no se pudo estimar (mismo contrato que PR-L2b). */
+  etaMinutes: number | null;
+  /**
+   * Fuente del cálculo:
+   *   - `'routes_api'`: éxito con Routes API
+   *   - `'routes_api_cached'`: éxito con cache de Routes API
+   *   - `'centroide'`: fallback PR-L2b (Routes API no aplicable o falló)
+   *   - `'unavailable'`: fallback también fue null (no hay ETA posible)
+   *
+   * No se expone en la respuesta pública — es para logging/observabilidad.
+   */
+  source: 'routes_api' | 'routes_api_cached' | 'centroide' | 'unavailable';
+}
+
+interface CachedEntry {
+  /** Distancia por carretera en km, normalizada de Routes API. */
+  distanceKm: number;
+  /** Timestamp del fetch original — para TTL. */
+  fetchedAt: number;
+}
+
+export interface RouteEtaCacheStore {
+  get(key: string): CachedEntry | undefined;
+  set(key: string, entry: CachedEntry): void;
+  /** Borra entradas expiradas. Llamado periódicamente. */
+  prune(nowMs: number): void;
+}
+
+/**
+ * TTL de cache: 5min. Suficientemente largo para evitar hammering en
+ * polling normal, suficientemente corto para que si el conductor toma
+ * un detour la próxima refresh lo recoja (la cache key ya invalida al
+ * cruzar grid de 0.01°, así que 5min es safety net).
+ */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Resolución del grid de cache. 0.01° ≈ 1.1km en Chile (latitud ~33°).
+ * Dos pings dentro del mismo grid square hits la misma cache entry —
+ * razonable porque la distancia al destino cambia <1km entre ellos.
+ */
+const CACHE_GRID_DECIMALS = 2;
+
+/**
+ * Implementación default in-memory. Sufficient para single-process
+ * Cloud Run. Si escalamos a múltiples instancias, swap por Redis con
+ * la misma interface — el cache es soft (miss → re-fetch, no error).
+ */
+class InMemoryRouteEtaCache implements RouteEtaCacheStore {
+  private readonly store = new Map<string, CachedEntry>();
+
+  get(key: string): CachedEntry | undefined {
+    return this.store.get(key);
+  }
+
+  set(key: string, entry: CachedEntry): void {
+    this.store.set(key, entry);
+  }
+
+  prune(nowMs: number): void {
+    for (const [key, entry] of this.store) {
+      if (nowMs - entry.fetchedAt > CACHE_TTL_MS) {
+        this.store.delete(key);
+      }
+    }
+  }
+}
+
+/**
+ * Singleton del cache para el módulo. Tests pueden pasar uno propio vía
+ * `opts.cacheStore` para isolation.
+ */
+const defaultCache = new InMemoryRouteEtaCache();
+
+/** Solo expuesto para tests — permite limpiar el singleton entre tests. */
+export function _resetDefaultCache(): void {
+  defaultCache.prune(Number.MAX_SAFE_INTEGER);
+}
+
+function buildCacheKey(tripId: string, lat: number, lng: number): string {
+  const gridLat = lat.toFixed(CACHE_GRID_DECIMALS);
+  const gridLng = lng.toFixed(CACHE_GRID_DECIMALS);
+  return `${tripId}:${gridLat}:${gridLng}`;
+}
+
+/**
+ * Calcula ETA usando Routes API si está disponible, con fallback a la
+ * estimación de centroide regional (PR-L2b).
+ */
+export async function computeRouteEta(input: ComputeRouteEtaInput): Promise<ComputeRouteEtaResult> {
+  const {
+    logger,
+    tripId,
+    currentLat,
+    currentLng,
+    destinationAddress,
+    avgSpeedKmh,
+    fallbackEtaMinutes,
+    routesApiKey,
+    fetchImpl,
+    cacheStore = defaultCache,
+    nowMs = Date.now(),
+  } = input;
+
+  // Early returns: si nos faltan inputs críticos, devolvemos el fallback
+  // sin tocar Routes API. Esto incluye los casos donde el fallback
+  // también es null (NO_ETA_STATUSES, sin posición, etc.).
+  if (!routesApiKey) {
+    return { etaMinutes: fallbackEtaMinutes, source: pickFallbackSource(fallbackEtaMinutes) };
+  }
+  if (currentLat === null || currentLng === null) {
+    return { etaMinutes: fallbackEtaMinutes, source: pickFallbackSource(fallbackEtaMinutes) };
+  }
+  if (avgSpeedKmh === null || avgSpeedKmh <= 0) {
+    return { etaMinutes: fallbackEtaMinutes, source: pickFallbackSource(fallbackEtaMinutes) };
+  }
+  if (!destinationAddress || destinationAddress.trim().length === 0) {
+    return { etaMinutes: fallbackEtaMinutes, source: pickFallbackSource(fallbackEtaMinutes) };
+  }
+
+  // Cache lookup. El grid de 0.01° garantiza que el vehículo debe haberse
+  // movido ≥1km para invalidar (suficiente para que la distancia al
+  // destino sea materially distinta).
+  const cacheKey = buildCacheKey(tripId, currentLat, currentLng);
+  const cached = cacheStore.get(cacheKey);
+  if (cached && nowMs - cached.fetchedAt <= CACHE_TTL_MS) {
+    const etaMinutes = computeEtaFromDistance(cached.distanceKm, avgSpeedKmh);
+    return { etaMinutes, source: 'routes_api_cached' };
+  }
+
+  // Cache miss o stale → fetch fresh.
+  try {
+    // computeRoutes acepta string origin/destination (geocoded). Para
+    // mejor precisión pasamos lat,lng como string en origin — Routes API
+    // lo interpreta como punto exacto sin geocoding.
+    const origin = `${currentLat},${currentLng}`;
+    const routes = await computeRoutes({
+      apiKey: routesApiKey,
+      origin,
+      destination: destinationAddress,
+      computeAlternatives: false,
+      ...(fetchImpl ? { fetchImpl } : {}),
+      logger,
+    });
+
+    const top = routes[0];
+    if (!top || top.distanceKm <= 0) {
+      logger.warn(
+        { tripId, currentLat, currentLng, destinationAddress },
+        'Routes API returned no usable route — falling back to centroid ETA',
+      );
+      return { etaMinutes: fallbackEtaMinutes, source: pickFallbackSource(fallbackEtaMinutes) };
+    }
+
+    cacheStore.set(cacheKey, { distanceKm: top.distanceKm, fetchedAt: nowMs });
+
+    const etaMinutes = computeEtaFromDistance(top.distanceKm, avgSpeedKmh);
+    return { etaMinutes, source: 'routes_api' };
+  } catch (err) {
+    // Cualquier error de la API: log y fallback. No throw — la respuesta
+    // del tracking nunca debe romperse por un upstream que falla.
+    if (err instanceof RoutesApiError) {
+      logger.warn(
+        { tripId, code: err.code, httpStatus: err.httpStatus, msg: err.message },
+        'Routes API error — falling back to centroid ETA',
+      );
+    } else {
+      logger.error(
+        { err, tripId },
+        'Unexpected error computing route ETA — falling back to centroid ETA',
+      );
+    }
+    return { etaMinutes: fallbackEtaMinutes, source: pickFallbackSource(fallbackEtaMinutes) };
+  }
+}
+
+function computeEtaFromDistance(distanceKm: number, avgSpeedKmh: number): number {
+  const etaHours = distanceKm / avgSpeedKmh;
+  const etaMins = etaHours * 60;
+  // Si el ETA computado es <1 min, redondeamos a 1 — UX consistente con PR-L2b.
+  return Math.max(1, Math.round(etaMins));
+}
+
+function pickFallbackSource(fallbackEtaMinutes: number | null): 'centroide' | 'unavailable' {
+  return fallbackEtaMinutes === null ? 'unavailable' : 'centroide';
+}

--- a/apps/api/src/services/get-public-tracking.ts
+++ b/apps/api/src/services/get-public-tracking.ts
@@ -31,6 +31,7 @@ import { and, desc, eq, gte, isNotNull } from 'drizzle-orm';
 import type { Db } from '../db/client.js';
 import { assignments, telemetryPoints, trips, vehicles } from '../db/schema.js';
 import { haversineKm } from './calcular-cobertura-telemetria.js';
+import { computeRouteEta } from './compute-route-eta.js';
 
 /**
  * Centroides aproximados (capital regional) para las 16 regiones de
@@ -152,8 +153,14 @@ export async function getPublicTracking(opts: {
   db: Db;
   logger: Logger;
   token: string;
+  /**
+   * Phase 5 PR-L2c — si está presente, calculamos el ETA con Routes API
+   * (distancia real por carretera al destino exacto). Si está ausente
+   * o el call falla, fallback al ETA de centroide regional (PR-L2b).
+   */
+  routesApiKey?: string | undefined;
 }): Promise<PublicTrackingResult> {
-  const { db, logger, token } = opts;
+  const { db, logger, token, routesApiKey } = opts;
 
   // Validar formato UUID antes de query — si no parece UUID, no
   // pegamos la DB (defensa contra scanning).
@@ -165,6 +172,7 @@ export async function getPublicTracking(opts: {
   const rows = await db
     .select({
       assignmentId: assignments.id,
+      tripId: trips.id,
       tripStatus: trips.status,
       trackingCode: trips.trackingCode,
       originAddr: trips.originAddressRaw,
@@ -233,16 +241,44 @@ export async function getPublicTracking(opts: {
     nowMs: now,
   });
 
-  // Phase 5 PR-L2b — ETA al centroide regional. Solo cuando el trip
-  // está activo (no entregado/cancelado), hay posición + avg_speed
-  // confiable, y el código de región está mapeado.
-  const etaMinutes = computeEtaMinutes({
+  // Phase 5 PR-L2b — ETA al centroide regional. Computado primero como
+  // fallback para PR-L2c. Si Routes API funciona (con routesApiKey
+  // presente), se reemplaza con la distancia real al destino exacto.
+  const fallbackEtaMinutes = computeEtaMinutes({
     currentLat: position?.latitude ?? null,
     currentLng: position?.longitude ?? null,
     destRegionCode: row.destRegionCode,
     avgSpeedKmh: progress.avg_speed_kmh_last_15min,
     tripStatus: row.tripStatus,
   });
+
+  // Phase 5 PR-L2c — upgrade a Routes API on-demand. Si trip está activo
+  // y hay posición + avgSpeed + routesApiKey + destinationAddress,
+  // pedimos a Routes API la distancia real por carretera al destino y
+  // recalculamos con el avgSpeed del vehículo. Cache de 5min + grid 0.01°
+  // evita hammering. Fallback automático al centroide si algo falla.
+  let etaMinutes = fallbackEtaMinutes;
+  if (!NO_ETA_STATUSES.has(row.tripStatus)) {
+    const routeEtaResult = await computeRouteEta({
+      logger,
+      tripId: row.tripId,
+      currentLat: position?.latitude ?? null,
+      currentLng: position?.longitude ?? null,
+      destinationAddress: row.destAddr,
+      avgSpeedKmh: progress.avg_speed_kmh_last_15min,
+      fallbackEtaMinutes,
+      routesApiKey,
+    });
+    etaMinutes = routeEtaResult.etaMinutes;
+    logger.debug(
+      {
+        tripId: row.tripId,
+        etaMinutes,
+        source: routeEtaResult.source,
+      },
+      'public tracking eta computed',
+    );
+  }
 
   return {
     status: 'found',

--- a/apps/api/test/unit/compute-route-eta.test.ts
+++ b/apps/api/test/unit/compute-route-eta.test.ts
@@ -1,0 +1,286 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  ComputeRouteEtaInput,
+  RouteEtaCacheStore,
+} from '../../src/services/compute-route-eta.js';
+import { _resetDefaultCache, computeRouteEta } from '../../src/services/compute-route-eta.js';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.SERVICE_NAME = 'booster-ai-api';
+  process.env.SERVICE_VERSION = '0.0.0-test';
+  process.env.LOG_LEVEL = 'error';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.REDIS_HOST = 'localhost';
+  process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173';
+  process.env.FIREBASE_PROJECT_ID = 'test';
+  process.env.API_AUDIENCE = 'https://api.boosterchile.com';
+  process.env.ALLOWED_CALLER_SA = 'caller@booster-ai.iam.gserviceaccount.com';
+});
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as ComputeRouteEtaInput['logger'];
+
+function makeCache(): RouteEtaCacheStore {
+  const store = new Map<string, { distanceKm: number; fetchedAt: number }>();
+  return {
+    get: (k) => store.get(k),
+    set: (k, v) => store.set(k, v),
+    prune: () => undefined,
+  };
+}
+
+/**
+ * Helper para construir un fetch mock que devuelve un response shape de Routes API.
+ */
+function makeFetchOk(distanceMeters: number, durationS = 7200): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        routes: [
+          {
+            distanceMeters,
+            duration: `${durationS}s`,
+            polyline: { encodedPolyline: 'fake_polyline_xyz' },
+          },
+        ],
+      }),
+  } as unknown as Response) as typeof fetch;
+}
+
+function makeFetchEmpty(): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ routes: [] }),
+  } as unknown as Response) as typeof fetch;
+}
+
+function makeFetchHttp500(): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    text: () => Promise.resolve('Internal'),
+  } as unknown as Response) as typeof fetch;
+}
+
+function makeFetchNetworkError(): typeof fetch {
+  return vi.fn().mockRejectedValue(new Error('ECONNREFUSED')) as typeof fetch;
+}
+
+const baseInput = (over: Partial<ComputeRouteEtaInput> = {}): ComputeRouteEtaInput => ({
+  logger: noopLogger,
+  tripId: 'trip-1',
+  currentLat: -33.45,
+  currentLng: -70.66,
+  destinationAddress: 'Av Ejemplo 123, Concepción',
+  avgSpeedKmh: 60,
+  fallbackEtaMinutes: 500,
+  routesApiKey: 'fake-key',
+  ...over,
+});
+
+beforeEach(() => {
+  _resetDefaultCache();
+  vi.clearAllMocks();
+});
+
+describe('computeRouteEta — fallback paths (no Routes API call)', () => {
+  it('sin routesApiKey → devuelve fallback con source=centroide', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const res = await computeRouteEta(baseInput({ routesApiKey: undefined, fetchImpl }));
+    expect(res).toEqual({ etaMinutes: 500, source: 'centroide' });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('sin posición actual → fallback (sin call)', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const res = await computeRouteEta(baseInput({ currentLat: null, currentLng: null, fetchImpl }));
+    expect(res.source).toBe('centroide');
+    expect(res.etaMinutes).toBe(500);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('avgSpeed null o cero → fallback (sin call)', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const r1 = await computeRouteEta(baseInput({ avgSpeedKmh: null, fetchImpl }));
+    const r2 = await computeRouteEta(baseInput({ avgSpeedKmh: 0, fetchImpl }));
+    expect(r1.source).toBe('centroide');
+    expect(r2.source).toBe('centroide');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('destinationAddress vacío → fallback (sin call)', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const r1 = await computeRouteEta(baseInput({ destinationAddress: '', fetchImpl }));
+    const r2 = await computeRouteEta(baseInput({ destinationAddress: '   ', fetchImpl }));
+    expect(r1.source).toBe('centroide');
+    expect(r2.source).toBe('centroide');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('fallback null preservado como unavailable', async () => {
+    const res = await computeRouteEta(
+      baseInput({ routesApiKey: undefined, fallbackEtaMinutes: null }),
+    );
+    expect(res).toEqual({ etaMinutes: null, source: 'unavailable' });
+  });
+});
+
+describe('computeRouteEta — Routes API happy paths', () => {
+  it('llamada exitosa → ETA recalculado con distancia real y avgSpeed actual', async () => {
+    // distanceMeters = 200_000 (200km), avgSpeedKmh = 60 → ETA = 200/60*60 = 200min
+    const fetchImpl = makeFetchOk(200_000);
+    const cache = makeCache();
+    const res = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    expect(res.source).toBe('routes_api');
+    expect(res.etaMinutes).toBe(200);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('segunda llamada misma posición → cache hit (sin fetch)', async () => {
+    const fetchImpl = makeFetchOk(150_000); // 150km → @60kmh = 150min
+    const cache = makeCache();
+    const first = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    const second = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    expect(first.source).toBe('routes_api');
+    expect(second.source).toBe('routes_api_cached');
+    expect(second.etaMinutes).toBe(150);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache hit usa avgSpeed actual (no el del primer fetch)', async () => {
+    // distance=120km cacheada → al cambiar avgSpeed de 60 a 30, ETA dobla.
+    const fetchImpl = makeFetchOk(120_000);
+    const cache = makeCache();
+    const first = await computeRouteEta(
+      baseInput({ fetchImpl, cacheStore: cache, avgSpeedKmh: 60 }),
+    );
+    const second = await computeRouteEta(
+      baseInput({ fetchImpl, cacheStore: cache, avgSpeedKmh: 30 }),
+    );
+    expect(first.etaMinutes).toBe(120); // 120km / 60kmh = 2h
+    expect(second.etaMinutes).toBe(240); // 120km / 30kmh = 4h
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('cache expira tras TTL 5min → refetch', async () => {
+    const fetchImpl = makeFetchOk(100_000);
+    const cache = makeCache();
+    const t0 = 1_000_000;
+    const first = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache, nowMs: t0 }));
+    // Simular paso de 6min
+    const second = await computeRouteEta(
+      baseInput({ fetchImpl, cacheStore: cache, nowMs: t0 + 6 * 60 * 1000 }),
+    );
+    expect(first.source).toBe('routes_api');
+    expect(second.source).toBe('routes_api'); // re-fetched, not cached
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('grid de cache 0.01°: movimiento <0.01° → mismo grid (cache hit)', async () => {
+    const fetchImpl = makeFetchOk(50_000);
+    const cache = makeCache();
+    // -33.45 vs -33.453 → toFixed(2) === '-33.45' para ambos
+    await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache, currentLat: -33.45 }));
+    const second = await computeRouteEta(
+      baseInput({ fetchImpl, cacheStore: cache, currentLat: -33.453 }),
+    );
+    expect(second.source).toBe('routes_api_cached');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('grid de cache 0.01°: movimiento ≥0.01° → grid distinto (cache miss)', async () => {
+    const fetchImpl = makeFetchOk(50_000);
+    const cache = makeCache();
+    await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache, currentLat: -33.45 }));
+    const second = await computeRouteEta(
+      baseInput({ fetchImpl, cacheStore: cache, currentLat: -33.46 }),
+    );
+    expect(second.source).toBe('routes_api');
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('computeRouteEta — Routes API failure paths', () => {
+  it('HTTP 500 → fallback centroide', async () => {
+    const fetchImpl = makeFetchHttp500();
+    const cache = makeCache();
+    const res = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    expect(res.source).toBe('centroide');
+    expect(res.etaMinutes).toBe(500); // del fallback
+  });
+
+  it('network error → fallback centroide', async () => {
+    const fetchImpl = makeFetchNetworkError();
+    const cache = makeCache();
+    const res = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    expect(res.source).toBe('centroide');
+    expect(res.etaMinutes).toBe(500);
+  });
+
+  it('Routes API devuelve sin routes → fallback centroide', async () => {
+    const fetchImpl = makeFetchEmpty();
+    const cache = makeCache();
+    const res = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    expect(res.source).toBe('centroide');
+  });
+
+  it('failure no cachea — siguiente call vuelve a intentar', async () => {
+    const cache = makeCache();
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('boom'),
+      } as unknown as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            routes: [
+              { distanceMeters: 90_000, duration: '3600s', polyline: { encodedPolyline: 'p' } },
+            ],
+          }),
+      } as unknown as Response) as unknown as typeof fetch;
+    const first = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    const second = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    expect(first.source).toBe('centroide');
+    expect(second.source).toBe('routes_api');
+    expect(second.etaMinutes).toBe(90); // 90km / 60kmh = 90min
+  });
+});
+
+describe('computeRouteEta — ETA edge cases', () => {
+  it('distancia muy corta → min 1 min (no zero)', async () => {
+    // 100m a 60kmh = 0.1min → clamped a 1
+    const fetchImpl = makeFetchOk(100);
+    const cache = makeCache();
+    const res = await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache }));
+    expect(res.etaMinutes).toBe(1);
+  });
+
+  it('cache por tripId — trips distintos no comparten cache', async () => {
+    const fetchImpl = makeFetchOk(100_000);
+    const cache = makeCache();
+    await computeRouteEta(baseInput({ fetchImpl, cacheStore: cache, tripId: 'trip-A' }));
+    const second = await computeRouteEta(
+      baseInput({ fetchImpl, cacheStore: cache, tripId: 'trip-B' }),
+    );
+    expect(second.source).toBe('routes_api'); // not cached
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- **Upgrade del ETA del tracking público**: de centroide regional + haversine × 1.3 (PR-L2b, error ±20-30%) a **distancia real por carretera al destino exacto** vía Routes API on-demand.
- **Cache 5min + grid 0.01°** para evitar hammering de Routes API (Routes API factura ~\$5/1000 calls; tracking polling × N consignees abiertos podría disparar miles de calls/viaje sin cache).
- **Fallback transparente**: si la API key no está configurada, o Routes API falla, o destAddress vacío → devolvemos el ETA de PR-L2b (centroide regional). La respuesta pública `eta_minutes: number | null` no cambia de shape.

## Fórmula

```
etaMins = (roadDistKm_routesApi / avgSpeedKmh) × 60
```

vs PR-L2b:
```
etaMins = (haversine(current → centroid) × 1.3 / avgSpeedKmh) × 60
```

Solo cambia el numerador: distancia real (Routes API) vs proxy (haversine × factor). Mantenemos `avgSpeedKmh` del vehículo (medido en telemetría últimos 15min) porque la duración que Routes API computa asume velocidades genéricas que no reflejan el camión cargado actual.

## Caching

- **Key**: `(tripId, currentLat.toFixed(2), currentLng.toFixed(2))`. 0.01° ≈ 1.1km en Chile, así que el vehículo debe moverse ≥1km para invalidar — la distancia al destino cambia <1km entre esos pings.
- **TTL**: 5min como safety net.
- **In-memory Map**: sufficient para single-process Cloud Run. Si escalamos a múltiples instancias, swap a Redis con la misma interface `RouteEtaCacheStore`.

## Fallback transparente

- Sin `GOOGLE_ROUTES_API_KEY` → centroide
- 4xx/5xx/network error de Routes API → centroide
- Empty routes response → centroide
- destAddress vacío → centroide
- Fallback null también → unavailable

Si Routes API es flaky, no rompemos el tracking público.

## Tests (17 nuevos)

- **Fallback paths** (5): sin API key, sin posición, avgSpeed null/cero, destAddress vacío, fallback null → unavailable
- **Happy paths** (6): llamada exitosa con distancia real, cache hit, cache hit usa avgSpeed actual (no del primer fetch), TTL expira → refetch, grid 0.01° within = cached, outside = miss
- **Failure paths** (4): HTTP 500, network error, empty routes, failure no cachea — siguiente call reintenta
- **Edge cases** (2): distancia muy corta → min 1 min, tripId distintos no comparten cache

Suite api total: **600 tests** ✓

## Backward compatibility

`PublicTrackingResponse.eta_minutes` sigue siendo `number | null`. La precisión mejorada es transparente al cliente web/móvil del tracking — sin cambios en `/tracking/\$token` UI.

## Test plan

- [x] Unit tests pass (17/17 nuevos)
- [x] Lint clean (Biome)
- [x] Typecheck clean
- [ ] CI verde
- [ ] Manual staging: con `GOOGLE_ROUTES_API_KEY` configurada (ya está desde Phase 1), abrir un tracking público de un trip activo y verificar que el ETA mostrado refleje road distance (vs centroide). Comparar con `gh pr` anterior.
- [ ] Manual staging: verificar log debug muestra `source: 'routes_api'` en lugar de `'centroide'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)