### PR TITLE
feat(liquidaciones): UI carrier para ver desglose + descargar DTE

### DIFF
--- a/apps/api/src/routes/me-liquidaciones.ts
+++ b/apps/api/src/routes/me-liquidaciones.ts
@@ -1,0 +1,100 @@
+import type { Logger } from '@booster-ai/logger';
+import { desc, eq } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { config as appConfig } from '../config.js';
+import type { Db } from '../db/client.js';
+import { assignments, facturasBoosterClp, liquidaciones, trips } from '../db/schema.js';
+import type { UserContext } from '../services/user-context.js';
+
+/**
+ * GET /me/liquidaciones — lista de liquidaciones del carrier activo
+ * (ADR-031 §4.1).
+ *
+ * Cada row incluye:
+ *   - Identificadores: trip tracking_code, asignacion_id, liquidacion_id.
+ *   - Importes: monto bruto, comisión, IVA, neto carrier, total factura
+ *     Booster.
+ *   - Status: `pending_consent`|`lista_para_dte`|`dte_emitido`|
+ *     `pagada_al_carrier`|`disputa`.
+ *   - DTE meta (cuando aplica): folio, emitido_en, dte_status SII,
+ *     pdf_url para descarga, provider que emitió.
+ *
+ * Skip silencioso (200 con lista vacía) si `PRICING_V2_ACTIVATED=false`:
+ * en entornos no-prod no hay liquidaciones, el carrier ve un mensaje
+ * desde la UI cuando viene vacío.
+ *
+ * Si el flag está on pero la empresa activa no es transportista, 403.
+ */
+export function createMeLiquidacionesRoutes(opts: { db: Db; logger: Logger }) {
+  const app = new Hono();
+
+  app.get('/liquidaciones', async (c) => {
+    if (!appConfig.PRICING_V2_ACTIVATED) {
+      return c.json({ error: 'feature_disabled' }, 503);
+    }
+    const userContext = c.get('userContext') as UserContext | undefined;
+    if (!userContext || !userContext.activeMembership) {
+      return c.json({ error: 'no_active_empresa' }, 400);
+    }
+    const activeEmpresa = userContext.activeMembership.empresa;
+    if (!activeEmpresa.isTransportista) {
+      return c.json({ error: 'forbidden_no_transportista' }, 403);
+    }
+    const empresaCarrierId = activeEmpresa.id;
+
+    const rows = await opts.db
+      .select({
+        liquidacionId: liquidaciones.id,
+        asignacionId: liquidaciones.asignacionId,
+        montoBrutoClp: liquidaciones.montoBrutoClp,
+        comisionPct: liquidaciones.comisionPct,
+        comisionClp: liquidaciones.comisionClp,
+        ivaComisionClp: liquidaciones.ivaComisionClp,
+        montoNetoCarrierClp: liquidaciones.montoNetoCarrierClp,
+        totalFacturaBoosterClp: liquidaciones.totalFacturaBoosterClp,
+        pricingMethodologyVersion: liquidaciones.pricingMethodologyVersion,
+        status: liquidaciones.status,
+        dteFolio: liquidaciones.dteFacturaBoosterFolio,
+        dteEmitidoEn: liquidaciones.dteFacturaBoosterEmitidoEn,
+        createdAt: liquidaciones.createdAt,
+        // Meta del DTE viene de `facturas_booster_clp` (tabla canónica).
+        facturaId: facturasBoosterClp.id,
+        dteStatus: facturasBoosterClp.dteStatus,
+        dtePdfUrl: facturasBoosterClp.dtePdfGcsUri,
+        dteProvider: facturasBoosterClp.dteProvider,
+        // Trip info para que el carrier identifique la liquidación.
+        trackingCode: trips.trackingCode,
+      })
+      .from(liquidaciones)
+      .leftJoin(facturasBoosterClp, eq(facturasBoosterClp.liquidacionId, liquidaciones.id))
+      .innerJoin(assignments, eq(assignments.id, liquidaciones.asignacionId))
+      .innerJoin(trips, eq(trips.id, assignments.tripId))
+      .where(eq(liquidaciones.empresaCarrierId, empresaCarrierId))
+      .orderBy(desc(liquidaciones.createdAt))
+      .limit(100);
+
+    return c.json({
+      liquidaciones: rows.map((r) => ({
+        liquidacion_id: r.liquidacionId,
+        asignacion_id: r.asignacionId,
+        tracking_code: r.trackingCode,
+        monto_bruto_clp: r.montoBrutoClp,
+        comision_pct: Number(r.comisionPct),
+        comision_clp: r.comisionClp,
+        iva_comision_clp: r.ivaComisionClp,
+        monto_neto_carrier_clp: r.montoNetoCarrierClp,
+        total_factura_booster_clp: r.totalFacturaBoosterClp,
+        pricing_methodology_version: r.pricingMethodologyVersion,
+        status: r.status,
+        dte_folio: r.dteFolio,
+        dte_emitido_en: r.dteEmitidoEn?.toISOString() ?? null,
+        dte_status: r.dteStatus,
+        dte_pdf_url: r.dtePdfUrl,
+        dte_provider: r.dteProvider,
+        creado_en: r.createdAt.toISOString(),
+      })),
+    });
+  });
+
+  return app;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -20,6 +20,7 @@ import { createCobraHoyAssignmentsRoutes, createCobraHoyMeRoutes } from './route
 import { createEmpresaRoutes } from './routes/empresas.js';
 import { createHealthRouter } from './routes/health.js';
 import { createMeConsentsRoutes } from './routes/me-consents.js';
+import { createMeLiquidacionesRoutes } from './routes/me-liquidaciones.js';
 import { createMeRoutes } from './routes/me.js';
 import { createOfferRoutes } from './routes/offers.js';
 import { createPublicTrackingRoutes } from './routes/public-tracking.js';
@@ -174,6 +175,10 @@ export function createServer(opts: CreateServerOptions): Hono {
     // Cobra Hoy historial (requiere userContext para empresa activa).
     app.use('/me/cobra-hoy/*', userContextMiddlewareForMe);
     meRouter.route('/', createCobraHoyMeRoutes({ db: opts.db, logger }));
+    // Liquidaciones del carrier activo (ADR-031 §4.1). Requiere
+    // userContext + flag PRICING_V2_ACTIVATED.
+    app.use('/me/liquidaciones', userContextMiddlewareForMe);
+    meRouter.route('/', createMeLiquidacionesRoutes({ db: opts.db, logger }));
     app.route('/me', meRouter);
 
     // Empresas — POST /empresas/onboarding crea user+empresa+membership.

--- a/apps/api/test/unit/me-liquidaciones.test.ts
+++ b/apps/api/test/unit/me-liquidaciones.test.ts
@@ -1,0 +1,195 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config as appConfig } from '../../src/config.js';
+import { createMeLiquidacionesRoutes } from '../../src/routes/me-liquidaciones.js';
+import type { UserContext } from '../../src/services/user-context.js';
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+const EMPRESA_CARRIER_ID = '11111111-1111-1111-1111-111111111111';
+
+function makeCarrierCtx(): UserContext {
+  return {
+    user: { id: 'u1', firebaseUid: 'fb1', fullName: 'F', email: 'f@x.cl' },
+    activeMembership: {
+      id: 'm1',
+      role: 'dueno',
+      status: 'activa',
+      empresa: {
+        id: EMPRESA_CARRIER_ID,
+        legalName: 'E',
+        rut: '76',
+        isGeneradorCarga: false,
+        isTransportista: true,
+        status: 'activa',
+      },
+    },
+    memberships: [],
+  } as unknown as UserContext;
+}
+
+function makeShipperCtx(): UserContext {
+  const ctx = makeCarrierCtx();
+  (ctx.activeMembership as { empresa: { isTransportista: boolean } }).empresa.isTransportista =
+    false;
+  return ctx;
+}
+
+function makeDb(rows: Array<Record<string, unknown>>) {
+  const chain: Record<string, unknown> = {
+    from: vi.fn(() => chain),
+    leftJoin: vi.fn(() => chain),
+    innerJoin: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(async () => rows),
+  };
+  return {
+    select: vi.fn(() => chain),
+  };
+}
+
+function buildApp(opts: { withContext: boolean; isCarrier?: boolean; db?: unknown }) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (opts.withContext) {
+      c.set('userContext', opts.isCarrier === false ? makeShipperCtx() : makeCarrierCtx());
+    }
+    await next();
+  });
+  app.route(
+    '/me',
+    createMeLiquidacionesRoutes({ db: (opts.db ?? {}) as never, logger: noopLogger }),
+  );
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appConfig.PRICING_V2_ACTIVATED = true;
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /me/liquidaciones — gating', () => {
+  it('flag off → 503', async () => {
+    appConfig.PRICING_V2_ACTIVATED = false;
+    const app = buildApp({ withContext: true });
+    const res = await app.request('/me/liquidaciones');
+    expect(res.status).toBe(503);
+  });
+
+  it('sin userContext → 400', async () => {
+    const app = buildApp({ withContext: false });
+    const res = await app.request('/me/liquidaciones');
+    expect(res.status).toBe(400);
+  });
+
+  it('empresa no es transportista → 403', async () => {
+    const app = buildApp({ withContext: true, isCarrier: false });
+    const res = await app.request('/me/liquidaciones');
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: 'forbidden_no_transportista' });
+  });
+});
+
+describe('GET /me/liquidaciones — lista', () => {
+  it('lista vacía → 200 con liquidaciones:[]', async () => {
+    const app = buildApp({ withContext: true, db: makeDb([]) });
+    const res = await app.request('/me/liquidaciones');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ liquidaciones: [] });
+  });
+
+  it('lista con liquidación sin DTE → row sin folio', async () => {
+    const created = new Date('2026-05-10T11:00:00Z');
+    const app = buildApp({
+      withContext: true,
+      db: makeDb([
+        {
+          liquidacionId: 'liq-1',
+          asignacionId: 'asg-1',
+          montoBrutoClp: 200000,
+          comisionPct: '12.00',
+          comisionClp: 24000,
+          ivaComisionClp: 4560,
+          montoNetoCarrierClp: 176000,
+          totalFacturaBoosterClp: 28560,
+          pricingMethodologyVersion: 'pricing-v2.0-cl-2026.06',
+          status: 'lista_para_dte',
+          dteFolio: null,
+          dteEmitidoEn: null,
+          createdAt: created,
+          facturaId: null,
+          dteStatus: null,
+          dtePdfUrl: null,
+          dteProvider: null,
+          trackingCode: 'TRK-001',
+        },
+      ]),
+    });
+    const res = await app.request('/me/liquidaciones');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { liquidaciones: Array<Record<string, unknown>> };
+    expect(body.liquidaciones).toHaveLength(1);
+    expect(body.liquidaciones[0]).toMatchObject({
+      liquidacion_id: 'liq-1',
+      tracking_code: 'TRK-001',
+      monto_bruto_clp: 200000,
+      comision_pct: 12,
+      monto_neto_carrier_clp: 176000,
+      status: 'lista_para_dte',
+      dte_folio: null,
+      dte_status: null,
+    });
+  });
+
+  it('lista con liquidación DTE emitido → folio + pdf_url + dte_status', async () => {
+    const created = new Date('2026-05-10T11:00:00Z');
+    const emitido = new Date('2026-05-10T11:01:00Z');
+    const app = buildApp({
+      withContext: true,
+      db: makeDb([
+        {
+          liquidacionId: 'liq-1',
+          asignacionId: 'asg-1',
+          montoBrutoClp: 200000,
+          comisionPct: '12.00',
+          comisionClp: 24000,
+          ivaComisionClp: 4560,
+          montoNetoCarrierClp: 176000,
+          totalFacturaBoosterClp: 28560,
+          pricingMethodologyVersion: 'pricing-v2.0-cl-2026.06',
+          status: 'dte_emitido',
+          dteFolio: '1234',
+          dteEmitidoEn: emitido,
+          createdAt: created,
+          facturaId: 'fact-1',
+          dteStatus: 'aceptado',
+          dtePdfUrl: 'https://mock.dte/1234.pdf',
+          dteProvider: 'mock',
+          trackingCode: 'TRK-001',
+        },
+      ]),
+    });
+    const res = await app.request('/me/liquidaciones');
+    const body = (await res.json()) as { liquidaciones: Array<Record<string, unknown>> };
+    expect(body.liquidaciones[0]).toMatchObject({
+      dte_folio: '1234',
+      dte_emitido_en: emitido.toISOString(),
+      dte_status: 'aceptado',
+      dte_pdf_url: 'https://mock.dte/1234.pdf',
+      dte_provider: 'mock',
+    });
+  });
+});

