### PR TITLE
feat(asignaciones): asignar conductor al assignment (cierra gap pre-Corfo)

### DIFF
--- a/apps/api/drizzle/0028_event_type_conductor_asignado.sql
+++ b/apps/api/drizzle/0028_event_type_conductor_asignado.sql
@@ -1,0 +1,17 @@
+-- Migration 0028 — Agrega event type 'conductor_asignado' a tipo_evento_viaje.
+--
+-- Necesario para que el endpoint POST /assignments/:id/asignar-conductor
+-- (creado para cerrar el flujo carrier → driver post-accept-offer) pueda
+-- registrar audit event cuando el carrier asigna o cambia el conductor
+-- de un assignment activo.
+--
+-- Diferente de 'asignacion_creada': ese evento se registra cuando el
+-- carrier acepta la oferta y se crea el assignment (con driver_user_id
+-- típicamente NULL). 'conductor_asignado' captura el segundo paso —
+-- elegir QUE persona específica conducirá.
+--
+-- Riesgo deploy: ALTER TYPE ADD VALUE es DDL no transaccional pero
+-- safe — el valor queda disponible inmediatamente para nuevos rows
+-- sin afectar a los existentes.
+
+ALTER TYPE tipo_evento_viaje ADD VALUE IF NOT EXISTS 'conductor_asignado';

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1780272000000,
       "tag": "0027_matching_backtest_runs",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1780358400000,
+      "tag": "0028_event_type_conductor_asignado",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/scripts/demo-dry-run.mjs
+++ b/apps/api/scripts/demo-dry-run.mjs
@@ -310,6 +310,42 @@ async function activateDriver(rut, pin) {
   return { idToken, syntheticEmail: res.body.synthetic_email };
 }
 
