### PR TITLE
feat(dte-cron): reconciliación queryStatus + retry de transient errors

### DIFF
--- a/apps/api/src/routes/admin-jobs.ts
+++ b/apps/api/src/routes/admin-jobs.ts
@@ -26,6 +26,7 @@ import { config as appConfig } from '../config.js';
 import type { Db } from '../db/client.js';
 import { procesarMensajesNoLeidos } from '../services/chat-whatsapp-fallback.js';
 import { procesarCobranzaCobraHoy } from '../services/procesar-cobranza-cobra-hoy.js';
+import { reconciliarDtes } from '../services/reconciliar-dtes.js';
 
 export function createAdminJobsRoutes(opts: {
   db: Db;
@@ -61,6 +62,32 @@ export function createAdminJobsRoutes(opts: {
    * (no es un error — el cron sigue activo aunque la feature esté off
    * por entornos de staging).
    */
+  /**
+   * ADR-024 — Cron de reconciliación DTE.
+   *
+   * Por tick:
+   *   1. queryStatus sobre facturas con `dte_status='en_proceso'` y
+   *      actualiza el campo según respuesta del provider.
+   *   2. Retry de facturas con transient error (sin folio, status
+   *      pending_dte, más de 5 min de antigüedad).
+   *
+   * No-op si `PRICING_V2_ACTIVATED=false` o no hay adapter activo.
+   * Frecuencia recomendada: cada hora.
+   */
+  app.post('/reconciliar-dtes', async (c) => {
+    const result = await reconciliarDtes({
+      db: opts.db,
+      logger: opts.logger,
+    });
+    return c.json({
+      ok: true,
+      queried_status: result.queriedStatus,
+      status_updated: result.statusUpdated,
+      retried: result.retried,
+      retried_ok: result.retriedOk,
+    });
+  });
+
   app.post('/cobra-hoy-cobranza', async (c) => {
     if (!appConfig.FACTORING_V1_ACTIVATED) {
       opts.logger.debug('cobra-hoy-cobranza: FACTORING_V1_ACTIVATED=false, skip');

--- a/apps/api/src/services/reconciliar-dtes.ts
+++ b/apps/api/src/services/reconciliar-dtes.ts
@@ -1,0 +1,244 @@
+import { DteProviderError, DteTransientError } from '@booster-ai/dte-provider';
+import type { Logger } from '@booster-ai/logger';
+import { and, desc, eq, isNotNull, isNull, lt, sql } from 'drizzle-orm';
+import { config as appConfig } from '../config.js';
+import type { Db } from '../db/client.js';
+import { facturasBoosterClp, liquidaciones } from '../db/schema.js';
+import { getDteEmitter } from './dte-emitter-factory.js';
+import { emitirDteLiquidacion } from './emitir-dte-liquidacion.js';
+
+/**
+ * ADR-024 — Cron de reconciliación de DTEs.
+ *
+ * Dos responsabilidades por tick:
+ *
+ *   1. **queryStatus de facturas `en_proceso`**: cuando emitimos un DTE,
+ *      Sovos típicamente devuelve folio inmediato pero el SII aún no
+ *      lo aceptó. Periódicamente preguntamos `adapter.queryStatus()` y
+ *      actualizamos `dte_status` ∈ {aceptado | rechazado | reparable |
+ *      anulado | en_proceso}.
+ *
+ *   2. **retry de transient errors**: facturas con tipo `comision_trip`
+ *      que tienen `liquidacionId` pero NO `dteFolio` y status='pending_dte'
+ *      vienen de un `emitFactura` que falló transient (timeout, 5xx).
+ *      Reintenta `emitirDteLiquidacion` cuyo race-safety check detecta
+ *      si alguien ya emitió en paralelo.
+ *
+ * **Frecuencia objetivo**: 1×/hora. Volumen esperado: <100 facturas/tick.
+ * Si crece, paginar con LIMIT + OFFSET (hoy LIMIT 500 hard cap).
+ *
+ * **Idempotente y safe re-correr**: cada paso es no-op si no aplica.
+ *
+ * **No-op si**:
+ *   - `PRICING_V2_ACTIVATED=false` (flag global apaga el módulo).
+ *   - Adapter es `null` (DTE_PROVIDER=disabled o sin creds Sovos).
+ */
+
+export interface ReconciliarDtesInput {
+  db: Db;
+  logger: Logger;
+  /**
+   * Cuántas facturas `en_proceso` consultar por tick. Default 200.
+   * Cap superior 500.
+   */
+  queryStatusLimit?: number;
+  /**
+   * Cuántas facturas con transient error reintentar por tick. Default 50.
+   * Cap superior 100.
+   */
+  retryEmitLimit?: number;
+  /**
+   * Edad mínima para que una factura `en_proceso` se reconcile. Evita
+   * race con emitFactura que recién terminó. Default 60 segundos.
+   */
+  minAgeForReconcileSeconds?: number;
+}
+
+export interface ReconciliarDtesResult {
+  /** Cuántas facturas `en_proceso` se consultaron (incl. sin cambios). */
+  queriedStatus: number;
+  /** De las consultadas, cuántas cambiaron de status. */
+  statusUpdated: number;
+  /** Cuántas facturas con transient error se reintentaron. */
+  retried: number;
+  /** De las reintentadas, cuántas terminaron emitidas. */
+  retriedOk: number;
+}
+
+export async function reconciliarDtes(input: ReconciliarDtesInput): Promise<ReconciliarDtesResult> {
+  const {
+    db,
+    logger,
+    queryStatusLimit = 200,
+    retryEmitLimit = 50,
+    minAgeForReconcileSeconds = 60,
+  } = input;
+
+  if (!appConfig.PRICING_V2_ACTIVATED) {
+    logger.debug('reconciliarDtes: PRICING_V2_ACTIVATED=false, skip');
+    return { queriedStatus: 0, statusUpdated: 0, retried: 0, retriedOk: 0 };
+  }
+  const adapter = getDteEmitter(logger);
+  if (!adapter) {
+    logger.debug('reconciliarDtes: no hay adapter activo, skip');
+    return { queriedStatus: 0, statusUpdated: 0, retried: 0, retriedOk: 0 };
+  }
+
+  const limitQuery = Math.min(Math.max(queryStatusLimit, 1), 500);
+  const limitRetry = Math.min(Math.max(retryEmitLimit, 1), 100);
+
+  // Step 1: reconciliar facturas en_proceso con queryStatus.
+  // rls-allowlist: cron platform-wide.
+  const enProcesoRows = await db
+    .select({
+      facturaId: facturasBoosterClp.id,
+      dteFolio: facturasBoosterClp.dteFolio,
+      dteTipo: facturasBoosterClp.dteTipo,
+      empresaDestinoId: facturasBoosterClp.empresaDestinoId,
+    })
+    .from(facturasBoosterClp)
+    .where(
+      and(
+        eq(facturasBoosterClp.dteStatus, 'en_proceso'),
+        isNotNull(facturasBoosterClp.dteFolio),
+        // Solo facturas con al menos `minAgeForReconcileSeconds` de
+        // antigüedad para evitar race con emitFactura que recién terminó.
+        lt(
+          facturasBoosterClp.dteEmitidaEn,
+          sql`now() - (${minAgeForReconcileSeconds} || ' seconds')::interval`,
+        ),
+      ),
+    )
+    .orderBy(desc(facturasBoosterClp.dteEmitidaEn))
+    .limit(limitQuery);
+
+  let statusUpdated = 0;
+  for (const row of enProcesoRows) {
+    if (!row.dteFolio) {
+      continue;
+    }
+    // Necesitamos el RUT del emisor — que en nuestro modelo es Booster
+    // (BOOSTER_RUT). El adapter queryStatus toma (folio, rutEmisor).
+    // En el futuro, si emitimos por carrier (DTE 52), aquí cambiamos.
+    let dteStatus: Awaited<ReturnType<typeof adapter.queryStatus>>;
+    try {
+      dteStatus = await adapter.queryStatus(row.dteFolio, appConfig.BOOSTER_RUT);
+    } catch (err) {
+      if (err instanceof DteTransientError) {
+        logger.warn(
+          { err, facturaId: row.facturaId, folio: row.dteFolio },
+          'reconciliarDtes: queryStatus transient, retry next tick',
+        );
+        continue;
+      }
+      if (err instanceof DteProviderError) {
+        logger.error(
+          { err, facturaId: row.facturaId, folio: row.dteFolio },
+          'reconciliarDtes: queryStatus provider error — skip esta factura',
+        );
+        continue;
+      }
+      // Error inesperado: throw para que Cloud Scheduler reintente el tick.
+      throw err;
+    }
+
+    // No persistir si el status no cambió (evita UPDATE no-op + escritura
+    // del trigger updated_at).
+    if (dteStatus.status === 'en_proceso') {
+      continue;
+    }
+    // rls-allowlist: cron platform-wide.
+    await db
+      .update(facturasBoosterClp)
+      .set({
+        dteStatus: dteStatus.status,
+        updatedAt: sql`now()`,
+      })
+      .where(eq(facturasBoosterClp.id, row.facturaId));
+    statusUpdated++;
+    logger.info(
+      {
+        facturaId: row.facturaId,
+        folio: row.dteFolio,
+        nuevoStatus: dteStatus.status,
+        mensaje: dteStatus.mensaje ?? null,
+      },
+      'reconciliarDtes: dte_status actualizado',
+    );
+  }
+
+  // Step 2: retry facturas comision_trip con transient error.
+  // Heurística: factura con tipo='comision_trip' + liquidacion_id + sin
+  // dte_folio + status='pending_dte' + más de 5 min de antigüedad
+  // (evita race con el wire post-INSERT que está en progreso).
+  // rls-allowlist: cron platform-wide.
+  const transientRows = await db
+    .select({
+      facturaId: facturasBoosterClp.id,
+      liquidacionId: facturasBoosterClp.liquidacionId,
+    })
+    .from(facturasBoosterClp)
+    .innerJoin(liquidaciones, eq(liquidaciones.id, facturasBoosterClp.liquidacionId))
+    .where(
+      and(
+        eq(facturasBoosterClp.tipo, 'comision_trip'),
+        isNotNull(facturasBoosterClp.liquidacionId),
+        isNull(facturasBoosterClp.dteFolio),
+        eq(facturasBoosterClp.status, 'pending_dte'),
+        lt(facturasBoosterClp.createdAt, sql`now() - interval '5 minutes'`),
+        eq(liquidaciones.status, 'lista_para_dte'),
+      ),
+    )
+    .orderBy(desc(facturasBoosterClp.createdAt))
+    .limit(limitRetry);
+
+  let retried = 0;
+  let retriedOk = 0;
+  for (const row of transientRows) {
+    if (!row.liquidacionId) {
+      continue;
+    }
+    retried++;
+    try {
+      const result = await emitirDteLiquidacion({
+        db,
+        logger,
+        liquidacionId: row.liquidacionId,
+      });
+      if (result.status === 'emitido' || result.status === 'ya_emitido') {
+        retriedOk++;
+        logger.info(
+          { liquidacionId: row.liquidacionId, dteStatus: result.status },
+          'reconciliarDtes: retry emit OK',
+        );
+      } else {
+        logger.warn(
+          { liquidacionId: row.liquidacionId, dteStatus: result.status },
+          'reconciliarDtes: retry emit no-emitido',
+        );
+      }
+    } catch (err) {
+      logger.error(
+        { err, liquidacionId: row.liquidacionId },
+        'reconciliarDtes: retry emit threw — skip',
+      );
+    }
+  }
+
+  logger.info(
+    {
+      queriedStatus: enProcesoRows.length,
+      statusUpdated,
+      retried,
+      retriedOk,
+    },
+    'reconciliarDtes: tick completado',
+  );
+
+  return {
+    queriedStatus: enProcesoRows.length,
+    statusUpdated,
+    retried,
+    retriedOk,
+  };
+}

--- a/apps/api/test/unit/admin-jobs-route.test.ts
+++ b/apps/api/test/unit/admin-jobs-route.test.ts
@@ -14,10 +14,15 @@ vi.mock('../../src/services/procesar-cobranza-cobra-hoy.js', () => ({
   procesarCobranzaCobraHoy: vi.fn(),
 }));
 
+vi.mock('../../src/services/reconciliar-dtes.js', () => ({
+  reconciliarDtes: vi.fn(),
+}));
+
 const { procesarMensajesNoLeidos } = await import('../../src/services/chat-whatsapp-fallback.js');
 const { procesarCobranzaCobraHoy } = await import(
   '../../src/services/procesar-cobranza-cobra-hoy.js'
 );
+const { reconciliarDtes } = await import('../../src/services/reconciliar-dtes.js');
 const { config: appConfig } = await import('../../src/config.js');
 
 const noop = (): void => undefined;
@@ -155,5 +160,40 @@ describe('POST /admin/jobs/cobra-hoy-cobranza', () => {
     const body = (await res.json()) as { moras_creadas: number; adelantos: unknown[] };
     expect(body.moras_creadas).toBe(0);
     expect(body.adelantos).toEqual([]);
+  });
+});
+
+describe('POST /admin/jobs/reconciliar-dtes', () => {
+  it('happy path: 200 con counts del service serializados snake_case', async () => {
+    (reconciliarDtes as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      queriedStatus: 12,
+      statusUpdated: 3,
+      retried: 2,
+      retriedOk: 1,
+    });
+    const app = await buildApp();
+    const res = await app.request('/admin/jobs/reconciliar-dtes', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      ok: true,
+      queried_status: 12,
+      status_updated: 3,
+      retried: 2,
+      retried_ok: 1,
+    });
+  });
+
+  it('tick vacío: 200 con counts en cero', async () => {
+    (reconciliarDtes as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      queriedStatus: 0,
+      statusUpdated: 0,
+      retried: 0,
+      retriedOk: 0,
+    });
+    const app = await buildApp();
+    const res = await app.request('/admin/jobs/reconciliar-dtes', { method: 'POST' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { queried_status: number };
+    expect(body.queried_status).toBe(0);
   });
 });

--- a/apps/api/test/unit/reconciliar-dtes.test.ts
+++ b/apps/api/test/unit/reconciliar-dtes.test.ts
@@ -1,0 +1,300 @@
+import { DteProviderRejectedError, DteTransientError } from '@booster-ai/dte-provider';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config as appConfig } from '../../src/config.js';
+
+vi.mock('../../src/services/dte-emitter-factory.js', () => ({
+  getDteEmitter: vi.fn(),
+  __resetDteEmitterCache: vi.fn(),
+}));
+vi.mock('../../src/services/emitir-dte-liquidacion.js', () => ({
+  emitirDteLiquidacion: vi.fn(),
+}));
+
+const { getDteEmitter } = await import('../../src/services/dte-emitter-factory.js');
+const { emitirDteLiquidacion } = await import('../../src/services/emitir-dte-liquidacion.js');
+const { reconciliarDtes } = await import('../../src/services/reconciliar-dtes.js');
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+interface DbQueues {
+  /** Cada select consume secuencialmente. */
+  selects?: unknown[][];
+}
+
+function makeDb(opts: DbQueues = {}) {
+  const selects = [...(opts.selects ?? [])];
+  const updateSetMock = vi.fn(() => ({
+    where: vi.fn(async () => []),
+  }));
+
+  const buildSelectChain = () => {
+    const chain: Record<string, unknown> = {
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(async () => selects.shift() ?? []),
+    };
+    return chain;
+  };
+
+  return {
+    db: {
+      select: vi.fn(() => buildSelectChain()),
+      update: vi.fn(() => ({ set: updateSetMock })),
+    },
+    updateSetMock,
+  };
+}
+
+const FACTURA_EN_PROCESO = {
+  facturaId: 'f1',
+  dteFolio: '1234',
+  dteTipo: 33,
+  empresaDestinoId: 'carrier-1',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appConfig.PRICING_V2_ACTIVATED = true;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('reconciliarDtes — short-circuits', () => {
+  it('flag off → todo 0', async () => {
+    appConfig.PRICING_V2_ACTIVATED = false;
+    const { db } = makeDb();
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result).toEqual({ queriedStatus: 0, statusUpdated: 0, retried: 0, retriedOk: 0 });
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('adapter null → todo 0', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce(null);
+    const { db } = makeDb();
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result).toEqual({ queriedStatus: 0, statusUpdated: 0, retried: 0, retriedOk: 0 });
+  });
+});
+
+describe('reconciliarDtes — step 1 queryStatus', () => {
+  it('factura en_proceso pasa a aceptado → UPDATE persistido', async () => {
+    const queryStatus = vi.fn().mockResolvedValue({
+      folio: '1234',
+      tipo: 33,
+      rutEmisor: '76.000.000-0',
+      status: 'aceptado',
+    });
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ queryStatus });
+    const { db, updateSetMock } = makeDb({
+      selects: [
+        [FACTURA_EN_PROCESO],
+        [], // no transient rows
+      ],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.queriedStatus).toBe(1);
+    expect(result.statusUpdated).toBe(1);
+    expect(updateSetMock).toHaveBeenCalledTimes(1);
+    const setArg = updateSetMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(setArg.dteStatus).toBe('aceptado');
+  });
+
+  it('factura sigue en_proceso → no UPDATE (evita escrituras no-op)', async () => {
+    const queryStatus = vi.fn().mockResolvedValue({
+      folio: '1234',
+      tipo: 33,
+      rutEmisor: '76.000.000-0',
+      status: 'en_proceso',
+    });
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ queryStatus });
+    const { db, updateSetMock } = makeDb({
+      selects: [[FACTURA_EN_PROCESO], []],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.queriedStatus).toBe(1);
+    expect(result.statusUpdated).toBe(0);
+    expect(updateSetMock).not.toHaveBeenCalled();
+  });
+
+  it('múltiples facturas → cada una se consulta', async () => {
+    const queryStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ folio: '1', tipo: 33, rutEmisor: '76', status: 'aceptado' })
+      .mockResolvedValueOnce({ folio: '2', tipo: 33, rutEmisor: '76', status: 'rechazado' })
+      .mockResolvedValueOnce({ folio: '3', tipo: 33, rutEmisor: '76', status: 'aceptado' });
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ queryStatus });
+    const { db } = makeDb({
+      selects: [
+        [
+          { ...FACTURA_EN_PROCESO, facturaId: 'f1', dteFolio: '1' },
+          { ...FACTURA_EN_PROCESO, facturaId: 'f2', dteFolio: '2' },
+          { ...FACTURA_EN_PROCESO, facturaId: 'f3', dteFolio: '3' },
+        ],
+        [],
+      ],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.queriedStatus).toBe(3);
+    expect(result.statusUpdated).toBe(3);
+    expect(queryStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it('queryStatus transient → skip esa, sigue con siguiente', async () => {
+    const queryStatus = vi
+      .fn()
+      .mockRejectedValueOnce(new DteTransientError('timeout'))
+      .mockResolvedValueOnce({ folio: '2', tipo: 33, rutEmisor: '76', status: 'aceptado' });
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ queryStatus });
+    const { db } = makeDb({
+      selects: [
+        [
+          { ...FACTURA_EN_PROCESO, facturaId: 'f1', dteFolio: '1' },
+          { ...FACTURA_EN_PROCESO, facturaId: 'f2', dteFolio: '2' },
+        ],
+        [],
+      ],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.queriedStatus).toBe(2);
+    expect(result.statusUpdated).toBe(1);
+  });
+
+  it('queryStatus provider rejected → skip esa factura sin throw', async () => {
+    const queryStatus = vi
+      .fn()
+      .mockRejectedValueOnce(new DteProviderRejectedError('folio no existe', '404'));
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ queryStatus });
+    const { db } = makeDb({
+      selects: [[FACTURA_EN_PROCESO], []],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.queriedStatus).toBe(1);
+    expect(result.statusUpdated).toBe(0);
+  });
+
+  it('queryStatus error desconocido → propaga (Cloud Scheduler retry)', async () => {
+    const queryStatus = vi.fn().mockRejectedValueOnce(new Error('bug'));
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({ queryStatus });
+    const { db } = makeDb({
+      selects: [[FACTURA_EN_PROCESO]],
+    });
+    await expect(reconciliarDtes({ db: db as never, logger: noopLogger })).rejects.toThrow('bug');
+  });
+});
+
+describe('reconciliarDtes — step 2 retry transient', () => {
+  it('sin transient rows → retried=0, retriedOk=0', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      queryStatus: vi.fn(),
+    });
+    const { db } = makeDb({
+      selects: [[], []],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.retried).toBe(0);
+    expect(result.retriedOk).toBe(0);
+  });
+
+  it('factura transient + emitirDteLiquidacion OK → retriedOk++', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      queryStatus: vi.fn(),
+    });
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'emitido',
+      folio: '9999',
+      facturaId: 'f-retry',
+      providerTrackId: 'tk',
+    });
+    const { db } = makeDb({
+      selects: [[], [{ facturaId: 'f-retry', liquidacionId: 'liq-1' }]],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.retried).toBe(1);
+    expect(result.retriedOk).toBe(1);
+  });
+
+  it('factura transient + ya_emitido (race) → retriedOk++', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      queryStatus: vi.fn(),
+    });
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'ya_emitido',
+      folio: '1234',
+    });
+    const { db } = makeDb({
+      selects: [[], [{ facturaId: 'f1', liquidacionId: 'liq-1' }]],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.retriedOk).toBe(1);
+  });
+
+  it('retry threw → log error pero sigue', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      queryStatus: vi.fn(),
+    });
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('boom'));
+    const { db } = makeDb({
+      selects: [[], [{ facturaId: 'f1', liquidacionId: 'liq-1' }]],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.retried).toBe(1);
+    expect(result.retriedOk).toBe(0);
+  });
+
+  it('retry pero service retorna validation_error → no cuenta como ok', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      queryStatus: vi.fn(),
+    });
+    (emitirDteLiquidacion as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      status: 'validation_error',
+      message: 'x',
+    });
+    const { db } = makeDb({
+      selects: [[], [{ facturaId: 'f1', liquidacionId: 'liq-1' }]],
+    });
+    const result = await reconciliarDtes({ db: db as never, logger: noopLogger });
+    expect(result.retried).toBe(1);
+    expect(result.retriedOk).toBe(0);
+  });
+});
+
+describe('reconciliarDtes — limits', () => {
+  it('queryStatusLimit cap superior 500', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      queryStatus: vi.fn(),
+    });
+    const { db } = makeDb({ selects: [[], []] });
+    await reconciliarDtes({
+      db: db as never,
+      logger: noopLogger,
+      queryStatusLimit: 9999,
+    });
+    // No throw — el cap se aplica internamente.
+    expect(db.select).toHaveBeenCalled();
+  });
+
+  it('retryEmitLimit default 50 + cap 100', async () => {
+    (getDteEmitter as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+      queryStatus: vi.fn(),
+    });
+    const { db } = makeDb({ selects: [[], []] });
+    await reconciliarDtes({
+      db: db as never,
+      logger: noopLogger,
+      retryEmitLimit: 9999,
+    });
+    expect(db.select).toHaveBeenCalled();
+  });
+});

