### PR TITLE
feat(dte-wire): factory + service + wire en liquidar-trip + admin reemit

### DIFF
--- a/apps/api/drizzle/0019_facturas_dte_provider_meta.sql
+++ b/apps/api/drizzle/0019_facturas_dte_provider_meta.sql
@@ -1,0 +1,19 @@
+-- ADR-024 sprint X+1 → wire — DTE provider metadata en facturas_booster_clp.
+--
+-- Agrega 3 columnas para:
+--   - `dte_provider`: tag del adapter que emitió ('sovos'|'mock'|'bsale'|...).
+--     Permite reconciliar histórico cuando rotamos provider.
+--   - `dte_provider_track_id`: id opaco del provider para soporte/auditoría.
+--   - `dte_status`: status SII canónico mapeado (`aceptado|rechazado|reparable|
+--     en_proceso|anulado`). El cron de reconciliación lee este campo.
+--
+-- Index parcial por `dte_status` para el cron de reconciliación que
+-- busca rows con DTE emitido pero status pendiente.
+
+ALTER TABLE facturas_booster_clp ADD COLUMN dte_provider text;
+ALTER TABLE facturas_booster_clp ADD COLUMN dte_provider_track_id text;
+ALTER TABLE facturas_booster_clp ADD COLUMN dte_status text;
+
+CREATE INDEX idx_facturas_dte_status
+  ON facturas_booster_clp (dte_status)
+  WHERE dte_status IS NOT NULL;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1779494400000,
       "tag": "0018_factoring_admin_notas",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1779580800000,
+      "tag": "0019_facturas_dte_provider_meta",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -18,6 +18,7 @@
     "@booster-ai/coaching-generator": "workspace:*",
     "@booster-ai/config": "workspace:*",
     "@booster-ai/driver-scoring": "workspace:*",
+    "@booster-ai/dte-provider": "workspace:*",
     "@booster-ai/factoring-engine": "workspace:*",
     "@booster-ai/logger": "workspace:*",
     "@booster-ai/matching-algorithm": "workspace:*",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -326,6 +326,43 @@ const apiEnvSchema = commonEnvSchema
      * Default vacío para que ningún entorno tenga acceso accidental.
      * Cloud Run prod debe setear esta var explícitamente.
      */
