### PR TITLE
fix(web): /app y /app/ofertas usan Layout — fix header roto en mobile (feria mañana)

### DIFF
--- a/apps/api/scripts/demo-dry-run.mjs
+++ b/apps/api/scripts/demo-dry-run.mjs
@@ -58,6 +58,12 @@ if (!FIREBASE_WEB_API_KEY) {
 const args = process.argv.slice(2);
 const ONLY_CLEANUP = args.includes('--cleanup');
 const KEEP_DATA = args.includes('--keep-data');
+// --seed-only: solo crea entidades base (empresas, users, vehículos,
+// conductor con PIN sin activar, zonas). NO crea trip, NO acepta
+// oferta, NO activa conductor. Útil para demos en vivo donde el
+// operador hace el flow en pantalla y necesita el PIN del conductor
+// disponible para mostrar el login D9 desde cero.
+const SEED_ONLY = args.includes('--seed-only');
 
 // ----------------------------------------------------------------------------
 // Helpers
@@ -390,6 +396,28 @@ async function main() {
 
   // Fase 1: seed
   const creds = await runSeed(adminToken);
+
+  if (SEED_ONLY) {
+    log('🎉', 'seed-only: entidades base creadas, listo para demo en vivo');
+    log('', '', '');
+    log('🔑', 'Credenciales (anotá el PIN ahora, no se vuelve a mostrar):');
+    log('  shipper:', `${creds.shipper_owner.email} / ${creds.shipper_owner.password}`);
+    log('  carrier:', `${creds.carrier_owner.email} / ${creds.carrier_owner.password}`);
+    log('  stakeholder:', `${creds.stakeholder.email} / ${creds.stakeholder.password}`);
+    log(
+      '  conductor:',
+      `RUT ${creds.conductor.rut} / PIN ${creds.conductor.activation_pin ?? '(ya activado)'}`,
+    );
+    log('', '', '');
+    log('ℹ️ ', 'Ahora podés navegar la UI manualmente:');
+    log('  •', 'Login shipper → publica un viaje desde /app/cargas/nuevo');
+    log('  •', 'Login carrier → ve la oferta en /app/ofertas → acepta');
+    log('  •', 'Carrier asigna conductor en /app/asignacion/:id (dropdown)');
+    log('  •', 'Login conductor → /login/conductor con RUT + PIN → activa');
+    log('  •', 'Conductor activa GPS en /app/conductor/modo');
+    await rotateAdminPassword(adminUid);
+    return;
+  }
 
   // Fase 2: shipper crea viaje + matching dispara
   const shipperToken = await signInWithEmailPassword(

--- a/apps/web/src/routes/app.test.tsx
+++ b/apps/web/src/routes/app.test.tsx
@@ -1,7 +1,15 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MeResponse } from '../hooks/use-me.js';
+
+// Layout (usado por AppRoute) internamente usa TanStack Query (vía
+// useSwitchCompany). Sin QueryClientProvider, los tests revientan.
+function renderWithQueryClient(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
 
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
@@ -64,13 +72,13 @@ afterEach(() => {
 
 describe('AppRoute', () => {
   it('contexto no onboarded → no renderiza dashboard', () => {
-    const { container } = render(<AppRoute />);
+    const { container } = renderWithQueryClient(<AppRoute />);
     expect(container.querySelector('h1')).toBeNull();
   });
 
   it('contexto onboarded → renderiza dashboard con título Bienvenido', () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.getByText('Bienvenido a Booster')).toBeInTheDocument();
     expect(screen.getAllByText('Booster SpA').length).toBeGreaterThan(0);
     expect(screen.getByText('Felipe')).toBeInTheDocument();
@@ -78,13 +86,13 @@ describe('AppRoute', () => {
 
   it('carrier → muestra card "Ofertas activas"', () => {
     providedContext = { kind: 'onboarded', me: makeMe('dueno', true, false) };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.getByText(/Ofertas activas/)).toBeInTheDocument();
   });
 
   it('carrier → muestra card "Modo Conductor" linkeada a /app/conductor/modo', () => {
     providedContext = { kind: 'onboarded', me: makeMe('dueno', true, false) };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     const link = screen.getByTestId('dashboard-link-modo-conductor');
     expect(link).toBeInTheDocument();
     // TanStack Link mock pasa `to` como atributo (no `href`).
@@ -93,13 +101,13 @@ describe('AppRoute', () => {
 
   it('shipper (no carrier) → NO muestra card "Modo Conductor"', () => {
     providedContext = { kind: 'onboarded', me: makeMe('dueno', false, true) };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.queryByTestId('dashboard-link-modo-conductor')).not.toBeInTheDocument();
   });
 
   it('shipper → muestra card "Crear carga"', () => {
     providedContext = { kind: 'onboarded', me: makeMe('dueno', false, true) };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.getByText(/Crear carga/)).toBeInTheDocument();
   });
 
@@ -108,7 +116,7 @@ describe('AppRoute', () => {
       kind: 'onboarded',
       me: makeMe('admin', true, false),
     };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.getByText(/Dispositivos pendientes/)).toBeInTheDocument();
   });
 
@@ -117,13 +125,13 @@ describe('AppRoute', () => {
     // vez de chequear el dashboard original chequeamos que el Navigate
     // stub aparezca y que "Dispositivos pendientes" NO esté.
     providedContext = { kind: 'onboarded', me: makeMe('despachador') };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.queryByText(/Dispositivos pendientes/)).not.toBeInTheDocument();
   });
 
   it('rol conductor → redirige a /app/conductor/modo (D9 surface guard)', () => {
     providedContext = { kind: 'onboarded', me: makeMe('conductor') };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app/conductor/modo');
     // El dashboard original NO debería renderizarse.
     expect(screen.queryByText('Bienvenido a Booster')).not.toBeInTheDocument();
@@ -133,7 +141,7 @@ describe('AppRoute', () => {
     const me = makeMe();
     (me.user as { is_platform_admin?: boolean }).is_platform_admin = true;
     providedContext = { kind: 'onboarded', me };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app/platform-admin');
     expect(screen.queryByText('Bienvenido a Booster')).not.toBeInTheDocument();
   });
@@ -155,14 +163,20 @@ describe('AppRoute', () => {
       active_membership: null,
     };
     providedContext = { kind: 'onboarded', me };
-    render(<AppRoute />);
+    renderWithQueryClient(<AppRoute />);
     expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app/platform-admin');
   });
 
-  it('click Salir → signOutUser', () => {
+  it('click Salir (vía menú mobile) → signOutUser', () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
-    render(<AppRoute />);
-    screen.getByRole('button', { name: 'Cerrar sesión' }).click();
+    renderWithQueryClient(<AppRoute />);
+    // En mobile, el botón Salir vive dentro del panel del menú
+    // hamburguesa. Abrir menú primero.
+    const menuButton = screen.getByRole('button', { name: 'Abrir menú' });
+    menuButton.click();
+    // El botón Salir del menú mobile tiene el texto literal "Salir".
+    const salir = screen.getByRole('button', { name: /Salir/i });
+    salir.click();
     expect(signOutUserMock).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -6,20 +6,17 @@ import {
   Bus,
   Headphones,
   Leaf,
-  LogOut,
   MapPinned,
   Package,
   PackagePlus,
   Radio,
   Receipt,
-  Settings,
   ShieldAlert,
   Truck,
-  User as UserIcon,
   Users,
 } from 'lucide-react';
+import { Layout } from '../components/Layout.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
-import { signOutUser } from '../hooks/use-auth.js';
 import type { MeResponse } from '../hooks/use-me.js';
 
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
@@ -77,410 +74,363 @@ function AppDashboard({ me }: { me: MeOnboarded }) {
     return <Navigate to="/app/stakeholder/zonas" />;
   }
 
-  async function handleSignOut() {
-    await signOutUser();
-  }
-
   return (
-    <div className="flex min-h-screen flex-col bg-neutral-50">
-      <header className="border-neutral-200 border-b bg-white">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-3">
-          <div className="flex items-center gap-3">
-            <div className="h-6 w-6 rounded-md bg-primary-500" aria-hidden />
-            <span className="font-semibold text-lg text-neutral-900">Booster AI</span>
-            {activeEmpresa && (
-              <span className="ml-3 rounded-md bg-neutral-100 px-2 py-1 font-medium text-neutral-700 text-xs">
-                {activeEmpresa.legal_name}
-              </span>
-            )}
-          </div>
+    <Layout me={me} title="Inicio">
+      <h1 className="font-bold text-2xl text-neutral-900 tracking-tight sm:text-3xl">
+        Bienvenido a Booster
+      </h1>
 
-          <div className="flex items-center gap-2">
-            <Link
-              to="/app/perfil"
-              className="flex items-center gap-2 rounded-md px-2 py-1 text-neutral-700 text-sm transition hover:bg-neutral-100"
-            >
-              <UserIcon className="h-4 w-4" aria-hidden />
-              <span>{me.user.full_name}</span>
-              <Settings className="h-3.5 w-3.5 text-neutral-400" aria-hidden />
-            </Link>
-            <button
-              type="button"
-              onClick={handleSignOut}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-neutral-600 text-sm transition hover:bg-neutral-100"
-              aria-label="Cerrar sesión"
-            >
-              <LogOut className="h-4 w-4" aria-hidden />
-              Salir
-            </button>
-          </div>
-        </div>
-      </header>
+      {activeEmpresa ? (
+        <p className="mt-2 text-neutral-600 text-sm sm:text-base">
+          Empresa activa: <span className="font-medium">{activeEmpresa.legal_name}</span>
+          {activeEmpresa.is_transportista && ' · Transportista'}
+          {activeEmpresa.is_generador_carga && ' · Generador de carga'}
+        </p>
+      ) : (
+        <p className="mt-2 text-neutral-600 text-sm sm:text-base">Sin empresa activa.</p>
+      )}
 
-      <main className="flex-1">
-        <div className="mx-auto max-w-6xl px-6 py-10">
-          <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">
-            Bienvenido a Booster
-          </h1>
-
-          {activeEmpresa ? (
-            <p className="mt-2 text-neutral-600">
-              Empresa activa: <span className="font-medium">{activeEmpresa.legal_name}</span>
-              {activeEmpresa.is_transportista && ' · Transportista'}
-              {activeEmpresa.is_generador_carga && ' · Generador de carga'}
-            </p>
-          ) : (
-            <p className="mt-2 text-neutral-600">Sin empresa activa.</p>
-          )}
-
-          {activeEmpresa?.is_transportista && (
-            <section className="mt-10">
-              <h2 className="font-semibold text-neutral-900 text-xl">Como transportista</h2>
-              <Link
-                to="/app/flota"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
-                data-testid="dashboard-link-flota"
+      {activeEmpresa?.is_transportista && (
+        <section className="mt-10">
+          <h2 className="font-semibold text-neutral-900 text-xl">Como transportista</h2>
+          <Link
+            to="/app/flota"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+            data-testid="dashboard-link-flota"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <MapPinned className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Seguimiento de flota</div>
-                    <div className="text-neutral-600 text-sm">
-                      Ubicación en tiempo real de todos tus vehículos en un mapa, con histórico.
-                    </div>
-                  </div>
+                <MapPinned className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Seguimiento de flota</div>
+                <div className="text-neutral-600 text-sm">
+                  Ubicación en tiempo real de todos tus vehículos en un mapa, con histórico.
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
 
-              <Link
-                to="/app/ofertas"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          <Link
+            to="/app/ofertas"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <Truck className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Ofertas activas</div>
-                    <div className="text-neutral-600 text-sm">
-                      Cargas disponibles para tu empresa. Acepta o rechaza rápido.
-                    </div>
-                  </div>
+                <Truck className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Ofertas activas</div>
+                <div className="text-neutral-600 text-sm">
+                  Cargas disponibles para tu empresa. Acepta o rechaza rápido.
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
 
-              <Link
-                to="/app/vehiculos"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          <Link
+            to="/app/vehiculos"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <Bus className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Vehículos</div>
-                    <div className="text-neutral-600 text-sm">
-                      Gestiona tu flota: alta, edición, asociación a Teltonika.
-                    </div>
-                  </div>
+                <Bus className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Vehículos</div>
+                <div className="text-neutral-600 text-sm">
+                  Gestiona tu flota: alta, edición, asociación a Teltonika.
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
 
-              <Link
-                to="/app/conductores"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
-                data-testid="dashboard-link-conductores"
+          <Link
+            to="/app/conductores"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+            data-testid="dashboard-link-conductores"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <Users className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Conductores</div>
-                    <div className="text-neutral-600 text-sm">
-                      Crea, edita y monitorea licencias y vencimientos de los conductores de tu
-                      empresa.
-                    </div>
-                  </div>
+                <Users className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Conductores</div>
+                <div className="text-neutral-600 text-sm">
+                  Crea, edita y monitorea licencias y vencimientos de los conductores de tu empresa.
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
 
-              {/* Phase 4 PR-K8 — entrypoint al Modo Conductor desde el
+          {/* Phase 4 PR-K8 — entrypoint al Modo Conductor desde el
                   dashboard principal. Ya existían links desde /app/ofertas
                   y /app/perfil, pero el dashboard es la primera surface
                   post-login: el carrier merece descubrirlo acá. */}
-              <Link
-                to="/app/conductor/modo"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
-                data-testid="dashboard-link-modo-conductor"
+          <Link
+            to="/app/conductor/modo"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+            data-testid="dashboard-link-modo-conductor"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <Headphones className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Modo Conductor</div>
-                    <div className="text-neutral-600 text-sm">
-                      Audio coaching, comandos de voz y permisos del navegador. Configura una vez
-                      antes de manejar.
-                    </div>
-                  </div>
-                </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
-
-              <Link
-                to="/app/cumplimiento"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-amber-500 hover:shadow-md"
-                data-testid="dashboard-link-cumplimiento"
-              >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-amber-50 text-amber-700"
-                    aria-hidden
-                  >
-                    <ShieldAlert className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Cumplimiento</div>
-                    <div className="text-neutral-600 text-sm">
-                      Documentos vencidos o por vencer de vehículos y conductores (revisión técnica,
-                      SOAP, licencia, antecedentes…).
-                    </div>
-                  </div>
-                </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
-
-              <Link
-                to="/app/cobra-hoy/historial"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-success-700 hover:shadow-md"
-              >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-success-50 text-success-700"
-                    aria-hidden
-                  >
-                    <Banknote className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Cobra hoy</div>
-                    <div className="text-neutral-600 text-sm">
-                      Solicita pronto pago de viajes entregados y revisa tu historial de adelantos.
-                    </div>
-                  </div>
-                </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
-
-              <Link
-                to="/app/liquidaciones"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
-              >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <Receipt className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Liquidaciones</div>
-                    <div className="text-neutral-600 text-sm">
-                      Desglose de cada viaje entregado: monto bruto, comisión, IVA y DTE Tipo 33.
-                    </div>
-                  </div>
-                </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
-            </section>
-          )}
-
-          {!activeEmpresa && (
-            <section className="mt-10 rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
-              <h2 className="font-semibold text-neutral-900 text-xl">Aún no tienes empresa</h2>
-              <p className="mt-2 text-neutral-700 text-sm">
-                Para usar Booster necesitas crear una empresa o unirte a una existente. Si recién te
-                registraste, hace falta completar el onboarding (RUT, datos legales, plan).
-              </p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                <Link
-                  to="/onboarding"
-                  className="inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white hover:bg-primary-700"
-                >
-                  Crear empresa
-                  <ArrowRight className="h-4 w-4" aria-hidden />
-                </Link>
-                {/* Atajo discreto para admins de plataforma (validación de
-                    autorización es server-side en el backend). */}
-                <Link
-                  to="/app/platform-admin"
-                  className="inline-flex items-center gap-2 rounded-md border border-neutral-300 px-4 py-2 font-medium text-neutral-700 text-sm hover:bg-neutral-100"
-                  data-testid="empty-state-link-platform-admin"
-                >
-                  Soy admin de plataforma
-                </Link>
+                <Headphones className="h-5 w-5" />
               </div>
-            </section>
-          )}
-
-          {activeEmpresa &&
-            !activeEmpresa.is_transportista &&
-            !activeEmpresa.is_generador_carga && (
-              <section className="mt-10 rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
-                <h2 className="font-semibold text-neutral-900 text-xl">
-                  Tu empresa todavía no opera
-                </h2>
-                <p className="mt-2 text-neutral-700 text-sm">
-                  Configura si vas a operar como generador de carga, transportista o ambos desde el
-                  perfil de empresa.
-                </p>
-              </section>
-            )}
-
-          {activeEmpresa?.is_generador_carga && (
-            <section className="mt-10">
-              <h2 className="font-semibold text-neutral-900 text-xl">Como generador de carga</h2>
-              <Link
-                to="/app/cargas/nueva"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
-              >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <PackagePlus className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Crear carga</div>
-                    <div className="text-neutral-600 text-sm">
-                      Origen, destino, tipo de carga y ventana de pickup. Matching automático con
-                      transportistas.
-                    </div>
-                  </div>
+              <div>
+                <div className="font-medium text-neutral-900">Modo Conductor</div>
+                <div className="text-neutral-600 text-sm">
+                  Audio coaching, comandos de voz y permisos del navegador. Configura una vez antes
+                  de manejar.
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
 
-              <Link
-                to="/app/cargas"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          <Link
+            to="/app/cumplimiento"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-amber-500 hover:shadow-md"
+            data-testid="dashboard-link-cumplimiento"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-amber-50 text-amber-700"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <Package className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Mis cargas</div>
-                    <div className="text-neutral-600 text-sm">
-                      Estado del matching, asignaciones, seguimiento en vivo.
-                    </div>
-                  </div>
+                <ShieldAlert className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Cumplimiento</div>
+                <div className="text-neutral-600 text-sm">
+                  Documentos vencidos o por vencer de vehículos y conductores (revisión técnica,
+                  SOAP, licencia, antecedentes…).
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
 
-              <Link
-                to="/app/sucursales"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
-                data-testid="dashboard-link-sucursales"
+          <Link
+            to="/app/cobra-hoy/historial"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-success-700 hover:shadow-md"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-success-50 text-success-700"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <Building2 className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Sucursales</div>
-                    <div className="text-neutral-600 text-sm">
-                      Bodegas, plantas y centros de distribución. Puntos físicos de origen y destino
-                      para tus cargas.
-                    </div>
-                  </div>
+                <Banknote className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Cobra hoy</div>
+                <div className="text-neutral-600 text-sm">
+                  Solicita pronto pago de viajes entregados y revisa tu historial de adelantos.
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
 
-              <Link
-                to="/app/certificados"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-emerald-500 hover:shadow-md"
+          <Link
+            to="/app/liquidaciones"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-emerald-50 text-emerald-700"
-                    aria-hidden
-                  >
-                    <Leaf className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">
-                      Certificados de huella de carbono
-                    </div>
-                    <div className="text-neutral-600 text-sm">
-                      Descarga los certificados firmados (GLEC v3.0 + SEC Chile 2024) de tus viajes
-                      entregados.
-                    </div>
-                  </div>
+                <Receipt className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Liquidaciones</div>
+                <div className="text-neutral-600 text-sm">
+                  Desglose de cada viaje entregado: monto bruto, comisión, IVA y DTE Tipo 33.
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
-            </section>
-          )}
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
+        </section>
+      )}
 
-          {isAdmin && activeEmpresa?.is_transportista && (
-            <section className="mt-10">
-              <h2 className="font-semibold text-neutral-900 text-xl">Administración</h2>
-              <Link
-                to="/app/admin/dispositivos"
-                className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+      {!activeEmpresa && (
+        <section className="mt-10 rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+          <h2 className="font-semibold text-neutral-900 text-xl">Aún no tienes empresa</h2>
+          <p className="mt-2 text-neutral-700 text-sm">
+            Para usar Booster necesitas crear una empresa o unirte a una existente. Si recién te
+            registraste, hace falta completar el onboarding (RUT, datos legales, plan).
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Link
+              to="/onboarding"
+              className="inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white hover:bg-primary-700"
+            >
+              Crear empresa
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+            {/* Atajo discreto para admins de plataforma (validación de
+                    autorización es server-side en el backend). */}
+            <Link
+              to="/app/platform-admin"
+              className="inline-flex items-center gap-2 rounded-md border border-neutral-300 px-4 py-2 font-medium text-neutral-700 text-sm hover:bg-neutral-100"
+              data-testid="empty-state-link-platform-admin"
+            >
+              Soy admin de plataforma
+            </Link>
+          </div>
+        </section>
+      )}
+
+      {activeEmpresa && !activeEmpresa.is_transportista && !activeEmpresa.is_generador_carga && (
+        <section className="mt-10 rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+          <h2 className="font-semibold text-neutral-900 text-xl">Tu empresa todavía no opera</h2>
+          <p className="mt-2 text-neutral-700 text-sm">
+            Configura si vas a operar como generador de carga, transportista o ambos desde el perfil
+            de empresa.
+          </p>
+        </section>
+      )}
+
+      {activeEmpresa?.is_generador_carga && (
+        <section className="mt-10">
+          <h2 className="font-semibold text-neutral-900 text-xl">Como generador de carga</h2>
+          <Link
+            to="/app/cargas/nueva"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
               >
-                <div className="flex items-center gap-4">
-                  <div
-                    className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                    aria-hidden
-                  >
-                    <Radio className="h-5 w-5" />
-                  </div>
-                  <div>
-                    <div className="font-medium text-neutral-900">Dispositivos pendientes</div>
-                    <div className="text-neutral-600 text-sm">
-                      Aprueba dispositivos Teltonika que conectaron y asignalos a vehículos.
-                    </div>
-                  </div>
+                <PackagePlus className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Crear carga</div>
+                <div className="text-neutral-600 text-sm">
+                  Origen, destino, tipo de carga y ventana de pickup. Matching automático con
+                  transportistas.
                 </div>
-                <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-              </Link>
-            </section>
-          )}
-        </div>
-      </main>
-    </div>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
+
+          <Link
+            to="/app/cargas"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
+              >
+                <Package className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Mis cargas</div>
+                <div className="text-neutral-600 text-sm">
+                  Estado del matching, asignaciones, seguimiento en vivo.
+                </div>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
+
+          <Link
+            to="/app/sucursales"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+            data-testid="dashboard-link-sucursales"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
+              >
+                <Building2 className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Sucursales</div>
+                <div className="text-neutral-600 text-sm">
+                  Bodegas, plantas y centros de distribución. Puntos físicos de origen y destino
+                  para tus cargas.
+                </div>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
+
+          <Link
+            to="/app/certificados"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-emerald-500 hover:shadow-md"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-emerald-50 text-emerald-700"
+                aria-hidden
+              >
+                <Leaf className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">
+                  Certificados de huella de carbono
+                </div>
+                <div className="text-neutral-600 text-sm">
+                  Descarga los certificados firmados (GLEC v3.0 + SEC Chile 2024) de tus viajes
+                  entregados.
+                </div>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
+        </section>
+      )}
+
+      {isAdmin && activeEmpresa?.is_transportista && (
+        <section className="mt-10">
+          <h2 className="font-semibold text-neutral-900 text-xl">Administración</h2>
+          <Link
+            to="/app/admin/dispositivos"
+            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
+          >
+            <div className="flex items-center gap-4">
+              <div
+                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
+                aria-hidden
+              >
+                <Radio className="h-5 w-5" />
+              </div>
+              <div>
+                <div className="font-medium text-neutral-900">Dispositivos pendientes</div>
+                <div className="text-neutral-600 text-sm">
+                  Aprueba dispositivos Teltonika que conectaron y asignalos a vehículos.
+                </div>
+              </div>
+            </div>
+            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
+          </Link>
+        </section>
+      )}
+    </Layout>
   );
 }

--- a/apps/web/src/routes/ofertas.test.tsx
+++ b/apps/web/src/routes/ofertas.test.tsx
@@ -1,7 +1,14 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MeResponse } from '../hooks/use-me.js';
+
+// Layout (usado por OfertasRoute) internamente usa TanStack Query.
+function renderWithQueryClient(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
 
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 type Ctx = { kind: 'onboarded'; me: MeOnboarded } | { kind: 'unmanaged' };
@@ -72,28 +79,28 @@ afterEach(() => {
 
 describe('OfertasRoute', () => {
   it('contexto no onboarded → no renderiza', () => {
-    const { container } = render(<OfertasRoute />);
+    const { container } = renderWithQueryClient(<OfertasRoute />);
     expect(container.querySelector('h1')).toBeNull();
   });
 
   it('empresa no transportista → warning', () => {
     providedContext = { kind: 'onboarded', me: makeMe(false) };
     useOffersMineMock.mockReturnValue({ isLoading: false, isError: false, data: undefined });
-    render(<OfertasRoute />);
+    renderWithQueryClient(<OfertasRoute />);
     expect(screen.getByText(/no opera como carrier/)).toBeInTheDocument();
   });
 
   it('carrier + loading → "Cargando ofertas"', () => {
     providedContext = { kind: 'onboarded', me: makeMe(true) };
     useOffersMineMock.mockReturnValue({ isLoading: true, isError: false, data: undefined });
-    render(<OfertasRoute />);
+    renderWithQueryClient(<OfertasRoute />);
     expect(screen.getByText(/Cargando ofertas/)).toBeInTheDocument();
   });
 
   it('carrier + error → mensaje de error', () => {
     providedContext = { kind: 'onboarded', me: makeMe(true) };
     useOffersMineMock.mockReturnValue({ isLoading: false, isError: true, data: undefined });
-    render(<OfertasRoute />);
+    renderWithQueryClient(<OfertasRoute />);
     expect(screen.getByText(/No pudimos cargar las ofertas/)).toBeInTheDocument();
   });
 
@@ -106,7 +113,7 @@ describe('OfertasRoute', () => {
       refetch: vi.fn(),
       isFetching: false,
     });
-    render(<OfertasRoute />);
+    renderWithQueryClient(<OfertasRoute />);
     expect(screen.getByTestId('empty-state')).toBeInTheDocument();
   });
 
@@ -124,7 +131,7 @@ describe('OfertasRoute', () => {
       refetch: vi.fn(),
       isFetching: false,
     });
-    render(<OfertasRoute />);
+    renderWithQueryClient(<OfertasRoute />);
     expect(screen.getAllByTestId('offer-card')).toHaveLength(2);
   });
 
@@ -138,7 +145,7 @@ describe('OfertasRoute', () => {
       refetch,
       isFetching: false,
     });
-    render(<OfertasRoute />);
+    renderWithQueryClient(<OfertasRoute />);
     screen.getByRole('button', { name: /Actualizar/ }).click();
     expect(refetch).toHaveBeenCalled();
   });
@@ -152,7 +159,7 @@ describe('OfertasRoute', () => {
       refetch: vi.fn(),
       isFetching: true,
     });
-    render(<OfertasRoute />);
+    renderWithQueryClient(<OfertasRoute />);
     expect(screen.getByRole('button', { name: /Actualizando/ })).toBeDisabled();
   });
 
@@ -165,7 +172,7 @@ describe('OfertasRoute', () => {
       refetch: vi.fn(),
       isFetching: false,
     });
-    render(<OfertasRoute />);
+    renderWithQueryClient(<OfertasRoute />);
     screen.getByRole('button', { name: /Salir/ }).click();
     expect(signOutUserMock).toHaveBeenCalled();
   });

--- a/apps/web/src/routes/ofertas.tsx
+++ b/apps/web/src/routes/ofertas.tsx
@@ -1,10 +1,10 @@
 import { Link } from '@tanstack/react-router';
-import { Headphones, Inbox, LogOut, RefreshCw, Settings, User as UserIcon } from 'lucide-react';
+import { Headphones, Inbox, RefreshCw } from 'lucide-react';
 import { EmptyState } from '../components/EmptyState.js';
+import { Layout } from '../components/Layout.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { OfferCard } from '../components/offers/OfferCard.js';
 import { VoiceAcceptOfferControl } from '../components/offers/VoiceAcceptOfferControl.js';
-import { signOutUser } from '../hooks/use-auth.js';
 import type { MeResponse } from '../hooks/use-me.js';
 import { useOffersMine } from '../hooks/use-offers.js';
 
@@ -36,135 +36,97 @@ function OfertasPage({ me }: { me: MeOnboarded }) {
 
   const offersQuery = useOffersMine({ enabled: isCarrier });
 
-  async function handleSignOut() {
-    await signOutUser();
-  }
-
   return (
-    <div className="flex min-h-screen flex-col bg-neutral-50">
-      <header className="border-neutral-200 border-b bg-white">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-3">
-          <div className="flex items-center gap-3">
-            <Link to="/app" className="flex items-center gap-3">
-              <div className="h-6 w-6 rounded-md bg-primary-500" aria-hidden />
-              <span className="font-semibold text-lg text-neutral-900">Booster AI</span>
-            </Link>
-            {activeEmpresa && (
-              <span className="ml-3 rounded-md bg-neutral-100 px-2 py-1 font-medium text-neutral-700 text-xs">
-                {activeEmpresa.legal_name}
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
-            <Link
-              to="/app/perfil"
-              className="flex items-center gap-2 rounded-md px-2 py-1 text-neutral-700 text-sm transition hover:bg-neutral-100"
-            >
-              <UserIcon className="h-4 w-4" aria-hidden />
-              <span>{me.user.full_name}</span>
-              <Settings className="h-3.5 w-3.5 text-neutral-400" aria-hidden />
-            </Link>
-            <button
-              type="button"
-              onClick={handleSignOut}
-              className="flex items-center gap-1 rounded-md px-2 py-1 text-neutral-600 text-sm transition hover:bg-neutral-100"
-            >
-              <LogOut className="h-4 w-4" aria-hidden />
-              Salir
-            </button>
-          </div>
+    <Layout me={me} title="Ofertas activas">
+      {/* Header de página: en mobile stack vertical (título arriba,
+          descripción debajo, botones full-width). En sm+ vuelve al
+          layout horizontal compacto. Antes era flex row fijo y
+          comprimía el título a 2 líneas cortadas. */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <h1 className="font-bold text-2xl text-neutral-900 tracking-tight sm:text-3xl">
+            Ofertas activas
+          </h1>
+          <p className="mt-1 text-neutral-600 text-sm">
+            Cargas disponibles para tu empresa. Las ofertas expiran en 1 hora.
+          </p>
         </div>
-      </header>
+        <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
+          <Link
+            to="/app/conductor/modo"
+            className="inline-flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm shadow-xs transition hover:bg-neutral-100"
+            data-testid="link-modo-conductor"
+          >
+            <Headphones className="h-4 w-4" aria-hidden />
+            Modo Conductor
+          </Link>
+          <button
+            type="button"
+            onClick={() => offersQuery.refetch()}
+            disabled={offersQuery.isFetching}
+            className="inline-flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm shadow-xs transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <RefreshCw
+              className={`h-4 w-4 ${offersQuery.isFetching ? 'animate-spin' : ''}`}
+              aria-hidden
+            />
+            {offersQuery.isFetching ? 'Actualizando…' : 'Actualizar'}
+          </button>
+        </div>
+      </div>
 
-      <main className="flex-1">
-        <div className="mx-auto max-w-6xl px-6 py-10">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">
-                Ofertas activas
-              </h1>
-              <p className="mt-1 text-neutral-600 text-sm">
-                Cargas disponibles para tu empresa. Las ofertas expiran en 1 hora.
-              </p>
-            </div>
-            <div className="flex items-center gap-2">
-              <Link
-                to="/app/conductor/modo"
-                className="flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm shadow-xs transition hover:bg-neutral-100"
-                data-testid="link-modo-conductor"
-              >
-                <Headphones className="h-4 w-4" aria-hidden />
-                Modo Conductor
-              </Link>
-              <button
-                type="button"
-                onClick={() => offersQuery.refetch()}
-                disabled={offersQuery.isFetching}
-                className="flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm shadow-xs transition hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                <RefreshCw
-                  className={`h-4 w-4 ${offersQuery.isFetching ? 'animate-spin' : ''}`}
-                  aria-hidden
-                />
-                {offersQuery.isFetching ? 'Actualizando…' : 'Actualizar'}
-              </button>
-            </div>
-          </div>
+      {!isCarrier && (
+        <output className="mt-6 block rounded-md border border-warning-500/30 bg-warning-50 p-4 text-sm text-warning-700">
+          Tu empresa <strong>{activeEmpresa?.legal_name}</strong> no opera como carrier. Esta vista
+          es solo para empresas transportistas. Si quieres activar este modo, contacta a{' '}
+          <a
+            href="mailto:soporte@boosterchile.com"
+            className="font-medium text-warning-700 underline"
+          >
+            soporte@boosterchile.com
+          </a>
+          .
+        </output>
+      )}
 
-          {!isCarrier && (
-            <output className="mt-6 block rounded-md border border-warning-500/30 bg-warning-50 p-4 text-sm text-warning-700">
-              Tu empresa <strong>{activeEmpresa?.legal_name}</strong> no opera como carrier. Esta
-              vista es solo para empresas transportistas. Si quieres activar este modo, contacta a{' '}
-              <a
-                href="mailto:soporte@boosterchile.com"
-                className="font-medium text-warning-700 underline"
-              >
-                soporte@boosterchile.com
-              </a>
-              .
-            </output>
-          )}
+      {isCarrier && offersQuery.isLoading && (
+        <div className="mt-10 text-center text-neutral-500 text-sm">Cargando ofertas…</div>
+      )}
 
-          {isCarrier && offersQuery.isLoading && (
-            <div className="mt-10 text-center text-neutral-500 text-sm">Cargando ofertas…</div>
-          )}
+      {isCarrier && offersQuery.isError && (
+        <output className="mt-6 block rounded-md border border-danger-500/30 bg-danger-50 p-4 text-danger-700 text-sm">
+          No pudimos cargar las ofertas. Probá actualizar.
+        </output>
+      )}
 
-          {isCarrier && offersQuery.isError && (
-            <output className="mt-6 block rounded-md border border-danger-500/30 bg-danger-50 p-4 text-danger-700 text-sm">
-              No pudimos cargar las ofertas. Probá actualizar.
-            </output>
-          )}
+      {isCarrier && offersQuery.data && offersQuery.data.offers.length === 0 && (
+        <div className="mt-10">
+          <EmptyState
+            icon={<Inbox className="h-10 w-10" aria-hidden />}
+            title="No hay ofertas activas ahora"
+            description="Cuando un generador de carga publique una compatible con tus zonas y vehículos, la verás aquí. Mantenemos esta vista actualizada cada 30 segundos."
+          />
+        </div>
+      )}
 
-          {isCarrier && offersQuery.data && offersQuery.data.offers.length === 0 && (
-            <div className="mt-10">
-              <EmptyState
-                icon={<Inbox className="h-10 w-10" aria-hidden />}
-                title="No hay ofertas activas ahora"
-                description="Cuando un generador de carga publique una compatible con tus zonas y vehículos, la verás aquí. Mantenemos esta vista actualizada cada 30 segundos."
-              />
-            </div>
-          )}
-
-          {isCarrier && offersQuery.data && offersQuery.data.offers.length > 0 && (
-            <div className="mt-6 space-y-4">
-              {/* Phase 4 PR-K7 — control de aceptación por voz. Solo se
+      {isCarrier && offersQuery.data && offersQuery.data.offers.length > 0 && (
+        <div className="mt-6 space-y-4">
+          {/* Phase 4 PR-K7 — control de aceptación por voz. Solo se
                   renderiza cuando hay EXACTAMENTE 1 oferta pendiente —
                   para >1 sería ambiguo qué oferta el comando "aceptar"
                   refiere. Doble confirmación protege contra falsos
                   positivos (aceptar oferta es contrato). */}
-              {offersQuery.data.offers.length === 1 && offersQuery.data.offers[0] && (
-                <VoiceAcceptOfferControl
-                  offerId={offersQuery.data.offers[0].id}
-                  trackingCode={offersQuery.data.offers[0].trip_request.tracking_code}
-                />
-              )}
-              {offersQuery.data.offers.map((o) => (
-                <OfferCard key={o.id} offer={o} />
-              ))}
-            </div>
+          {offersQuery.data.offers.length === 1 && offersQuery.data.offers[0] && (
+            <VoiceAcceptOfferControl
+              offerId={offersQuery.data.offers[0].id}
+              trackingCode={offersQuery.data.offers[0].trip_request.tracking_code}
+            />
           )}
+          {offersQuery.data.offers.map((o) => (
+            <OfferCard key={o.id} offer={o} />
+          ))}
         </div>
-      </main>
-    </div>
+      )}
+    </Layout>
   );
 }


### PR DESCRIPTION
## Summary

Bug detectado por Felipe al conectarse desde su teléfono con Transportes Van Oosterwyk: en **`/app`** y **`/app/ofertas`** el header está roto en mobile:
- "Booster AI" parte a 2 líneas
- Selector empresa apretado a 3 líneas
- **"Salir" se sale del viewport** → scroll horizontal en toda la app

Auditado con Playwright en viewport 390x844 (iPhone 14). Las pantallas que ya usan el componente `Layout` (`/app/cargas/nueva`, `/app/conductor/modo`) se ven perfectas con hamburguesa mobile — el bug solo afectaba a dos pantallas con header inline desktop-only.

## Fix

- **`/app` (AppDashboard)**: elimina header inline propio, envuelve el cuerpo con `<Layout>`. H1 escala responsive (`text-2xl` mobile / `text-3xl` sm+).
- **`/app/ofertas`**: mismo refactor + el header de página interno (título + descripción + 2 botones) ahora stack vertical en mobile (`flex-col gap-3`) y horizontal compacto en sm+. Antes los botones competían con el título por el espacio y lo apretaban a 2 líneas con corte raro.
- **Tests**: `app.test.tsx` + `ofertas.test.tsx` wrapeados en QueryClientProvider porque `Layout` ahora consume TanStack Query internamente (vía `useSwitchCompany`). 25 tests siguen pasando.

## Bonus

Agrega flag `--seed-only` al dry-run script — útil para preparar demos en vivo sin pre-ejecutar trip + accept (deja el PIN del conductor disponible para mostrar el flow desde cero).

## Cambios

| Archivo | Δ |
|---|---|
| `apps/web/src/routes/app.tsx` | -114 +13 (header inline → Layout) |
| `apps/web/src/routes/app.test.tsx` | +18 (QueryClientProvider wrapper) |
| `apps/web/src/routes/ofertas.tsx` | -67 +44 (header inline → Layout + stack vertical) |
| `apps/web/src/routes/ofertas.test.tsx` | +12 (QueryClientProvider wrapper) |
| `apps/api/scripts/demo-dry-run.mjs` | +30 (flag `--seed-only`) |

## Evidencia

```
$ pnpm --filter=@booster-ai/web typecheck → 0 errores
$ pnpm --filter=@booster-ai/web test → 908 passed
$ pnpm biome check (touched files) → clean
```

## ⚡ Bloqueante: Feria de Transporte y Logística mañana (martes)

Felipe va a demostrar la PWA desde su celular delante de público. El bug es visible en cualquier pantalla `/app` o `/app/ofertas` — fundamental antes de mañana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)