--- a/infrastructure/scheduling.tf
+++ b/infrastructure/scheduling.tf
@@ -140,3 +140,49 @@ resource "google_cloud_scheduler_job" "cobra_hoy_cobranza" {
     module.service_api,
   ]
 }
+
+# -----------------------------------------------------------------------------
+# ADR-024 — Cron de reconciliación DTE
+# -----------------------------------------------------------------------------
+# Cada hora. El handler:
+#   1. queryStatus sobre facturas con dte_status='en_proceso' (>1 min de
+#      antigüedad para evitar race) — actualiza dte_status según SII.
+#   2. Retry de facturas con transient error (sin folio, status pending_dte,
+#      >5 min).
+#
+# Skip silencioso si PRICING_V2_ACTIVATED=false o sin adapter activo.
+resource "google_cloud_scheduler_job" "reconciliar_dtes" {
+  name        = "reconciliar-dtes"
+  description = "Hourly: queryStatus de facturas DTE en_proceso + retry de transient errors."
+  project     = google_project.booster_ai.project_id
+
+  region    = "southamerica-east1"
+  schedule  = "0 * * * *"
+  time_zone = "America/Santiago"
+
+  retry_config {
+    retry_count          = 3
+    min_backoff_duration = "60s"
+    max_backoff_duration = "300s"
+    max_doublings        = 2
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "${local.cloud_run_api_url}/admin/jobs/reconciliar-dtes"
+    body        = base64encode("{}")
+    headers = {
+      "Content-Type" = "application/json"
+    }
+
+    oidc_token {
+      service_account_email = google_service_account.internal_cron_invoker.email
+      audience              = local.cloud_run_api_url
+    }
+  }
+
+  depends_on = [
+    google_project_service.apis,
+    module.service_api,
+  ]
+}


