### PR TITLE
fix(migration-0015): referenciar asignaciones (español) en lugar de assignments

### DIFF
--- a/apps/api/drizzle/0015_pricing_v2.sql
+++ b/apps/api/drizzle/0015_pricing_v2.sql
@@ -78,7 +78,7 @@ COMMENT ON COLUMN carrier_memberships.consent_terms_v2_aceptado_en IS
 -- =============================================================================
 CREATE TABLE liquidaciones (
   id                                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  asignacion_id                       uuid NOT NULL UNIQUE REFERENCES assignments(id) ON DELETE RESTRICT,
+  asignacion_id                       uuid NOT NULL UNIQUE REFERENCES asignaciones(id) ON DELETE RESTRICT,
   empresa_carrier_id                  uuid NOT NULL REFERENCES empresas(id),
   tier_slug_aplicado                  text NOT NULL REFERENCES membership_tiers(slug),
   monto_bruto_clp                     integer NOT NULL CHECK (monto_bruto_clp >= 0),


### PR DESCRIPTION
## Summary

**Hotfix crítico** que desbloquea deploys del API en producción.

La migration `0015_pricing_v2.sql` (introducida en PR #127, ADR-030) referenciaba la tabla \`assignments\` (inglés), pero la convención bilingüe del repo (desde migration 0004) renombra esa tabla a \`asignaciones\` (español).

Resultado: cada nuevo deploy del API fallaba en startup con \`relation "assignments" does not exist\`. Cloud Run quedó sirviendo tráfico desde revision 00140 (Sun 20:52 UTC) mientras revisions 141-159 fallaban.

Detectado al deployar PR #157 (sprint demo features). Bloqueando todo el pipeline.

## Cambio

Una línea:

\`\`\`diff
- asignacion_id uuid NOT NULL UNIQUE REFERENCES assignments(id) ON DELETE RESTRICT,
+ asignacion_id uuid NOT NULL UNIQUE REFERENCES asignaciones(id) ON DELETE RESTRICT,
\`\`\`

## Verificación de estado en prod

Esta migration **nunca había sido aplicada exitosamente** — todos los intentos desde su introducción fallaron. No hay rows que migrar ni estado parcial que limpiar:
- Drizzle envuelve cada migration en transacción → fallo = rollback total.
- Las tablas \`membership_tiers\`, \`carrier_memberships\`, \`liquidaciones\`, \`facturas_booster_clp\` no existen en prod.

Con este fix Drizzle la verá como nueva y la aplicará limpio.

## Test plan

- [x] Diff es 1 línea (\`assignments\` → \`asignaciones\`).
- [x] La tabla \`asignaciones\` existe en prod desde migration 0004.
- [ ] CI verde (verificar)
- [ ] Deploy exitoso post-merge
- [ ] Smoke test: \`GET /api.boosterchile.com/health\` responde 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)