+    /**
+     * ADR-024 — Provider activo para emisión de DTEs (factura comisión
+     * Booster al carrier post-liquidación). Valores válidos:
+     *   - 'disabled' (default): no se emiten DTEs. Las liquidaciones
+     *     quedan `lista_para_dte` indefinidamente. Útil en staging y
+     *     mientras no hay creds.
+     *   - 'mock': MockDteAdapter — folios sintéticos in-memory. Útil
+     *     en dev para validar el flow sin tocar Sovos. Restart del
+     *     server pierde la secuencia (no persistente).
+     *   - 'sovos': SovosDteAdapter contra Paperless Chile. Exige
+     *     SOVOS_API_KEY + SOVOS_BASE_URL.
+     */
+    DTE_PROVIDER: z.enum(['disabled', 'mock', 'sovos']).default('disabled'),
+
+    /**
+     * Sovos credentials (solo se leen cuando `DTE_PROVIDER='sovos'`).
+     * Optional para que dev/staging arranque sin estas. Cuando el
+     * factory las necesita y faltan, se lanza DteNotConfiguredError.
+     */
+    SOVOS_API_KEY: z.string().min(1).optional(),
+    SOVOS_BASE_URL: z.string().url().optional(),
+
+    /**
+     * Datos de Booster Chile SpA como emisor de la factura comisión.
+     * Hardcoded por env para no exponerlos en el repo. Se inyectan al
+     * SovosAdapter en cada emisión.
+     *
+     * BOOSTER_RUT debe ser el RUT real registrado en SII (cuando
+     * Booster Chile SpA esté constituida) — placeholder en config para
+     * dev/staging.
+     */
+    BOOSTER_RUT: z.string().min(1).default('76.000.000-0'),
+    BOOSTER_RAZON_SOCIAL: z.string().min(1).default('Booster Chile SpA'),
+    BOOSTER_GIRO: z.string().min(1).default('Marketplace digital de logística'),
+    BOOSTER_DIRECCION: z.string().min(1).default('Av. Providencia 1000'),
+    BOOSTER_COMUNA: z.string().min(1).default('Providencia'),
+
     BOOSTER_PLATFORM_ADMIN_EMAILS: z
       .string()
       .default('')

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1436,6 +1436,14 @@ export const facturasBoosterClp = pgTable(
     dteFolio: text('dte_folio'),
     dteEmitidaEn: timestamp('dte_emitida_en', { withTimezone: true }),
     dtePdfGcsUri: text('dte_pdf_gcs_uri'),
+    // ADR-024 wire — provider que emitió el DTE ('sovos'|'mock'|'bsale'|...).
+    // Permite reconciliar histórico cuando rotamos provider.
+    dteProvider: text('dte_provider'),
+    // ID opaco del provider (track_id Sovos, etc.) para soporte y auditoría.
+    dteProviderTrackId: text('dte_provider_track_id'),
+    // Status SII canónico: `aceptado|rechazado|reparable|en_proceso|anulado`.
+    // Cron de reconciliación lo lee para queryStatus contra el provider.
+    dteStatus: text('dte_status'),
     status: text('status').notNull(),
     venceEn: timestamp('vence_en', { withTimezone: true }).notNull(),
     pagadaEn: timestamp('pagada_en', { withTimezone: true }),

--- a/apps/api/src/routes/admin-liquidaciones.ts
+++ b/apps/api/src/routes/admin-liquidaciones.ts
@@ -1,0 +1,108 @@
+import type { Logger } from '@booster-ai/logger';
+import type { Context } from 'hono';
+import { Hono } from 'hono';
+import { config as appConfig } from '../config.js';
+import type { Db } from '../db/client.js';
+import { emitirDteLiquidacion } from '../services/emitir-dte-liquidacion.js';
+import type { UserContext } from '../services/user-context.js';
+
+/**
+ * Endpoints admin platform-wide para liquidaciones (ADR-031 + ADR-024).
+ *
+ * Audiencia: operadores de Booster Chile SpA listados en
+ * `BOOSTER_PLATFORM_ADMIN_EMAILS`. NO admins de empresa carrier.
+ *
+ *   POST /admin/liquidaciones/:id/emitir-dte
+ *        → reintenta emisión del DTE Tipo 33 manualmente. Idempotente:
+ *          si la liquidación ya tiene folio, retorna `ya_emitido`.
+ *          Útil tras transient errors o tras configurar Sovos.
+ *
+ * En el futuro: GET /admin/liquidaciones para listar pendientes,
+ * POST /admin/liquidaciones/:id/anular para disputas, etc.
+ */
+export function createAdminLiquidacionesRoutes(opts: { db: Db; logger: Logger }) {
+  const app = new Hono();
+
+  // biome-ignore lint/suspicious/noExplicitAny: hono Context genéricos.
+  function requirePlatformAdmin(c: Context<any, any, any>) {
+    if (!appConfig.PRICING_V2_ACTIVATED) {
+      return {
+        ok: false as const,
+        response: c.json({ error: 'feature_disabled' }, 503),
+      };
+    }
+    const userContext = c.get('userContext') as UserContext | undefined;
+    if (!userContext) {
+      return { ok: false as const, response: c.json({ error: 'unauthorized' }, 401) };
+    }
+    const email = userContext.user.email?.toLowerCase();
+    const allowlist = appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS;
+    if (!email || !allowlist.includes(email)) {
+      return {
+        ok: false as const,
+        response: c.json({ error: 'forbidden_platform_admin' }, 403),
+      };
+    }
+    return { ok: true as const, adminEmail: email };
+  }
+
+  app.post('/:id/emitir-dte', async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const liquidacionId = c.req.param('id');
+
+    const result = await emitirDteLiquidacion({
+      db: opts.db,
+      logger: opts.logger,
+      liquidacionId,
+    });
+
+    opts.logger.info(
+      {
+        liquidacionId,
+        adminEmail: auth.adminEmail,
+        dteStatus: result.status,
+      },
+      'admin: emitirDteLiquidacion manual trigger',
+    );
+
+    // Mapeo del result canónico a HTTP status.
+    switch (result.status) {
+      case 'liquidacion_not_found':
+        return c.json({ error: 'liquidacion_not_found' }, 404);
+      case 'empresa_carrier_not_found':
+        return c.json({ error: 'empresa_carrier_not_found' }, 404);
+      case 'skipped':
+        return c.json({ ok: true, skipped: true, reason: result.reason }, 200);
+      case 'ya_emitido':
+        return c.json({ ok: true, already_emitted: true, folio: result.folio }, 200);
+      case 'validation_error':
+        return c.json({ error: 'validation_error', message: result.message }, 422);
+      case 'transient_error':
+        return c.json({ error: 'transient_error', message: result.message }, 503);
+      case 'provider_rejected':
+        return c.json(
+          {
+            error: 'provider_rejected',
+            provider_code: result.providerCode,
+            message: result.message,
+          },
+          502,
+        );
+      case 'emitido':
+        return c.json(
+          {
+            ok: true,
+            folio: result.folio,
+            factura_id: result.facturaId,
+            provider_track_id: result.providerTrackId,
+          },
+          201,
+        );
+    }
+  });
+
+  return app;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -12,6 +12,7 @@ import { createUserContextMiddleware } from './middleware/user-context.js';
 import { createAdminCobraHoyRoutes } from './routes/admin-cobra-hoy.js';
 import { createAdminDispositivosRoutes } from './routes/admin-dispositivos.js';
 import { createAdminJobsRoutes } from './routes/admin-jobs.js';
+import { createAdminLiquidacionesRoutes } from './routes/admin-liquidaciones.js';
 import { createAssignmentsRoutes } from './routes/assignments.js';
 import { createCertificatesRoutes } from './routes/certificates.js';
 import { createChatRoutes } from './routes/chat.js';
@@ -317,6 +318,13 @@ export function createServer(opts: CreateServerOptions): Hono {
     app.use('/admin/cobra-hoy/*', firebaseAuthMiddleware);
     app.use('/admin/cobra-hoy/*', userContextMiddleware);
     app.route('/admin/cobra-hoy', createAdminCobraHoyRoutes({ db: opts.db, logger }));
+
+    // Admin platform-wide: re-emisión manual de DTEs Tipo 33 (ADR-024 +
+    // ADR-031). Auth via BOOSTER_PLATFORM_ADMIN_EMAILS allowlist en el
+    // handler. Útil tras transient errors o tras configurar Sovos.
+    app.use('/admin/liquidaciones/*', firebaseAuthMiddleware);
+    app.use('/admin/liquidaciones/*', userContextMiddleware);
+    app.route('/admin/liquidaciones', createAdminLiquidacionesRoutes({ db: opts.db, logger }));
 
     // Vehículos de la empresa activa.
     app.use('/vehiculos/*', firebaseAuthMiddleware);

--- a/apps/api/src/services/dte-emitter-factory.ts
+++ b/apps/api/src/services/dte-emitter-factory.ts
@@ -1,0 +1,85 @@
+import {
+  type DteEmitter,
+  DteNotConfiguredError,
+  MockDteAdapter,
+  SovosDteAdapter,
+} from '@booster-ai/dte-provider';
+import type { Logger } from '@booster-ai/logger';
+import { config as appConfig } from '../config.js';
+
+/**
+ * ADR-024 — factory que devuelve el adapter activo según `DTE_PROVIDER`.
+ *
+ * Comportamiento por valor:
+ *   - `'disabled'` → retorna `null`. El caller debe skipear silencioso
+ *     con warn. Las liquidaciones quedan `lista_para_dte` indefinida-
+ *     mente (operable, sin DTE presentado al SII).
+ *   - `'mock'` → MockDteAdapter — in-memory, folios sintéticos. Útil en
+ *     dev y staging. No retiene estado entre restarts.
+ *   - `'sovos'` → SovosDteAdapter contra Paperless Chile. Exige
+ *     SOVOS_API_KEY + SOVOS_BASE_URL — sin éstas, lanza
+ *     `DteNotConfiguredError` (que el caller traduce a skip).
+ *
+ * **Singleton** por process: el factory cachea el adapter creado para
+ * que MockAdapter retenga su secuencia de folios mientras el proceso
+ * Node vive. SovosAdapter también se cachea para reusar el AbortController
+ * pool implícito de Node fetch.
+ */
+
+let cached: { provider: string; emitter: DteEmitter | null } | null = null;
+
+export function getDteEmitter(logger: Logger): DteEmitter | null {
+  if (cached && cached.provider === appConfig.DTE_PROVIDER) {
+    return cached.emitter;
+  }
+  cached = {
+    provider: appConfig.DTE_PROVIDER,
+    emitter: buildEmitter(logger),
+  };
+  return cached.emitter;
+}
+
+/**
+ * Reset del caché — solo para tests. NO usar en producción.
+ */
+export function __resetDteEmitterCache(): void {
+  cached = null;
+}
+
+function buildEmitter(logger: Logger): DteEmitter | null {
+  switch (appConfig.DTE_PROVIDER) {
+    case 'disabled':
+      logger.debug('dte-emitter-factory: DTE_PROVIDER=disabled — no adapter activo');
+      return null;
+    case 'mock':
+      logger.info('dte-emitter-factory: usando MockDteAdapter (dev/staging)');
+      return new MockDteAdapter();
+    case 'sovos':
+      if (!appConfig.SOVOS_API_KEY || !appConfig.SOVOS_BASE_URL) {
+        logger.warn(
+          { hasKey: !!appConfig.SOVOS_API_KEY, hasBaseUrl: !!appConfig.SOVOS_BASE_URL },
+          'dte-emitter-factory: DTE_PROVIDER=sovos pero faltan SOVOS_API_KEY/BASE_URL — adapter no creado',
+        );
+        return null;
+      }
+      try {
+        logger.info(
+          { baseUrl: appConfig.SOVOS_BASE_URL },
+          'dte-emitter-factory: usando SovosDteAdapter',
+        );
+        return new SovosDteAdapter({
+          apiKey: appConfig.SOVOS_API_KEY,
+          baseUrl: appConfig.SOVOS_BASE_URL,
+        });
+      } catch (err) {
+        // DteNotConfiguredError debería propagarse al startup si el
+        // operador tuvo intención de Sovos; lo loggeamos y devolvemos
+        // null para que el service downstream pueda decidir.
+        if (err instanceof DteNotConfiguredError) {
+          logger.error({ err }, 'dte-emitter-factory: SovosDteAdapter rejected config');
+          return null;
+        }
+        throw err;
+      }
+  }
+}

--- a/apps/api/src/services/emitir-dte-liquidacion.ts
+++ b/apps/api/src/services/emitir-dte-liquidacion.ts
@@ -1,0 +1,300 @@
+import {
+  type DteEmitter,
+  DteNotConfiguredError,
+  DteProviderRejectedError,
+  DteTransientError,
+  DteValidationError,
+  type FacturaInput,
+} from '@booster-ai/dte-provider';
+import type { Logger } from '@booster-ai/logger';
+import { and, eq, sql } from 'drizzle-orm';
+import { config as appConfig } from '../config.js';
+import type { Db } from '../db/client.js';
+import { empresas, facturasBoosterClp, liquidaciones } from '../db/schema.js';
+import { getDteEmitter } from './dte-emitter-factory.js';
+
+/**
+ * ADR-024 + ADR-031 §4.1 — emite el DTE Tipo 33 (factura comisión
+ * Booster al carrier) asociado a una liquidación.
+ *
+ * Flow:
+ *   1. Lookup liquidación + empresa carrier (receptor).
+ *   2. Skip silencioso si:
+ *      - flag PRICING_V2_ACTIVATED off → no emite.
+ *      - liquidación ya tiene DTE folio asignado → idempotente, return ok.
+ *      - liquidación status != `lista_para_dte` → no aplica.
+ *      - adapter es null (DTE_PROVIDER=disabled o sin creds Sovos).
+ *   3. INSERT row en `facturas_booster_clp` con tipo='comision_trip'
+ *      y dte_folio=NULL (placeholder previo al call al provider).
+ *      Race-safety: si ya existe row por la misma liquidacion_id +
+ *      tipo='comision_trip', se reusa (idempotente).
+ *   4. Llama `adapter.emitFactura()` con el payload canónico.
+ *   5. UPDATE factura con dte_folio + dte_emitida_en + pdf_url +
+ *      provider + status='aceptado' (Sovos no devuelve status SII
+ *      en emit; queryStatus reconcilia después).
+ *   6. UPDATE liquidación con dte_factura_booster_folio +
+ *      dte_factura_booster_emitido_en + status='dte_emitido'.
+ *
+ * **Idempotente**: re-correr post-éxito no re-emite (los UPDATEs son
+ * no-op porque la liquidación ya tiene folio).
+ *
+ * **Fire-and-forget compatible**: errores transient se loggean WARN y
+ * retornan `{ status: 'transient_error' }` — el caller (liquidar-trip)
+ * no propaga, espera el cron de reemisión.
+ */
+
+export interface EmitirDteLiquidacionInput {
+  db: Db;
+  logger: Logger;
+  liquidacionId: string;
+}
+
+export type EmitirDteLiquidacionResult =
+  | { status: 'skipped'; reason: 'flag_disabled' | 'no_adapter' | 'liquidacion_no_aplicable' }
+  | { status: 'ya_emitido'; folio: string }
+  | { status: 'liquidacion_not_found' }
+  | { status: 'empresa_carrier_not_found' }
+  | { status: 'validation_error'; message: string }
+  | { status: 'transient_error'; message: string }
+  | { status: 'provider_rejected'; providerCode: string; message: string }
+  | {
+      status: 'emitido';
+      folio: string;
+      facturaId: string;
+      providerTrackId: string | undefined;
+    };
+
+export async function emitirDteLiquidacion(
+  input: EmitirDteLiquidacionInput,
+): Promise<EmitirDteLiquidacionResult> {
+  const { db, logger, liquidacionId } = input;
+
+  if (!appConfig.PRICING_V2_ACTIVATED) {
+    logger.debug({ liquidacionId }, 'emitirDteLiquidacion: PRICING_V2_ACTIVATED=false, skip');
+    return { status: 'skipped', reason: 'flag_disabled' };
+  }
+
+  const adapter = getDteEmitter(logger);
+  if (!adapter) {
+    logger.debug({ liquidacionId }, 'emitirDteLiquidacion: no hay adapter activo, skip');
+    return { status: 'skipped', reason: 'no_adapter' };
+  }
+
+  // (1) Lookup liquidación + carrier.
+  const liqRows = await db
+    .select({
+      id: liquidaciones.id,
+      asignacionId: liquidaciones.asignacionId,
+      empresaCarrierId: liquidaciones.empresaCarrierId,
+      comisionClp: liquidaciones.comisionClp,
+      ivaComisionClp: liquidaciones.ivaComisionClp,
+      totalFacturaBoosterClp: liquidaciones.totalFacturaBoosterClp,
+      status: liquidaciones.status,
+      dteFacturaBoosterFolio: liquidaciones.dteFacturaBoosterFolio,
+      pricingMethodologyVersion: liquidaciones.pricingMethodologyVersion,
+    })
+    .from(liquidaciones)
+    .where(eq(liquidaciones.id, liquidacionId))
+    .limit(1);
+  const liq = liqRows[0];
+  if (!liq) {
+    return { status: 'liquidacion_not_found' };
+  }
+
+  if (liq.dteFacturaBoosterFolio) {
+    logger.info(
+      { liquidacionId, folio: liq.dteFacturaBoosterFolio },
+      'emitirDteLiquidacion: liquidación ya tiene DTE, idempotente',
+    );
+    return { status: 'ya_emitido', folio: liq.dteFacturaBoosterFolio };
+  }
+
+  if (liq.status !== 'lista_para_dte') {
+    logger.debug(
+      { liquidacionId, currentStatus: liq.status },
+      'emitirDteLiquidacion: liquidación no está lista_para_dte, skip',
+    );
+    return { status: 'skipped', reason: 'liquidacion_no_aplicable' };
+  }
+
+  const carrierRows = await db
+    .select({
+      id: empresas.id,
+      legalName: empresas.legalName,
+      rut: empresas.rut,
+      addressStreet: empresas.addressStreet,
+      addressCity: empresas.addressCity,
+    })
+    .from(empresas)
+    .where(eq(empresas.id, liq.empresaCarrierId))
+    .limit(1);
+  const carrier = carrierRows[0];
+  if (!carrier) {
+    return { status: 'empresa_carrier_not_found' };
+  }
+
+  // (2) INSERT factura placeholder (o reusar si existe).
+  // rls-allowlist: factura platform-wide — protegido por flag.
+  const facturaExistingRows = await db
+    .select({
+      id: facturasBoosterClp.id,
+      dteFolio: facturasBoosterClp.dteFolio,
+    })
+    .from(facturasBoosterClp)
+    .where(
+      and(
+        eq(facturasBoosterClp.liquidacionId, liquidacionId),
+        eq(facturasBoosterClp.tipo, 'comision_trip'),
+      ),
+    )
+    .limit(1);
+  let facturaId: string;
+  if (facturaExistingRows[0]) {
+    facturaId = facturaExistingRows[0].id;
+    if (facturaExistingRows[0].dteFolio) {
+      // Race: alguien más emitió. Reconciliar liquidación y retornar.
+      await syncLiquidacionFolio(db, liquidacionId, facturaExistingRows[0].dteFolio);
+      return { status: 'ya_emitido', folio: facturaExistingRows[0].dteFolio };
+    }
+  } else {
+    const ventInDays = 30;
+    const venceEn = new Date(Date.now() + ventInDays * 24 * 60 * 60 * 1000);
+    // rls-allowlist: factura platform-wide — protegido por flag.
+    const inserted = await db
+      .insert(facturasBoosterClp)
+      .values({
+        empresaDestinoId: carrier.id,
+        tipo: 'comision_trip',
+        liquidacionId: liquidacionId,
+        subtotalClp: liq.comisionClp,
+        ivaClp: liq.ivaComisionClp,
+        totalClp: liq.totalFacturaBoosterClp,
+        dteTipo: 33,
+        status: 'pending_dte',
+        venceEn,
+      })
+      .returning({ id: facturasBoosterClp.id });
+    const created = inserted[0];
+    if (!created) {
+      throw new Error('emitirDteLiquidacion: INSERT factura no devolvió id');
+    }
+    facturaId = created.id;
+  }
+
+  // (3) Build payload + llamar adapter.
+  const fechaHoy = new Date().toISOString().slice(0, 10);
+  const facturaInput: FacturaInput = {
+    emisor: {
+      rut: appConfig.BOOSTER_RUT,
+      razonSocial: appConfig.BOOSTER_RAZON_SOCIAL,
+      giro: appConfig.BOOSTER_GIRO,
+      direccion: appConfig.BOOSTER_DIRECCION,
+      comuna: appConfig.BOOSTER_COMUNA,
+    },
+    receptor: {
+      rut: carrier.rut,
+      razonSocial: carrier.legalName,
+      ...(carrier.addressStreet ? { direccion: carrier.addressStreet } : {}),
+      ...(carrier.addressCity ? { comuna: carrier.addressCity } : {}),
+    },
+    fechaEmision: fechaHoy,
+    items: [
+      {
+        descripcion: `Comisión Booster sobre asignación ${liq.asignacionId} (${liq.pricingMethodologyVersion})`,
+        montoNetoClp: liq.comisionClp,
+        exento: false,
+      },
+    ],
+  };
+
+  let dteResult: Awaited<ReturnType<DteEmitter['emitFactura']>>;
+  try {
+    dteResult = await adapter.emitFactura(facturaInput);
+  } catch (err) {
+    return handleProviderError(err, logger, { liquidacionId, facturaId });
+  }
+
+  // (4) UPDATE factura con folio + meta.
+  // rls-allowlist: factura platform-wide — protegido por flag.
+  await db
+    .update(facturasBoosterClp)
+    .set({
+      dteFolio: dteResult.folio,
+      dteEmitidaEn: new Date(dteResult.emitidoEn),
+      ...(dteResult.pdfUrl ? { dtePdfGcsUri: dteResult.pdfUrl } : {}),
+      dteProvider: appConfig.DTE_PROVIDER,
+      ...(dteResult.providerTrackId ? { dteProviderTrackId: dteResult.providerTrackId } : {}),
+      // Sovos no devuelve status SII en emit — el cron de reconciliación
+      // hace queryStatus después. Default initial: 'en_proceso'.
+      dteStatus: 'en_proceso',
+      status: 'dte_emitido',
+      updatedAt: sql`now()`,
+    })
+    .where(eq(facturasBoosterClp.id, facturaId));
+
+  // (5) UPDATE liquidación.
+  await syncLiquidacionFolio(db, liquidacionId, dteResult.folio);
+
+  logger.info(
+    {
+      liquidacionId,
+      facturaId,
+      folio: dteResult.folio,
+      provider: appConfig.DTE_PROVIDER,
+      montoTotal: dteResult.montoTotalClp,
+    },
+    'emitirDteLiquidacion: DTE emitido',
+  );
+
+  return {
+    status: 'emitido',
+    folio: dteResult.folio,
+    facturaId,
+    providerTrackId: dteResult.providerTrackId,
+  };
+}
+
+async function syncLiquidacionFolio(db: Db, liquidacionId: string, folio: string): Promise<void> {
+  await db
+    .update(liquidaciones)
+    .set({
+      dteFacturaBoosterFolio: folio,
+      dteFacturaBoosterEmitidoEn: new Date(),
+      status: 'dte_emitido',
+      updatedAt: sql`now()`,
+    })
+    .where(eq(liquidaciones.id, liquidacionId));
+}
+
+function handleProviderError(
+  err: unknown,
+  logger: Logger,
+  ctx: { liquidacionId: string; facturaId: string },
+): EmitirDteLiquidacionResult {
+  if (err instanceof DteNotConfiguredError) {
+    logger.warn({ err, ...ctx }, 'emitirDteLiquidacion: adapter not configured at call time');
+    return { status: 'skipped', reason: 'no_adapter' };
+  }
+  if (err instanceof DteValidationError) {
+    logger.error({ err, ...ctx }, 'emitirDteLiquidacion: payload validation falló');
+    return { status: 'validation_error', message: err.message };
+  }
+  if (err instanceof DteTransientError) {
+    logger.warn({ err, ...ctx }, 'emitirDteLiquidacion: transient — re-emisión vía cron');
+    return { status: 'transient_error', message: err.message };
+  }
+  if (err instanceof DteProviderRejectedError) {
+    logger.error(
+      { err, providerCode: err.providerCode, ...ctx },
+      'emitirDteLiquidacion: provider rechazó — escalar a admin',
+    );
+    return {
+      status: 'provider_rejected',
+      providerCode: err.providerCode,
+      message: err.message,
+    };
+  }
+  // Unknown error — propagamos para que el orchestrator lo logueé como
+  // unhandled. Acá NO clasificamos como transient porque puede ser bug.
+  throw err;
+}

--- a/apps/api/src/services/liquidar-trip.ts
+++ b/apps/api/src/services/liquidar-trip.ts
@@ -7,6 +7,7 @@ import {
 import { and, eq } from 'drizzle-orm';
 import type { Db } from '../db/client.js';
 import { assignments, carrierMemberships, liquidaciones, membershipTiers } from '../db/schema.js';
+import { emitirDteLiquidacion } from './emitir-dte-liquidacion.js';
 
 /**
  * Service orquestador de liquidación del trip (ADR-030 §8).
@@ -183,6 +184,26 @@ export async function liquidarTrip(input: LiquidarTripInput): Promise<LiquidarTr
       },
       'liquidarTrip: liquidación creada',
     );
+
+    // ADR-024 wire — emisión fire-and-forget del DTE Tipo 33. Solo
+    // si la liquidación está `lista_para_dte` (con consent v2 firmado).
+    // Si el provider no está configurado, el service skipea con warn
+    // y la liquidación queda en `lista_para_dte` para el cron de
+    // reemisión futuro. NUNCA bloquea el cierre del trip.
+    if (status === 'lista_para_dte') {
+      try {
+        const dteResult = await emitirDteLiquidacion({ db, logger, liquidacionId });
+        logger.info(
+          { liquidacionId, dteStatus: dteResult.status },
+          'liquidarTrip: emitirDteLiquidacion completado',
+        );
+      } catch (err) {
+        logger.error(
+          { err, liquidacionId },
+          'liquidarTrip: emitirDteLiquidacion threw — liquidación queda lista_para_dte',
+        );
+      }
+    }
 
     return status === 'pending_consent'
       ? { status: 'pending_consent', liquidacionId }

--- a/apps/api/test/unit/admin-liquidaciones.test.ts
+++ b/apps/api/test/unit/admin-liquidaciones.test.ts
@@ -1,0 +1,182 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config as appConfig } from '../../src/config.js';
+import { createAdminLiquidacionesRoutes } from '../../src/routes/admin-liquidaciones.js';
+import type { UserContext } from '../../src/services/user-context.js';
+
+vi.mock('../../src/services/emitir-dte-liquidacion.js', () => ({
+  emitirDteLiquidacion: vi.fn(),
+}));
+
+const { emitirDteLiquidacion } = await import('../../src/services/emitir-dte-liquidacion.js');
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+const ADMIN_EMAIL = 'dev@boosterchile.com';
+
+function makeUserCtx(email: string): UserContext {
+  return {
+    user: { id: 'u1', firebaseUid: 'fb1', fullName: 'F', email },
+    activeMembership: {
+      id: 'm1',
+      role: 'dueno',
+      status: 'activa',
+      empresa: {
+        id: 'e1',
+        legalName: 'E',
+        rut: '76',
+        isGeneradorCarga: false,
+        isTransportista: true,
+        status: 'activa',
+      },
+    },
+    memberships: [],
+  } as unknown as UserContext;
+}
+
+function buildApp(opts: { withContext: boolean; email?: string }) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (opts.withContext) {
+      c.set('userContext', makeUserCtx(opts.email ?? ADMIN_EMAIL));
+    }
+    await next();
+  });
+  app.route(
+    '/admin/liquidaciones',
+    createAdminLiquidacionesRoutes({ db: {} as never, logger: noopLogger }),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appConfig.PRICING_V2_ACTIVATED = true;
+  appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS = [ADMIN_EMAIL];
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /admin/liquidaciones/:id/emitir-dte — gating', () => {
+  it('flag PRICING_V2 off → 503', async () => {
+    appConfig.PRICING_V2_ACTIVATED = false;
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(503);
+  });
+
+  it('sin userContext → 401', async () => {
+    const app = buildApp({ withContext: false });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(401);
+  });
+
+  it('email no en allowlist → 403', async () => {
+    const app = buildApp({ withContext: true, email: 'rando@example.com' });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /admin/liquidaciones/:id/emitir-dte — service mapping', () => {
+  it('liquidacion_not_found → 404', async () => {
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'liquidacion_not_found',
+    });
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(404);
+  });
+
+  it('empresa_carrier_not_found → 404', async () => {
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'empresa_carrier_not_found',
+    });
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(404);
+  });
+
+  it('skipped → 200 con reason', async () => {
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'skipped',
+      reason: 'no_adapter',
+    });
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, skipped: true, reason: 'no_adapter' });
+  });
+
+  it('ya_emitido → 200 con folio + already_emitted', async () => {
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'ya_emitido',
+      folio: 'folio-99',
+    });
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, already_emitted: true, folio: 'folio-99' });
+  });
+
+  it('validation_error → 422', async () => {
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'validation_error',
+      message: 'RUT inválido',
+    });
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(422);
+  });
+
+  it('transient_error → 503 (caller debe reintentar)', async () => {
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'transient_error',
+      message: 'timeout',
+    });
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(503);
+  });
+
+  it('provider_rejected → 502', async () => {
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'provider_rejected',
+      providerCode: '400',
+      message: 'cert expirado',
+    });
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { provider_code: string };
+    expect(body.provider_code).toBe('400');
+  });
+
+  it('emitido → 201 con folio + factura_id', async () => {
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'emitido',
+      folio: 'folio-new-1234',
+      facturaId: 'factura-1',
+      providerTrackId: 'track-abc',
+    });
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/admin/liquidaciones/liq-1/emitir-dte', { method: 'POST' });
+    expect(res.status).toBe(201);
+    expect(await res.json()).toEqual({
+      ok: true,
+      folio: 'folio-new-1234',
+      factura_id: 'factura-1',
+      provider_track_id: 'track-abc',
+    });
+  });
+});

--- a/apps/api/test/unit/dte-emitter-factory.test.ts
+++ b/apps/api/test/unit/dte-emitter-factory.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config as appConfig } from '../../src/config.js';
+import { __resetDteEmitterCache, getDteEmitter } from '../../src/services/dte-emitter-factory.js';
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetDteEmitterCache();
+});
+afterEach(() => {
+  __resetDteEmitterCache();
+});
+
+describe('getDteEmitter', () => {
+  it('DTE_PROVIDER=disabled → null', () => {
+    appConfig.DTE_PROVIDER = 'disabled';
+    expect(getDteEmitter(noopLogger)).toBeNull();
+  });
+
+  it('DTE_PROVIDER=mock → MockDteAdapter instance (no exige creds)', () => {
+    appConfig.DTE_PROVIDER = 'mock';
+    const emitter = getDteEmitter(noopLogger);
+    expect(emitter).not.toBeNull();
+    // Smoke test del contrato.
+    expect(typeof emitter?.emitFactura).toBe('function');
+    expect(typeof emitter?.emitGuiaDespacho).toBe('function');
+    expect(typeof emitter?.queryStatus).toBe('function');
+    expect(typeof emitter?.voidDocument).toBe('function');
+  });
+
+  it('DTE_PROVIDER=sovos sin creds → null + warn', () => {
+    appConfig.DTE_PROVIDER = 'sovos';
+    appConfig.SOVOS_API_KEY = undefined;
+    appConfig.SOVOS_BASE_URL = undefined;
+    const emitter = getDteEmitter(noopLogger);
+    expect(emitter).toBeNull();
+    expect(noopLogger.warn).toHaveBeenCalled();
+  });
+
+  it('DTE_PROVIDER=sovos con creds → SovosDteAdapter instance', () => {
+    appConfig.DTE_PROVIDER = 'sovos';
+    appConfig.SOVOS_API_KEY = 'test-key';
+    appConfig.SOVOS_BASE_URL = 'https://api.sovos.cl/v1';
+    const emitter = getDteEmitter(noopLogger);
+    expect(emitter).not.toBeNull();
+    expect(typeof emitter?.emitFactura).toBe('function');
+  });
+
+  it('caché: segundo getDteEmitter con misma config retorna mismo instance', () => {
+    appConfig.DTE_PROVIDER = 'mock';
+    const e1 = getDteEmitter(noopLogger);
+    const e2 = getDteEmitter(noopLogger);
+    expect(e1).toBe(e2);
+  });
+
+  it('caché: cambio de provider invalida y crea nuevo instance', () => {
+    appConfig.DTE_PROVIDER = 'mock';
+    const e1 = getDteEmitter(noopLogger);
+    appConfig.DTE_PROVIDER = 'disabled';
+    const e2 = getDteEmitter(noopLogger);
+    expect(e1).not.toBe(e2);
+    expect(e2).toBeNull();
+  });
+
+  it('__resetDteEmitterCache fuerza nueva creación', () => {
+    appConfig.DTE_PROVIDER = 'mock';
+    const e1 = getDteEmitter(noopLogger);
+    __resetDteEmitterCache();
+    const e2 = getDteEmitter(noopLogger);
+    expect(e1).not.toBe(e2);
+    expect(e2).not.toBeNull();
+  });
+});

--- a/apps/api/test/unit/emitir-dte-liquidacion.test.ts
+++ b/apps/api/test/unit/emitir-dte-liquidacion.test.ts
@@ -1,0 +1,329 @@
+import {
+  DteNotConfiguredError,
+  DteProviderRejectedError,
+  DteTransientError,
+  DteValidationError,
+} from '@booster-ai/dte-provider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config as appConfig } from '../../src/config.js';
+
+vi.mock('../../src/services/dte-emitter-factory.js', () => ({
+  getDteEmitter: vi.fn(),
+  __resetDteEmitterCache: vi.fn(),
+}));
+
+const { getDteEmitter } = await import('../../src/services/dte-emitter-factory.js');
+const { emitirDteLiquidacion } = await import('../../src/services/emitir-dte-liquidacion.js');
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+interface DbQueues {
+  /** Lista de arrays que cada `.limit(1)` consume secuencialmente. */
+  selects?: unknown[][];
+  /** Para `INSERT ... RETURNING`. */
+  inserts?: unknown[][];
+}
+
+function makeDb(opts: DbQueues = {}) {
+  const selects = [...(opts.selects ?? [])];
+  const inserts = [...(opts.inserts ?? [])];
+
+  const buildSelectChain = () => {
+    const chain: Record<string, unknown> = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      limit: vi.fn(async () => selects.shift() ?? []),
+    };
+    return chain;
+  };
+
+  const buildInsertChain = () => ({
+    values: vi.fn(() => ({
+      returning: vi.fn(async () => inserts.shift() ?? []),
+    })),
+  });
+
+  const updateSetMock = vi.fn(() => ({
+    where: vi.fn(async () => []),
+  }));
+  const buildUpdateChain = () => ({
+    set: updateSetMock,
+  });
+
+  return {
+    db: {
+      select: vi.fn(() => buildSelectChain()),
+      insert: vi.fn(() => buildInsertChain()),
+      update: vi.fn(() => buildUpdateChain()),
+    },
+    updateSetMock,
+  };
+}
+
+const LIQ_ID = '11111111-1111-1111-1111-111111111111';
+const CARRIER_ID = '22222222-2222-2222-2222-222222222222';
+
+const LIQ_LISTA = {
+  id: LIQ_ID,
+  asignacionId: 'asg-1',
+  empresaCarrierId: CARRIER_ID,
+  comisionClp: 24000,
+  ivaComisionClp: 4560,
+  totalFacturaBoosterClp: 28560,
+  status: 'lista_para_dte',
+  dteFacturaBoosterFolio: null,
+  pricingMethodologyVersion: 'pricing-v2.0-cl-2026.06',
+};
+
+const CARRIER = {
+  id: CARRIER_ID,
+  legalName: 'Transportes Test SpA',
+  rut: '76.123.456-7',
+  addressStreet: 'Camino X 123',
+  addressCity: 'Quilicura',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appConfig.PRICING_V2_ACTIVATED = true;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('emitirDteLiquidacion — short-circuits', () => {
+  it('flag off → skipped:flag_disabled, no DB queries', async () => {
+    appConfig.PRICING_V2_ACTIVATED = false;
+    const { db } = makeDb();
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result).toEqual({ status: 'skipped', reason: 'flag_disabled' });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('adapter null → skipped:no_adapter', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
+    const { db } = makeDb();
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result).toEqual({ status: 'skipped', reason: 'no_adapter' });
+  });
+
+  it('liquidación inexistente → liquidacion_not_found', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      emitFactura: vi.fn(),
+    });
+    const { db } = makeDb({ selects: [[]] });
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result).toEqual({ status: 'liquidacion_not_found' });
+  });
+
+  it('liquidación ya tiene folio → ya_emitido (idempotente)', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      emitFactura: vi.fn(),
+    });
+    const { db } = makeDb({
+      selects: [[{ ...LIQ_LISTA, dteFacturaBoosterFolio: 'folio-99' }]],
+    });
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result).toEqual({ status: 'ya_emitido', folio: 'folio-99' });
+  });
+
+  it('liquidación en status pending_consent → skipped:no_aplicable', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      emitFactura: vi.fn(),
+    });
+    const { db } = makeDb({
+      selects: [[{ ...LIQ_LISTA, status: 'pending_consent' }]],
+    });
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result).toEqual({ status: 'skipped', reason: 'liquidacion_no_aplicable' });
+  });
+
+  it('empresa carrier no existe → empresa_carrier_not_found', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      emitFactura: vi.fn(),
+    });
+    const { db } = makeDb({
+      selects: [[LIQ_LISTA], []], // liq OK, carrier vacío
+    });
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result).toEqual({ status: 'empresa_carrier_not_found' });
+  });
+});
+
+describe('emitirDteLiquidacion — happy path', () => {
+  it('emite, persiste factura + liquidación con folio', async () => {
+    const emitFactura = vi.fn().mockResolvedValue({
+      folio: '1234',
+      tipo: 33,
+      rutEmisor: '76.000.000-0',
+      emitidoEn: '2026-05-10T12:00:00Z',
+      montoTotalClp: 28560,
+      pdfUrl: 'https://mock.dte/1234.pdf',
+      providerTrackId: 'track-abc',
+    });
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ emitFactura });
+    const { db } = makeDb({
+      selects: [
+        [LIQ_LISTA], // liquidación
+        [CARRIER], // carrier
+        [], // factura existing vacío
+      ],
+      inserts: [[{ id: 'factura-new-id' }]],
+    });
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result.status).toBe('emitido');
+    if (result.status === 'emitido') {
+      expect(result.folio).toBe('1234');
+      expect(result.facturaId).toBe('factura-new-id');
+      expect(result.providerTrackId).toBe('track-abc');
+    }
+    expect(emitFactura).toHaveBeenCalledTimes(1);
+    // Payload contenía datos del emisor desde config.
+    const arg = emitFactura.mock.calls[0]?.[0];
+    expect(arg.emisor.razonSocial).toBe(appConfig.BOOSTER_RAZON_SOCIAL);
+    expect(arg.receptor.rut).toBe(CARRIER.rut);
+    expect(arg.items[0]?.montoNetoClp).toBe(24000);
+  });
+
+  it('reusa factura placeholder existing si ya hay row sin folio', async () => {
+    const emitFactura = vi.fn().mockResolvedValue({
+      folio: '5678',
+      tipo: 33,
+      rutEmisor: '76.000.000-0',
+      emitidoEn: '2026-05-10T12:00:00Z',
+      montoTotalClp: 28560,
+    });
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ emitFactura });
+    const { db } = makeDb({
+      selects: [[LIQ_LISTA], [CARRIER], [{ id: 'factura-existing-id', dteFolio: null }]],
+    });
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result.status).toBe('emitido');
+    if (result.status === 'emitido') {
+      expect(result.facturaId).toBe('factura-existing-id');
+    }
+    // No INSERT — reusamos.
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it('race: factura existing ya tiene folio → ya_emitido sin re-llamar provider', async () => {
+    const emitFactura = vi.fn();
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ emitFactura });
+    const { db } = makeDb({
+      selects: [[LIQ_LISTA], [CARRIER], [{ id: 'factura-existing-id', dteFolio: 'folio-race-99' }]],
+    });
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result).toEqual({ status: 'ya_emitido', folio: 'folio-race-99' });
+    expect(emitFactura).not.toHaveBeenCalled();
+  });
+});
+
+describe('emitirDteLiquidacion — provider errors', () => {
+  function setupForProviderError(error: unknown) {
+    const emitFactura = vi.fn().mockRejectedValue(error);
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ emitFactura });
+    return makeDb({
+      selects: [[LIQ_LISTA], [CARRIER], []],
+      inserts: [[{ id: 'factura-new-id' }]],
+    });
+  }
+
+  it('DteNotConfiguredError → skipped:no_adapter', async () => {
+    const { db } = setupForProviderError(new DteNotConfiguredError('no creds'));
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result).toEqual({ status: 'skipped', reason: 'no_adapter' });
+  });
+
+  it('DteValidationError → validation_error', async () => {
+    const { db } = setupForProviderError(new DteValidationError('RUT inválido'));
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result.status).toBe('validation_error');
+  });
+
+  it('DteTransientError → transient_error (caller debe reintentar)', async () => {
+    const { db } = setupForProviderError(new DteTransientError('timeout'));
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result.status).toBe('transient_error');
+  });
+
+  it('DteProviderRejectedError → provider_rejected con código', async () => {
+    const { db } = setupForProviderError(new DteProviderRejectedError('cert expirado', '400'));
+    const result = await emitirDteLiquidacion({
+      db: db as never,
+      logger: noopLogger,
+      liquidacionId: LIQ_ID,
+    });
+    expect(result.status).toBe('provider_rejected');
+    if (result.status === 'provider_rejected') {
+      expect(result.providerCode).toBe('400');
+    }
+  });
+
+  it('Error desconocido → propaga (no clasifica como transient)', async () => {
+    const { db } = setupForProviderError(new Error('bug'));
+    await expect(
+      emitirDteLiquidacion({
+        db: db as never,
+        logger: noopLogger,
+        liquidacionId: LIQ_ID,
+      }),
+    ).rejects.toThrow('bug');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       '@booster-ai/driver-scoring':
         specifier: workspace:*
         version: link:../../packages/driver-scoring
+      '@booster-ai/dte-provider':
+        specifier: workspace:*
+        version: link:../../packages/dte-provider
       '@booster-ai/factoring-engine':
         specifier: workspace:*
         version: link:../../packages/factoring-engine


### PR DESCRIPTION
## Summary

Conecta el package \`@booster-ai/dte-provider\` (PR #145) **end-to-end con el flow de liquidación** de pricing v2. Backwards-compatible: default \`DTE_PROVIDER=disabled\`, las liquidaciones existentes quedan en \`lista_para_dte\` hasta que se active el adapter.

Activación operacional:
1. Setear \`DTE_PROVIDER=mock\` en staging → MockAdapter emite folios sintéticos, valida wire end-to-end.
2. Setear \`DTE_PROVIDER=sovos\` + \`SOVOS_API_KEY\` + \`SOVOS_BASE_URL\` en prod cuando Sovos UAT sea aceptada.

## Componentes

### Schema
- Migration **0019**: agrega \`dte_provider\`, \`dte_provider_track_id\`, \`dte_status\` a \`facturas_booster_clp\` + index parcial por status (cron de reconciliación lo lee).
- Drizzle schema espejado.

### Config
- \`DTE_PROVIDER\`: enum \`'disabled' | 'mock' | 'sovos'\` (default \`disabled\`).
- \`SOVOS_API_KEY\`, \`SOVOS_BASE_URL\`: optional, requeridos cuando provider=sovos.
- \`BOOSTER_RUT\`, \`BOOSTER_RAZON_SOCIAL\`, \`BOOSTER_GIRO\`, \`BOOSTER_DIRECCION\`, \`BOOSTER_COMUNA\`: datos del emisor (Booster Chile SpA) — defaults seguros para dev.

### Factory
- \`services/dte-emitter-factory.ts\`: singleton del adapter activo, caché invalidado por cambio de \`DTE_PROVIDER\`. Hook \`__resetDteEmitterCache()\` para tests.

### Service orchestrator
- \`services/emitir-dte-liquidacion.ts\`: 9 branches de result.
- Lookup liquidación + carrier → build \`FacturaInput\` canónico → adapter → persiste folio en \`facturas_booster_clp\` + sincroniza \`liquidaciones.status='dte_emitido'\`.
- **Idempotente**: race-safety check sobre factura existing con folio.
- **Fire-and-forget compatible**: errores transient son \`{ status: 'transient_error' }\`, no throw.

### Wire en liquidar-trip
- Post-INSERT cuando \`status='lista_para_dte'\` → llama \`emitirDteLiquidacion\` con try/catch — errores se loggean pero NUNCA bloquean el cierre del trip.

### Endpoint admin
- \`POST /admin/liquidaciones/:id/emitir-dte\` con allowlist \`BOOSTER_PLATFORM_ADMIN_EMAILS\`. Útil para reemisión manual tras transient errors o tras configurar Sovos. Result mapping completo: 200/201/404/422/502/503.

## Mapeo HTTP del admin endpoint

| Service result | HTTP |
|---|---|
| \`liquidacion_not_found\` / \`empresa_carrier_not_found\` | 404 |
| \`skipped\` (flag, no_adapter, no_aplicable) | 200 |
| \`ya_emitido\` | 200 |
| \`validation_error\` | 422 |
| \`transient_error\` | 503 |
| \`provider_rejected\` | 502 |
| \`emitido\` (nuevo) | 201 |

## Evidencia

\`\`\`
API: 655 tests pass (+32 nuevos)
  - dte-emitter-factory.test.ts (7): provider switching, caché
  - emitir-dte-liquidacion.test.ts (14): all 9 result branches
  - admin-liquidaciones.test.ts (11): gating + result→HTTP mapping
lint: 0 errors
typecheck: clean
liquidar-trip existing tests siguen verde (wire es fire-and-forget)
\`\`\`

## Test plan

- [ ] Migration 0019 aplica sin error en staging.
- [ ] Setear \`DTE_PROVIDER=mock\` en staging → cerrar trip con consent firmado → liquidación pasa a \`dte_emitido\` con folio sintético \"1\", \"2\", ...
- [ ] Probar admin reemit: \`POST /admin/liquidaciones/:id/emitir-dte\` con email en allowlist → 201 ó 200 idempotente.
- [ ] Cuando Sovos UAT lista: setear \`DTE_PROVIDER=sovos\` + creds → smoke test sintético contra UAT.

## Próximos sub-pasos de ADR-024

- ⏳ Sprint X+2: Felipe contacta Sovos, obtiene sandbox UAT, valida shape exacto del payload (este PR usa best-effort).
- ⏳ Carrier credential workflow (.pfx en Secret Manager por carrier).
- ⏳ Cron de reconciliación que reemita transient errors + queryStatus periódico para actualizar \`dte_status\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)