### PR TITLE
chore(infra): declarar MATCHING_ALGORITHM_V2_ACTIVATED en Terraform IaC

### DIFF
--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -123,6 +123,13 @@ module "service_api" {
     # contra esto. Sin esta env var los endpoints /admin/jobs/* responden
     # 401 (configurable en server.ts).
     INTERNAL_CRON_CALLER_SA = google_service_account.internal_cron_invoker.email
+
+    # ADR-033 — Matching engine v2 feature flag + pesos custom. Default
+    # `false` mantiene el v1 capacity-only intacto. Flip a `true` cuando
+    # los backtests muestren delta favorable. Reversible sin redeploy de
+    # código. Ver variables.tf para rollout plan.
+    MATCHING_ALGORITHM_V2_ACTIVATED = tostring(var.matching_algorithm_v2_activated)
+    MATCHING_V2_WEIGHTS_JSON        = var.matching_v2_weights_json
   })
   secrets = merge(local.common_secrets, {
     # Mismo secret que el bot — un solo lugar de verdad para rotaciones.
@@ -285,13 +292,13 @@ module "service_telemetry_processor" {
   concurrency   = 10 # control de rate a Firestore/BigQuery
 
   env_vars = merge(local.common_env_vars, {
-    SERVICE_NAME            = "booster-ai-telemetry-processor"
-    REDIS_HOST              = google_redis_instance.main.host
-    REDIS_PORT              = tostring(google_redis_instance.main.port)
+    SERVICE_NAME = "booster-ai-telemetry-processor"
+    REDIS_HOST   = google_redis_instance.main.host
+    REDIS_PORT   = tostring(google_redis_instance.main.port)
     # Wave 2 B3 — crash trace persistence
-    GCS_CRASH_TRACES_BUCKET = google_storage_bucket.crash_traces.name
-    BIGQUERY_CRASH_DATASET  = google_bigquery_dataset.telemetry.dataset_id
-    BIGQUERY_CRASH_TABLE    = google_bigquery_table.crash_events.table_id
+    GCS_CRASH_TRACES_BUCKET          = google_storage_bucket.crash_traces.name
+    BIGQUERY_CRASH_DATASET           = google_bigquery_dataset.telemetry.dataset_id
+    BIGQUERY_CRASH_TABLE             = google_bigquery_table.crash_events.table_id
     PUBSUB_SUBSCRIPTION_CRASH_TRACES = google_pubsub_subscription.crash_traces_processor.name
   })
   secrets = local.common_secrets

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -256,3 +256,45 @@ variable "gke_operator_authorized_cidrs" {
   }))
   default = []
 }
