### PR TITLE
feat(assignments): driver ve la ruta eco-eficiente durante el viaje (Phase 1 PR-H5)

### DIFF
--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -33,12 +33,20 @@ import {
 } from '../db/schema.js';
 import { confirmarEntregaViaje } from '../services/confirmar-entrega-viaje.js';
 import type { EmitirCertificadoConfig } from '../services/emitir-certificado-viaje.js';
+import { getAssignmentEcoRoute } from '../services/get-assignment-eco-route.js';
 import { INCIDENT_TYPES, reportarIncidente } from '../services/reportar-incidente.js';
 
 export function createAssignmentsRoutes(opts: {
   db: Db;
   logger: Logger;
   certConfig?: Partial<EmitirCertificadoConfig>;
+  /**
+   * Phase 1 PR-H5 — Routes API key opcional. Si está presente, el
+   * endpoint /assignments/:id/eco-route fetches polyline desde Routes
+   * API; si no, devuelve { polyline_encoded: null, status: 'no_routes_api_key' }
+   * sin error (la página del driver sigue funcional sin mapa).
+   */
+  routesApiKey?: string | undefined;
 }) {
   const app = new Hono();
 
@@ -222,6 +230,49 @@ export function createAssignmentsRoutes(opts: {
         driver_name: row.driverName,
         ubicacion_actual: ubicacionActual,
       },
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // GET /:id/eco-route — polyline de la ruta sugerida por Routes API
+  // para que el driver la visualice durante el viaje (Phase 1 PR-H5).
+  //
+  // Cierra el loop carrier→driver: el carrier ya veía la ruta antes de
+  // aceptar (EcoRouteMapPreview del eco-preview, PR-H4). Post-accept,
+  // el driver entra a /app/asignaciones/:id y también debe poder ver
+  // esa misma ruta para navegarla con consciencia de huella de carbono.
+  //
+  // Auth: carrier owner del assignment. Devuelve 404 si no existe, 403
+  // si pertenece a otra empresa. Si Routes API no está configurado o
+  // falla, devuelve 200 con `polyline_encoded: null` + status code
+  // legible — la página del driver sigue funcionando sin el mapa.
+  // ---------------------------------------------------------------------
+  app.get('/:id/eco-route', async (c) => {
+    const auth = requireCarrierAuth(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const assignmentId = c.req.param('id');
+    const empresaId = auth.activeMembership.empresa.id;
+
+    const result = await getAssignmentEcoRoute({
+      db: opts.db,
+      logger: opts.logger,
+      assignmentId,
+      empresaId,
+      ...(opts.routesApiKey ? { routesApiKey: opts.routesApiKey } : {}),
+    });
+    if (result.kind === 'not_found') {
+      return c.json({ error: 'assignment_not_found', code: 'assignment_not_found' }, 404);
+    }
+    if (result.kind === 'forbidden') {
+      return c.json({ error: 'forbidden', code: 'forbidden_owner_mismatch' }, 403);
+    }
+    return c.json({
+      polyline_encoded: result.data.polylineEncoded,
+      distance_km: result.data.distanceKm,
+      duration_s: result.data.durationS,
+      status: result.data.status,
     });
   });
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -262,6 +262,10 @@ export function createServer(opts: CreateServerOptions): Hono {
       db: opts.db,
       logger,
       certConfig,
+      // Phase 1 PR-H5 — Routes API key para que GET /assignments/:id/eco-route
+      // pueda devolver la polyline. Sin esta key, el endpoint devuelve
+      // polyline_encoded=null con status='no_routes_api_key' (no error).
+      ...(config.GOOGLE_ROUTES_API_KEY ? { routesApiKey: config.GOOGLE_ROUTES_API_KEY } : {}),
     });
     const chatRouter = createChatRoutes({
       db: opts.db,

--- a/apps/api/src/services/get-assignment-eco-route.ts
+++ b/apps/api/src/services/get-assignment-eco-route.ts
@@ -1,0 +1,161 @@
+/**
+ * Eco-route polyline para una assignment (Phase 1 PR-H5).
+ *
+ * Cierra el loop entre la decisión carrier-side y la ejecución
+ * driver-side: el carrier ya veía el mapa de la ruta sugerida antes
+ * de aceptar (PR-H4 EcoRouteMapPreview). Post-accept, el driver
+ * entra a `/app/asignaciones/:id` y también debe poder ver esa misma
+ * ruta para navegarla con consciencia de huella de carbono.
+ *
+ * **Diseño**:
+ *   - Endpoint dedicado para assignments (NO reutiliza
+ *     `/offers/:id/eco-preview`) porque:
+ *       a) Post-accept la oferta puede pasar de pendiente → aceptada
+ *          → cancelada; el contrato semántico de "preview pre-decisión"
+ *          ya no aplica.
+ *       b) Aquí el caller es el conductor (no necesariamente el mismo
+ *          user que aceptó la oferta); el chequeo de ownership es por
+ *          empresa, no por offer status.
+ *       c) Reduce cantidad de datos en la respuesta — el driver solo
+ *          necesita la ruta visual, no las emisiones detalladas (esas
+ *          ya están persistidas en `metricas_viaje` al cierre).
+ *
+ *   - Solo expone `polyline_encoded` + `distance_km` + `duration_s`.
+ *     NO recalcula emisiones ni intensidad (esos viven en metricas_viaje
+ *     y se sirven via behavior-score endpoint).
+ *
+ *   - Sin cache propio: confiamos en el cache de Routes API (CDN HTTP
+ *     cache) + el cliente cachea con TanStack Query staleTime 30min.
+ *     A diferencia de tracking público (PR-L2c) que poll cada 30s, el
+ *     driver visita la assignment una pocas veces por viaje, así que
+ *     el costo bruto es bajo.
+ *
+ * **Fallback**: si Routes API falla o no hay API key configurada,
+ * devolvemos polyline=null pero NO 4xx/5xx — la página del driver
+ * sigue funcionando con resto de su contenido (chat, behavior score,
+ * cards de confirmación/incidente). Ver code 'eco_route_unavailable'.
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import { eq } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { assignments, trips } from '../db/schema.js';
+import { RoutesApiError, computeRoutes } from './routes-api.js';
+
+export interface AssignmentEcoRoute {
+  /** Polyline encoded de Routes API. null cuando no se pudo obtener (sin key, API failure, etc). */
+  polylineEncoded: string | null;
+  /** Distancia por carretera en km. null cuando polyline=null. */
+  distanceKm: number | null;
+  /** Duración estimada en segundos. null cuando polyline=null. */
+  durationS: number | null;
+  /**
+   * Code legible para el UI cuando no hay polyline:
+   *   - 'ok': polyline presente
+   *   - 'no_routes_api_key': API key no configurada en el entorno
+   *   - 'routes_api_failed': Routes API rechazó o falló
+   *   - 'route_empty': Routes API no encontró ruta
+   */
+  status: 'ok' | 'no_routes_api_key' | 'routes_api_failed' | 'route_empty';
+}
+
+export type GetAssignmentEcoRouteResult =
+  | { kind: 'ok'; data: AssignmentEcoRoute }
+  | { kind: 'not_found' }
+  | { kind: 'forbidden' };
+
+export async function getAssignmentEcoRoute(opts: {
+  db: Db;
+  logger: Logger;
+  assignmentId: string;
+  empresaId: string;
+  routesApiKey?: string | undefined;
+}): Promise<GetAssignmentEcoRouteResult> {
+  const { db, logger, assignmentId, empresaId, routesApiKey } = opts;
+
+  // Cargar assignment + trip en una query (origin/destination addresses).
+  const rows = await db
+    .select({
+      assignmentId: assignments.id,
+      assignmentEmpresaId: assignments.empresaId,
+      originAddress: trips.originAddressRaw,
+      destinationAddress: trips.destinationAddressRaw,
+    })
+    .from(assignments)
+    .innerJoin(trips, eq(trips.id, assignments.tripId))
+    .where(eq(assignments.id, assignmentId))
+    .limit(1);
+
+  const row = rows[0];
+  if (!row) {
+    return { kind: 'not_found' };
+  }
+  if (row.assignmentEmpresaId !== empresaId) {
+    return { kind: 'forbidden' };
+  }
+
+  if (!routesApiKey) {
+    return {
+      kind: 'ok',
+      data: {
+        polylineEncoded: null,
+        distanceKm: null,
+        durationS: null,
+        status: 'no_routes_api_key',
+      },
+    };
+  }
+
+  try {
+    const routes = await computeRoutes({
+      apiKey: routesApiKey,
+      origin: row.originAddress,
+      destination: row.destinationAddress,
+      computeAlternatives: false,
+      logger,
+    });
+    const top = routes[0];
+    if (!top || top.distanceKm <= 0 || !top.polylineEncoded) {
+      logger.warn(
+        { assignmentId, origin: row.originAddress, destination: row.destinationAddress },
+        'Routes API returned no usable route for assignment eco-route',
+      );
+      return {
+        kind: 'ok',
+        data: {
+          polylineEncoded: null,
+          distanceKm: null,
+          durationS: null,
+          status: 'route_empty',
+        },
+      };
+    }
+    return {
+      kind: 'ok',
+      data: {
+        polylineEncoded: top.polylineEncoded,
+        distanceKm: top.distanceKm,
+        durationS: top.durationS,
+        status: 'ok',
+      },
+    };
+  } catch (err) {
+    if (err instanceof RoutesApiError) {
+      logger.warn(
+        { assignmentId, code: err.code, httpStatus: err.httpStatus },
+        'Routes API error fetching assignment eco-route',
+      );
+    } else {
+      logger.error({ err, assignmentId }, 'Unexpected error fetching assignment eco-route');
+    }
+    return {
+      kind: 'ok',
+      data: {
+        polylineEncoded: null,
+        distanceKm: null,
+        durationS: null,
+        status: 'routes_api_failed',
+      },
+    };
+  }
+}

--- a/apps/api/test/unit/get-assignment-eco-route.test.ts
+++ b/apps/api/test/unit/get-assignment-eco-route.test.ts
@@ -1,0 +1,246 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.SERVICE_NAME = 'booster-ai-api';
+  process.env.SERVICE_VERSION = '0.0.0-test';
+  process.env.LOG_LEVEL = 'error';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.REDIS_HOST = 'localhost';
+  process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173';
+  process.env.FIREBASE_PROJECT_ID = 'test';
+  process.env.API_AUDIENCE = 'https://api.boosterchile.com';
+  process.env.ALLOWED_CALLER_SA = 'caller@booster-ai.iam.gserviceaccount.com';
+});
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+};
+
+vi.mock('../../src/services/routes-api.js', () => ({
+  RoutesApiError: class RoutesApiError extends Error {
+    code: string;
+    httpStatus: number | null;
+    constructor(message: string, code: string, httpStatus: number | null) {
+      super(message);
+      this.code = code;
+      this.httpStatus = httpStatus;
+    }
+  },
+  computeRoutes: vi.fn(),
+}));
+
+const { computeRoutes, RoutesApiError } = await import('../../src/services/routes-api.js');
+const { getAssignmentEcoRoute } = await import('../../src/services/get-assignment-eco-route.js');
+
+const ASSIGNMENT_ID = '00000000-0000-0000-0000-000000000a01';
+const EMPRESA_ID = '00000000-0000-0000-0000-000000000e01';
+const OTHER_EMPRESA_ID = '00000000-0000-0000-0000-000000000e02';
+
+interface JoinRow {
+  assignmentId: string;
+  assignmentEmpresaId: string;
+  originAddress: string;
+  destinationAddress: string;
+}
+
+function makeDb(row: JoinRow | null) {
+  const limitFn = vi.fn().mockResolvedValue(row ? [row] : []);
+  const whereFn = vi.fn(() => ({ limit: limitFn }));
+  const innerJoinFn = vi.fn(() => ({ where: whereFn }));
+  const fromFn = vi.fn(() => ({ innerJoin: innerJoinFn }));
+  const selectFn = vi.fn(() => ({ from: fromFn }));
+  return { select: selectFn } as never;
+}
+
+const validRow: JoinRow = {
+  assignmentId: ASSIGNMENT_ID,
+  assignmentEmpresaId: EMPRESA_ID,
+  originAddress: 'Av Origen 123, Santiago',
+  destinationAddress: 'Av Destino 456, Concepción',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getAssignmentEcoRoute', () => {
+  it('assignment no existe → not_found', async () => {
+    const db = makeDb(null);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: EMPRESA_ID,
+    });
+    expect(result.kind).toBe('not_found');
+  });
+
+  it('ownership mismatch → forbidden', async () => {
+    const db = makeDb(validRow);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: OTHER_EMPRESA_ID,
+    });
+    expect(result.kind).toBe('forbidden');
+  });
+
+  it('sin routesApiKey → ok con status=no_routes_api_key + polyline null', async () => {
+    const db = makeDb(validRow);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: EMPRESA_ID,
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data).toEqual({
+        polylineEncoded: null,
+        distanceKm: null,
+        durationS: null,
+        status: 'no_routes_api_key',
+      });
+    }
+    expect(computeRoutes).not.toHaveBeenCalled();
+  });
+
+  it('Routes API exitosa → polyline + distance + duration', async () => {
+    (computeRoutes as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      {
+        distanceKm: 350.2,
+        durationS: 12_600,
+        fuelL: 70.4,
+        polylineEncoded: 'route_xyz',
+      },
+    ]);
+    const db = makeDb(validRow);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: EMPRESA_ID,
+      routesApiKey: 'fake-key',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data).toEqual({
+        polylineEncoded: 'route_xyz',
+        distanceKm: 350.2,
+        durationS: 12_600,
+        status: 'ok',
+      });
+    }
+    expect(computeRoutes).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'fake-key',
+        origin: validRow.originAddress,
+        destination: validRow.destinationAddress,
+        computeAlternatives: false,
+      }),
+    );
+  });
+
+  it('Routes API devuelve [] → status=route_empty', async () => {
+    (computeRoutes as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+    const db = makeDb(validRow);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: EMPRESA_ID,
+      routesApiKey: 'fake-key',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data.status).toBe('route_empty');
+      expect(result.data.polylineEncoded).toBeNull();
+    }
+  });
+
+  it('Routes API devuelve route con distance 0 → route_empty', async () => {
+    (computeRoutes as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { distanceKm: 0, durationS: 0, fuelL: null, polylineEncoded: 'x' },
+    ]);
+    const db = makeDb(validRow);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: EMPRESA_ID,
+      routesApiKey: 'fake-key',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data.status).toBe('route_empty');
+    }
+  });
+
+  it('Routes API devuelve polyline vacío → route_empty (defensivo)', async () => {
+    (computeRoutes as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { distanceKm: 100, durationS: 3000, fuelL: null, polylineEncoded: '' },
+    ]);
+    const db = makeDb(validRow);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: EMPRESA_ID,
+      routesApiKey: 'fake-key',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data.status).toBe('route_empty');
+      expect(result.data.polylineEncoded).toBeNull();
+    }
+  });
+
+  it('Routes API tira RoutesApiError → routes_api_failed (no throw)', async () => {
+    (computeRoutes as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new (RoutesApiError as never as new (m: string, c: string, h: number | null) => Error)(
+        'quota',
+        'quota_exceeded',
+        429,
+      ),
+    );
+    const db = makeDb(validRow);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: EMPRESA_ID,
+      routesApiKey: 'fake-key',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data.status).toBe('routes_api_failed');
+      expect(result.data.polylineEncoded).toBeNull();
+    }
+  });
+
+  it('error genérico de Routes API → routes_api_failed (no throw)', async () => {
+    (computeRoutes as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('weird network'));
+    const db = makeDb(validRow);
+    const result = await getAssignmentEcoRoute({
+      db,
+      logger: noopLogger as never,
+      assignmentId: ASSIGNMENT_ID,
+      empresaId: EMPRESA_ID,
+      routesApiKey: 'fake-key',
+    });
+    expect(result.kind).toBe('ok');
+    if (result.kind === 'ok') {
+      expect(result.data.status).toBe('routes_api_failed');
+    }
+  });
+});