+async function listMyConductores(carrierToken, carrierEmpresaId) {
+  const res = await apiCall('GET', '/conductores', {
+    token: carrierToken,
+    empresaId: carrierEmpresaId,
+  });
+  if (res.status !== 200) {
+    fail('list conductores', res);
+  }
+  return res.body.conductores ?? [];
+}
+
+async function assignDriver(carrierToken, carrierEmpresaId, assignmentId, driverUserId) {
+  log('👷', 'Phase 4b: carrier asigna conductor al assignment');
+  const res = await apiCall('POST', `/assignments/${assignmentId}/asignar-conductor`, {
+    token: carrierToken,
+    empresaId: carrierEmpresaId,
+    body: { driver_user_id: driverUserId },
+  });
+  if (res.status !== 200) {
+    fail('asignar-conductor', res);
+  }
+  log(
+    '  ✓',
+    'conductor asignado al assignment',
+    `driver_user_id=${res.body.new_driver_user_id} name=${res.body.driver_name}`,
+  );
+}
+
+async function listMyAssignmentsAsDriver(driverToken) {
+  const res = await apiCall('GET', '/me/assignments', { token: driverToken });
+  if (res.status !== 200) {
+    fail('list /me/assignments', res);
+  }
+  return res.body.assignments ?? [];
+}
+
 async function reportDriverPosition(driverToken, assignmentId) {
   log('📍', 'Phase 5: conductor reporta GPS (1 punto, simulado)');
   // Lat/lng intermedio entre Maipú y Valparaíso (ruta 68 aprox).
@@ -410,6 +446,40 @@ async function main() {
     log('  !', 'conductor ya activado — saltando driver-activate');
     // Para el dry-run completo necesitaríamos el password, que se regenera
     // al re-activar. Saltamos GPS si no podemos loguear como driver.
+  }
+
+  // Fase 4b: carrier asigna el conductor al assignment.
+  // Esto cierra el gap del flow accept-offer (que crea el assignment con
+  // driver_user_id=NULL). Sin este paso, driver-position falla con
+  // 403 not_assigned_driver.
+  if (assignment && driverToken) {
+    // Listar los conductores del carrier para encontrar el user_id del
+    // conductor demo (cuyo RUT está en creds.conductor.rut).
+    const conductores = await listMyConductores(carrierToken, creds.carrier_empresa_id);
+    // Match por RUT normalizado (cred RUT viene canónico).
+    const demoConductor = conductores.find(
+      (c) => c.user?.rut === creds.conductor.rut || c.user_id !== undefined,
+    );
+    if (demoConductor) {
+      await assignDriver(
+        carrierToken,
+        creds.carrier_empresa_id,
+        assignment.id,
+        demoConductor.user_id,
+      );
+    } else {
+      log('  ⚠', 'conductor demo no aparece en la lista del carrier — skip asignación');
+    }
+  }
+
+  // Fase 4c: verificar que /me/assignments del driver lista el assignment.
+  if (driverToken) {
+    const driverAssignments = await listMyAssignmentsAsDriver(driverToken);
+    log(
+      '📋',
+      'Phase 4c: GET /me/assignments del driver',
+      `total=${driverAssignments.length} primer trip=${driverAssignments[0]?.trip?.tracking_code ?? '(vacío)'}`,
+    );
   }
 
   // Fase 5: conductor reporta GPS (si pudimos loguear)

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -254,6 +254,14 @@ export const tripEventTypeEnum = pgEnum('tipo_evento_viaje', [
   'oferta_rechazada',
   'oferta_expirada',
   'asignacion_creada',
+  /**
+   * Carrier asigna (o reasigna) un conductor específico a un assignment.
+   * Distinto de 'asignacion_creada' (que registra la creación del
+   * assignment tras accept-offer, típicamente con driver_user_id=NULL).
+   * Payload: { assignment_id, previous_driver_user_id, new_driver_user_id,
+   *            driver_name, acting_user_id }.
+   */
+  'conductor_asignado',
   'recogida_confirmada',
   'entrega_confirmada',
   'cancelado',

--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -32,6 +32,13 @@ import {
   users as usersTable,
   vehicles,
 } from '../db/schema.js';
+import {
+  AssignmentNotFoundError,
+  AssignmentNotMutableError,
+  AssignmentNotOwnedError,
+  DriverNotInCarrierError,
+  asignarConductorAAssignment,
+} from '../services/asignar-conductor-a-assignment.js';
 import { confirmarEntregaViaje } from '../services/confirmar-entrega-viaje.js';
 import type { EmitirCertificadoConfig } from '../services/emitir-certificado-viaje.js';
 import { getAssignmentEcoRoute } from '../services/get-assignment-eco-route.js';
@@ -601,6 +608,79 @@ export function createAssignmentsRoutes(opts: {
       generated_at: row.generadoEn,
       status: 'disponible',
     });
+  });
+
+  // ---------------------------------------------------------------------
+  // POST /:id/asignar-conductor — Carrier asigna un conductor específico
+  // al assignment. Cierra el gap dejado por accept-offer (que crea el
+  // assignment con driver_user_id=NULL) y habilita el flujo del driver
+  // (driver-position, conductor-modo) que valida driver_user_id ===
+  // userContext.user.id.
+  //
+  // Auth: carrier owner del assignment. Rol requerido: dueno, admin,
+  // despachador (no operador genérico — esto es decisión de operación).
+  //
+  // Body: { driver_user_id: UUID }
+  // ---------------------------------------------------------------------
+  const asignarConductorBodySchema = z.object({
+    driver_user_id: z.string().uuid(),
+  });
+
+  app.post('/:id/asignar-conductor', zValidator('json', asignarConductorBodySchema), async (c) => {
+    const auth = requireCarrierAuth(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    // Rol-gate: dueno/admin/despachador. Los roles 'operador',
+    // 'visualizador', 'conductor' o 'stakeholder_*' no pueden asignar.
+    const role = auth.activeMembership.membership.role;
+    const allowedRoles = ['dueno', 'admin', 'despachador'] as const;
+    if (!(allowedRoles as readonly string[]).includes(role)) {
+      return c.json({ error: 'forbidden_role', code: 'forbidden_role', role }, 403);
+    }
+
+    const assignmentId = c.req.param('id');
+    const { driver_user_id } = c.req.valid('json');
+
+    try {
+      const result = await asignarConductorAAssignment({
+        db: opts.db,
+        logger: opts.logger,
+        assignmentId,
+        driverUserId: driver_user_id,
+        empresaId: auth.activeMembership.empresa.id,
+        actingUserId: auth.userContext.user.id,
+      });
+      return c.json({
+        ok: true,
+        assignment_id: result.assignmentId,
+        previous_driver_user_id: result.previousDriverUserId,
+        new_driver_user_id: result.newDriverUserId,
+        driver_name: result.driverName,
+      });
+    } catch (err) {
+      if (err instanceof AssignmentNotFoundError) {
+        return c.json({ error: 'assignment_not_found', code: 'assignment_not_found' }, 404);
+      }
+      if (err instanceof AssignmentNotOwnedError) {
+        return c.json({ error: 'forbidden_owner_mismatch', code: 'forbidden_owner_mismatch' }, 403);
+      }
+      if (err instanceof AssignmentNotMutableError) {
+        return c.json(
+          {
+            error: 'assignment_not_mutable',
+            code: 'assignment_not_mutable',
+            status: err.status,
+          },
+          409,
+        );
+      }
+      if (err instanceof DriverNotInCarrierError) {
+        return c.json({ error: 'driver_not_in_carrier', code: 'driver_not_in_carrier' }, 400);
+      }
+      opts.logger.error({ err, assignmentId }, 'asignar-conductor failed');
+      return c.json({ error: 'internal_server_error' }, 500);
+    }
   });
 
   return app;

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -1,11 +1,19 @@
 import type { Logger } from '@booster-ai/logger';
 import { profileUpdateInputSchema } from '@booster-ai/shared-schemas';
 import { zValidator } from '@hono/zod-validator';
-import { and, eq } from 'drizzle-orm';
+import { and, desc, eq, inArray } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { config as appConfig } from '../config.js';
 import type { Db } from '../db/client.js';
-import { carrierMemberships, empresas, memberships, users } from '../db/schema.js';
+import {
+  assignments,
+  carrierMemberships,
+  empresas,
+  memberships,
+  trips,
+  users,
+  vehicles,
+} from '../db/schema.js';
 import type { FirebaseClaims } from '../middleware/firebase-auth.js';
 
 /**
@@ -188,6 +196,109 @@ export function createMeRoutes(opts: { db: Db; logger: Logger }) {
       },
       memberships: membershipsPayload,
       active_membership: active,
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // GET /me/assignments — assignments donde el user autenticado es
+  // el conductor asignado (assignments.driver_user_id === user.id).
+  //
+  // Devuelve los assignments activos (status IN ['asignado', 'en_proceso'])
+  // ordenados por más reciente primero. Sin paginación por ahora: un
+  // conductor rara vez tiene > 2-3 assignments activos simultáneos.
+  //
+  // Uso: la UI /app/conductor/modo lista los assignments y deja al
+  // conductor elegir cuál activar (en vez de pedir UUID copiado, que era
+  // el placeholder MVP). El conductor sólo ve los que están en estado
+  // operacional — si necesita el histórico (entregados), iría a otra
+  // surface dedicada (futuro).
+  //
+  // Auth: solo Firebase claims. NO requiere activeMembership (un
+  // conductor multi-empresa puede ver todos sus assignments sin tener
+  // que setear empresa activa). Pero igual scope al user.id.
+  // ---------------------------------------------------------------------
+  app.get('/assignments', async (c) => {
+    const claims = c.get('firebaseClaims') as FirebaseClaims | undefined;
+    if (!claims) {
+      return c.json({ error: 'internal_server_error' }, 500);
+    }
+    const userRows = await opts.db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.firebaseUid, claims.uid))
+      .limit(1);
+    const user = userRows[0];
+    if (!user) {
+      return c.json({ error: 'user_not_found', code: 'user_not_found' }, 404);
+    }
+
+    // Estados activos del assignment según assignmentStatusEnum:
+    //   asignado → carrier aceptó, todavía no se recoge la carga
+    //   recogido → conductor confirmó recogida, en tránsito a destino
+    // Excluímos: entregado (terminal), cancelado (terminal).
+    const ACTIVE_STATUSES = ['asignado', 'recogido'] as const;
+    const rows = await opts.db
+      .select({
+        assignmentId: assignments.id,
+        assignmentStatus: assignments.status,
+        empresaId: assignments.empresaId,
+        empresaLegalName: empresas.legalName,
+        acceptedAt: assignments.acceptedAt,
+        pickedUpAt: assignments.pickedUpAt,
+        agreedPriceClp: assignments.agreedPriceClp,
+        tripId: trips.id,
+        trackingCode: trips.trackingCode,
+        tripStatus: trips.status,
+        originAddressRaw: trips.originAddressRaw,
+        originRegionCode: trips.originRegionCode,
+        destinationAddressRaw: trips.destinationAddressRaw,
+        destinationRegionCode: trips.destinationRegionCode,
+        cargoType: trips.cargoType,
+        cargoWeightKg: trips.cargoWeightKg,
+        pickupWindowStart: trips.pickupWindowStart,
+        pickupWindowEnd: trips.pickupWindowEnd,
+        vehicleId: assignments.vehicleId,
+        vehiclePlate: vehicles.plate,
+      })
+      .from(assignments)
+      .innerJoin(trips, eq(trips.id, assignments.tripId))
+      .leftJoin(empresas, eq(empresas.id, assignments.empresaId))
+      .leftJoin(vehicles, eq(vehicles.id, assignments.vehicleId))
+      .where(
+        and(eq(assignments.driverUserId, user.id), inArray(assignments.status, ACTIVE_STATUSES)),
+      )
+      .orderBy(desc(assignments.acceptedAt));
+
+    return c.json({
+      assignments: rows.map((r) => ({
+        id: r.assignmentId,
+        status: r.assignmentStatus,
+        accepted_at: r.acceptedAt,
+        picked_up_at: r.pickedUpAt,
+        agreed_price_clp: r.agreedPriceClp,
+        carrier_empresa: {
+          id: r.empresaId,
+          legal_name: r.empresaLegalName,
+        },
+        vehicle: r.vehicleId ? { id: r.vehicleId, plate: r.vehiclePlate ?? null } : null,
+        trip: {
+          id: r.tripId,
+          tracking_code: r.trackingCode,
+          status: r.tripStatus,
+          origin: {
+            address_raw: r.originAddressRaw,
+            region_code: r.originRegionCode,
+          },
+          destination: {
+            address_raw: r.destinationAddressRaw,
+            region_code: r.destinationRegionCode,
+          },
+          cargo_type: r.cargoType,
+          cargo_weight_kg: r.cargoWeightKg,
+          pickup_window_start: r.pickupWindowStart,
+          pickup_window_end: r.pickupWindowEnd,
+        },
+      })),
     });
   });
 

--- a/apps/api/src/services/asignar-conductor-a-assignment.ts
+++ b/apps/api/src/services/asignar-conductor-a-assignment.ts
@@ -1,0 +1,201 @@
+import type { Logger } from '@booster-ai/logger';
+import { and, eq, isNull } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { assignments, conductores, tripEvents, users } from '../db/schema.js';
+
+/**
+ * Asigna un conductor específico a un assignment existente.
+ *
+ * Contexto: hasta acá, el flujo del accept-offer creaba el assignment con
+ * `driver_user_id = NULL` y no había forma de setearlo después. El
+ * resultado: el endpoint `/assignments/:id/driver-position` (que valida
+ * `assignment.driverUserId === user.id`) era inalcanzable, y la UI
+ * `/app/conductor/modo` exigía que el conductor pegara manualmente el
+ * UUID del assignment (UX placeholder).
+ *
+ * Este servicio cierra el flujo: el carrier (dueño/admin/despachador)
+ * elige uno de sus conductores activos y lo asocia al assignment.
+ *
+ * Reglas:
+ *   1. El assignment debe existir y pertenecer al carrier que invoca.
+ *   2. El driver_user_id debe corresponder a un conductor ACTIVO de
+ *      ese mismo carrier (sino, un carrier podría asignar conductores
+ *      de otra empresa — riesgo de filtrado de datos).
+ *   3. El assignment NO puede estar finalizado (cancelado/entregado).
+ *      Para reasignaciones mid-trip por ahora bloqueamos; cuando aparezca
+ *      el caso de uso real lo añadimos como `allow_reassign`.
+ *   4. Si el assignment ya tiene driver_user_id seteado, permitimos
+ *      cambiarlo siempre que el assignment esté en estado `asignado` o
+ *      `en_proceso`. La auditoría queda en trip_events.
+ *
+ * Side effect:
+ *   - UPDATE assignments SET driver_user_id, updated_at
+ *   - INSERT trip_events { event_type='conductor_asignado', payload }
+ *
+ * Decisión de modelo: el campo es `driver_user_id` (users.id), NO
+ * `conductor_id` (conductores.id). Razón: el endpoint del driver
+ * (driver-position) hace `assignment.driverUserId === userContext.user.id`,
+ * el matching natural con el user autenticado vía Firebase. La tabla
+ * conductores guarda metadata extra (licencia, PIN de activación) pero
+ * el `users.id` es el handle estable.
+ */
+
+export class AssignmentNotFoundError extends Error {
+  constructor(public readonly id: string) {
+    super(`Assignment ${id} not found`);
+    this.name = 'AssignmentNotFoundError';
+  }
+}
+
+export class AssignmentNotOwnedError extends Error {
+  constructor(
+    public readonly id: string,
+    public readonly empresaId: string,
+  ) {
+    super(`Assignment ${id} is not owned by empresa ${empresaId}`);
+    this.name = 'AssignmentNotOwnedError';
+  }
+}
+
+export class AssignmentNotMutableError extends Error {
+  constructor(
+    public readonly id: string,
+    public readonly status: string,
+  ) {
+    super(`Assignment ${id} is in status ${status}, cannot reassign driver`);
+    this.name = 'AssignmentNotMutableError';
+  }
+}
+
+export class DriverNotInCarrierError extends Error {
+  constructor(
+    public readonly driverUserId: string,
+    public readonly empresaId: string,
+  ) {
+    super(`Driver ${driverUserId} is not an active conductor of empresa ${empresaId}`);
+    this.name = 'DriverNotInCarrierError';
+  }
+}
+
+export interface AsignarConductorInput {
+  db: Db;
+  logger: Logger;
+  assignmentId: string;
+  driverUserId: string;
+  /** Empresa carrier que está haciendo la asignación. */
+  empresaId: string;
+  /** User id del operador que dispara la asignación (audit). */
+  actingUserId: string;
+}
+
+export interface AsignarConductorOutput {
+  assignmentId: string;
+  previousDriverUserId: string | null;
+  newDriverUserId: string;
+  driverName: string | null;
+}
+
+/**
+ * Estados en los que SÍ se puede asignar/cambiar conductor. Una vez
+ * `entregado` o `cancelado`, el assignment es terminal — no tiene sentido
+ * tocar el conductor. Cuando ya está `recogido` (en tránsito) hace sentido
+ * permitir reasignación (ej. relevo de chofer en mid-trip), aunque ese
+ * caso de uso es raro y el cliente puede deshabilitarlo en la UI.
+ */
+const MUTABLE_STATUSES = ['asignado', 'recogido'] as const;
+
+export async function asignarConductorAAssignment(
+  input: AsignarConductorInput,
+): Promise<AsignarConductorOutput> {
+  const { db, logger, assignmentId, driverUserId, empresaId, actingUserId } = input;
+
+  return await db.transaction(async (tx) => {
+    // 1. Verificar assignment existe + pertenece al carrier + es mutable.
+    const [assignment] = await tx
+      .select({
+        id: assignments.id,
+        empresaId: assignments.empresaId,
+        status: assignments.status,
+        driverUserId: assignments.driverUserId,
+        tripId: assignments.tripId,
+      })
+      .from(assignments)
+      .where(eq(assignments.id, assignmentId))
+      .limit(1);
+
+    if (!assignment) {
+      throw new AssignmentNotFoundError(assignmentId);
+    }
+    if (assignment.empresaId !== empresaId) {
+      throw new AssignmentNotOwnedError(assignmentId, empresaId);
+    }
+    if (!(MUTABLE_STATUSES as readonly string[]).includes(assignment.status)) {
+      throw new AssignmentNotMutableError(assignmentId, assignment.status);
+    }
+
+    // 2. Verificar driver_user_id es un conductor activo del MISMO carrier.
+    //    El JOIN con users sirve para sacar el fullName para el audit log.
+    const [driverRow] = await tx
+      .select({
+        userId: users.id,
+        userFullName: users.fullName,
+        conductorId: conductores.id,
+      })
+      .from(conductores)
+      .innerJoin(users, eq(users.id, conductores.userId))
+      .where(
+        and(
+          eq(conductores.userId, driverUserId),
+          eq(conductores.empresaId, empresaId),
+          isNull(conductores.deletedAt),
+        ),
+      )
+      .limit(1);
+
+    if (!driverRow) {
+      throw new DriverNotInCarrierError(driverUserId, empresaId);
+    }
+
+    // 3. UPDATE assignment.
+    await tx
+      .update(assignments)
+      .set({
+        driverUserId,
+        updatedAt: new Date(),
+      })
+      .where(eq(assignments.id, assignmentId));
+
+    // 4. Audit event en trip_events.
+    await tx.insert(tripEvents).values({
+      tripId: assignment.tripId,
+      eventType: 'conductor_asignado',
+      payload: {
+        assignment_id: assignmentId,
+        previous_driver_user_id: assignment.driverUserId,
+        new_driver_user_id: driverUserId,
+        driver_name: driverRow.userFullName,
+        acting_user_id: actingUserId,
+      },
+      // El audit lo dispara la UI del carrier, así que source='web'.
+      // Si en el futuro un cron asigna automáticamente, ajustar a 'sistema'.
+      source: 'web',
+    });
+
+    logger.info(
+      {
+        assignmentId,
+        previousDriverUserId: assignment.driverUserId,
+        newDriverUserId: driverUserId,
+        empresaId,
+      },
+      'conductor asignado a assignment',
+    );
+
+    return {
+      assignmentId,
+      previousDriverUserId: assignment.driverUserId,
+      newDriverUserId: driverUserId,
+      driverName: driverRow.userFullName ?? null,
+    };
+  });
+}

--- a/apps/api/test/unit/asignar-conductor-a-assignment.test.ts
+++ b/apps/api/test/unit/asignar-conductor-a-assignment.test.ts
@@ -1,0 +1,291 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AssignmentNotFoundError,
+  AssignmentNotMutableError,
+  AssignmentNotOwnedError,
+  DriverNotInCarrierError,
+  asignarConductorAAssignment,
+} from '../../src/services/asignar-conductor-a-assignment.js';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.SERVICE_NAME = 'booster-ai-api';
+  process.env.SERVICE_VERSION = '0.0.0-test';
+  process.env.LOG_LEVEL = 'error';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.REDIS_HOST = 'localhost';
+  process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173';
+  process.env.FIREBASE_PROJECT_ID = 'test';
+  process.env.API_AUDIENCE = 'https://api.boosterchile.com';
+  process.env.ALLOWED_CALLER_SA = 'caller@booster-ai.iam.gserviceaccount.com';
+});
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as Parameters<typeof asignarConductorAAssignment>[0]['logger'];
+
+const ASSIGNMENT_ID = '00000000-0000-0000-0000-000000000a01';
+const TRIP_ID = '00000000-0000-0000-0000-000000000a02';
+const EMPRESA_ID = '00000000-0000-0000-0000-000000000a03';
+const ACTING_USER_ID = '00000000-0000-0000-0000-000000000a04';
+const DRIVER_USER_ID = '00000000-0000-0000-0000-000000000a05';
+
+interface AssignmentRow {
+  id: string;
+  empresaId: string;
+  status: string;
+  driverUserId: string | null;
+  tripId: string;
+}
+interface DriverRow {
+  userId: string;
+  userFullName: string;
+  conductorId: string;
+}
+
+/**
+ * Mock progresivo del tx: 2 selects encadenados (assignment, driver),
+ * 1 update y 1 insert. Patrón consistente con seed-demo.test.ts y
+ * reportar-incidente.test.ts.
+ */
+function makeDbStub(opts: {
+  assignmentRow?: AssignmentRow | null;
+  driverRow?: DriverRow | null;
+}) {
+  const selectQueue: unknown[][] = [];
+  if (opts.assignmentRow !== undefined) {
+    selectQueue.push(opts.assignmentRow === null ? [] : [opts.assignmentRow]);
+  }
+  if (opts.driverRow !== undefined) {
+    selectQueue.push(opts.driverRow === null ? [] : [opts.driverRow]);
+  }
+
+  const limitFn = vi.fn(() => Promise.resolve(selectQueue.shift() ?? []));
+  const whereFn = vi.fn(() => ({ limit: limitFn }));
+  const innerJoinFn = vi.fn(() => ({ where: whereFn }));
+  const fromFn = vi.fn(() => ({
+    where: whereFn,
+    innerJoin: innerJoinFn,
+  }));
+  const selectFn = vi.fn(() => ({ from: fromFn }));
+
+  const updateWhereFn = vi.fn(() => Promise.resolve());
+  const updateSetFn = vi.fn(() => ({ where: updateWhereFn }));
+  const updateFn = vi.fn(() => ({ set: updateSetFn }));
+
+  const insertValuesFn = vi.fn(() => Promise.resolve());
+  const insertFn = vi.fn(() => ({ values: insertValuesFn }));
+
+  const tx = {
+    select: selectFn,
+    update: updateFn,
+    insert: insertFn,
+  };
+
+  const transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(tx));
+
+  return {
+    db: { transaction } as unknown as Parameters<typeof asignarConductorAAssignment>[0]['db'],
+    spies: {
+      selectFn,
+      updateFn,
+      updateSetFn,
+      insertFn,
+      insertValuesFn,
+      transaction,
+    },
+  };
+}
+
+const baseAssignment = (overrides: Partial<AssignmentRow> = {}): AssignmentRow => ({
+  id: ASSIGNMENT_ID,
+  empresaId: EMPRESA_ID,
+  status: 'asignado',
+  driverUserId: null,
+  tripId: TRIP_ID,
+  ...overrides,
+});
+
+const baseDriver = (overrides: Partial<DriverRow> = {}): DriverRow => ({
+  userId: DRIVER_USER_ID,
+  userFullName: 'Pedro González (Demo)',
+  conductorId: '00000000-0000-0000-0000-000000000a06',
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('asignarConductorAAssignment', () => {
+  it('happy path: asigna el conductor a un assignment sin driver previo', async () => {
+    const stub = makeDbStub({
+      assignmentRow: baseAssignment(),
+      driverRow: baseDriver(),
+    });
+    const result = await asignarConductorAAssignment({
+      db: stub.db,
+      logger: noopLogger,
+      assignmentId: ASSIGNMENT_ID,
+      driverUserId: DRIVER_USER_ID,
+      empresaId: EMPRESA_ID,
+      actingUserId: ACTING_USER_ID,
+    });
+    expect(result.assignmentId).toBe(ASSIGNMENT_ID);
+    expect(result.previousDriverUserId).toBeNull();
+    expect(result.newDriverUserId).toBe(DRIVER_USER_ID);
+    expect(result.driverName).toBe('Pedro González (Demo)');
+    expect(stub.spies.updateFn).toHaveBeenCalled();
+    expect(stub.spies.insertFn).toHaveBeenCalled(); // audit event
+  });
+
+  it('reasignación: permite cambiar el conductor si el assignment está en estado asignado', async () => {
+    const previousDriverId = '00000000-0000-0000-0000-0000000000ff';
+    const stub = makeDbStub({
+      assignmentRow: baseAssignment({ driverUserId: previousDriverId }),
+      driverRow: baseDriver(),
+    });
+    const result = await asignarConductorAAssignment({
+      db: stub.db,
+      logger: noopLogger,
+      assignmentId: ASSIGNMENT_ID,
+      driverUserId: DRIVER_USER_ID,
+      empresaId: EMPRESA_ID,
+      actingUserId: ACTING_USER_ID,
+    });
+    expect(result.previousDriverUserId).toBe(previousDriverId);
+    expect(result.newDriverUserId).toBe(DRIVER_USER_ID);
+  });
+
+  it('estado recogido: permite reasignación mid-trip (caso relevo de chofer)', async () => {
+    const stub = makeDbStub({
+      assignmentRow: baseAssignment({ status: 'recogido' }),
+      driverRow: baseDriver(),
+    });
+    const result = await asignarConductorAAssignment({
+      db: stub.db,
+      logger: noopLogger,
+      assignmentId: ASSIGNMENT_ID,
+      driverUserId: DRIVER_USER_ID,
+      empresaId: EMPRESA_ID,
+      actingUserId: ACTING_USER_ID,
+    });
+    expect(result.newDriverUserId).toBe(DRIVER_USER_ID);
+  });
+
+  it('AssignmentNotFoundError: assignment no existe', async () => {
+    const stub = makeDbStub({ assignmentRow: null });
+    await expect(
+      asignarConductorAAssignment({
+        db: stub.db,
+        logger: noopLogger,
+        assignmentId: ASSIGNMENT_ID,
+        driverUserId: DRIVER_USER_ID,
+        empresaId: EMPRESA_ID,
+        actingUserId: ACTING_USER_ID,
+      }),
+    ).rejects.toThrow(AssignmentNotFoundError);
+  });
+
+  it('AssignmentNotOwnedError: assignment pertenece a OTRO carrier', async () => {
+    const stub = makeDbStub({
+      assignmentRow: baseAssignment({ empresaId: 'otra-empresa-id' }),
+    });
+    await expect(
+      asignarConductorAAssignment({
+        db: stub.db,
+        logger: noopLogger,
+        assignmentId: ASSIGNMENT_ID,
+        driverUserId: DRIVER_USER_ID,
+        empresaId: EMPRESA_ID,
+        actingUserId: ACTING_USER_ID,
+      }),
+    ).rejects.toThrow(AssignmentNotOwnedError);
+  });
+
+  it('AssignmentNotMutableError: assignment está entregado (terminal)', async () => {
+    const stub = makeDbStub({
+      assignmentRow: baseAssignment({ status: 'entregado' }),
+    });
+    await expect(
+      asignarConductorAAssignment({
+        db: stub.db,
+        logger: noopLogger,
+        assignmentId: ASSIGNMENT_ID,
+        driverUserId: DRIVER_USER_ID,
+        empresaId: EMPRESA_ID,
+        actingUserId: ACTING_USER_ID,
+      }),
+    ).rejects.toThrow(AssignmentNotMutableError);
+  });
+
+  it('AssignmentNotMutableError: assignment está cancelado', async () => {
+    const stub = makeDbStub({
+      assignmentRow: baseAssignment({ status: 'cancelado' }),
+    });
+    await expect(
+      asignarConductorAAssignment({
+        db: stub.db,
+        logger: noopLogger,
+        assignmentId: ASSIGNMENT_ID,
+        driverUserId: DRIVER_USER_ID,
+        empresaId: EMPRESA_ID,
+        actingUserId: ACTING_USER_ID,
+      }),
+    ).rejects.toThrow(AssignmentNotMutableError);
+  });
+
+  it('DriverNotInCarrierError: el driver no es conductor activo del carrier', async () => {
+    const stub = makeDbStub({
+      assignmentRow: baseAssignment(),
+      driverRow: null,
+    });
+    await expect(
+      asignarConductorAAssignment({
+        db: stub.db,
+        logger: noopLogger,
+        assignmentId: ASSIGNMENT_ID,
+        driverUserId: DRIVER_USER_ID,
+        empresaId: EMPRESA_ID,
+        actingUserId: ACTING_USER_ID,
+      }),
+    ).rejects.toThrow(DriverNotInCarrierError);
+  });
+
+  it('audit event: registra trip_events con previous/new driver + acting user', async () => {
+    const stub = makeDbStub({
+      assignmentRow: baseAssignment(),
+      driverRow: baseDriver(),
+    });
+    await asignarConductorAAssignment({
+      db: stub.db,
+      logger: noopLogger,
+      assignmentId: ASSIGNMENT_ID,
+      driverUserId: DRIVER_USER_ID,
+      empresaId: EMPRESA_ID,
+      actingUserId: ACTING_USER_ID,
+    });
+    expect(stub.spies.insertValuesFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tripId: TRIP_ID,
+        eventType: 'conductor_asignado',
+        source: 'web',
+        payload: expect.objectContaining({
+          assignment_id: ASSIGNMENT_ID,
+          previous_driver_user_id: null,
+          new_driver_user_id: DRIVER_USER_ID,
+          driver_name: 'Pedro González (Demo)',
+          acting_user_id: ACTING_USER_ID,
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/test/unit/assignments-route.test.ts
+++ b/apps/api/test/unit/assignments-route.test.ts
@@ -12,8 +12,26 @@ beforeAll(() => {
 vi.mock('../../src/services/confirmar-entrega-viaje.js', () => ({
   confirmarEntregaViaje: vi.fn(),
 }));
+// Mock asignar-conductor para validar el wire HTTP por separado del
+// servicio (que ya tiene su propio test file). Importamos las clases de
+// error reales para que el route las pueda detectar via instanceof.
+vi.mock('../../src/services/asignar-conductor-a-assignment.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/services/asignar-conductor-a-assignment.js')>();
+  return {
+    ...actual,
+    asignarConductorAAssignment: vi.fn(),
+  };
+});
 
 const { confirmarEntregaViaje } = await import('../../src/services/confirmar-entrega-viaje.js');
+const {
+  asignarConductorAAssignment,
+  AssignmentNotFoundError,
+  AssignmentNotMutableError,
+  AssignmentNotOwnedError,
+  DriverNotInCarrierError,
+} = await import('../../src/services/asignar-conductor-a-assignment.js');
 
 const noop = (): void => undefined;
 const noopLogger = {
@@ -323,5 +341,137 @@ describe('PATCH /assignments/:id/confirmar-entrega', () => {
       headers: { 'x-test-userctx': VALID_CTX },
     });
     expect(res.status).toBe(404);
+  });
+});
+
+describe('POST /assignments/:id/asignar-conductor', () => {
+  const VALID_BODY = { driver_user_id: '00000000-0000-0000-0000-000000000a05' };
+
+  // El test header VALID_CTX no incluía 'membership' (subobjeto), pero
+  // el endpoint nuevo lee `auth.activeMembership.membership.role`. Para
+  // estos tests usamos un contexto extendido con rol explícito.
+  const CTX_DUENO = JSON.stringify({
+    user: { id: USER_ID },
+    activeMembership: {
+      empresa: { id: CARRIER_EMP, isTransportista: true, status: 'activa' },
+      membership: { role: 'dueno' },
+    },
+  });
+
+  function makeReq(body: unknown = VALID_BODY, headers: Record<string, string> = {}) {
+    return {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        ...headers,
+      },
+      body: JSON.stringify(body),
+    };
+  }
+
+  it('sin auth → 401', async () => {
+    const app = await buildApp({ db: makeDb() });
+    const res = await app.request(`/assignments/${ASSIGNMENT_ID}/asignar-conductor`, makeReq());
+    expect(res.status).toBe(401);
+  });
+
+  it('rol no permitido (operador) → 403 forbidden_role', async () => {
+    const app = await buildApp({ db: makeDb() });
+    const ctx = JSON.stringify({
+      user: { id: USER_ID },
+      activeMembership: {
+        empresa: { id: CARRIER_EMP, isTransportista: true, status: 'activa' },
+        membership: { role: 'operador' },
+      },
+    });
+    const res = await app.request(
+      `/assignments/${ASSIGNMENT_ID}/asignar-conductor`,
+      makeReq(VALID_BODY, { 'x-test-userctx': ctx }),
+    );
+    expect(res.status).toBe(403);
+    expect((await res.json()) as { code: string }).toEqual(
+      expect.objectContaining({ code: 'forbidden_role' }),
+    );
+  });
+
+  it('body inválido (driver_user_id no es UUID) → 400', async () => {
+    const app = await buildApp({ db: makeDb() });
+    const res = await app.request(
+      `/assignments/${ASSIGNMENT_ID}/asignar-conductor`,
+      makeReq({ driver_user_id: 'not-a-uuid' }, { 'x-test-userctx': CTX_DUENO }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('happy path: rol dueno → 200 + payload', async () => {
+    (asignarConductorAAssignment as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      assignmentId: ASSIGNMENT_ID,
+      previousDriverUserId: null,
+      newDriverUserId: VALID_BODY.driver_user_id,
+      driverName: 'Pedro González',
+    });
+    const app = await buildApp({ db: makeDb() });
+    const res = await app.request(
+      `/assignments/${ASSIGNMENT_ID}/asignar-conductor`,
+      makeReq(VALID_BODY, { 'x-test-userctx': CTX_DUENO }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; driver_name: string };
+    expect(body.ok).toBe(true);
+    expect(body.driver_name).toBe('Pedro González');
+  });
+
+  it('service AssignmentNotFoundError → 404', async () => {
+    (asignarConductorAAssignment as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new AssignmentNotFoundError(ASSIGNMENT_ID),
+    );
+    const app = await buildApp({ db: makeDb() });
+    const res = await app.request(
+      `/assignments/${ASSIGNMENT_ID}/asignar-conductor`,
+      makeReq(VALID_BODY, { 'x-test-userctx': CTX_DUENO }),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('service AssignmentNotOwnedError → 403', async () => {
+    (asignarConductorAAssignment as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new AssignmentNotOwnedError(ASSIGNMENT_ID, 'otra'),
+    );
+    const app = await buildApp({ db: makeDb() });
+    const res = await app.request(
+      `/assignments/${ASSIGNMENT_ID}/asignar-conductor`,
+      makeReq(VALID_BODY, { 'x-test-userctx': CTX_DUENO }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('service AssignmentNotMutableError → 409 con status incluido', async () => {
+    (asignarConductorAAssignment as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new AssignmentNotMutableError(ASSIGNMENT_ID, 'entregado'),
+    );
+    const app = await buildApp({ db: makeDb() });
+    const res = await app.request(
+      `/assignments/${ASSIGNMENT_ID}/asignar-conductor`,
+      makeReq(VALID_BODY, { 'x-test-userctx': CTX_DUENO }),
+    );
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { code: string; status: string };
+    expect(body.code).toBe('assignment_not_mutable');
+    expect(body.status).toBe('entregado');
+  });
+
+  it('service DriverNotInCarrierError → 400', async () => {
+    (asignarConductorAAssignment as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new DriverNotInCarrierError(VALID_BODY.driver_user_id, CARRIER_EMP),
+    );
+    const app = await buildApp({ db: makeDb() });
+    const res = await app.request(
+      `/assignments/${ASSIGNMENT_ID}/asignar-conductor`,
+      makeReq(VALID_BODY, { 'x-test-userctx': CTX_DUENO }),
+    );
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { code: string }).toEqual(
+      expect.objectContaining({ code: 'driver_not_in_carrier' }),
+    );
   });
 });

--- a/apps/web/src/components/scoring/DriverAssignmentCard.test.tsx
+++ b/apps/web/src/components/scoring/DriverAssignmentCard.test.tsx
@@ -1,0 +1,222 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiError, api } from '../../lib/api-client.js';
+import { DriverAssignmentCard } from './DriverAssignmentCard.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const SAMPLE_CONDUCTORES = [
+  {
+    id: 'c1',
+    user_id: 'u-driver-1',
+    user: {
+      id: 'u-driver-1',
+      full_name: 'Pedro González',
+      rut: '12.345.678-5',
+      is_pending: false,
+    },
+    status: 'activo',
+  },
+  {
+    id: 'c2',
+    user_id: 'u-driver-2',
+    user: {
+      id: 'u-driver-2',
+      full_name: 'Ana Martínez',
+      rut: '11.222.333-K',
+      is_pending: false,
+    },
+    status: 'activo',
+  },
+  {
+    id: 'c3',
+    user_id: 'u-driver-3',
+    user: {
+      id: 'u-driver-3',
+      full_name: 'Pending Driver',
+      rut: '99.888.777-1',
+      is_pending: true, // todavía no activado — debería filtrarse del dropdown
+    },
+    status: 'activo',
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('DriverAssignmentCard', () => {
+  it('assignment terminal (entregado) → no renderiza nada', () => {
+    const Wrapper = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <DriverAssignmentCard
+          assignmentId="a1"
+          currentDriverName={null}
+          assignmentStatus="entregado"
+        />
+      </Wrapper>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('sin conductor asignado → muestra prompt + dropdown poblado con conductores activos', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ conductores: SAMPLE_CONDUCTORES });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <DriverAssignmentCard
+          assignmentId="a1"
+          currentDriverName={null}
+          assignmentStatus="asignado"
+        />
+      </Wrapper>,
+    );
+
+    expect(await screen.findByText(/Asignar conductor/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Una vez asignado, podrá ver la asignación en su Modo Conductor/),
+    ).toBeInTheDocument();
+
+    // Dropdown tiene los activos (sin el pending).
+    const select = await screen.findByTestId('driver-assignment-select');
+    expect(select).toBeInTheDocument();
+    // Opciones renderizadas
+    expect(screen.getByText(/Pedro González · 12\.345\.678-5/)).toBeInTheDocument();
+    expect(screen.getByText(/Ana Martínez · 11\.222\.333-K/)).toBeInTheDocument();
+    expect(screen.queryByText(/Pending Driver/)).toBeNull(); // filtrado
+  });
+
+  it('con conductor ya asignado → muestra "Conductor actual" + opción de cambiar', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ conductores: SAMPLE_CONDUCTORES });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <DriverAssignmentCard
+          assignmentId="a1"
+          currentDriverName="Pedro González"
+          assignmentStatus="asignado"
+        />
+      </Wrapper>,
+    );
+    expect(await screen.findByText(/Conductor asignado/)).toBeInTheDocument();
+    expect(screen.getByText(/Conductor actual:/)).toBeInTheDocument();
+    expect(screen.getByText('Pedro González')).toBeInTheDocument();
+    // Botón dice "Cambiar conductor" cuando ya hay uno
+    expect(await screen.findByRole('button', { name: /Cambiar conductor/i })).toBeInTheDocument();
+  });
+
+  it('asignar exitoso → muestra confirmación', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ conductores: SAMPLE_CONDUCTORES });
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValue({
+      ok: true,
+      assignment_id: 'a1',
+      previous_driver_user_id: null,
+      new_driver_user_id: 'u-driver-1',
+      driver_name: 'Pedro González',
+    });
+
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <DriverAssignmentCard
+          assignmentId="a1"
+          currentDriverName={null}
+          assignmentStatus="asignado"
+        />
+      </Wrapper>,
+    );
+
+    const select = (await screen.findByTestId('driver-assignment-select')) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'u-driver-1' } });
+
+    const submit = screen.getByTestId('driver-assignment-submit');
+    fireEvent.click(submit);
+
+    await waitFor(() => {
+      expect(postSpy).toHaveBeenCalledWith('/assignments/a1/asignar-conductor', {
+        driver_user_id: 'u-driver-1',
+      });
+    });
+    expect(await screen.findByText(/Conductor asignado:/)).toBeInTheDocument();
+  });
+
+  it('error 403 forbidden_role → mensaje humanizado sobre permiso', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ conductores: SAMPLE_CONDUCTORES });
+    vi.spyOn(api, 'post').mockRejectedValue(new ApiError(403, 'forbidden_role', null, 'forbidden'));
+
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <DriverAssignmentCard
+          assignmentId="a1"
+          currentDriverName={null}
+          assignmentStatus="asignado"
+        />
+      </Wrapper>,
+    );
+
+    const select = (await screen.findByTestId('driver-assignment-select')) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'u-driver-1' } });
+    fireEvent.click(screen.getByTestId('driver-assignment-submit'));
+
+    expect(
+      await screen.findByText(/No tenés permiso para asignar conductores/),
+    ).toBeInTheDocument();
+  });
+
+  it('error driver_not_in_carrier → mensaje claro sin código técnico', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ conductores: SAMPLE_CONDUCTORES });
+    vi.spyOn(api, 'post').mockRejectedValue(
+      new ApiError(400, 'driver_not_in_carrier', null, 'driver_not_in_carrier'),
+    );
+
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <DriverAssignmentCard
+          assignmentId="a1"
+          currentDriverName={null}
+          assignmentStatus="asignado"
+        />
+      </Wrapper>,
+    );
+
+    const select = (await screen.findByTestId('driver-assignment-select')) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: 'u-driver-1' } });
+    fireEvent.click(screen.getByTestId('driver-assignment-submit'));
+
+    expect(
+      await screen.findByText(/El conductor elegido no pertenece a tu empresa/),
+    ).toBeInTheDocument();
+  });
+
+  it('sin conductores activos → muestra empty state con link a crear', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({ conductores: [] });
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <DriverAssignmentCard
+          assignmentId="a1"
+          currentDriverName={null}
+          assignmentStatus="asignado"
+        />
+      </Wrapper>,
+    );
+    expect(await screen.findByText(/No tenés conductores activos/)).toBeInTheDocument();
+    // Y NO se muestra el form (no se debería poder asignar).
+    expect(screen.queryByTestId('driver-assignment-select')).toBeNull();
+  });
+});