+
+# ---------------------------------------------------------------------------
+# Matching engine v2 — feature flag + pesos custom (ADR-033)
+# ---------------------------------------------------------------------------
+# Activación del scoring multifactor con backhaul awareness. Cuando es
+# `false` (default), el matching usa v1 capacity-only — el path actual,
+# bit-exacto. Cuando es `true`, el orchestrator hace lookups extras
+# (trips activos del carrier, histórico 7d, ofertas 90d, tier) y aplica
+# `scoreCandidateV2`.
+#
+# Rollout plan:
+#   1. Mantener `false` en main mientras se evalúa con backtest UI
+#      (/app/platform-admin/matching).
+#   2. Si las corridas muestran delta favorable, override a `true` en
+#      `tfvars.prod` o `terraform.tfvars.local` y aplicar.
+#   3. Monitorear 7d con métricas habituales (offer acceptance rate,
+#      time-to-match, distribución de empresas con offer).
+#   4. Si métricas estables, mantener; sino, revertir el flag (`false`
+#      en variables.tf o tfvars).
+#
+# Flip es reversible sin redeploy de código — solo cambia env var via
+# `terraform apply` (Cloud Run respawneará la revision en segundos).
+variable "matching_algorithm_v2_activated" {
+  description = "Activa el scoring multifactor v2 con backhaul awareness (ADR-033). false = v1 capacity-only."
+  type        = bool
+  default     = false
+}
+
+# Pesos custom JSON para los componentes del scoring v2. Empty string →
+# usa `DEFAULT_WEIGHTS_V2` del package matching-algorithm
+# (0.40 capacidad / 0.35 backhaul / 0.15 reputacion / 0.10 tier). Útil
+# para A/B testing post-launch sin redeploy de código.
+#
+# Shape esperado:
+#   {"capacidad":0.4,"backhaul":0.35,"reputacion":0.15,"tier":0.1}
+# Suma debe ser ≈ 1.0; el api hace validateWeights() runtime y cae a
+# defaults con WARN log si parsing falla.
+variable "matching_v2_weights_json" {
+  description = "JSON con pesos custom para scoring v2 (ADR-033). Empty → DEFAULT_WEIGHTS_V2 hardcoded."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## Summary

Follow-up del stack ADR-033 (PRs #167-#170 ya mergeados y deployados a prod). Mueve los env vars del matching v2 a Terraform para que el rollout sea declarativo y trackeable en IaC.

## Por qué

Hasta acá los env vars del matching v2 caían al default \`false\` del schema Zod en \`apps/api/src/config.ts\`. Funcionaba (el v1 sigue activo), pero el flip a \`true\` habría requerido modificar el Cloud Run revision con \`gcloud run services update --set-env-vars=...\`, generando drift contra la IaC declarada.

Después de este PR, el flip se hace cambiando una línea en \`tfvars.prod\` o \`terraform.tfvars.local\` + \`terraform apply\` — Cloud Run respawnea el revision en segundos, sin redeploy de código. Reversible con el mismo flujo.

## Cambios

| Archivo | Δ |
|---|---|
| \`infrastructure/variables.tf\` | +43 (2 vars + docs del rollout plan) |
| \`infrastructure/compute.tf\` | +7 (2 env vars en module.service_api) |

\`\`\`hcl
variable \"matching_algorithm_v2_activated\" {
  description = \"Activa el scoring multifactor v2 con backhaul awareness (ADR-033). false = v1 capacity-only.\"
  type        = bool
  default     = false
}

variable \"matching_v2_weights_json\" {
  description = \"JSON con pesos custom para scoring v2 (ADR-033). Empty → DEFAULT_WEIGHTS_V2 hardcoded.\"
  type        = string
  default     = \"\"
}

# En module.service_api.env_vars:
MATCHING_ALGORITHM_V2_ACTIVATED = tostring(var.matching_algorithm_v2_activated)
MATCHING_V2_WEIGHTS_JSON        = var.matching_v2_weights_json
\`\`\`

## Plan de activación (post-merge)

1. Operador entra a https://app.boosterchile.com/app/platform-admin/matching
2. Dispara 2-3 corridas de backtest con distintos rangos de fecha y pesos
3. Si las métricas son favorables (overlap razonable, scoreDeltaAvg positivo, backhaul hit rate >0):
   ```
   # en terraform.tfvars.local o tfvars.prod
   matching_algorithm_v2_activated = true
   ```
4. \`terraform apply\` → Cloud Run respawnea con el flag on
5. Monitorear 7 días con métricas habituales (offer acceptance, time-to-match, distribución de carriers)
6. Si métricas estables → mantener. Si no → revertir el flag.

## Evidencia

\`\`\`
$ terraform fmt -check variables.tf compute.tf
(0 changes)

$ terraform validate
Success! The configuration is valid.
\`\`\`

\`terraform plan\` no se puede correr local (gcloud reauth required) — el plan corre en CI/Cloud Build antes de merge.

## Test plan

- [ ] Verificar CI verde (terraform plan + Trivy IaC)
- [ ] Una vez merged + applied: confirmar revision del api tiene env var con value \"false\":
   ```bash
   gcloud run services describe booster-ai-api --region=southamerica-west1 \\
     --format='value(spec.template.spec.containers[0].env)' | grep MATCHING
   ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)