--- a/apps/web/src/components/scoring/AssignmentEcoRouteCard.test.tsx
+++ b/apps/web/src/components/scoring/AssignmentEcoRouteCard.test.tsx
@@ -1,0 +1,167 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../../lib/api-client.js';
+
+// Mock the EcoRouteMapPreview to avoid mounting Google Maps in tests.
+vi.mock('../offers/EcoRouteMapPreview.js', () => ({
+  EcoRouteMapPreview: ({ polylineEncoded }: { polylineEncoded: string }) => (
+    <div data-testid="map-preview" data-polyline={polylineEncoded}>
+      [eco map preview]
+    </div>
+  ),
+}));
+
+const { AssignmentEcoRouteCard } = await import('./AssignmentEcoRouteCard.js');
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const ASSIGNMENT_ID = 'a-1';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('AssignmentEcoRouteCard', () => {
+  it('default collapsed: no body, no fetch', () => {
+    const spy = vi.spyOn(api, 'get');
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <AssignmentEcoRouteCard assignmentId={ASSIGNMENT_ID} />
+      </Wrapper>,
+    );
+    expect(screen.getByTestId('assignment-eco-route-toggle')).toBeInTheDocument();
+    expect(screen.queryByTestId('assignment-eco-route-body')).not.toBeInTheDocument();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('click expand → dispara fetch a /assignments/:id/eco-route', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      polyline_encoded: 'route_xyz',
+      distance_km: 350,
+      duration_s: 12_600,
+      status: 'ok',
+    });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <AssignmentEcoRouteCard assignmentId={ASSIGNMENT_ID} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('assignment-eco-route-toggle'));
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(`/assignments/${ASSIGNMENT_ID}/eco-route`),
+    );
+    await waitFor(() => expect(screen.getByTestId('map-preview')).toBeInTheDocument());
+    expect(screen.getByTestId('map-preview')).toHaveAttribute('data-polyline', 'route_xyz');
+  });
+
+  it('expanded + status=ok muestra distancia y duración', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      polyline_encoded: 'route_xyz',
+      distance_km: 350.7,
+      duration_s: 12_600,
+      status: 'ok',
+    });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <AssignmentEcoRouteCard assignmentId={ASSIGNMENT_ID} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('assignment-eco-route-toggle'));
+    await waitFor(() => expect(screen.getByText(/351 km/)).toBeInTheDocument());
+    expect(screen.getByText(/210 min/)).toBeInTheDocument();
+  });
+
+  it('status=no_routes_api_key → mensaje "mapa no disponible"', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      polyline_encoded: null,
+      distance_km: null,
+      duration_s: null,
+      status: 'no_routes_api_key',
+    });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <AssignmentEcoRouteCard assignmentId={ASSIGNMENT_ID} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('assignment-eco-route-toggle'));
+    await waitFor(() =>
+      expect(screen.getByText(/no está disponible en este entorno/i)).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('map-preview')).not.toBeInTheDocument();
+  });
+
+  it('status=routes_api_failed → mensaje transitorio', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      polyline_encoded: null,
+      distance_km: null,
+      duration_s: null,
+      status: 'routes_api_failed',
+    });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <AssignmentEcoRouteCard assignmentId={ASSIGNMENT_ID} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('assignment-eco-route-toggle'));
+    await waitFor(() => expect(screen.getByText(/error transitorio/i)).toBeInTheDocument());
+  });
+
+  it('status=route_empty → mensaje "verifica las direcciones"', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      polyline_encoded: null,
+      distance_km: null,
+      duration_s: null,
+      status: 'route_empty',
+    });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <AssignmentEcoRouteCard assignmentId={ASSIGNMENT_ID} />
+      </Wrapper>,
+    );
+    fireEvent.click(screen.getByTestId('assignment-eco-route-toggle'));
+    await waitFor(() => expect(screen.getByText(/verifica las direcciones/i)).toBeInTheDocument());
+  });
+
+  it('toggle collapse-expand mantiene cache (sin re-fetch al re-expandir)', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      polyline_encoded: 'route_xyz',
+      distance_km: 100,
+      duration_s: 3600,
+      status: 'ok',
+    });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <AssignmentEcoRouteCard assignmentId={ASSIGNMENT_ID} />
+      </Wrapper>,
+    );
+    const toggle = screen.getByTestId('assignment-eco-route-toggle');
+    fireEvent.click(toggle); // expand
+    await waitFor(() => expect(screen.getByTestId('map-preview')).toBeInTheDocument());
+    fireEvent.click(toggle); // collapse
+    expect(screen.queryByTestId('map-preview')).not.toBeInTheDocument();
+    fireEvent.click(toggle); // re-expand
+    await waitFor(() => expect(screen.getByTestId('map-preview')).toBeInTheDocument());
+    // staleTime 30min → no re-fetch
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/scoring/AssignmentEcoRouteCard.tsx
+++ b/apps/web/src/components/scoring/AssignmentEcoRouteCard.tsx
@@ -1,0 +1,137 @@
+import { ChevronDown, ChevronUp, Leaf, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { useAssignmentEcoRoute } from '../../hooks/use-assignment-eco-route.js';
+import { EcoRouteMapPreview } from '../offers/EcoRouteMapPreview.js';
+
+/**
+ * Card de la ruta eco sugerida durante el viaje (Phase 1 PR-H5).
+ *
+ * Cierra el loop carrier→driver: el carrier ya veía el mapa antes de
+ * aceptar (EcoRouteMapPreview en OfferCard); ahora el driver también
+ * la ve durante el viaje en `/app/asignaciones/:id`.
+ *
+ * **UX**:
+ *   - Collapsed por default (no agrega ruido a la surface activa que
+ *     ya tiene confirmar-entrega + incidente + chat).
+ *   - Expand-on-tap fetches la polyline (lazy — no Routes API call
+ *     hasta que el driver pida verla).
+ *   - Si la API devuelve `polyline_encoded: null`, mostramos un
+ *     mensaje legible — la card sigue rendereada con su microcopy
+ *     para que el carrier sepa POR QUÉ no hay mapa.
+ *
+ * **Por qué un card y no inline**: el carrier ya tiene un montón de
+ * surface arriba (confirmar-entrega, incidente, behavior score post-
+ * entrega, cobra-hoy si entregado). Embedded el mapa siempre visible
+ * agrega un componente pesado (Google Maps SDK) a CADA visita de la
+ * página. El expand-on-tap mantiene la carga inicial liviana.
+ */
+
+export interface AssignmentEcoRouteCardProps {
+  assignmentId: string;
+}
+
+export function AssignmentEcoRouteCard({ assignmentId }: AssignmentEcoRouteCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const query = useAssignmentEcoRoute(assignmentId, { enabled: expanded });
+
+  return (
+    <section
+      aria-label="Ruta eco-eficiente sugerida"
+      className="border-success-700/15 border-b bg-success-50/30 px-4 py-3"
+      data-testid="assignment-eco-route-card"
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-center justify-between gap-2 text-left"
+        aria-expanded={expanded}
+        data-testid="assignment-eco-route-toggle"
+      >
+        <span className="flex items-center gap-2 text-success-800 text-sm">
+          <Leaf className="h-4 w-4" aria-hidden />
+          <span className="font-semibold">Ruta eco-eficiente sugerida</span>
+        </span>
+        {expanded ? (
+          <ChevronUp className="h-4 w-4 text-success-700" aria-hidden />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-success-700" aria-hidden />
+        )}
+      </button>
+
+      {expanded && (
+        <div className="mt-3" data-testid="assignment-eco-route-body">
+          <EcoRouteBody query={query} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function EcoRouteBody({ query }: { query: ReturnType<typeof useAssignmentEcoRoute> }) {
+  if (query.isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-success-700 text-xs">
+        <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden />
+        Calculando ruta sugerida con Google Routes…
+      </div>
+    );
+  }
+  if (query.isError || !query.data) {
+    return (
+      <div className="rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 text-xs">
+        No pudimos cargar la ruta sugerida ahora. Intenta abrirla de nuevo en unos segundos.
+      </div>
+    );
+  }
+  const d = query.data;
+  if (!d.polyline_encoded) {
+    return (
+      <div className="rounded-md border border-neutral-200 bg-white p-3 text-neutral-600 text-xs">
+        {explainStatus(d.status)}
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      <EcoRouteMapPreview polylineEncoded={d.polyline_encoded} height={220} />
+      <p className="text-[11px] text-neutral-600">
+        Esta es la ruta sobre la que calculamos el preview de huella de carbono que viste antes de
+        aceptar. Si te desvías, el cálculo final se hace con los datos reales de tu vehículo al
+        cerrar el viaje.
+      </p>
+      {(d.distance_km != null || d.duration_s != null) && (
+        <dl className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-neutral-700">
+          {d.distance_km != null && (
+            <div>
+              <dt className="inline text-neutral-500">Distancia: </dt>
+              <dd className="inline font-medium">{d.distance_km.toFixed(0)} km</dd>
+            </div>
+          )}
+          {d.duration_s != null && (
+            <div>
+              <dt className="inline text-neutral-500">Duración est.: </dt>
+              <dd className="inline font-medium">{Math.round(d.duration_s / 60)} min</dd>
+            </div>
+          )}
+        </dl>
+      )}
+    </div>
+  );
+}
+
+function explainStatus(
+  status: 'ok' | 'no_routes_api_key' | 'routes_api_failed' | 'route_empty',
+): string {
+  switch (status) {
+    case 'ok':
+      // No debería llegar acá (polyline_encoded != null cuando ok), pero
+      // sirve para exhaustiveness — TypeScript chequea.
+      return 'Ruta disponible.';
+    case 'no_routes_api_key':
+      return 'El mapa de la ruta sugerida no está disponible en este entorno.';
+    case 'routes_api_failed':
+      return 'Hubo un error transitorio al traer la ruta. Intenta de nuevo en unos segundos.';
+    case 'route_empty':
+      return 'No pudimos resolver una ruta entre el origen y el destino — verifica las direcciones.';
+  }
+}

--- a/apps/web/src/hooks/use-assignment-eco-route.ts
+++ b/apps/web/src/hooks/use-assignment-eco-route.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api-client.js';
+
+/**
+ * Hook para fetchear la polyline de la ruta sugerida en una asignación
+ * post-accept (Phase 1 PR-H5). Wraps `GET /assignments/:id/eco-route`.
+ *
+ * **Diseño**:
+ *   - `enabled` controla cuando se dispara la query (típicamente cuando
+ *     el carrier toca "Ver ruta sugerida" o se monta el bloque del mapa).
+ *   - `staleTime: 30min` porque la ruta no cambia durante el viaje (origen
+ *     y destino son fijos a nivel trip); evita re-fetch innecesario al
+ *     navegar de vuelta a la página.
+ *   - El response shape es defensivo: `polyline_encoded` puede ser
+ *     `null` con un `status` legible ('no_routes_api_key' |
+ *     'routes_api_failed' | 'route_empty') — el cliente decide qué
+ *     mostrar (fallback o mapa).
+ */
+
+export interface AssignmentEcoRouteResponse {
+  polyline_encoded: string | null;
+  distance_km: number | null;
+  duration_s: number | null;
+  status: 'ok' | 'no_routes_api_key' | 'routes_api_failed' | 'route_empty';
+}
+
+export function useAssignmentEcoRoute(assignmentId: string, opts: { enabled?: boolean } = {}) {
+  return useQuery<AssignmentEcoRouteResponse>({
+    queryKey: ['assignment-eco-route', assignmentId],
+    queryFn: () => api.get<AssignmentEcoRouteResponse>(`/assignments/${assignmentId}/eco-route`),
+    enabled: opts.enabled ?? true,
+    staleTime: 30 * 60 * 1000, // 30 min: ruta no cambia durante el viaje
+    retry: 1,
+  });
+}

--- a/apps/web/src/routes/asignacion-detalle.tsx
+++ b/apps/web/src/routes/asignacion-detalle.tsx
@@ -21,6 +21,7 @@ import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { ChatPanel } from '../components/chat/ChatPanel.js';
 import { PushSubscribeBanner } from '../components/chat/PushSubscribeBanner.js';
 import { CobraHoyButton } from '../components/cobra-hoy/CobraHoyButton.js';
+import { AssignmentEcoRouteCard } from '../components/scoring/AssignmentEcoRouteCard.js';
 import { BehaviorScoreCard } from '../components/scoring/BehaviorScoreCard.js';
 import { DeliveryConfirmCard } from '../components/scoring/DeliveryConfirmCard.js';
 import { IncidentReportCard } from '../components/scoring/IncidentReportCard.js';
@@ -122,6 +123,15 @@ function AsignacionDetallePage() {
           </div>
         </div>
       </div>
+
+      {/* Phase 1 PR-H5 — Ruta eco-eficiente sugerida (post-accept).
+          Collapsed por default; el driver expande on-tap para ver la
+          polyline de Routes API sobre el mapa. Cierra el loop
+          carrier→driver: misma ruta que vio antes de aceptar, ahora
+          disponible durante el viaje para navegación consciente de
+          huella. Visible para cualquier trip activo o entregado (la
+          ruta sigue siendo informativa post-entrega para revisar). */}
+      {!isClosed && <AssignmentEcoRouteCard assignmentId={assignmentId} />}
 
       {/* Phase 4 PR-K4 — confirmación de entrega hands-free (voz +
           botón visual). Visible para el carrier mientras el trip está


### PR DESCRIPTION
## Summary

- **Cierra el loop carrier→driver** de la visión PO. PR-H4 mostró el mapa de la ruta sugerida al carrier ANTES de aceptar. Este PR la muestra al driver DURANTE el viaje.
- Nuevo endpoint `GET /assignments/:id/eco-route` con fallback transparente cuando Routes API no está disponible.
- Nuevo card "Ruta eco-eficiente sugerida" en `/app/asignaciones/:id`, collapsed por default, lazy expand-on-tap.

## El gap que cierra

Antes: carrier acepta la oferta sabiendo qué ruta optimiza huella → driver entra a la asignación y NO ve esa ruta → navega con su Google Maps personal sin contexto.

Después: misma ruta visible para el driver durante el viaje, con microcopy que explica "esta es la ruta sobre la que calculamos el preview de huella; si te desvías, el cálculo final usa los datos reales de tu vehículo".

## Diseño

### Endpoint dedicado, no reusa `/offers/:id/eco-preview`

Post-accept la semántica de "preview pre-decisión" ya no aplica. El caller es el driver (no necesariamente quien aceptó); ownership check por `empresaId`. Response payload liviano: solo polyline + distance + duration.

### Fallback transparente

Si Routes API key no está, falla, o devuelve sin ruta, devolvemos **200** con `polyline_encoded: null` + `status: 'no_routes_api_key' | 'routes_api_failed' | 'route_empty'`. La página del driver sigue funcional sin el mapa.

### Lazy expand-on-tap

Google Maps SDK pesa ~100KB. Card collapsed por default → driver toca para expandir → solo entonces el fetch + map mount ocurren. `staleTime: 30min` evita re-fetchs al toggling collapse/expand o re-visitar la página.

## Tests (+16 nuevos)

**API** (+9): not_found, forbidden, sin routesApiKey, happy path, empty routes, distance=0, polyline vacío, RoutesApiError, error genérico
**Web** (+7): default collapsed, fetch on expand, status=ok render, status=no_routes_api_key / routes_api_failed / route_empty messages, cache persiste toggle

Suites: api **625 → 634**, web **811 → 818** ✓

## Test plan

- [x] Unit tests pass (16/16 nuevos)
- [x] Lint clean
- [x] Typecheck clean
- [ ] CI verde
- [ ] Manual staging: entrar a `/app/asignaciones/:id` post-accept, tap card "Ruta eco-eficiente sugerida", ver mapa con polyline + markers O/D

🤖 Generated with [Claude Code](https://claude.com/claude-code)