--- a/apps/web/src/components/scoring/DriverAssignmentCard.tsx
+++ b/apps/web/src/components/scoring/DriverAssignmentCard.tsx
@@ -1,0 +1,231 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { AlertTriangle, CheckCircle2, Loader2, User, UserPlus } from 'lucide-react';
+import { type FormEvent, useState } from 'react';
+import { ApiError, api } from '../../lib/api-client.js';
+
+/**
+ * Card carrier-side: asignar conductor a un assignment activo.
+ *
+ * Antes de este componente, los assignments se creaban con
+ * driver_user_id=NULL y no había forma de setearlo después → el endpoint
+ * `/assignments/:id/driver-position` era inalcanzable y la UI
+ * /app/conductor/modo exigía pegar el UUID manualmente.
+ *
+ * Ahora el carrier (rol dueno/admin/despachador) elige uno de sus
+ * conductores activos del dropdown y lo asocia con un click. El backend
+ * valida que el conductor sea efectivamente del mismo carrier
+ * (defensa anti-cross-tenant).
+ *
+ * Visible mientras el assignment esté en estado mutable
+ * (`asignado` | `recogido`). Permite reasignar (caso de uso: relevo de
+ * chofer mid-trip).
+ */
+
+interface ConductorListItem {
+  id: string;
+  user_id: string;
+  user: {
+    id: string;
+    full_name: string | null;
+    rut: string | null;
+    is_pending: boolean;
+  };
+  status: string;
+}
+
+interface AsignarResponse {
+  ok: true;
+  assignment_id: string;
+  previous_driver_user_id: string | null;
+  new_driver_user_id: string;
+  driver_name: string | null;
+}
+
+export interface DriverAssignmentCardProps {
+  assignmentId: string;
+  /** Nombre del conductor actualmente asignado, si hay. */
+  currentDriverName: string | null;
+  /** Estado actual del assignment — solo permitimos asignar en mutables. */
+  assignmentStatus: string;
+}
+
+const MUTABLE_ASSIGNMENT_STATUSES = new Set(['asignado', 'recogido']);
+
+export function DriverAssignmentCard({
+  assignmentId,
+  currentDriverName,
+  assignmentStatus,
+}: DriverAssignmentCardProps) {
+  const queryClient = useQueryClient();
+  const [selectedDriverUserId, setSelectedDriverUserId] = useState('');
+  const [submitState, setSubmitState] = useState<
+    | { kind: 'idle' }
+    | { kind: 'submitting' }
+    | { kind: 'success'; driverName: string | null }
+    | { kind: 'error'; message: string }
+  >({ kind: 'idle' });
+
+  const conductoresQ = useQuery<{ conductores: ConductorListItem[] }>({
+    queryKey: ['conductores-list-for-assignment'],
+    queryFn: () => api.get<{ conductores: ConductorListItem[] }>('/conductores'),
+  });
+
+  const isMutable = MUTABLE_ASSIGNMENT_STATUSES.has(assignmentStatus);
+  if (!isMutable) {
+    // Para estados terminales (entregado/cancelado) no mostramos la card.
+    return null;
+  }
+
+  const conductoresActivos = (conductoresQ.data?.conductores ?? []).filter(
+    (c) => c.status !== 'baja' && !c.user.is_pending,
+  );
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!selectedDriverUserId) {
+      return;
+    }
+    setSubmitState({ kind: 'submitting' });
+    try {
+      const res = await api.post<AsignarResponse>(
+        `/assignments/${assignmentId}/asignar-conductor`,
+        { driver_user_id: selectedDriverUserId },
+      );
+      setSubmitState({ kind: 'success', driverName: res.driver_name });
+      // Invalidar el query del detalle del assignment para refrescar
+      // el driver_name visible en el header.
+      await queryClient.invalidateQueries({
+        queryKey: ['assignment-detail', assignmentId],
+      });
+    } catch (err) {
+      const msg = humanizeAsignarError(err);
+      setSubmitState({ kind: 'error', message: msg });
+    }
+  }
+
+  return (
+    <section
+      aria-label="Asignar conductor"
+      className="border-neutral-200 border-b bg-white px-4 py-3"
+      data-testid="driver-assignment-card"
+    >
+      <div className="flex items-start gap-3">
+        <User className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
+        <div className="flex-1">
+          <h2 className="font-semibold text-neutral-900 text-sm">
+            {currentDriverName ? 'Conductor asignado' : 'Asignar conductor'}
+          </h2>
+          {currentDriverName ? (
+            <p className="mt-1 text-neutral-700 text-sm">
+              Conductor actual: <strong>{currentDriverName}</strong>
+            </p>
+          ) : (
+            <p className="mt-1 text-neutral-600 text-sm">
+              Elegí el conductor que va a hacer este viaje. Una vez asignado, podrá ver la
+              asignación en su Modo Conductor y reportar su posición GPS.
+            </p>
+          )}
+
+          {conductoresQ.isLoading && (
+            <div className="mt-3 inline-flex items-center gap-2 text-neutral-500 text-sm">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+              Cargando conductores…
+            </div>
+          )}
+
+          {conductoresQ.isError && (
+            <div className="mt-3 rounded-md border border-danger-200 bg-danger-50 p-2 text-danger-700 text-xs">
+              No pudimos cargar la lista de conductores. Recargá la página.
+            </div>
+          )}
+
+          {!conductoresQ.isLoading && !conductoresQ.isError && conductoresActivos.length === 0 && (
+            <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-2 text-amber-900 text-xs">
+              No tenés conductores activos. Creá uno en{' '}
+              <a href="/app/conductores/nuevo" className="underline">
+                Conductores
+              </a>{' '}
+              antes de poder asignar.
+            </div>
+          )}
+
+          {conductoresActivos.length > 0 && (
+            <form onSubmit={handleSubmit} className="mt-3 flex flex-col gap-2 sm:flex-row">
+              <select
+                value={selectedDriverUserId}
+                onChange={(e) => setSelectedDriverUserId(e.target.value)}
+                disabled={submitState.kind === 'submitting'}
+                className="flex-1 rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+                data-testid="driver-assignment-select"
+              >
+                <option value="">— Elegí un conductor —</option>
+                {conductoresActivos.map((c) => (
+                  <option key={c.user_id} value={c.user_id}>
+                    {c.user.full_name ?? '(sin nombre)'} · {c.user.rut ?? 'sin RUT'}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="submit"
+                disabled={!selectedDriverUserId || submitState.kind === 'submitting'}
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white hover:bg-primary-700 disabled:opacity-50"
+                data-testid="driver-assignment-submit"
+              >
+                {submitState.kind === 'submitting' ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                    Asignando…
+                  </>
+                ) : (
+                  <>
+                    <UserPlus className="h-4 w-4" aria-hidden />
+                    {currentDriverName ? 'Cambiar conductor' : 'Asignar'}
+                  </>
+                )}
+              </button>
+            </form>
+          )}
+
+          {submitState.kind === 'success' && (
+            <div className="mt-3 inline-flex items-center gap-2 rounded-md border border-success-200 bg-success-50 px-3 py-2 text-success-700 text-sm">
+              <CheckCircle2 className="h-4 w-4" aria-hidden />
+              Conductor asignado: <strong>{submitState.driverName ?? '(sin nombre)'}</strong>
+            </div>
+          )}
+
+          {submitState.kind === 'error' && (
+            <div className="mt-3 flex items-start gap-2 rounded-md border border-danger-200 bg-danger-50 p-2 text-danger-700 text-xs">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
+              <span>{submitState.message}</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Traduce errores del API a mensajes operacionales sin códigos crudos.
+ */
+function humanizeAsignarError(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.code === 'forbidden_role') {
+      return 'No tenés permiso para asignar conductores. Pedile a un usuario dueño o admin que lo haga.';
+    }
+    if (err.code === 'driver_not_in_carrier') {
+      return 'El conductor elegido no pertenece a tu empresa.';
+    }
+    if (err.code === 'assignment_not_mutable') {
+      return 'No se puede asignar conductor: este viaje ya terminó (entregado o cancelado).';
+    }
+    if (err.code === 'assignment_not_found') {
+      return 'La asignación no existe.';
+    }
+    if (err.code === 'forbidden_owner_mismatch') {
+      return 'Esta asignación no es de tu empresa.';
+    }
+    return `${err.status}: ${err.message}`;
+  }
+  return (err as Error).message;
+}

--- a/apps/web/src/routes/asignacion-detalle.tsx
+++ b/apps/web/src/routes/asignacion-detalle.tsx
@@ -24,6 +24,7 @@ import { CobraHoyButton } from '../components/cobra-hoy/CobraHoyButton.js';
 import { AssignmentEcoRouteCard } from '../components/scoring/AssignmentEcoRouteCard.js';
 import { BehaviorScoreCard } from '../components/scoring/BehaviorScoreCard.js';
 import { DeliveryConfirmCard } from '../components/scoring/DeliveryConfirmCard.js';
+import { DriverAssignmentCard } from '../components/scoring/DriverAssignmentCard.js';
 import { IncidentReportCard } from '../components/scoring/IncidentReportCard.js';
 import { api } from '../lib/api-client.js';
 
@@ -123,6 +124,20 @@ function AsignacionDetallePage() {
           </div>
         </div>
       </div>
+
+      {/* Asignar conductor — visible mientras el assignment esté
+          mutable (asignado | recogido). Antes de aceptar este componente
+          no existía: el flow accept-offer creaba la assignment con
+          driver_user_id=NULL y no había forma de setearlo después.
+          Sin conductor asignado, el endpoint /assignments/:id/driver-position
+          rechaza con 403 y el conductor no puede reportar GPS. */}
+      {tripQ.data?.assignment && (
+        <DriverAssignmentCard
+          assignmentId={assignmentId}
+          currentDriverName={tripQ.data.assignment.driver_name}
+          assignmentStatus={tripQ.data.assignment.status}
+        />
+      )}
 
       {/* Phase 1 PR-H5 — Ruta eco-eficiente sugerida (post-accept).
           Collapsed por default; el driver expande on-tap para ver la

--- a/apps/web/src/routes/conductor-modo.test.tsx
+++ b/apps/web/src/routes/conductor-modo.test.tsx
@@ -47,6 +47,23 @@ vi.mock('../services/coaching-voice.js', () => ({
   saveAutoplayPreference: (v: boolean) => saveAutoplayPreferenceSpy(v),
 }));
 
+// Mock api-client para que el flujo "lista de asignaciones" en
+// MobileGpsReporterCard pueda ser controlado por test. Por defecto
+// devuelve lista vacía (el conductor sin asignaciones), pero los tests
+// específicos pueden override.
+const apiGetSpy = vi.fn();
+vi.mock('../lib/api-client.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../lib/api-client.js')>('../lib/api-client.js');
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      get: (...args: unknown[]) => apiGetSpy(...args),
+    },
+  };
+});
+
 const { ConductorModoRoute } = await import('./conductor-modo.js');
 
 function makeMe(): MeOnboarded {
@@ -71,6 +88,9 @@ beforeEach(() => {
   vi.clearAllMocks();
   loadAutoplayPreferenceSpy.mockReturnValue(false);
   queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
+  // Default: el driver no tiene asignaciones activas. Tests específicos
+  // pueden mockear con assignments populados.
+  apiGetSpy.mockResolvedValue({ assignments: [] });
 });
 
 afterEach(() => {
@@ -172,5 +192,72 @@ describe('ConductorModoRoute', () => {
     render(<ConductorModoRoute />);
     const toggle = screen.getByTestId('autoplay-toggle') as HTMLInputElement;
     expect(toggle.checked).toBe(true);
+  });
+
+  describe('GPS reporter — lista de asignaciones (reemplaza pegar UUID)', () => {
+    const sampleAssignment = {
+      id: 'asg-123-456',
+      status: 'asignado',
+      trip: {
+        id: 'trip-1',
+        tracking_code: 'BOO-ABC123',
+        status: 'asignado',
+        origin: { address_raw: 'Av. Pajaritos 1234, Maipú', region_code: 'XIII' },
+        destination: { address_raw: 'Av. Brasil 2345, Valparaíso', region_code: 'V' },
+        cargo_type: 'carga_seca',
+        cargo_weight_kg: 5000,
+        pickup_window_start: null,
+        pickup_window_end: null,
+      },
+      carrier_empresa: { id: 'emp-c', legal_name: 'Transportes Demo Sur S.A.' },
+      vehicle: { id: 'veh-1', plate: 'DEMO01' },
+    };
+
+    it('sin asignaciones activas → muestra estado vacío explicativo', async () => {
+      providedContext = { kind: 'onboarded', me: makeMe() };
+      apiGetSpy.mockResolvedValue({ assignments: [] });
+      render(<ConductorModoRoute />);
+      expect(
+        await screen.findByText(/No tenés asignaciones activas en este momento/),
+      ).toBeInTheDocument();
+    });
+
+    it('con asignaciones → lista con tracking, ruta, carga y vehículo', async () => {
+      providedContext = { kind: 'onboarded', me: makeMe() };
+      apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
+      render(<ConductorModoRoute />);
+      expect(await screen.findByText('BOO-ABC123')).toBeInTheDocument();
+      expect(
+        screen.getByText(/Av\. Pajaritos 1234, Maipú → Av\. Brasil 2345, Valparaíso/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Transportes Demo Sur S\.A\./)).toBeInTheDocument();
+      expect(screen.getByText('DEMO01')).toBeInTheDocument();
+    });
+
+    it('asignación única → se pre-selecciona automáticamente', async () => {
+      providedContext = { kind: 'onboarded', me: makeMe() };
+      apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
+      render(<ConductorModoRoute />);
+      const card = await screen.findByTestId(`gps-reporter-assignment-${sampleAssignment.id}`);
+      // El estilo selected aplica clases bg-primary-50.
+      expect(card.className).toMatch(/bg-primary-50/);
+    });
+
+    it('click en una asignación la selecciona', async () => {
+      providedContext = { kind: 'onboarded', me: makeMe() };
+      const second = {
+        ...sampleAssignment,
+        id: 'asg-999',
+        trip: { ...sampleAssignment.trip, tracking_code: 'BOO-XYZ' },
+      };
+      apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment, second] });
+      render(<ConductorModoRoute />);
+      const card2 = await screen.findByTestId('gps-reporter-assignment-asg-999');
+      fireEvent.click(card2);
+      // Ahora la segunda card debería estar resaltada.
+      await waitFor(() => {
+        expect(card2.className).toMatch(/bg-primary-50/);
+      });
+    });
   });
 });

--- a/apps/web/src/routes/conductor-modo.tsx
+++ b/apps/web/src/routes/conductor-modo.tsx
@@ -16,6 +16,7 @@ import { Layout } from '../components/Layout.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { useDriverPositionReporter } from '../hooks/use-driver-position-reporter.js';
 import type { MeResponse } from '../hooks/use-me.js';
+import { ApiError, api } from '../lib/api-client.js';
 import { loadAutoplayPreference, saveAutoplayPreference } from '../services/coaching-voice.js';
 import {
   type PermissionState,
@@ -170,11 +171,75 @@ function ConductorModoPage({ me }: { me: MeOnboarded }) {
 // D2 — Card: Reporte GPS móvil para vehículos SIN Teltonika
 // ---------------------------------------------------------------------------
 
+interface DriverAssignment {
+  id: string;
+  status: string;
+  trip: {
+    id: string;
+    tracking_code: string;
+    status: string;
+    origin: { address_raw: string; region_code: string | null };
+    destination: { address_raw: string; region_code: string | null };
+    cargo_type: string;
+    cargo_weight_kg: number | null;
+    pickup_window_start: string | null;
+    pickup_window_end: string | null;
+  };
+  carrier_empresa: { id: string; legal_name: string | null };
+  vehicle: { id: string; plate: string | null } | null;
+}
+
 function MobileGpsReporterCard({ geoPermission }: { geoPermission: PermissionStatus }) {
-  const [assignmentId, setAssignmentId] = useState('');
+  // Estado de la lista de asignaciones activas del conductor logueado.
+  // Se carga al montar; el conductor elige una en vez de pegar UUID.
+  const [assignments, setAssignments] = useState<DriverAssignment[]>([]);
+  const [loadingAssignments, setLoadingAssignments] = useState(false);
+  const [assignmentsError, setAssignmentsError] = useState<string | null>(null);
+  const [selectedAssignmentId, setSelectedAssignmentId] = useState<string>('');
   const reporter = useDriverPositionReporter();
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: cargar una sola
+  // vez al montar el componente.
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingAssignments(true);
+    setAssignmentsError(null);
+    api
+      .get<{ assignments: DriverAssignment[] }>('/me/assignments')
+      .then((res) => {
+        if (cancelled) {
+          return;
+        }
+        setAssignments(res.assignments);
+        // Pre-seleccionar si hay una sola asignación activa.
+        if (res.assignments.length === 1) {
+          setSelectedAssignmentId(res.assignments[0]?.id ?? '');
+        }
+      })
+      .catch((err) => {
+        if (cancelled) {
+          return;
+        }
+        const msg =
+          err instanceof ApiError
+            ? err.status === 404
+              ? 'No encontramos tu cuenta en el sistema.'
+              : `${err.status}: ${err.message}`
+            : (err as Error).message;
+        setAssignmentsError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoadingAssignments(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const canStart =
-    geoPermission === 'granted' && assignmentId.trim().length > 0 && !reporter.isWatching;
+    geoPermission === 'granted' && selectedAssignmentId.trim().length > 0 && !reporter.isWatching;
 
   return (
     <section
@@ -190,7 +255,7 @@ function MobileGpsReporterCard({ geoPermission }: { geoPermission: PermissionSta
           </h2>
           <p className="mt-1 text-neutral-600 text-sm">
             Si tu vehículo no tiene equipo Teltonika instalado, podemos seguir tu trayecto usando el
-            GPS de tu teléfono. Pega el ID de tu asignación activa y presiona "Iniciar reporte".
+            GPS de tu teléfono. Elegí cuál asignación querés reportar.
           </p>
 
           {geoPermission !== 'granted' && (
@@ -199,34 +264,89 @@ function MobileGpsReporterCard({ geoPermission }: { geoPermission: PermissionSta
             </div>
           )}
 
-          <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto]">
-            <input
-              type="text"
-              value={assignmentId}
-              onChange={(e) => setAssignmentId(e.target.value)}
-              placeholder="ID de asignación (UUID)"
-              className="rounded-md border border-neutral-300 px-3 py-2 font-mono text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
-              disabled={reporter.isWatching}
-              data-testid="gps-reporter-assignment-input"
-            />
+          {loadingAssignments && (
+            <div className="mt-3 text-neutral-500 text-sm">Cargando tus asignaciones…</div>
+          )}
+
+          {assignmentsError && (
+            <div className="mt-3 rounded-md border border-danger-200 bg-danger-50 p-2 text-danger-700 text-xs">
+              No pudimos cargar tus asignaciones: {assignmentsError}
+            </div>
+          )}
+
+          {!loadingAssignments && !assignmentsError && assignments.length === 0 && (
+            <div className="mt-3 rounded-md border border-neutral-200 bg-neutral-50 p-3 text-neutral-600 text-sm">
+              No tenés asignaciones activas en este momento. Cuando tu carrier te asigne un viaje,
+              aparecerá acá.
+            </div>
+          )}
+
+          {assignments.length > 0 && (
+            <div className="mt-3 space-y-2">
+              <div className="text-neutral-700 text-xs uppercase tracking-wide">
+                Tus asignaciones activas
+              </div>
+              <ul className="space-y-2" data-testid="gps-reporter-assignment-list">
+                {assignments.map((a) => {
+                  const isSelected = selectedAssignmentId === a.id;
+                  return (
+                    <li key={a.id}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedAssignmentId(a.id)}
+                        disabled={reporter.isWatching}
+                        className={`w-full rounded-md border p-3 text-left transition disabled:opacity-50 ${
+                          isSelected
+                            ? 'border-primary-500 bg-primary-50'
+                            : 'border-neutral-200 hover:bg-neutral-50'
+                        }`}
+                        data-testid={`gps-reporter-assignment-${a.id}`}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="font-mono text-neutral-500 text-xs">
+                            {a.trip.tracking_code}
+                          </div>
+                          <div className="text-neutral-500 text-xs">
+                            {a.vehicle?.plate ?? 'Sin patente'}
+                          </div>
+                        </div>
+                        <div className="mt-1 text-neutral-900 text-sm">
+                          {a.trip.origin.address_raw} → {a.trip.destination.address_raw}
+                        </div>
+                        <div className="mt-1 text-neutral-500 text-xs">
+                          {a.trip.cargo_type} ·{' '}
+                          {a.trip.cargo_weight_kg
+                            ? `${a.trip.cargo_weight_kg.toLocaleString('es-CL')} kg`
+                            : 'peso no declarado'}{' '}
+                          · {a.carrier_empresa.legal_name ?? 'Carrier'}
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+          )}
+
+          <div className="mt-3">
             {reporter.isWatching ? (
               <button
                 type="button"
                 onClick={() => reporter.stop()}
-                className="rounded-md bg-danger-600 px-4 py-2 font-medium text-sm text-white hover:bg-danger-700"
+                className="w-full rounded-md bg-danger-600 px-4 py-2 font-medium text-sm text-white hover:bg-danger-700"
                 data-testid="gps-reporter-stop"
               >
-                Detener
+                Detener reporte
               </button>
             ) : (
               <button
                 type="button"
-                onClick={() => reporter.start(assignmentId.trim())}
+                onClick={() => reporter.start(selectedAssignmentId.trim())}
                 disabled={!canStart}
-                className="rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white hover:bg-primary-700 disabled:opacity-50"
+                className="w-full rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white hover:bg-primary-700 disabled:opacity-50"
                 data-testid="gps-reporter-start"
               >
-                Iniciar reporte
+                Iniciar reporte de la asignación seleccionada
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary

Cierra el gap operacional del flujo del conductor identificado durante el dry-run pre-demo Corfo (lunes 18-may). Implementa la **Opción B** del reporte que te di: endpoint dedicado + UI carrier dropdown + UI driver con lista de asignaciones.

## Problema que resuelve

Antes de este PR:
- El campo \`assignments.driverUserId\` **nunca se seteaba** en ningún code path después del accept-offer
- El endpoint POST \`/assignments/:id/driver-position\` requería \`driverUserId === user.id\` → siempre devolvía **403 not_assigned_driver**
- La UI \`/app/conductor/modo\` pedía al conductor **pegar manualmente el UUID** del assignment (placeholder MVP)
- No existía surface para que el carrier asignara un conductor específico

## Solución

### Backend (4 piezas)

1. **Migration 0028**: agrega \`'conductor_asignado'\` al enum \`tipo_evento_viaje\` para audit logs
2. **Service \`asignar-conductor-a-assignment.ts\`**: validaciones rigurosas
   - Assignment existe + pertenece al carrier que invoca
   - Driver es conductor activo del MISMO carrier (defensa anti-cross-tenant)
   - Assignment está en estado mutable (\`asignado\` | \`recogido\`)
3. **Endpoint** \`POST /assignments/:id/asignar-conductor\` con rol-gate (dueno/admin/despachador)
4. **Endpoint** \`GET /me/assignments\` para que el driver vea sus asignaciones activas

### Frontend carrier

Nuevo componente \`DriverAssignmentCard\` en \`/app/asignacion/:id\`:
- Dropdown de conductores activos del carrier (filtra pendientes y dados de baja)
- Botón \"Asignar\" / \"Cambiar conductor\" según estado actual
- \`humanizeError()\` traduce códigos del API (forbidden_role, driver_not_in_carrier, assignment_not_mutable…) a mensajes naturales sin jerga
- Solo visible mientras el assignment esté en estado mutable

### Frontend driver

\`/app/conductor/modo\` carga \`GET /me/assignments\` al montar:
- Lista las asignaciones activas con tracking + ruta + carga + carrier + vehículo
- Pre-selección automática si hay una sola asignación
- Estado vacío explicativo (\"No tenés asignaciones activas\")
- Reemplaza por completo el input \"pegar UUID\"

## Cambios

| Archivo | Δ |
|---|---|
| \`apps/api/drizzle/0028_event_type_conductor_asignado.sql\` | +20 nuevo |
| \`apps/api/src/services/asignar-conductor-a-assignment.ts\` | +180 nuevo |
| \`apps/api/src/routes/assignments.ts\` | +85 (endpoint nuevo + imports) |
| \`apps/api/src/routes/me.ts\` | +97 (endpoint /me/assignments) |
| \`apps/api/src/db/schema.ts\` | +8 (enum value + comentario) |
| \`apps/web/src/components/scoring/DriverAssignmentCard.tsx\` | +215 nuevo |
| \`apps/web/src/routes/asignacion-detalle.tsx\` | +14 (wire card) |
| \`apps/web/src/routes/conductor-modo.tsx\` | +140 -60 (reemplazo UI) |
| \`apps/api/scripts/demo-dry-run.mjs\` | +50 (Phases 4b + 4c) |
| **Tests** (4 archivos) | +28 tests nuevos |

## Evidencia

\`\`\`
$ pnpm --filter=@booster-ai/api typecheck → 0 errores
$ pnpm --filter=@booster-ai/api test → 890 passed (+17)
$ pnpm --filter=@booster-ai/web typecheck → 0 errores
$ pnpm --filter=@booster-ai/web test → 908 passed (+11)
$ pnpm biome check (archivos tocados) → 0 errores
\`\`\`

**Tests nuevos:**
- 9 \`asignar-conductor-a-assignment.test.ts\` (happy, reasignación, todos los error paths, audit event)
- 8 \`assignments-route.test.ts\` (auth gates, rol, validación, todos los error codes del service)
- 4 \`conductor-modo.test.tsx\` (lista vacía, populated, pre-selección, click select)
- 7 \`DriverAssignmentCard.test.tsx\` (terminal hide, prompt, current driver, asignar éxito, errores humanizados, sin conductores)

## Post-merge plan

1. Esperar deploy automático del release pipeline
2. Migration 0028 corre al startup del api
3. Re-correr el dry-run script:
   \`\`\`bash
   FIREBASE_WEB_API_KEY=... node apps/api/scripts/demo-dry-run.mjs --keep-data
   \`\`\`
4. Verificar Phase 5 (driver-position) ahora pasa con ✓ en vez de ⚠ 403

## Test plan

- [ ] CI verde
- [ ] Tras merge + deploy: dry-run end-to-end completo sin errores
- [ ] Como carrier (demo-carrier@boosterchile.com): entrar a \`/app/asignacion/:id\` → ver dropdown → asignar → verificar mensaje de éxito
- [ ] Como conductor (RUT + PIN): entrar a \`/app/conductor/modo\` → ver lista de asignaciones con tracking + ruta → pre-selección automática → click Iniciar reporte → GPS empieza
- [ ] Verificar audit event en BD:
  \`\`\`sql
  SELECT event_type, payload FROM eventos_viaje WHERE event_type='conductor_asignado' ORDER BY recorded_at DESC LIMIT 1;
  \`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)