--- a/apps/web/src/hooks/use-liquidaciones.ts
+++ b/apps/web/src/hooks/use-liquidaciones.ts
@@ -1,0 +1,54 @@
+import { useQuery } from '@tanstack/react-query';
+import { ApiError, api } from '../lib/api-client.js';
+
+/**
+ * Hook de liquidaciones del carrier activo (ADR-031 §4.1).
+ *
+ * GET /me/liquidaciones devuelve la lista paginada (LIMIT 100). Si el
+ * flag está off (503), la UI muestra mensaje específico. Si la empresa
+ * activa no es transportista (403), la página avisa "sin permisos".
+ */
+
+export type LiquidacionStatus =
+  | 'pending_consent'
+  | 'lista_para_dte'
+  | 'dte_emitido'
+  | 'pagada_al_carrier'
+  | 'disputa';
+
+export type DteStatusValue = 'en_proceso' | 'aceptado' | 'rechazado' | 'reparable' | 'anulado';
+
+export interface LiquidacionRow {
+  liquidacion_id: string;
+  asignacion_id: string;
+  tracking_code: string;
+  monto_bruto_clp: number;
+  comision_pct: number;
+  comision_clp: number;
+  iva_comision_clp: number;
+  monto_neto_carrier_clp: number;
+  total_factura_booster_clp: number;
+  pricing_methodology_version: string;
+  status: LiquidacionStatus;
+  dte_folio: string | null;
+  dte_emitido_en: string | null;
+  dte_status: DteStatusValue | null;
+  dte_pdf_url: string | null;
+  dte_provider: string | null;
+  creado_en: string;
+}
+
+export function useLiquidaciones(opts: { enabled?: boolean } = {}) {
+  return useQuery<{ liquidaciones: LiquidacionRow[] }>({
+    queryKey: ['liquidaciones'],
+    queryFn: () => api.get<{ liquidaciones: LiquidacionRow[] }>('/me/liquidaciones'),
+    enabled: opts.enabled ?? true,
+    staleTime: 30_000,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && (error.status === 503 || error.status === 403)) {
+        return false;
+      }
+      return failureCount < 2;
+    },
+  });
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -12,6 +12,7 @@ import { ConductorModoRoute } from './routes/conductor-modo.js';
 import { IndexRoute } from './routes/index.js';
 import { LegalCobraHoyRoute } from './routes/legal-cobra-hoy.js';
 import { LegalTerminosRoute } from './routes/legal-terminos.js';