### PR DESCRIPTION
## Summary

Cierra otro loop operacional de ADR-024. Cron diario que:
1. **queryStatus** sobre facturas con \`dte_status='en_proceso'\` → actualiza el campo según respuesta del provider.
2. **Retry** de facturas con transient error (sin folio, \`pending_dte\`, >5 min).

Sin este cron, los transient errors (timeout Sovos, 5xx) quedaban colgados — la liquidación marcaba la factura como \`pending_dte\` y nadie la retomaba hasta intervención manual.

## Comportamiento

- **Schedule**: cada hora (\`0 * * * *\` America/Santiago) vía Cloud Scheduler.
- **Caps por tick**: 500 queryStatus / 100 retries (configurables, hard cap).
- **Edad mínima 60s** para queryStatus (evita race con emitFactura recién terminado).
- **Edad mínima 5min** para retry (evita race con el wire fire-and-forget en \`liquidar-trip\`).
- **Skip silencioso** si \`PRICING_V2_ACTIVATED=false\` o sin adapter activo.
- **Idempotente**: re-correr es seguro. UPDATE no-op si el status no cambió.

## Manejo de errores per-row

| Error en queryStatus | Comportamiento |
|---|---|
| \`DteTransientError\` | log warn + skip, retoma next tick |
| \`DteProviderRejectedError\` | log error + skip (folio inválido = caso escalable) |
| \`DteValidationError\` | (no esperado en queryStatus) propaga |
| Unknown error | propaga → Cloud Scheduler reintenta el tick |

## Componentes

- \`services/reconciliar-dtes.ts\` (nuevo): 2 steps + 15 tests.
- \`routes/admin-jobs.ts\`: POST \`/admin/jobs/reconciliar-dtes\` con flag gate via service.
- \`infrastructure/scheduling.tf\`: \`google_cloud_scheduler_job.reconciliar_dtes\` + retry config.

## Evidencia

\`\`\`
api: 674 tests pass (+17 nuevos)
  - reconciliar-dtes (15): short-circuits, queryStatus step
    (aceptado, rechazado, sigue en_proceso, transient skip,
    provider rejected, unknown propaga), retry step (vacío,
    emitido, ya_emitido, threw, validation_error), límites
  - admin-jobs-route (+2): happy path + tick vacío
lint: 0 errors
typecheck: clean
\`\`\`

## Test plan

- [ ] \`terraform apply\` crea el Cloud Scheduler job.
- [ ] Manual: \`gcloud scheduler jobs run reconciliar-dtes\` con DTE_PROVIDER=mock → MockAdapter responde \`en_proceso\` (default), tick 1 no actualiza. Después \`adapter.setStatus(folio, 'aceptado')\` → tick 2 actualiza \`dte_status='aceptado'\`.
- [ ] Forzar transient en \`emitirDteLiquidacion\` (modificar SovosAdapter para throw transient) → factura queda en pending_dte sin folio. Tick del cron la reintenta y emite OK.

## Estado del rollout ADR-024

- ✅ Sprint X+1: package skeleton (#145)
- ✅ Wire end-to-end con MockAdapter (#148)
- ✅ Cron de reconciliación (este PR)
- ⏳ Sprint X+2: Sovos UAT + carrier credentials .pfx en Secret Manager

🤖 Generated with [Claude Code](https://claude.com/claude-code)