### PR TITLE
feat(web): link "Modo Conductor" desde el dashboard /app (Phase 4 PR-K8b)

### DIFF
--- a/apps/web/src/routes/app.test.tsx
+++ b/apps/web/src/routes/app.test.tsx
@@ -79,6 +79,21 @@ describe('AppRoute', () => {
     expect(screen.getByText(/Ofertas activas/)).toBeInTheDocument();
   });
 
+  it('carrier → muestra card "Modo Conductor" linkeada a /app/conductor/modo', () => {
+    providedContext = { kind: 'onboarded', me: makeMe('dueno', true, false) };
+    render(<AppRoute />);
+    const link = screen.getByTestId('dashboard-link-modo-conductor');
+    expect(link).toBeInTheDocument();
+    // TanStack Link mock pasa `to` como atributo (no `href`).
+    expect(link).toHaveAttribute('to', '/app/conductor/modo');
+  });
+
+  it('shipper (no carrier) → NO muestra card "Modo Conductor"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe('dueno', false, true) };
+    render(<AppRoute />);
+    expect(screen.queryByTestId('dashboard-link-modo-conductor')).not.toBeInTheDocument();
+  });
+
   it('shipper → muestra card "Crear carga"', () => {
     providedContext = { kind: 'onboarded', me: makeMe('dueno', false, true) };
     render(<AppRoute />);

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -3,6 +3,7 @@ import {
   ArrowRight,
   Banknote,
   Bus,
+  Headphones,
   Leaf,
   LogOut,
   Package,
@@ -141,6 +142,33 @@ function AppDashboard({ me }: { me: MeOnboarded }) {
                     <div className="font-medium text-neutral-900">Vehículos</div>
                     <div className="text-neutral-600 text-sm">
                       Tu flota: agregar, editar, asociar dispositivos Teltonika.
+                    </div>
+                  </div>
+                </div>
+                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+              </Link>
+
+              {/* Phase 4 PR-K8 — entrypoint al Modo Conductor desde el
+                  dashboard principal. Ya existían links desde /app/ofertas
+                  y /app/perfil, pero el dashboard es la primera surface
+                  post-login: el carrier merece descubrirlo acá. */}
+              <Link
+                to="/app/conductor/modo"
+                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+                data-testid="dashboard-link-modo-conductor"
+              >
+                <div className="flex items-center gap-4">
+                  <div
+                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                    aria-hidden
+                  >
+                    <Headphones className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <div className="font-medium text-neutral-900">Modo Conductor</div>
+                    <div className="text-neutral-600 text-sm">
+                      Audio coaching, comandos de voz y permisos del navegador. Configura una vez
+                      antes de manejar.
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary

Pequeña mejora de discoverability del Modo Conductor introducido en PR-K8 (#141). Faltaba el entrypoint desde el dashboard principal `/app` — la primera surface post-login.

## Cambio

Una nueva card en la sección "Como transportista" del dashboard, entre "Vehículos" y "Cobra Hoy". Visible solo cuando `activeEmpresa.is_transportista=true`.

## Tests (+2)

- carrier muestra la card con `to="/app/conductor/modo"`
- shipper no la muestra (gated por `is_transportista`)

Suite web: 818 → **820 tests** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)