### PR TITLE
docs(telemetry): Wave 3 v2 — preload CA root + ADR-040

### DIFF
--- a/docs/adr/040-wave-3-tls-ca-preload-fmc150.md
+++ b/docs/adr/040-wave-3-tls-ca-preload-fmc150.md
@@ -1,0 +1,90 @@
+# ADR-040 — Wave 3 TLS: Pre-cargar CA root al device FMC150 antes de activar TLS
+
+**Fecha**: 2026-05-12
+**Estado**: Accepted (validado en producción)
+**Supersede parcialmente**: ADR-005 — sección "Status post-Wave 3" (procedimiento Wave 3 inicial)
+**Refs**: `docs/handoff/2026-05-11-wave-3-incidente-rollback.md`, `docs/research/teltonika-fmc150/INSTRUCTIVO-WAVE-3.md`, `docs/runbooks/wave-2-3-deploy.md` §5.2
+
+## Contexto
+
+El plan original de Wave 3 (ADR-005) asumía que el firmware FMC150 tenía pre-instaladas las CA roots públicas comunes y que el handshake TLS contra el cert servidor Let's Encrypt funcionaría sin pasos adicionales en el device.
+
+El 2026-05-08 se pusheó `FMC150_Booster_Wave3_1.cfg` al device productivo del cliente Van Oosterwyk (IMEI `863238075489155`). El device:
+- Aplicó el cfg correctamente (`2020:1` TLS encryption primary, `2004:telemetry-tls.boosterchile.com`, `2005:5061`).
+- Aparecía "En línea" en FOTA Web (canal RMS sano).
+- Pero **no enviaba un solo record codec8 al gateway** durante 3 días.
+
+Diagnóstico el 2026-05-11:
+- Server-side todo OK (cert válido, LB UP, firewall abierto, handshake TLS verificado server-side desde dentro del cluster).
+- Device-side: TLS handshake fallaba — el firmware FMC150 `04.01.00.Rev.08` no incluye `ISRG Root X1` (CA root de Let's Encrypt) en su trust store, por lo que no podía validar la cadena `server cert → R13 (intermediate) → ISRG Root X1`.
+
+Resolución inicial (2026-05-11): rollback a Wave 2 plain via SMS-MT `setparam` (rollback documentado en ADR mismo).
+Resolución definitiva (2026-05-12): Wave 3 v2 con paso pre-cert ANTES de activar TLS.
+
+## Decisión
+
+**Procedimiento Wave 3 v2** para FMC150 firmware `04.01.00.Rev.08` (y otros firmwares FMx con trust store limitado):
+
+### Orden estricto del rollout
+
+1. **Paso 0 (nuevo) — Cargar CA root al device**. Vía FOTA Web → "Cargar certificado TLS de usuario" con `isrgrootx1.pem` (Let's Encrypt root, válido hasta 2035). Esperar a que la task pase a `Completado` en FOTA.
+
+2. **Paso 1 — Push cfg Wave 3** (`FMC150_Booster_Wave3.cfg` con `2020:1`, `2021:1`, hosts/ports TLS). Recién después del Paso 0.
+
+### Validaciones de cierre (gate G3.4 extendido)
+
+- TLS handshake primario completa: confirmar puerto local 5061 en `/proc/net/tcp6` del pod gateway, no solo "handshake IMEI completado" en logs.
+- Persistencia: enviar SMS `cpureset`, confirmar reconexión post-boot en TLS 5061 (sin re-cargar cert).
+- Failover DR: patch `targetPort` del Service primary a puerto cerrado, confirmar device conecta al cluster DR `us-central1` en `telemetry-dr.boosterchile.com:5061`.
+
+### Rollback path estándar
+
+Mantener **dos vías de rollback** documentadas y probadas:
+
+- **Configurador local USB** (Teltonika Configurator desktop): Load `FMC150_Booster_Wave2.cfg` → Save to device. Requiere acceso físico.
+- **SMS-MT** via operador SIM: `  setparam 2020:0;2004:telemetry.boosterchile.com;2005:5027` (2 espacios líderes obligatorios cuando cfg tiene `1250:0` SMS Login disabled con login/pass vacíos).
+
+## Lecciones aprendidas que motivan esta decisión
+
+1. **FOTA Web warning "FMx not compatible with TLS secure certificate transfer" es falso positivo** para firmware FMC150 `04.01.00.Rev.08`. La carga del cert SÍ funciona y persiste a través de `cpureset` completo (validado en producción 2026-05-12).
+
+2. **"En línea" en FOTA Web ≠ telemetría operativa**. FOTA Web track el canal RMS (`fm.teltonika.lt`), independiente del flujo codec8 hacia el gateway. La verificación de telemetría productiva debe hacerse contra logs del gateway o métricas custom, no contra FOTA Web.
+
+3. **Polling RMS del firmware FMC150 04.01.x no es inmediato**. Requiere ventana cellular sostenida (varios segundos de HTTPS estable) que no siempre ocurre en vehículos en movimiento por zonas rurales/cordillera chilena. Las tasks de FOTA pueden quedar Pendiente horas si el vehículo no entra en zona urbana estable. Mitigación: planificar rollouts cuando el vehículo está detenido (final de turno, depot/garage).
+
+4. **Sintaxis SMS Teltonika con SMS Login disabled**: los 2 espacios líderes (`  command`) son obligatorios cuando `1250:0` con login/pass vacíos. Sin ellos el device descarta el SMS silenciosamente. Verificado vs documentación oficial Teltonika (ambigua) y vs comportamiento productivo.
+
+5. **Sin SMS-MO activo (default en Truphone IoT)** el device no puede confirmar ejecución de comandos. La única señal indirecta es la observación del efecto en el gateway (TLS errors paran / records empiezan a llegar).
+
+## Consecuencias
+
+### Positivas
+
+- Wave 3 productivo y validado en cliente Van Oosterwyk desde 2026-05-12.
+- Procedimiento reproducible para devices nuevos: subir cert una vez, después push cfg Wave 3 normal.
+- Rollback remoto sin acceso físico verificado y documentado.
+
+### Negativas / riesgos
+
+- **Renovación intermediate Let's Encrypt**: la cadena actual es `R13 → ISRG Root X1`. Si Let's Encrypt rota el intermediate (cada ~2 años), los devices siguen OK porque validan contra el root. Pero **si rotaran el root** (cambio a ISRG Root X2 ECDSA), habría que pushear el nuevo root a toda la flota antes de la rotación. ISRG Root X1 vence 2035-06-04 — tiempo amplio.
+
+- **Single point of failure si el cert local en device se corrompe** (no documentado por Teltonika cómo o cuándo puede ocurrir). Mitigación: el rollback SMS plain Wave 2 sigue siendo opción válida.
+
+- **Tiempo de rollout por device** se duplica (2 tasks FOTA en vez de 1), agregando latencia operacional. Aceptable para flota inicial pequeña, debería optimizarse con tooling cuando la flota crezca (>20 devices).
+
+## Estado de las pre-conditions originales del ADR-005
+
+| Pre-condition | Estado 2026-05-12 |
+|---|---|
+| G2.3 — Capacity load test PASS | Pendiente (saltado por incidente P1 — formalizar) |
+| G3.4 — DR failover test PASS | **PASS** (validado 2026-05-12 14:34 UTC en device productivo) |
+| Wave 2 estable >7 días | N/A (saltado por incidente P1) |
+
+Las pre-conditions G2.3 y "Wave 2 estable 7d" se saltaron por necesidad operacional (incidente P1 requirió rollout urgente). Esto NO es procedimiento estándar — para próximos devices que se incorporen a Wave 3, las pre-conditions deben respetarse.
+
+## Cambios derivados
+
+- `docs/research/teltonika-fmc150/INSTRUCTIVO-WAVE-3.md`: nueva §0 con paso de cert preload + corrección de la afirmación errónea "no hace falta subir CA al device".
+- `docs/runbooks/wave-2-3-deploy.md` §5.2: agregado Paso 0 obligatorio + rollback SMS alternativo.
+- Memoria reference `reference_wave_3_v2_secuencia.md` (nueva).
+- Memoria reference `reference_teltonika_sms_commands.md` (existente, complementa esta ADR).

--- a/docs/handoff/2026-05-11-wave-3-incidente-rollback.md
+++ b/docs/handoff/2026-05-11-wave-3-incidente-rollback.md
@@ -1,0 +1,180 @@
+# Handoff — Incidente Wave 3 TLS: device sin telemetría 32+h (2026-05-11)
+
+**Severidad**: P1 — primer cliente productivo (Van Oosterwyk) sin telemetría.
+**Owner**: Felipe Vicencio (PO).
+**Detección**: 2026-05-11 ~10:00 CLT vía verificación manual del PO.
+**Causa raíz**: cfg `FMC150_Booster_Wave3_1.cfg` (push 2026-05-08 23:11) activó TLS en el device sin que el firmware FMC150 `04.01.00.Rev.08` complete handshake contra cert Let's Encrypt del LB primary.
+**Resolución**: 2026-05-11 16:00 UTC — vía `setparam` por SMS-MT (Truphone Connect) con sintaxis `  setparam 2020:0;2004:telemetry.boosterchile.com;2005:5027` (2 espacios prefijo). Device reconectó plain `:5027`, telemetría restablecida.
+**Wave 3 v2 — éxito final**: 2026-05-12 — Cargado `isrgrootx1.pem` al device via FOTA, pusheado cfg Wave 3, device reconectó TLS 5061 exitosamente. Las 3 validaciones (puerto TLS 5061, persistencia post-cpureset, failover DR) pasaron. Wave 3 productivo y validado. Ver **ADR-040** para procedimiento definitivo.
+
+## TL;DR
+
+- Server-side **100% operativo**: services TLS + plain UP en primary y DR, certs `Ready`, pods sin restarts, firewall abierto, handshake TLS verificado server-side desde dentro del cluster (TLSv1.2 / cert válido).
+- Device-side **roto**: el Teltonika no abre TCP a ninguno de los 3 endpoints (`:5027`, primary `:5061`, DR `:5061`). 0 records codec8 en buffer del pod (~32h).
+- FOTA Web marca el device "En línea" pero esa señal es el canal RMS (`fm.teltonika.lt`), independiente del flujo codec8 → nuestro gateway.
+
+## Evidencia
+
+```
+PRIMARY pods:        2/2 Running 20-32h sin restart
+Service plain :5027: LB 34.176.238.106  UP  6d14h
+Service TLS   :5061: LB 34.176.1.94     UP  2d21h
+Certificate primary: Ready=True (Let's Encrypt prod, 2d20h)
+DR Service TLS:      LB 136.116.208.86  UP  2d20h
+DR Certificate:      Ready=True
+Firewall :5027 + :5061 + :5061 DR: INGRESS 0.0.0.0/0 ALLOW
+
+TLS probe desde Pod (sin firewall externo):
+  CONNECTION ESTABLISHED / TLSv1.2 / Verification: OK / CN=telemetry-tls.boosterchile.com
+
+externalTrafficPolicy=Local en ambos services → sourceIp NO enmascarado por SNAT.
+
+Logs gateway primary últimas 24h:
+  11,521 conexiones totales — todas con imei=null, sourceIp 10.20.1.1 (healthcheck GCP LB)
+  0 conexiones con imei populado
+  0 records recibidos
+  16 "tls handshake error" / hora — patrón inconsistente con device retry (sin sourceIp porque socket close pre-context); probable scanner internet
+
+Conexiones con IMEI 863238075489155: 0 (ninguna en todo el buffer del pod)
+```
+
+## Diff Wave 2 → Wave 3_1 (cfg parseado)
+
+Sólo 7 parámetros cambian entre el cfg que funcionaba (Wave 2) y el actual (Wave 3_1):
+
+| Param | Wave 2 (works) | Wave 3_1 (current, broken) |
+|---|---|---|
+| 2004 (domain primary) | `telemetry.boosterchile.com` | `telemetry-tls.boosterchile.com` |
+| 2005 (port primary) | `5027` | `5061` |
+| 2007 (domain backup) | (vacío) | `telemetry-dr.boosterchile.com` |
+| 2008 (port backup) | `0` | `5061` |
+| 2010 (backup enable) | `0` | `1` |
+| **2020 (TLS primary)** | **`0`** | **`1`** ← culpable |
+| **2021 (TLS backup)** | **`0`** | **`1`** ← culpable |
+
+## Acción que resolvió (SMS-MT via Truphone Connect)
+
+**FOTA Web NO funcionó como vía**:
+- Task "Configuración de la carga" Wave 2 quedó **Pendiente** 1.5h sin que el device la procesara (polling RMS interrumpido por cobertura cellular intermitente — vehículo en movimiento).
+- FOTA Web Cloud **no tiene opción de "Send command" ni "Reboot"** en la UI actual (verificado parseando dropdown de tipos de tarea: solo firmware/cfg/autorizaciones/cert TLS/logs/OEM).
+
+**Lo que sí funcionó**:
+
+Truphone Connect → SIM Cards → ICCID `8944474400008090359` → Send SMS:
+```
+  setparam 2020:0;2004:telemetry.boosterchile.com;2005:5027
+```
+
+**Crítico**: el SMS DEBE empezar con **2 espacios** porque el cfg tiene `1250:0` (SMS Login disabled) con `1251`/`1252` vacíos — el firmware FMC150 04.01.x usa la sintaxis `<login> <password> <command>` y exige los separadores espacio aunque login/password sean vacíos. Sin los 2 espacios, el device descarta el SMS silenciosamente (3 intentos previos sin espacios = Delivered pero sin efecto).
+
+Tiempo de resolución una vez enviado SMS con sintaxis correcta: ~46 min (incluye ventana de cobertura intermitente del vehículo).
+
+Datos clave Truphone:
+- MSISDN del device: `4915299520975` (Truphone Global, número alemán roaming)
+- SMS MO Service: **Suspended** → device NO puede confirmar ejecución via SMS-MO
+- SMS MT Service: Active → vía válida para enviar comandos
+- Portal: https://iot.truphone.com/sims/{ICCID}/ y https://iot.truphone.com/sms/
+
+## Acciones previas que NO funcionaron
+
+1. **FOTA "Configuración de la carga"** con cfg Wave 2 (task 171659313 Pendiente) — device no completaba polling RMS por movimiento + zonas marginales.
+2. **SMS `web_connect`** ×3 (sin espacios) — Delivered pero sin efecto (sintaxis rechazada).
+3. **SMS `cpureset`** (sin espacios) — Delivered, probable que sí ejecutó (10 min silencio TLS errors 14:53-15:03 consistente con reset), pero al volver retomó cfg Wave 3.
+4. **SMS `setparam ...`** (sin espacios) — Delivered pero sin efecto.
+
+## Monitoreo post-rollback
+
+```bash
+kubectl --context=gke_booster-ai-494222_southamerica-west1_booster-ai-telemetry \
+  logs -n telemetry deployment/telemetry-tcp-gateway --follow \
+  | grep --line-buffered 863238075489155
+```
+
+Esperado en <5 min: log con `imei:"863238075489155", recordsReceived:N, recordsPublished:N`.
+
+Si no aparece en 10 min: device puede tener problema cellular (Truphone APN, signal). Verificar en FOTA Web → Detalles del dispositivo → última actividad RMS.
+
+## Estado post-resolución (verificar)
+
+Telemetría restablecida pero quedan **acciones pendientes**:
+
+1. **¿`setparam` persistió en flash o solo RAM?** Si solo RAM, al próximo `cpureset` o pérdida de poder el device vuelve a Wave 3 → reincidirá el outage. Verificar:
+   - Próximo polling RMS exitoso del device → "Configuración" en FOTA Web debería seguir mostrando `Wave3_1.cfg` aunque el device está corriendo Wave 2 effective.
+   - Para hacerlo permanente: push de cfg Wave 2 vía FOTA cuando el device tenga ventana de cobertura estable (task 171659313 sigue Pendiente — debería completar sola).
+2. **Cancelar o dejar la task Wave 2 pendiente en FOTA**: si se aplica, sobrescribe el setparam con un cfg completo Wave 2 (deseable para persistencia).
+3. **Cobertura intermitente del vehículo**: factor agravante. Documentar como riesgo recurrente para flota productiva.
+
+## Intento Wave 3 v2 — 2026-05-11 tarde (no concluido)
+
+Tras estabilizar Wave 2 en la mañana, se intentó re-introducir Wave 3 con CA root preinstalada:
+
+**Acciones ejecutadas:**
+1. Descargado `isrgrootx1.pem` de https://letsencrypt.org/certs/isrgrootx1.pem.
+2. Verificado cadena del cert servidor: `CN=telemetry-tls.boosterchile.com → CN=R13 → ISRG Root X1` ✓.
+3. FOTA Web → tarea "Cargar certificado TLS de usuario" con `isrgrootx1.pem` (task 171686771) → **Pendiente**.
+4. FOTA Web → tarea "Configuración de la carga" con `FMC150_Booster_Wave3_1.cfg` (task 171686944) → **Pendiente**.
+5. SMS-MT `  cpureset` enviado para forzar polling RMS — device reseteo confirmado (sesión TCP nueva), pero **polling RMS no completó post-boot**.
+6. SMS-MT `  dotaskrequest` enviado para pedir tasks RMS sin reset — Delivery pendiente (vehículo en ruta con señal débil).
+
+**Resultado**: las 2 tasks Wave 3 quedaron Pendientes. **Wave 3 NO se aplicó** en esta sesión.
+
+**Blockers operacionales identificados:**
+- **FOTA WEB warning**: "FMx platform communication channel security is **not compatible** with TLS secure certificate transfer requirements. Use with caution. FT platform devices are fully compatible". El FMC150 es FMx — la carga del cert puede no funcionar aunque la task aplique.
+- **Polling RMS del firmware FMC150 04.01.00.Rev.08 no completa post-cpureset** durante operación normal (vehículo en ruta con cobertura intermitente). Solo se completó la mañana (task Wave 2 rollback 171659313) cuando hubo una ventana cellular suficientemente estable.
+- **`dotaskrequest` SMS**: no se pudo validar efectividad en esta sesión (vehículo entró en zona sin señal antes del delivery).
+
+**Camino corregido para próximo intento** (cuando vehículo esté detenido en cobertura estable, ej. final de turno):
+1. Las 2 tasks Wave 3 ya están en cola, no requieren re-armado.
+2. Cuando "Visto en" en FOTA Web se actualice a una hora reciente → polling RMS completó → tasks deberían aplicar automáticamente.
+3. Si task de cert falla por warning FMx → única vía garantizada es **Configurador USB en taller** (técnico, cable, software Teltonika Configurator desktop).
+4. Si task de cert OK pero handshake TLS falla → SMS rollback armado: `  setparam 2020:0;2004:telemetry.boosterchile.com;2005:5027` (probado y confiable, 30s para restaurar Wave 2).
+
+## Plan para re-introducir Wave 3 (defer, posterior a estabilización)
+
+El TLS dual-endpoint es válido como objetivo, pero requiere paso previo no contemplado en el runbook actual:
+
+1. **Cargar CA root de Let's Encrypt en el device** vía FOTA Web (file ID `1551` o el correspondiente al FMC150 cfg gen 13.0.0.0). Sin esto, el firmware no valida el cert servidor.
+2. Verificar parámetro de TLS Verify (probablemente `2018` o `2019`) — confirmar contra manual oficial Teltonika.
+3. Smoke test contra **un device de lab** con la combinación CA root + TLS Verify + cert servidor antes de tocar producción.
+4. Recién después, push Wave 3 a flota productiva.
+
+Pre-conditions del runbook original (`docs/runbooks/wave-2-3-deploy.md` §5.2) deben actualizarse con el paso del CA root.
+
+## Aprendizajes operacionales (referencia futura)
+
+1. **FOTA Web Cloud NO tiene Send command / Reboot remoto** en la UI — solo firmware uploads, cfg push/pull, autorizaciones, cert TLS, logs, archivos OEM. Para comandos al device (cpureset, setparam, getstatus, web_connect) **hay que ir por SMS-MT via SIM operator** (Truphone Connect en este caso).
+
+2. **Sintaxis SMS Teltonika FMC150 04.01.x**: el comando debe ir precedido del par `<login> <password>`. Si ambos están vacíos en cfg (`1250:0`, `1251`/`1252` vacíos), igualmente requiere **2 espacios prefijo** (`  command`). Sin ellos el device descarta el SMS silenciosamente (Delivered pero no ejecutado).
+
+3. **"En línea" en FOTA Web ≠ reportando codec8**: FOTA Web track RMS (`fm.teltonika.lt`), independiente del flujo codec8. Un device puede estar "En línea" en FOTA y simultáneamente sin enviar telemetría.
+
+4. **"Visto en" de FOTA Web** = último ping RMS exitoso, no actividad cellular. Puede mostrar valores muy desactualizados aunque la SIM tenga data session activa (verificar en portal del operador SIM).
+
+5. **Truphone Connect — datos útiles**:
+   - URL detalle SIM: `https://iot.truphone.com/sims/{ICCID}/`
+   - URL send SMS: `https://iot.truphone.com/sms/`
+   - URL SMS History: `https://iot.truphone.com/sms/history/`
+   - Para FMC150 con ICCID `8944474400008090359`: MSISDN `4915299520975`, SMS MO **Suspended** (device no responde por SMS), SMS MT **Active**.
+
+6. **Sin SMS MO el device no confirma ejecución de comandos**: la única señal indirecta de éxito es observar el efecto en el gateway (TLS errors paran / records empiezan a llegar).
+
+7. **Cobertura cellular intermitente (vehículos en movimiento por zonas rurales/cordillera chilena)** es factor agravante recurrente. Tanto polling RMS como SMS quedan en cola del SMSC/operador hasta ventana de señal estable.
+
+8. **Comando `setparam` Teltonika**:
+   - Single: `setparam <id>:<val>`
+   - Multi: `setparam <id1>:<val1>;<id2>:<val2>;...` (separador `;`)
+   - Params clave para server: `2004` (domain primary), `2005` (port primary), `2007/2008` (backup), `2010` (backup enable), `2020/2021` (TLS encryption primary/backup).
+
+## Follow-ups técnicos
+
+- **Mejorar log del gateway**: el evento `tlsClientError` no captura `socket.remoteAddress` porque el socket está cerrado al momento de log. Workaround: registrar `connection` event del `tls.Server` y mantener `remoteAddress` en una `WeakMap` para correlacionar.
+- **Alerta Cloud Monitoring**: definir alerta P1 en métrica custom `device_records_per_minute` filtrado por IMEI productivo. Threshold: 0 records en 15 min → page.
+- **Health check vía FOTA RMS NO ES SUFICIENTE**: documentar en CLAUDE.md / runbook que "En línea" en FOTA es señal de RMS (control plane Teltonika), no de codec8 hacia nuestro gateway. Son canales independientes.
+- **ADR follow-up de ADR-005**: superseder sección "Status post-Wave 3" cuando el rollout corregido se ejecute.
+
+## Referencias
+
+- Handoff previo: [2026-05-10-wave-3-tls-ready.md](2026-05-10-wave-3-tls-ready.md) (decía "código mergeado, bloqueado operacionalmente" — pero el cfg Wave 3 fue pusheado el 2026-05-08 prematuramente, antes de las pre-conditions del runbook).
+- Runbook: `docs/runbooks/wave-2-3-deploy.md` §5.2.
+- INSTRUCTIVO: `docs/research/teltonika-fmc150/INSTRUCTIVO-WAVE-3.md`.
+- ADR-005: Stack telemetría IoT.

--- a/docs/research/teltonika-fmc150/INSTRUCTIVO-WAVE-3.md
+++ b/docs/research/teltonika-fmc150/INSTRUCTIVO-WAVE-3.md
@@ -4,6 +4,29 @@
 
 > **Backup obligatorio**: antes de tocar nada, **Save to file** la cfg actual del device como `FMC150_Booster_Wave2.cfg` (si no la tenés ya). Eso queda como rollback.
 
+> **⚠️ Lección 2026-05-11**: el firmware FMC150 `04.01.00.Rev.08` **no tiene `ISRG Root X1` (CA root Let's Encrypt) preinstalado** en su trust store. Sin el paso §0, el handshake TLS falla silenciosamente y el device queda sin enviar telemetría hasta rollback manual. **Hacer §0 ANTES de tocar §1**.
+
+---
+
+## §0 — Cargar CA root `ISRG Root X1` al device (obligatorio para FMx)
+
+Esta task **debe completarse antes** de pushear el cfg Wave 3. Si se hace en orden inverso, el device queda con cfg apuntando a TLS pero sin CA → handshake falla.
+
+1. **Obtener el cert** ISRG Root X1 PEM:
+   ```bash
+   curl -sS -o /tmp/isrgrootx1.pem https://letsencrypt.org/certs/isrgrootx1.pem
+   openssl x509 -in /tmp/isrgrootx1.pem -noout -subject -dates
+   # Subject: ISRG Root X1, válido hasta 2035-06-04
+   ```
+
+2. **FOTA Web** → Dispositivo → **Crear tarea** → tipo **"Cargar certificado TLS de usuario"** → subir `isrgrootx1.pem`.
+
+   > FOTA muestra un warning amarillo: *"FMx platform communication channel security is not compatible with TLS secure certificate transfer requirements. Use with caution."* **Es falso positivo** — en producción 2026-05-11 con firmware `04.01.00.Rev.08` el cert SÍ se transfirió correctamente y persistió a través de `cpureset` completo (validación 2026-05-12).
+
+3. **Esperar a que la task pase a Completado** en FOTA. Solo después, ir a §1 con el cfg Wave 3.
+
+> Si el vehículo está en operación con cellular intermitente, la task puede tardar horas en Completarse (requiere polling RMS exitoso). Una ventana de cellular estable de varios minutos (vehículo detenido en zona urbana) basta.
+
 ---
 
 ## §1 — `GPRS → Server Settings` (primary → TLS)
@@ -15,7 +38,7 @@
 | Protocol | TCP | TCP (TLS va por encima) |
 | **TLS Encryption** | None | **TLS** |
 
-> El cert es Let's Encrypt (CA pública). El FMC150 valida contra su trust store interno — no hace falta subir CA al device.
+> El cert servidor es Let's Encrypt (chain: `server → R13 → ISRG Root X1`). Con §0 completado, el FMC150 valida el chain contra el ISRG Root X1 ya cargado al device.
 
 ---
 
@@ -57,11 +80,23 @@ Si el primary se cae:
 
 Si el handshake TLS falla (cert expirado, CA no confiable en device, etc.):
 
+### Opción A — Configurador local (con acceso físico al device)
+
 1. **Load from file** → `FMC150_Booster_Wave2.cfg`.
 2. **Save to device**.
 3. Device vuelve a primary plain `telemetry.boosterchile.com:5027`. Records reanudan.
 
-> Wave 2 sigue siendo soportado por el server (Service `telemetry-tcp-gateway` con port 5027 plain sigue activo). El rollback es inmediato.
+### Opción B — Rollback remoto vía SMS (probado 2026-05-11)
+
+Si no hay acceso físico al device pero la SIM acepta SMS-MT (en Truphone Connect, "SMS MT Service: Active"):
+
+```
+  setparam 2020:0;2004:telemetry.boosterchile.com;2005:5027
+```
+
+**Crítico**: los 2 espacios líderes son obligatorios porque cfg tiene `1250:0` (SMS Login disabled) con `1251`/`1252` vacíos. Sin los espacios el firmware FMC150 04.01.x descarta el SMS silenciosamente. Tiempo de rollback efectivo: ~30s desde Delivered + reconexión cellular del device.
+
+> Wave 2 sigue siendo soportado por el server (Service `telemetry-tcp-gateway` con port 5027 plain sigue activo). El rollback es inmediato una vez el device aplica el setparam.
 
 ---
 

--- a/docs/runbooks/wave-2-3-deploy.md
+++ b/docs/runbooks/wave-2-3-deploy.md
@@ -392,18 +392,40 @@ Solo después de:
 - [ ] G3.4 listo (failover test PASS, ver §6.2).
 - [ ] Wave 2 estable >7 días en producción sin alertas P0/P1 críticas.
 
-Por device:
+> **⚠️ Pre-step obligatorio aprendido del incidente 2026-05-11** (ver ADR-040): el firmware FMC150 `04.01.00.Rev.08` no tiene `ISRG Root X1` (CA root Let's Encrypt) en su trust store. Sin pre-cargar la CA, el handshake TLS falla silenciosamente y el device queda sin telemetría hasta rollback manual.
+
+Por device, **en este orden estricto**:
+
+**Paso 0 — Cargar CA root (una sola vez por device)**:
+1. Obtener `ISRG Root X1` PEM: `curl -sS -o /tmp/isrgrootx1.pem https://letsencrypt.org/certs/isrgrootx1.pem`
+2. FOTA WEB → tarea **"Cargar certificado TLS de usuario"** con `isrgrootx1.pem` (cancelar warning FMx — verificado funcional en prod 2026-05-12).
+3. Esperar status **Completado** en FOTA (depende de ventana de polling RMS del device).
+
+**Paso 1 — Push cfg Wave 3**:
 1. Update cfg con:
    - **Server Mode (primary)**: TLS, Domain `telemetry-tls.boosterchile.com`,
      Port 5061.
    - **Server Mode (backup)**: Backup, Domain
      `telemetry-dr.boosterchile.com`, Port 5061, TLS Enable.
-2. Push.
+2. FOTA WEB → tarea **"Configuración de la carga"** con `FMC150_Booster_Wave3.cfg`.
 3. Verificar conexión TLS via logs del gateway:
    ```bash
    kubectl logs -n telemetry deployment/telemetry-tcp-gateway \
      --tail=100 --context=booster-primary | grep "handshake IMEI completado"
    ```
+4. Validar puerto local (5061 = TLS, 5027 = plain):
+   ```bash
+   kubectl exec -n telemetry <pod> -- sh -c 'cat /proc/net/tcp6 | awk "NR>1 && \$4==\"01\" {print \$2}"'
+   # 0x13C5 = 5061 TLS ← esperado
+   ```
+
+**Rollback remoto si handshake falla** (sin acceso físico):
+
+SMS-MT vía operador SIM con sintaxis (2 espacios prefijo críticos):
+```
+  setparam 2020:0;2004:telemetry.boosterchile.com;2005:5027
+```
+ETA rollback: ~30s post-Delivered. Probado 2026-05-11.
 
 ---
 


### PR DESCRIPTION
## Summary

- **ADR-040** documenta el procedimiento Wave 3 v2 validado en producción 2026-05-12 con cliente Van Oosterwyk: cargar `ISRG Root X1` PEM al device FMC150 vía FOTA ANTES de pushear cfg TLS. Sin este paso, el firmware `04.01.00.Rev.08` no puede validar el chain Let's Encrypt y el handshake falla silenciosamente.
- **3 validaciones logradas en producción**: TLS 5061 confirmado vía `/proc/net/tcp6`, persistencia post-`cpureset`, failover DR (~2 min) tras patch del Service primary.
- **Rollback SMS-MT** documentado: `  setparam 2020:0;2004:telemetry.boosterchile.com;2005:5027` con 2 espacios líderes obligatorios.

> **Nota**: el ADR se numeró 040 (no 033 como decía el PR original) porque `docs/adr/033-matching-algorithm-v2-multifactor-backhaul-aware.md` ya está mergeado en main. 040 es el siguiente número libre tras 039 (site-settings).

## Cambios

- `docs/adr/040-wave-3-tls-ca-preload-fmc150.md` (nuevo) — supersede sección "Status post-Wave 3" de ADR-005.
- `docs/research/teltonika-fmc150/INSTRUCTIVO-WAVE-3.md` — §0 nueva (cargar CA), §4 rollback SMS.
- `docs/runbooks/wave-2-3-deploy.md` §5.2 — Paso 0 obligatorio + verificación puerto local + rollback SMS.
- `docs/handoff/2026-05-11-wave-3-incidente-rollback.md` (nuevo) — outcome final del incidente P1.

## Rebase 2026-05-16

- Rebase sobre `github/main` (commit `6c67fe6`) para arrastrar bump `@opentelemetry/*` a 0.218 del PR #184 → resuelve `npm audit FAILURE`.
- Rename ADR 033 → 040 + actualización de 3 referencias internas (header del ADR, runbook §5.2, handoff outcome).

## Test plan

- [x] Validación 1.1 (puerto 5061 TLS): `/proc/net/tcp6` muestra `0x13C5` en pod gateway primary
- [x] Validación 1.2 (persistencia post-reset): SMS `  cpureset` → sesión 55415 cerró → reconectó 55416 directo a TLS 5061 sin re-cargar nada
- [x] Validación 1.3 (failover DR): patch `targetPort` 5061→9999 → device conectó al cluster DR us-central1 en ~2 min → revert OK
- [x] Documentación leída end-to-end por PO
- [ ] CI verde post-rebase (npm audit debe pasar tras bump OpenTelemetry)

Co-Authored-By: Claude Opus 4.7 (1M context)