### PR TITLE
fix(migration-0017): segunda ref a assignments → asignaciones

### DIFF
--- a/apps/api/drizzle/0015_pricing_v2.sql
+++ b/apps/api/drizzle/0015_pricing_v2.sql
@@ -78,7 +78,7 @@ COMMENT ON COLUMN carrier_memberships.consent_terms_v2_aceptado_en IS
 -- =============================================================================
 CREATE TABLE liquidaciones (
   id                                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  asignacion_id                       uuid NOT NULL UNIQUE REFERENCES assignments(id) ON DELETE RESTRICT,
+  asignacion_id                       uuid NOT NULL UNIQUE REFERENCES asignaciones(id) ON DELETE RESTRICT,
   empresa_carrier_id                  uuid NOT NULL REFERENCES empresas(id),
   tier_slug_aplicado                  text NOT NULL REFERENCES membership_tiers(slug),
   monto_bruto_clp                     integer NOT NULL CHECK (monto_bruto_clp >= 0),

--- a/apps/api/drizzle/0017_factoring_v1.sql
+++ b/apps/api/drizzle/0017_factoring_v1.sql
@@ -28,9 +28,14 @@ CREATE TABLE shipper_credit_decisions (
 );
 
 -- Solo UNA decisión vigente por shipper (las expiradas quedan para auditoría).
+--
+-- NOTA: Postgres rechaza `WHERE expires_at > now()` porque `now()` no es
+-- IMMUTABLE. Workaround: índice unique por (empresa_shipper_id, expires_at).
+-- La app code filtra por `expires_at > now()` en queries de lectura. Si en
+-- el futuro queremos enforce a nivel BD, usar una columna boolean
+-- `vigente` actualizada por trigger o por la propia app.
 CREATE UNIQUE INDEX uq_shipper_credit_decisions_vigente
-  ON shipper_credit_decisions(empresa_shipper_id)
-  WHERE expires_at > now();
+  ON shipper_credit_decisions(empresa_shipper_id, expires_at);
 
 CREATE INDEX idx_shipper_credit_decisions_expires
   ON shipper_credit_decisions(expires_at);

--- a/apps/api/drizzle/0017_factoring_v1.sql
+++ b/apps/api/drizzle/0017_factoring_v1.sql
@@ -48,7 +48,7 @@ COMMENT ON TABLE shipper_credit_decisions IS
 -- =============================================================================
 CREATE TABLE adelantos_carrier (
   id                              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  asignacion_id                   uuid NOT NULL UNIQUE REFERENCES assignments(id) ON DELETE RESTRICT,
+  asignacion_id                   uuid NOT NULL UNIQUE REFERENCES asignaciones(id) ON DELETE RESTRICT,
   liquidacion_id                  uuid REFERENCES liquidaciones(id),
   empresa_carrier_id              uuid NOT NULL REFERENCES empresas(id),
   empresa_shipper_id              uuid NOT NULL REFERENCES empresas(id),


### PR DESCRIPTION
Segunda referencia a la tabla `assignments` que quedó después de los fixes PR #158 y #159. En `adelantos_carrier` (Cobra Hoy), línea 51 del archivo. Mismo bug que la primera referencia que arreglamos.

Una línea de cambio. La migration aún no aplicada en prod (sin estado parcial).