### PR TITLE
fix(migration-0017): partial unique index falla por now() no-IMMUTABLE

### DIFF
--- a/apps/api/drizzle/0015_pricing_v2.sql
+++ b/apps/api/drizzle/0015_pricing_v2.sql
@@ -78,7 +78,7 @@ COMMENT ON COLUMN carrier_memberships.consent_terms_v2_aceptado_en IS
 -- =============================================================================
 CREATE TABLE liquidaciones (
   id                                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  asignacion_id                       uuid NOT NULL UNIQUE REFERENCES assignments(id) ON DELETE RESTRICT,
+  asignacion_id                       uuid NOT NULL UNIQUE REFERENCES asignaciones(id) ON DELETE RESTRICT,
   empresa_carrier_id                  uuid NOT NULL REFERENCES empresas(id),
   tier_slug_aplicado                  text NOT NULL REFERENCES membership_tiers(slug),
   monto_bruto_clp                     integer NOT NULL CHECK (monto_bruto_clp >= 0),

--- a/apps/api/drizzle/0017_factoring_v1.sql
+++ b/apps/api/drizzle/0017_factoring_v1.sql
@@ -28,9 +28,14 @@ CREATE TABLE shipper_credit_decisions (
 );
 
 -- Solo UNA decisión vigente por shipper (las expiradas quedan para auditoría).
+--
+-- NOTA: Postgres rechaza `WHERE expires_at > now()` porque `now()` no es
+-- IMMUTABLE. Workaround: índice unique por (empresa_shipper_id, expires_at).
+-- La app code filtra por `expires_at > now()` en queries de lectura. Si en
+-- el futuro queremos enforce a nivel BD, usar una columna boolean
+-- `vigente` actualizada por trigger o por la propia app.
 CREATE UNIQUE INDEX uq_shipper_credit_decisions_vigente
-  ON shipper_credit_decisions(empresa_shipper_id)
-  WHERE expires_at > now();
+  ON shipper_credit_decisions(empresa_shipper_id, expires_at);
 
 CREATE INDEX idx_shipper_credit_decisions_expires
   ON shipper_credit_decisions(expires_at);


### PR DESCRIPTION
## Summary

Continuación del hotfix de PR #158. Después de mergear el fix de migration 0015, drizzle avanzó al siguiente fallo: migration 0017 (Factoring v1) crea un partial unique index con `WHERE expires_at > now()`, que Postgres rechaza porque `now()` no es IMMUTABLE.

\`functions in index predicate must be marked IMMUTABLE\`

## Cambio

Una línea:

\`\`\`diff
- CREATE UNIQUE INDEX uq_shipper_credit_decisions_vigente
-   ON shipper_credit_decisions(empresa_shipper_id)
-   WHERE expires_at > now();
+ CREATE UNIQUE INDEX uq_shipper_credit_decisions_vigente
+   ON shipper_credit_decisions(empresa_shipper_id, expires_at);
\`\`\`

La app code filtra por \`expires_at > now()\` en queries de lectura. La unicidad estricta a nivel BD ahora es por \`(empresa_shipper_id, expires_at)\` — permite múltiples rows por shipper, una por cada underwriting histórico.

## Verificación

- Migration 0017 nunca se aplicó exitosamente en prod (bloqueado por este bug). Sin estado parcial que limpiar.
- App code de factoring está flag-gated (\`FACTORING_V1_ACTIVATED\`) por lo que tampoco depende todavía del comportamiento exacto del índice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)