+import { LiquidacionesRoute } from './routes/liquidaciones.js';
 import { LoginRoute } from './routes/login.js';
 import { OfertasRoute } from './routes/ofertas.js';
 import { OnboardingRoute } from './routes/onboarding.js';
@@ -190,6 +191,14 @@ const legalCobraHoyRoute = createRoute({
   component: LegalCobraHoyRoute,
 });
 
+// ADR-031 §4.1 — Listado de liquidaciones del carrier activo. Surface
+// dedicada bajo /app con DTE Tipo 33 descargable cuando esté emitido.
+const liquidacionesRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/app/liquidaciones',
+  component: LiquidacionesRoute,
+});
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
   loginRoute,
@@ -213,6 +222,7 @@ const routeTree = rootRoute.addChildren([
   legalTerminosRoute,
   cobraHoyHistorialRoute,
   legalCobraHoyRoute,
+  liquidacionesRoute,
   adminCobraHoyRoute,
 ]);
 

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -8,6 +8,7 @@ import {
   Package,
   PackagePlus,
   Radio,
+  Receipt,
   Settings,
   Truck,
   User as UserIcon,
@@ -162,6 +163,27 @@ function AppDashboard({ me }: { me: MeOnboarded }) {
                     <div className="font-medium text-neutral-900">Cobra hoy</div>
                     <div className="text-neutral-600 text-sm">
                       Solicita pronto pago de viajes entregados y revisa tu historial de adelantos.
+                    </div>
+                  </div>
+                </div>
+                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+              </Link>
+
+              <Link
+                to="/app/liquidaciones"
+                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+              >
+                <div className="flex items-center gap-4">
+                  <div
+                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                    aria-hidden
+                  >
+                    <Receipt className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <div className="font-medium text-neutral-900">Liquidaciones</div>
+                    <div className="text-neutral-600 text-sm">
+                      Desglose de cada viaje entregado: monto bruto, comisión, IVA y DTE Tipo 33.
                     </div>
                   </div>
                 </div>

--- a/apps/web/src/routes/liquidaciones.test.tsx
+++ b/apps/web/src/routes/liquidaciones.test.tsx
@@ -1,0 +1,189 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+import { ApiError, api } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
+let providedContext: Ctx = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: Ctx) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+vi.mock('../components/Layout.js', () => ({
+  Layout: ({ children }: { children: ReactNode }) => <div data-testid="layout">{children}</div>,
+}));
+
+vi.mock('../components/EmptyState.js', () => ({
+  EmptyState: ({ title }: { title: string }) => <div data-testid="empty-state">{title}</div>,
+  emptyStateActionClass: 'btn',
+}));
+
+const { LiquidacionesRoute } = await import('./liquidaciones.js');
+
+function makeMe(isCarrier: boolean): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: { id: 'u', full_name: 'F' } as MeOnboarded['user'],
+    memberships: [],
+    active_membership: {
+      id: 'm',
+      role: 'dueno',
+      status: 'activa',
+      joined_at: null,
+      empresa: {
+        id: 'e',
+        legal_name: 'E',
+        rut: '76',
+        is_generador_carga: false,
+        is_transportista: isCarrier,
+        status: 'activa',
+      },
+    } as MeOnboarded['active_membership'],
+  } as MeOnboarded;
+}
+
+function makeWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+function renderRoute() {
+  const Wrapper = makeWrapper();
+  return render(
+    <Wrapper>
+      <LiquidacionesRoute />
+    </Wrapper>,
+  );
+}
+
+const LIQ_SIN_DTE = {
+  liquidacion_id: 'liq-1',
+  asignacion_id: 'asg-1',
+  tracking_code: 'TRK-001',
+  monto_bruto_clp: 200000,
+  comision_pct: 12,
+  comision_clp: 24000,
+  iva_comision_clp: 4560,
+  monto_neto_carrier_clp: 176000,
+  total_factura_booster_clp: 28560,
+  pricing_methodology_version: 'pricing-v2.0-cl-2026.06',
+  status: 'lista_para_dte' as const,
+  dte_folio: null,
+  dte_emitido_en: null,
+  dte_status: null,
+  dte_pdf_url: null,
+  dte_provider: null,
+  creado_en: '2026-05-10T11:00:00Z',
+};
+
+const LIQ_DTE_EMITIDO = {
+  ...LIQ_SIN_DTE,
+  status: 'dte_emitido' as const,
+  dte_folio: '1234',
+  dte_emitido_en: '2026-05-10T11:01:00Z',
+  dte_status: 'aceptado' as const,
+  dte_pdf_url: 'https://mock.dte/1234.pdf',
+  dte_provider: 'mock',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  providedContext = { kind: 'unmanaged' };
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('LiquidacionesRoute — gating', () => {
+  it('contexto unmanaged → render vacío', () => {
+    const { container } = renderRoute();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shipper (no carrier) → mensaje sin permisos', () => {
+    providedContext = { kind: 'onboarded', me: makeMe(false) };
+    renderRoute();
+    expect(screen.getByText(/Sin permisos/)).toBeInTheDocument();
+    expect(screen.getByText(/exclusivas de empresas transportistas/i)).toBeInTheDocument();
+  });
+
+  it('flag off (503) → banner explicativo', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    vi.spyOn(api, 'get').mockRejectedValue(new ApiError(503, 'feature_disabled', null));
+    renderRoute();
+    expect(await screen.findByText(/Las liquidaciones aún no están activas/i)).toBeInTheDocument();
+  });
+
+  it('403 no_transportista (defensa en profundidad) → banner danger', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+    vi.spyOn(api, 'get').mockRejectedValue(new ApiError(403, 'forbidden_no_transportista', null));
+    renderRoute();
+    expect(await screen.findByText(/exclusivas de empresas transportistas/i)).toBeInTheDocument();
+  });
+});
+
+describe('LiquidacionesRoute — lista', () => {
+  beforeEach(() => {
+    providedContext = { kind: 'onboarded', me: makeMe(true) };
+  });
+
+  it('lista vacía → EmptyState', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ liquidaciones: [] });
+    renderRoute();
+    expect(await screen.findByText(/Aún no tienes liquidaciones/i)).toBeInTheDocument();
+  });
+
+  it('liquidación sin DTE → tabla con "—" en columna DTE', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ liquidaciones: [LIQ_SIN_DTE] });
+    renderRoute();
+    expect(await screen.findByText('Lista para DTE')).toBeInTheDocument();
+    expect(screen.getByText('TRK-001')).toBeInTheDocument();
+    expect(screen.getByText(/12\.00%/)).toBeInTheDocument();
+    // Sin folio.
+    expect(screen.queryByText('1234')).not.toBeInTheDocument();
+  });
+
+  it('liquidación con DTE aceptado → folio + badge SII aceptado + link PDF', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ liquidaciones: [LIQ_DTE_EMITIDO] });
+    renderRoute();
+    expect(await screen.findByText('1234')).toBeInTheDocument();
+    expect(screen.getByText('SII aceptado')).toBeInTheDocument();
+    const pdfLink = screen.getByRole('link', { name: /PDF/i });
+    expect(pdfLink).toHaveAttribute('href', 'https://mock.dte/1234.pdf');
+    expect(pdfLink).toHaveAttribute('target', '_blank');
+  });
+
+  it('summary cards: cuenta + bruto + neto', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      liquidaciones: [LIQ_DTE_EMITIDO, { ...LIQ_SIN_DTE, liquidacion_id: 'liq-2' }],
+    });
+    renderRoute();
+    // Wait until row content visible (esperando la fila — más específico
+    // que el h1 que está pre-load).
+    expect(await screen.findByText('1234')).toBeInTheDocument();
+    // 2 entries × monto_bruto_clp 200000.
+    expect(screen.getByText('$ 400.000')).toBeInTheDocument();
+    // 2 entries × neto 176000.
+    expect(screen.getByText('$ 352.000')).toBeInTheDocument();
+  });
+
+  it('liquidación rechazada por SII → badge danger', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      liquidaciones: [{ ...LIQ_DTE_EMITIDO, dte_status: 'rechazado' as const }],
+    });
+    renderRoute();
+    expect(await screen.findByText('SII rechazado')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/liquidaciones.tsx
+++ b/apps/web/src/routes/liquidaciones.tsx
@@ -1,0 +1,320 @@
+import { Link } from '@tanstack/react-router';
+import { ArrowLeft, Download, FileText, Receipt } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { EmptyState, emptyStateActionClass } from '../components/EmptyState.js';
+import { Layout } from '../components/Layout.js';
+import { ProtectedRoute } from '../components/ProtectedRoute.js';
+import {
+  type DteStatusValue,
+  type LiquidacionRow,
+  type LiquidacionStatus,
+  useLiquidaciones,
+} from '../hooks/use-liquidaciones.js';
+import type { MeResponse } from '../hooks/use-me.js';
+import { ApiError } from '../lib/api-client.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+
+/**
+ * /app/liquidaciones — listado del carrier de sus liquidaciones de
+ * viajes entregados (ADR-031 §4.1).
+ *
+ * Cada fila muestra trip, monto bruto, comisión Booster, neto al
+ * carrier, IVA y status de la liquidación. Si tiene DTE emitido,
+ * muestra folio + descarga del PDF.
+ *
+ * Flag-gated por backend (503 → banner). Acceso restringido a
+ * empresas con `is_transportista` (403 → mensaje claro).
+ */
+export function LiquidacionesRoute() {
+  return (
+    <ProtectedRoute meRequirement="require-onboarded">
+      {(ctx) => {
+        if (ctx.kind !== 'onboarded') {
+          return null;
+        }
+        const isCarrier = ctx.me.active_membership?.empresa.is_transportista ?? false;
+        if (!isCarrier) {
+          return <NoCarrierPermission />;
+        }
+        return <LiquidacionesPage me={ctx.me} />;
+      }}
+    </ProtectedRoute>
+  );
+}
+
+function LiquidacionesPage({ me }: { me: MeOnboarded }) {
+  const liqsQ = useLiquidaciones();
+
+  const featureDisabled = liqsQ.error instanceof ApiError && liqsQ.error.status === 503;
+  const forbidden = liqsQ.error instanceof ApiError && liqsQ.error.status === 403;
+
+  return (
+    <Layout me={me} title="Liquidaciones">
+      <div className="flex items-center gap-3">
+        <Link
+          to="/app"
+          className="inline-flex items-center gap-1 text-neutral-500 text-sm hover:text-neutral-700"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Inicio
+        </Link>
+      </div>
+
+      <header className="mt-4 flex items-start gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary-50 text-primary-700">
+          <Receipt className="h-6 w-6" aria-hidden />
+        </div>
+        <div>
+          <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">Liquidaciones</h1>
+          <p className="mt-1 text-neutral-600 text-sm">
+            Cada viaje entregado genera una liquidación con monto bruto, comisión Booster, IVA y
+            neto al transportista. Cuando el SII acepta el DTE, podrás descargar la factura.
+          </p>
+        </div>
+      </header>
+
+      {forbidden && (
+        <output className="mt-6 block rounded-md border border-danger-500/30 bg-danger-50 p-4 text-danger-700 text-sm">
+          Las liquidaciones son exclusivas de empresas transportistas. Si tu rol cambió, contactá al
+          admin de tu empresa.
+        </output>
+      )}
+
+      {featureDisabled && (
+        <output className="mt-6 block rounded-md border border-neutral-200 bg-neutral-50 p-4 text-neutral-700 text-sm">
+          Las liquidaciones aún no están activas en este entorno.
+        </output>
+      )}
+
+      {!forbidden && !featureDisabled && liqsQ.isLoading && (
+        <p className="mt-8 text-neutral-500">Cargando liquidaciones…</p>
+      )}
+
+      {!forbidden && !featureDisabled && liqsQ.data && liqsQ.data.liquidaciones.length === 0 && (
+        <div className="mt-8">
+          <EmptyState
+            icon={<FileText className="h-10 w-10" aria-hidden />}
+            title="Aún no tienes liquidaciones"
+            description="Cuando un viaje entregado se procese, la liquidación aparecerá acá con el desglose y el DTE Tipo 33 de la comisión Booster."
+            action={
+              <Link to="/app/ofertas" className={emptyStateActionClass}>
+                Ver ofertas activas
+              </Link>
+            }
+          />
+        </div>
+      )}
+
+      {!forbidden && !featureDisabled && liqsQ.data && liqsQ.data.liquidaciones.length > 0 && (
+        <>
+          <div className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <SummaryCard title="Liquidaciones" value={liqsQ.data.liquidaciones.length.toString()} />
+            <SummaryCard
+              title="Total bruto"
+              value={fmt(sumByField(liqsQ.data.liquidaciones, 'monto_bruto_clp'))}
+            />
+            <SummaryCard
+              title="Total neto recibido"
+              value={fmt(sumByField(liqsQ.data.liquidaciones, 'monto_neto_carrier_clp'))}
+            />
+          </div>
+
+          <div className="mt-6 overflow-x-auto rounded-lg border border-neutral-200 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-neutral-200">
+              <thead className="bg-neutral-50">
+                <tr>
+                  <Th>Creada</Th>
+                  <Th>Trip</Th>
+                  <Th className="text-right">Monto bruto</Th>
+                  <Th className="text-right">Comisión</Th>
+                  <Th className="text-right">Neto</Th>
+                  <Th>Estado</Th>
+                  <Th>DTE</Th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-neutral-100 bg-white">
+                {liqsQ.data.liquidaciones.map((l) => (
+                  <tr key={l.liquidacion_id} className="hover:bg-neutral-50">
+                    <Td className="text-neutral-600 text-xs">{formatDate(l.creado_en)}</Td>
+                    <Td>
+                      <Link
+                        to="/app/asignaciones/$id"
+                        params={{ id: l.asignacion_id }}
+                        className="font-mono text-primary-700 text-xs hover:underline"
+                      >
+                        {l.tracking_code}
+                      </Link>
+                    </Td>
+                    <Td className="text-right font-medium">{fmt(l.monto_bruto_clp)}</Td>
+                    <Td className="text-right text-neutral-600 text-xs">
+                      {fmt(l.comision_clp)} ({l.comision_pct.toFixed(2)}%)
+                    </Td>
+                    <Td className="text-right font-semibold text-success-700">
+                      {fmt(l.monto_neto_carrier_clp)}
+                    </Td>
+                    <Td>
+                      <StatusBadge status={l.status} />
+                    </Td>
+                    <Td>
+                      <DteCell row={l} />
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="mt-4 text-neutral-500 text-xs">
+            Las liquidaciones se calculan con la metodología{' '}
+            <code>{liqsQ.data.liquidaciones[0]?.pricing_methodology_version}</code> capturada al
+            momento del cierre del viaje. Cambios futuros a comisión o IVA no se aplican
+            retroactivamente.
+          </p>
+        </>
+      )}
+    </Layout>
+  );
+}
+
+function DteCell({ row }: { row: LiquidacionRow }) {
+  if (!row.dte_folio) {
+    return <span className="text-neutral-400 text-xs">—</span>;
+  }
+  return (
+    <div className="flex flex-col gap-0.5">
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-neutral-900 text-xs">{row.dte_folio}</span>
+        <DteStatusBadge status={row.dte_status} />
+      </div>
+      {row.dte_pdf_url && (
+        <a
+          href={row.dte_pdf_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex w-fit items-center gap-1 rounded-md border border-neutral-300 px-2 py-0.5 font-medium text-primary-700 text-xs transition hover:bg-primary-50"
+        >
+          <Download className="h-3 w-3" aria-hidden />
+          PDF
+        </a>
+      )}
+    </div>
+  );
+}
+
+function NoCarrierPermission() {
+  return (
+    <div className="mx-auto max-w-2xl px-6 py-12">
+      <div className="rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+        <h2 className="font-semibold text-neutral-900 text-xl">Sin permisos</h2>
+        <p className="mt-2 text-neutral-600 text-sm">
+          Las liquidaciones son exclusivas de empresas transportistas.
+        </p>
+        <Link to="/app" className="mt-4 inline-block text-primary-600 underline">
+          Volver al inicio
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: LiquidacionStatus }) {
+  const map: Record<LiquidacionStatus, { label: string; className: string }> = {
+    pending_consent: {
+      label: 'Pendiente consent',
+      className: 'bg-amber-50 text-amber-700',
+    },
+    lista_para_dte: {
+      label: 'Lista para DTE',
+      className: 'bg-neutral-100 text-neutral-700',
+    },
+    dte_emitido: {
+      label: 'DTE emitido',
+      className: 'bg-primary-50 text-primary-700',
+    },
+    pagada_al_carrier: {
+      label: 'Pagada',
+      className: 'bg-success-50 text-success-700',
+    },
+    disputa: {
+      label: 'En disputa',
+      className: 'bg-danger-50 text-danger-700',
+    },
+  };
+  const v = map[status];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 font-medium text-xs ${v.className}`}
+    >
+      {v.label}
+    </span>
+  );
+}
+
+function DteStatusBadge({ status }: { status: DteStatusValue | null }) {
+  if (!status) {
+    return null;
+  }
+  const map: Record<DteStatusValue, { label: string; className: string }> = {
+    en_proceso: { label: 'SII en proceso', className: 'bg-neutral-100 text-neutral-600' },
+    aceptado: { label: 'SII aceptado', className: 'bg-success-50 text-success-700' },
+    reparable: { label: 'SII reparable', className: 'bg-amber-50 text-amber-700' },
+    rechazado: { label: 'SII rechazado', className: 'bg-danger-50 text-danger-700' },
+    anulado: { label: 'Anulado', className: 'bg-neutral-100 text-neutral-500' },
+  };
+  const v = map[status];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-1.5 py-0 font-medium text-[10px] ${v.className}`}
+    >
+      {v.label}
+    </span>
+  );
+}
+
+function Th({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <th
+      className={`px-4 py-2 text-left font-medium text-neutral-500 text-xs uppercase tracking-wider ${className}`}
+    >
+      {children}
+    </th>
+  );
+}
+
+function Td({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return (
+    <td className={`px-4 py-3 align-top text-neutral-800 text-sm ${className}`}>{children}</td>
+  );
+}
+
+function SummaryCard({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+      <span className="font-medium text-neutral-500 text-xs uppercase tracking-wider">{title}</span>
+      <div className="mt-2 font-semibold text-2xl text-neutral-900">{value}</div>
+    </div>
+  );
+}
+
+function sumByField<K extends keyof LiquidacionRow>(items: LiquidacionRow[], field: K): number {
+  return items.reduce((acc, l) => {
+    const v = l[field];
+    return acc + (typeof v === 'number' ? v : 0);
+  }, 0);
+}
+
+function fmt(clp: number): string {
+  return `$ ${clp.toLocaleString('es-CL')}`;
+}
+
+function formatDate(iso: string): string {
+  return new Intl.DateTimeFormat('es-CL', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'America/Santiago',
+  }).format(new Date(iso));
+}


### PR DESCRIPTION
## Summary

Surface dedicada \`/app/liquidaciones\` para que el carrier vea cada liquidación de viaje entregado con el desglose completo (bruto / comisión / IVA / neto) + folio DTE + link de descarga del PDF cuando el SII lo aceptó.

Hasta este PR el carrier sólo veía la comisión cobrada por mensaje WhatsApp post-trip. Ahora tiene un **historial auditable end-to-end** con visibilidad del status del SII.

## Componentes

### Backend
- \`GET /me/liquidaciones\` (\`apps/api/src/routes/me-liquidaciones.ts\`):
  - SELECT con leftJoin a \`facturas_booster_clp\` para traer \`dte_folio\`, \`dte_status\`, \`dte_pdf_url\`, \`dte_provider\`.
  - innerJoin a \`trips\` para incluir \`tracking_code\` (carrier identifica la liquidación por el código del viaje, no por UUID interno).
  - Gating: 503 si \`PRICING_V2_ACTIVATED=false\`, 403 si empresa activa no es transportista, 400 sin userContext.
  - LIMIT 100 ordenado por creación desc.
- Mount en server.ts bajo \`/me\`.
- **6 tests**: gating (flag, no ctx, no carrier), lista vacía, row sin DTE (folio null), row con DTE emitido (mapeo de todos los campos serializados snake_case).

### Web
- \`hooks/use-liquidaciones.ts\`: \`useLiquidaciones()\` con retry skip on 503/403.
- \`routes/liquidaciones.tsx\`:
  - Tabla 7 columnas: creada / trip (link a asignación) / bruto / comisión + % / neto / estado / DTE.
  - \`DteCell\` muestra folio + \`DteStatusBadge\` (en_proceso | aceptado | reparable | rechazado | anulado) + link PDF cuando \`dte_pdf_url\` populado.
  - SummaryCards: cuenta total + monto bruto agregado + neto recibido agregado.
  - Footer con metodología versionada \`pricing-v2.0-cl-2026.06\` y disclaimer de no-retroactividad.
- \`router.tsx\`: nueva ruta \`/app/liquidaciones\`.
- \`routes/app.tsx\`: link en dashboard sección carrier con icono \`Receipt\`.
- **9 tests**: gating, lista vacía, sin DTE, con DTE + PDF link, summary cards math, badge SII rechazado.

## Mapeo HTTP del endpoint

| Caso | Status | Body |
|---|---|---|
| Flag off | 503 | \`{error: 'feature_disabled'}\` |
| Sin auth | 400 | \`{error: 'no_active_empresa'}\` |
| No carrier | 403 | \`{error: 'forbidden_no_transportista'}\` |
| Lista vacía | 200 | \`{liquidaciones: []}\` |
| Con rows | 200 | \`{liquidaciones: [...]}\` con leftJoin DTE meta |

## Evidencia

\`\`\`
API: 663 tests pass (+6 me-liquidaciones)
Web: 820 tests pass (+9 liquidaciones page)
lint: 0 errors
typecheck api+web: clean
\`\`\`

## Test plan

- [ ] Login como carrier con liquidaciones existentes en BD → ve tabla con DTE folio si Sovos lo emitió.
- [ ] Click en PDF link → abre en nueva pestaña.
- [ ] Carrier sin liquidaciones → EmptyState con CTA "Ver ofertas activas".
- [ ] Login como shipper → mensaje "Sin permisos".
- [ ] Setear \`PRICING_V2_ACTIVATED=false\` → banner "Las liquidaciones aún no están activas".

🤖 Generated with [Claude Code](https://claude.com/claude-code)