### PR TITLE
fix(api): toISOString defensivo en /conductores y /me/assignments

### DIFF
--- a/apps/api/src/routes/conductores.ts
+++ b/apps/api/src/routes/conductores.ts
@@ -48,6 +48,50 @@ function placeholderEmail(rut: string): string {
   return `pending-rut-${rut.replace(/[.\-]/g, '')}@boosterchile.invalid`;
 }
 
+/**
+ * Helpers defensivos para serializar Dates de Drizzle.
+ *
+ * `Date.toISOString()` lanza RangeError "Invalid time value" si el Date
+ * tiene tiempo NaN — caso edge que ocurre cuando node-postgres parsea un
+ * timestamp con formato inesperado (TZ awareness rara, etc.). Sin estos
+ * helpers, una sola fila con un timestamp corrupto rompe el endpoint
+ * completo con 500. Caso real detectado durante el dry-run pre-Corfo.
+ */
+function safeIsoString(value: unknown): string | null {
+  if (value == null) {
+    return null;
+  }
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isNaN(t) ? null : value.toISOString();
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  return null;
+}
+
+/**
+ * Devuelve YYYY-MM-DD si el Date es válido. Null si es inválido o null.
+ * Si viene como string, devuelve los primeros 10 chars.
+ */
+function safeDateString(value: unknown): string | null {
+  if (value == null) {
+    return null;
+  }
+  if (value instanceof Date) {
+    const t = value.getTime();
+    if (Number.isNaN(t)) {
+      return null;
+    }
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'string') {
+    return value.slice(0, 10);
+  }
+  return null;
+}
+
 export function createConductoresRoutes(opts: { db: Db; logger: Logger }) {
   const app = new Hono();
 
@@ -124,15 +168,12 @@ export function createConductoresRoutes(opts: { db: Db; logger: Logger }) {
         empresa_id: r.empresa_id,
         license_class: r.license_class,
         license_number: r.license_number,
-        license_expiry:
-          r.license_expiry instanceof Date
-            ? r.license_expiry.toISOString().slice(0, 10)
-            : r.license_expiry,
+        license_expiry: safeDateString(r.license_expiry),
         is_extranjero: r.is_extranjero,
         status: r.status,
-        created_at: r.created_at,
-        updated_at: r.updated_at,
-        deleted_at: r.deleted_at,
+        created_at: safeIsoString(r.created_at),
+        updated_at: safeIsoString(r.updated_at),
+        deleted_at: safeIsoString(r.deleted_at),
         user: {
           id: r.user_id,
           full_name: r.user_full_name,

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -269,12 +269,27 @@ export function createMeRoutes(opts: { db: Db; logger: Logger }) {
       )
       .orderBy(desc(assignments.acceptedAt));
 
+    // Helper: serializar Dates de Drizzle de forma defensiva — un Date
+    // con NaN time (raro pero ocurre con TZ awareness rara de pg) rompe
+    // todo el response al hacer JSON.stringify implícito (toISOString
+    // throws RangeError). Mejor null que 500.
+    const safeIso = (d: unknown): string | null => {
+      if (d == null) {
+        return null;
+      }
+      if (d instanceof Date) {
+        const t = d.getTime();
+        return Number.isNaN(t) ? null : d.toISOString();
+      }
+      return typeof d === 'string' ? d : null;
+    };
+
     return c.json({
       assignments: rows.map((r) => ({
         id: r.assignmentId,
         status: r.assignmentStatus,
-        accepted_at: r.acceptedAt,
-        picked_up_at: r.pickedUpAt,
+        accepted_at: safeIso(r.acceptedAt),
+        picked_up_at: safeIso(r.pickedUpAt),
         agreed_price_clp: r.agreedPriceClp,
         carrier_empresa: {
           id: r.empresaId,
@@ -295,8 +310,8 @@ export function createMeRoutes(opts: { db: Db; logger: Logger }) {
           },
           cargo_type: r.cargoType,
           cargo_weight_kg: r.cargoWeightKg,
-          pickup_window_start: r.pickupWindowStart,
-          pickup_window_end: r.pickupWindowEnd,
+          pickup_window_start: safeIso(r.pickupWindowStart),
+          pickup_window_end: safeIso(r.pickupWindowEnd),
         },
       })),
     });


### PR DESCRIPTION
## Summary

Detectado durante re-dry-run pre-Corfo después de mergear #176: GET /conductores devuelve **500 RangeError 'Invalid time value'** en la fila del conductor demo. Causa: Drizzle a veces devuelve un Date con NaN getTime() y Hono.c.json hace JSON.stringify implícito que llama toISOString → throw, tumbando todo el endpoint por una fila.

## Fix

Helpers `safeIsoString` y `safeDateString` que chequean `Number.isNaN(d.getTime())` antes de serializar. Si el Date es inválido devuelven null en lugar de propagar el throw.

Aplica a:
- `/conductores` (lista): license_expiry, created_at, updated_at, deleted_at
- `/me/assignments` (nuevo de PR #176): accepted_at, picked_up_at, pickup_window_start, pickup_window_end

No cambia tests existentes — siguen pasando con Dates válidas (caso normal). La defensa es contra rows corruptos / edge cases de node-postgres parsing.

## Evidencia

- typecheck: 0 errores
- tests api conductores: 17 passed (sin regresiones)

## Por qué urgente

Bloqueante para que el dry-run end-to-end del demo Corfo pueda completar la Phase 4b (asignar conductor) — el script llama `GET /conductores` para encontrar el driver_user_id antes de asignar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)