### PR TITLE
fix(seed-demo): crear zonas operativas para el carrier (matching produce 0 ofertas sin esto)

### DIFF
--- a/apps/api/src/services/seed-demo.ts
+++ b/apps/api/src/services/seed-demo.ts
@@ -19,6 +19,7 @@ import {
   trips,
   users,
   vehicles,
+  zones,
 } from '../db/schema.js';
 import { generateActivationPin, hashActivationPin } from './activation-pin.js';
 
@@ -230,7 +231,37 @@ export async function seedDemo(opts: {
     fuelType: 'diesel',
   });
 
-  // 8. Conductor del carrier — flujo placeholder + PIN (D9).
+  // 8. Zonas operativas del carrier. Sin zonas, el matching engine no
+  //    encuentra al carrier como candidato (filtro de zona/región es el
+  //    primer paso en runMatching). Cubrimos región XIII (RM) donde el
+  //    shipper tiene sucursales — y de paso V (Valparaíso) y VI (O'Higgins)
+  //    para que el carrier aparezca como candidato si la demo crea trips
+  //    interregionales típicos (RM → V, V → VI, etc.).
+  //
+  //    Tipo 'ambos' = el carrier recoge Y entrega en esa región. Es la
+  //    opción más permisiva, alineada con un transportista real que opera
+  //    multi-región. Si el operador quiere afinar (solo pickup vs solo
+  //    delivery), puede editar desde la UI carrier.
+  await ensureZone({
+    db,
+    empresaId: carrierEmpresaId,
+    regionCode: 'XIII',
+    zoneType: 'ambos',
+  });
+  await ensureZone({
+    db,
+    empresaId: carrierEmpresaId,
+    regionCode: 'V',
+    zoneType: 'ambos',
+  });
+  await ensureZone({
+    db,
+    empresaId: carrierEmpresaId,
+    regionCode: 'VI',
+    zoneType: 'ambos',
+  });
+
+  // 9. Conductor del carrier — flujo placeholder + PIN (D9).
   const driverResult = await ensureConductor({
     db,
     firebaseAuth,
@@ -397,6 +428,7 @@ export async function deleteDemo(opts: { db: Db; logger: Logger }): Promise<{
       }
 
       await tx.delete(vehicles).where(eq(vehicles.empresaId, emp.id));
+      await tx.delete(zones).where(eq(zones.empresaId, emp.id));
       await tx.delete(sucursalesEmpresa).where(eq(sucursalesEmpresa.empresaId, emp.id));
       await tx.delete(memberships).where(eq(memberships.empresaId, emp.id));
       await tx.delete(empresas).where(eq(empresas.id, emp.id));
@@ -619,6 +651,45 @@ async function ensureSucursal(opts: {
     addressRegion: opts.addressRegion,
     latitude: opts.latitude,
     longitude: opts.longitude,
+  });
+}
+
+/**
+ * Idempotente: si ya existe una zona activa con la misma terna
+ * (empresa, region, tipo), no la duplica. Las zonas son críticas para
+ * que el matching engine considere al carrier candidato — sin una zona
+ * en la región del origen del trip, `runMatching` falla en el primer
+ * filtro con `no_carrier_in_origin_region`.
+ */
+async function ensureZone(opts: {
+  db: Db;
+  empresaId: string;
+  regionCode: string;
+  zoneType: 'recogida' | 'entrega' | 'ambos';
+}): Promise<void> {
+  const { db, empresaId, regionCode, zoneType } = opts;
+  const existing = await db
+    .select({ id: zones.id })
+    .from(zones)
+    .where(eq(zones.empresaId, empresaId));
+  // Lookup en memoria por terna (empresa, region, tipo). Set chico.
+  const existingByKey = await db
+    .select({
+      id: zones.id,
+      regionCode: zones.regionCode,
+      zoneType: zones.zoneType,
+    })
+    .from(zones)
+    .where(eq(zones.empresaId, empresaId));
+  if (existingByKey.some((z) => z.regionCode === regionCode && z.zoneType === zoneType)) {
+    return;
+  }
+  void existing;
+  await db.insert(zones).values({
+    empresaId,
+    regionCode,
+    zoneType,
+    isActive: true,
   });
 }
 

--- a/apps/api/test/unit/seed-demo.test.ts
+++ b/apps/api/test/unit/seed-demo.test.ts
@@ -183,9 +183,18 @@ describe('seedDemo', () => {
         [],
         // 13. ensureVehicle DEMO02: → []
         [],
-        // 14. ensureConductor: select users by rut → []
+        // 14. ensureZone XIII: 2 selects
         [],
-        // 14b. select conductores by userId → []
+        [],
+        // 15. ensureZone V: 2 selects
+        [],
+        [],
+        // 16. ensureZone VI: 2 selects
+        [],
+        [],
+        // 17. ensureConductor: select users by rut → []
+        [],
+        // 17b. select conductores by userId → []
         [],
       ],
       inserts: [
@@ -213,6 +222,12 @@ describe('seedDemo', () => {
         [{ id: 'veh-1' }],
         // vehicle 2
         [{ id: 'veh-2' }],
+        // zone XIII
+        [],
+        // zone V
+        [],
+        // zone VI
+        [],
         // user conductor
         [{ id: 'cond-user' }],
         // conductor
@@ -272,6 +287,15 @@ describe('seedDemo', () => {
         [{ id: 'veh-existing-1' }],
         // vehicle DEMO02: exists
         [{ id: 'veh-existing-2' }],
+        // zone XIII: 2 selects (existe → skip)
+        [],
+        [{ regionCode: 'XIII', zoneType: 'ambos' }],
+        // zone V: 2 selects (no existe → insert)
+        [],
+        [],
+        // zone VI: 2 selects (no existe → insert)
+        [],
+        [],
         // conductor: select users by rut → exists, placeholder UID (regen PIN)
         [{ id: 'cond-user-existing', firebaseUid: 'pending-rut:12345678-5' }],
         // select conductores by userId → exists, not deleted
@@ -279,6 +303,10 @@ describe('seedDemo', () => {
       ],
       inserts: [
         // segunda sucursal (la primera se saltó)
+        [],
+        // zone V (XIII se saltó)
+        [],
+        // zone VI
         [],
       ],
     });
@@ -465,10 +493,10 @@ describe('deleteDemo', () => {
     const out = await deleteDemo({ db: stub.db, logger: noopLogger });
     expect(out.empresas_eliminadas).toBe(1);
     expect(out.viajes_eliminados).toBe(0);
-    // tx.delete: vehicles, sucursales, memberships, empresa = 4 (sin trips,
-    // sin telemetría, sin conductores).
+    // tx.delete: vehicles, zones, sucursales, memberships, empresa = 5 (sin
+    // trips, sin telemetría, sin conductores).
     const calls = (stub.tx.delete as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
-    expect(calls).toBe(4);
+    expect(calls).toBe(5);
   });
 
   it('empresa demo con conductores → borra cascada incluida users sin otras memberships', async () => {
@@ -508,9 +536,9 @@ describe('deleteDemo', () => {
     const out = await deleteDemo({ db: stub.db, logger: noopLogger });
     expect(out.empresas_eliminadas).toBe(1);
     // tx.delete: posiciones_movil, telemetria_puntos, eventos_conduccion,
-    //            vehicles, sucursales, memberships, empresa = 7
+    //            vehicles, zones, sucursales, memberships, empresa = 8
     const calls = (stub.tx.delete as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
-    expect(calls).toBe(7);
+    expect(calls).toBe(8);
   });
 
   it('empresa demo con viajes históricos → cascada completa por trip', async () => {
@@ -530,9 +558,10 @@ describe('deleteDemo', () => {
     expect(out.empresas_eliminadas).toBe(1);
     expect(out.viajes_eliminados).toBe(2);
     // tx.delete: chat_messages, trip_events, trip_metrics, assignments,
-    //            offers, trips, vehicles, sucursales, memberships, empresa = 10
+    //            offers, trips, vehicles, zones, sucursales, memberships,
+    //            empresa = 11
     const calls = (stub.tx.delete as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
-    expect(calls).toBe(10);
+    expect(calls).toBe(11);
   });
 
   it('viajes con offers/assignments al carrier demo se incluyen aunque shipper no sea demo', async () => {
@@ -570,9 +599,9 @@ describe('deleteDemo', () => {
     const { deleteDemo } = await import('../../src/services/seed-demo.js');
     const out = await deleteDemo({ db: stub.db, logger: noopLogger });
     expect(out.empresas_eliminadas).toBe(1);
-    // tx.delete: conductores, vehicles, sucursales, memberships, empresa = 5
-    // (NO user porque tiene otra membership)
+    // tx.delete: conductores, vehicles, zones, sucursales, memberships,
+    //            empresa = 6 (NO user porque tiene otra membership)
     const calls = (stub.tx.delete as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
-    expect(calls).toBe(5);
+    expect(calls).toBe(6);
   });
 });


### PR DESCRIPTION
## Summary

Segundo bloqueante crítico para la **demo Corfo (lunes 18-may)**: el seed creaba el carrier sin zonas operativas, así que el matching engine descartaba al carrier en el primer filtro (\`no_carrier_in_origin_region\`) y todos los viajes terminaban en estado \`expirado\` sin haber notificado a nadie.

La UI de zonas existe (D7) pero requiere flujo manual carrier-side. Para una demo idempotente y autocontenida hace falta que el seed plante zonas del carrier directamente.

## Fix

1. **Nuevo helper \`ensureZone(empresa, region, tipo)\`** — idempotente, no duplica por terna empresa+region+tipo.
2. **El seed crea 3 zonas con tipo \`ambos\`** para el carrier demo:
   - XIII (Metropolitana) — donde el shipper tiene sucursales, alimenta el flujo natural de la demo
   - V (Valparaíso) y VI (O'Higgins) — para permitir trips interregionales típicos sin tener que crear zonas extra durante la demo
3. **\`deleteDemo\` ahora borra zonas** en la cascada (sino el siguiente apply fallaría por FK restrict).

## Tests

- \`seedDemo\` happy path + idempotencia actualizados con las 6 nuevas selects (2 por zona) y 3 inserts
- \`deleteDemo\` con +1 delete por escenario (zones)

## Por qué es bloqueante para Corfo

Con PR #173 (cascada de viajes) mergeado pero sin este fix:
- Felipe ejecuta seed
- Crea viaje como shipper
- Matching corre, busca carrier en región XIII, **no encuentra ninguno**
- Trip va directo a estado \`expirado\` sin generar ofertas
- Demo muere ahí

## Evidencia

\`\`\`
$ pnpm --filter=@booster-ai/api typecheck → 0 errores
$ pnpm --filter=@booster-ai/api test → 873 passed
$ pnpm biome check → clean
\`\`\`

## Test plan

- [ ] CI verde
- [ ] Tras merge + deploy: dry-run end-to-end debería funcionar (los 2 fixes sumados habilitan el flujo completo)
- [ ] Verificar zonas creadas:
   ```sql
   SELECT empresa_id, region_code, tipo_zona FROM zonas WHERE empresa_id IN
     (SELECT id FROM empresas WHERE rut='77888222-K');
   ```
   Debería retornar 3 filas (XIII, V, VI) todas tipo='ambos'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)