### PR TITLE
fix(admin): platform admin bypassa /onboarding y aterriza en /app/platform-admin

### DIFF
--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -3,6 +3,7 @@ import { profileUpdateInputSchema } from '@booster-ai/shared-schemas';
 import { zValidator } from '@hono/zod-validator';
 import { and, eq } from 'drizzle-orm';
 import { Hono } from 'hono';
+import { config as appConfig } from '../config.js';
 import type { Db } from '../db/client.js';
 import { carrierMemberships, empresas, memberships, users } from '../db/schema.js';
 import type { FirebaseClaims } from '../middleware/firebase-auth.js';
@@ -75,6 +76,43 @@ export function createMeRoutes(opts: { db: Db; logger: Logger }) {
       }
     }
 
+    // ---------------------------------------------------------------------
+    // Platform admin auto-provisioning. Si el email Firebase está en la
+    // allowlist `BOOSTER_PLATFORM_ADMIN_EMAILS`, el user opera como admin
+    // de plataforma — no tiene empresa propia, su único hub es
+    // /app/platform-admin. Auto-creamos el row en `usuarios` la primera
+    // vez para que `/me` devuelva `needs_onboarding=false` y no quede
+    // bloqueado en el flow tenant de /onboarding.
+    //
+    // Trust boundary: la allowlist (env var) es la fuente de autoridad;
+    // mismo patrón que `requirePlatformAdmin` en admin-seed.ts. Si el
+    // email cambia o sale de la allowlist, el `is_platform_admin=true`
+    // queda como caché en BD (no se revoca automáticamente — eso
+    // requiere intervención manual o un job periódico).
+    // ---------------------------------------------------------------------
+    if (!user && claims.email) {
+      const adminAllowlist = appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS;
+      const isAdminEmail = adminAllowlist.includes(claims.email.toLowerCase());
+      if (isAdminEmail) {
+        const fullName = claims.name?.trim() ?? claims.email.split('@')[0] ?? 'Platform Admin';
+        const inserted = await opts.db
+          .insert(users)
+          .values({
+            firebaseUid: claims.uid,
+            email: claims.email,
+            fullName,
+            isPlatformAdmin: true,
+            status: 'activo',
+          })
+          .returning();
+        user = inserted[0];
+        opts.logger.info(
+          { email: claims.email, userId: user?.id },
+          'platform admin auto-provisioned from allowlist',
+        );
+      }
+    }
+
     if (!user) {
       return c.json({
         needs_onboarding: true,
@@ -129,6 +167,13 @@ export function createMeRoutes(opts: { db: Db; logger: Logger }) {
       active = activeMembershipsList[0] ?? null;
     }
 
+    // La allowlist env-var es la fuente de autoridad para platform admin
+    // (mismo patrón que requirePlatformAdmin). Si el email está en la
+    // allowlist, lo devolvemos true aunque el column en BD sea stale.
+    const adminAllowlist = appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS;
+    const isPlatformAdmin =
+      user.isPlatformAdmin || adminAllowlist.includes(user.email.toLowerCase());
+
     return c.json({
       needs_onboarding: false,
       user: {
@@ -138,7 +183,7 @@ export function createMeRoutes(opts: { db: Db; logger: Logger }) {
         phone: user.phone,
         whatsapp_e164: user.whatsappE164,
         rut: user.rut,
-        is_platform_admin: user.isPlatformAdmin,
+        is_platform_admin: isPlatformAdmin,
         status: user.status,
       },
       memberships: membershipsPayload,

--- a/apps/api/test/unit/me-platform-admin.test.ts
+++ b/apps/api/test/unit/me-platform-admin.test.ts
@@ -1,0 +1,319 @@
+import { Hono } from 'hono';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.SERVICE_NAME = 'booster-ai-api';
+  process.env.SERVICE_VERSION = '0.0.0-test';
+  process.env.LOG_LEVEL = 'error';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.REDIS_HOST = 'localhost';
+  process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173';
+  process.env.FIREBASE_PROJECT_ID = 'test';
+  process.env.API_AUDIENCE = 'https://api.boosterchile.com';
+  process.env.ALLOWED_CALLER_SA = 'caller@booster-ai.iam.gserviceaccount.com';
+  process.env.BOOSTER_PLATFORM_ADMIN_EMAILS = 'admin@boosterchile.com';
+});
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as Parameters<typeof import('../../src/routes/me.js').createMeRoutes>[0]['logger'];
+
+/**
+ * Mock de DB con queue de selects + capacidad de capturar inserts.
+ * Para /me necesitamos hasta 3 selects:
+ *   1. users by firebase_uid
+ *   2. users by email (account linking) — solo si emailVerified
+ *   3. memberships (cuando user existe)
+ * Y posiblemente 1 insert (auto-provision admin).
+ */
+function makeDbStub(opts: {
+  userByFirebaseUid?: Record<string, unknown> | null;
+  userByEmail?: Record<string, unknown> | null;
+  memberships?: Record<string, unknown>[];
+  insertReturning?: Record<string, unknown>[];
+}) {
+  const selectResults: Array<Record<string, unknown>[]> = [];
+  selectResults.push(opts.userByFirebaseUid ? [opts.userByFirebaseUid] : []);
+  // Para el account linking solo se invoca si !user && emailVerified. En el
+  // test setup decidimos qué devolver: si no se llama, queda en queue.
+  selectResults.push(opts.userByEmail ? [opts.userByEmail] : []);
+  // Memberships join.
+  selectResults.push(opts.memberships ?? []);
+
+  const limit = vi.fn(() => Promise.resolve(selectResults.shift() ?? []));
+  const innerJoin = vi.fn(() => ({
+    where: vi.fn(() => Promise.resolve(selectResults.shift() ?? [])),
+  }));
+  const where = vi.fn(() => ({
+    limit,
+    then: (resolve: (v: unknown[]) => void) => resolve(selectResults.shift() ?? []),
+  }));
+  const from = vi.fn(() => ({ where, innerJoin }));
+  const select = vi.fn(() => ({ from }));
+
+  const insertCalls: Array<Record<string, unknown>> = [];
+  const insertReturning = vi.fn(() => Promise.resolve(opts.insertReturning ?? []));
+  const insertValues = vi.fn((vals: Record<string, unknown>) => {
+    insertCalls.push(vals);
+    return { returning: insertReturning };
+  });
+  const insert = vi.fn(() => ({ values: insertValues }));
+
+  const updateReturning = vi.fn(() => Promise.resolve([]));
+  const updateWhere = vi.fn(() => ({ returning: updateReturning }));
+  const set = vi.fn(() => ({ where: updateWhere }));
+  const update = vi.fn(() => ({ set }));
+
+  return {
+    db: { select, insert, update } as unknown as Parameters<
+      typeof import('../../src/routes/me.js').createMeRoutes
+    >[0]['db'],
+    insertCalls,
+  };
+}
+
+async function buildApp(
+  db: Parameters<typeof import('../../src/routes/me.js').createMeRoutes>[0]['db'],
+) {
+  const { createMeRoutes } = await import('../../src/routes/me.js');
+  const app = new Hono();
+  app.use('/me/*', async (c, next) => {
+    const claimsHeader = c.req.header('x-test-claims');
+    if (claimsHeader) {
+      const parsed = JSON.parse(claimsHeader) as {
+        uid: string;
+        email?: string;
+        emailVerified?: boolean;
+      };
+      c.set('firebaseClaims', {
+        uid: parsed.uid,
+        email: parsed.email,
+        emailVerified: parsed.emailVerified ?? false,
+        name: undefined,
+        picture: undefined,
+        custom: {},
+      });
+    }
+    await next();
+  });
+  app.route('/me', createMeRoutes({ db, logger: noopLogger }));
+  return app;
+}
+
+describe('GET /me — platform admin auto-provisioning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('email NO en allowlist + user no existe → needs_onboarding=true (sin auto-provision)', async () => {
+    const { db, insertCalls } = makeDbStub({
+      userByFirebaseUid: null,
+      userByEmail: null,
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me', {
+      headers: {
+        'x-test-claims': JSON.stringify({
+          uid: 'fb-rando',
+          email: 'random@example.com',
+          emailVerified: true,
+        }),
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { needs_onboarding: boolean };
+    expect(body.needs_onboarding).toBe(true);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('email en allowlist + user no existe → auto-provisiona admin', async () => {
+    const provisionedUser = {
+      id: 'u-admin',
+      firebaseUid: 'fb-admin',
+      email: 'admin@boosterchile.com',
+      fullName: 'Admin',
+      phone: null,
+      whatsappE164: null,
+      rut: null,
+      status: 'activo',
+      isPlatformAdmin: true,
+    };
+    const { db, insertCalls } = makeDbStub({
+      userByFirebaseUid: null,
+      userByEmail: null,
+      memberships: [],
+      insertReturning: [provisionedUser],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me', {
+      headers: {
+        'x-test-claims': JSON.stringify({
+          uid: 'fb-admin',
+          email: 'admin@boosterchile.com',
+          emailVerified: true,
+        }),
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      needs_onboarding: boolean;
+      user: { is_platform_admin: boolean; email: string };
+      active_membership: unknown;
+    };
+    expect(body.needs_onboarding).toBe(false);
+    expect(body.user.is_platform_admin).toBe(true);
+    expect(body.user.email).toBe('admin@boosterchile.com');
+    expect(body.active_membership).toBeNull();
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0]?.firebaseUid).toBe('fb-admin');
+    expect(insertCalls[0]?.isPlatformAdmin).toBe(true);
+    expect(insertCalls[0]?.status).toBe('activo');
+  });
+
+  it('email en allowlist case-insensitive (mayúsculas) → auto-provisiona', async () => {
+    const provisionedUser = {
+      id: 'u-admin',
+      firebaseUid: 'fb-admin',
+      email: 'ADMIN@boosterchile.com',
+      fullName: 'admin',
+      phone: null,
+      whatsappE164: null,
+      rut: null,
+      status: 'activo',
+      isPlatformAdmin: true,
+    };
+    const { db, insertCalls } = makeDbStub({
+      userByFirebaseUid: null,
+      userByEmail: null,
+      memberships: [],
+      insertReturning: [provisionedUser],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me', {
+      headers: {
+        'x-test-claims': JSON.stringify({
+          uid: 'fb-admin',
+          email: 'ADMIN@boosterchile.com',
+          emailVerified: true,
+        }),
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: { is_platform_admin: boolean } };
+    expect(body.user.is_platform_admin).toBe(true);
+    expect(insertCalls).toHaveLength(1);
+  });
+
+  it('user existe con is_platform_admin=false pero email en allowlist → fuerza true en respuesta', async () => {
+    const existingUser = {
+      id: 'u-1',
+      firebaseUid: 'fb-admin',
+      email: 'admin@boosterchile.com',
+      fullName: 'Admin',
+      phone: null,
+      whatsappE164: null,
+      rut: null,
+      status: 'activo',
+      isPlatformAdmin: false, // stale en BD
+    };
+    const { db, insertCalls } = makeDbStub({
+      userByFirebaseUid: existingUser,
+      memberships: [],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me', {
+      headers: {
+        'x-test-claims': JSON.stringify({
+          uid: 'fb-admin',
+          email: 'admin@boosterchile.com',
+          emailVerified: true,
+        }),
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      user: { is_platform_admin: boolean };
+      needs_onboarding: boolean;
+    };
+    expect(body.needs_onboarding).toBe(false);
+    expect(body.user.is_platform_admin).toBe(true); // allowlist override
+    expect(insertCalls).toHaveLength(0); // no re-insert
+  });
+
+  it('user existe is_platform_admin=true → respuesta true sin tocar BD', async () => {
+    const existingUser = {
+      id: 'u-1',
+      firebaseUid: 'fb-admin',
+      email: 'felipe@boosterchile.com', // NO en allowlist
+      fullName: 'Felipe',
+      phone: null,
+      whatsappE164: null,
+      rut: null,
+      status: 'activo',
+      isPlatformAdmin: true,
+    };
+    const { db, insertCalls } = makeDbStub({
+      userByFirebaseUid: existingUser,
+      memberships: [],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me', {
+      headers: {
+        'x-test-claims': JSON.stringify({
+          uid: 'fb-admin',
+          email: 'felipe@boosterchile.com',
+          emailVerified: true,
+        }),
+      },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: { is_platform_admin: boolean } };
+    expect(body.user.is_platform_admin).toBe(true);
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it('email allowlist sin nombre Firebase → usa email local-part como fullName', async () => {
+    const insertedRow = {
+      id: 'u-admin',
+      firebaseUid: 'fb-admin',
+      email: 'admin@boosterchile.com',
+      fullName: 'admin', // local part de admin@boosterchile.com
+      phone: null,
+      whatsappE164: null,
+      rut: null,
+      status: 'activo',
+      isPlatformAdmin: true,
+    };
+    const { db, insertCalls } = makeDbStub({
+      userByFirebaseUid: null,
+      userByEmail: null,
+      memberships: [],
+      insertReturning: [insertedRow],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me', {
+      headers: {
+        'x-test-claims': JSON.stringify({
+          uid: 'fb-admin',
+          email: 'admin@boosterchile.com',
+          emailVerified: true,
+        }),
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(insertCalls[0]?.fullName).toBe('admin');
+  });
+});

--- a/apps/web/src/routes/app.test.tsx
+++ b/apps/web/src/routes/app.test.tsx
@@ -129,6 +129,36 @@ describe('AppRoute', () => {
     expect(screen.queryByText('Bienvenido a Booster')).not.toBeInTheDocument();
   });
 
+  it('platform admin → redirige a /app/platform-admin (sin importar memberships)', () => {
+    const me = makeMe();
+    (me.user as { is_platform_admin?: boolean }).is_platform_admin = true;
+    providedContext = { kind: 'onboarded', me };
+    render(<AppRoute />);
+    expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app/platform-admin');
+    expect(screen.queryByText('Bienvenido a Booster')).not.toBeInTheDocument();
+  });
+
+  it('platform admin SIN memberships (auto-provisioned) → redirige a /app/platform-admin', () => {
+    const me: MeOnboarded = {
+      needs_onboarding: false,
+      user: {
+        id: 'u',
+        email: 'admin@boosterchile.com',
+        full_name: 'Admin',
+        phone: null,
+        whatsapp_e164: null,
+        rut: null,
+        is_platform_admin: true,
+        status: 'activo',
+      },
+      memberships: [],
+      active_membership: null,
+    };
+    providedContext = { kind: 'onboarded', me };
+    render(<AppRoute />);
+    expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app/platform-admin');
+  });
+
   it('click Salir → signOutUser', () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
     render(<AppRoute />);

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -52,6 +52,15 @@ function AppDashboard({ me }: { me: MeOnboarded }) {
   const myRole = me.active_membership?.role;
   const isAdmin = myRole === 'dueno' || myRole === 'admin';
 
+  // Platform admin surface guard. El admin de plataforma no es tenant: no
+  // tiene empresa propia ni rol de tenant. Su único hub es
+  // /app/platform-admin (seed, ops platform-wide). Si además tuviera
+  // memberships de testing, puede navegar manualmente a las otras
+  // surfaces — pero el landing por defecto es el panel admin.
+  if (me.user.is_platform_admin) {
+    return <Navigate to="/app/platform-admin" />;
+  }
+
   // D9 — Driver surface guard. Si el rol activo es 'conductor', el user
   // no debería ver el dashboard carrier (ofertas/vehículos/cargas).
   // Redirigimos a /app/conductor/modo (su único hub). Excepción: si el


### PR DESCRIPTION
## Problema

Al loguearse con un email de la allowlist \`BOOSTER_PLATFORM_ADMIN_EMAILS\`, el usuario quedaba atrapado en \`/onboarding\` pidiendo declarar si la empresa es "Generador de carga" o "Transportista" — semántica de tenant que **no aplica** al admin de plataforma.

Screenshot del problema: el admin \`dev@boosterchile.com\` aparecía en el step 1/4 del wizard de onboarding, sin ruta para llegar al panel admin.

## Causa

\`GET /me\` devolvía \`needs_onboarding=true\` porque el row en \`usuarios\` no existía. El admin existe en Firebase Auth pero nunca pasó por el onboarding (por diseño — no es tenant).

## Fix

1. **API** (\`apps/api/src/routes/me.ts\`):
   - \`GET /me\` auto-provisiona el user en \`usuarios\` con \`is_platform_admin=true\` si el email Firebase está en la allowlist y el row no existe.
   - El response fuerza \`is_platform_admin=true\` desde la env var (defensa contra columna stale).
   - Devuelve \`needs_onboarding=false\` con \`active_membership=null\`.

2. **Web** (\`apps/web/src/routes/app.tsx\`):
   - \`AppDashboard\` chequea \`me.user.is_platform_admin\` **antes** que los otros surface guards (conductor, stakeholder) y hace \`<Navigate to="/app/platform-admin" />\`.

3. **Defense in depth via ProtectedRoute (sin cambios)**: \`/onboarding\` ya redirige a \`/app\` cuando \`me.needs_onboarding=false\`. Con #1, esto encadena: admin login → \`/me\` returns onboarded+admin → \`/onboarding\` → \`/app\` → \`/app/platform-admin\`.

## Trust boundary

La env var \`BOOSTER_PLATFORM_ADMIN_EMAILS\` es la fuente de autoridad — mismo patrón que \`requirePlatformAdmin\` en \`admin-seed.ts\`. La columna BD \`is_platform_admin\` queda como caché.

## Test plan

- [x] 6 unit tests API (\`me-platform-admin.test.ts\`): email no allowlist, allowlist+user inexistente, case-insensitive, user existente con flag stale, user is_platform_admin=true sin allowlist, fullName fallback
- [x] 2 unit tests web (\`app.test.tsx\`): admin con memberships + admin sin memberships ambos redirigen a \`/app/platform-admin\`
- [x] \`pnpm lint\` exit 0
- [x] \`pnpm typecheck\` exit 0
- [x] \`pnpm test:coverage\` exit 0 (todos los thresholds pasan)
- [ ] Smoke en producción: login con \`dev@boosterchile.com\` aterriza directo en \`/app/platform-admin\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)