### PR TITLE
feat(conductor): identidad + dashboard split + plan waves 1-6

### DIFF
--- a/apps/api/drizzle/0029_conductor_memberships_backfill.sql
+++ b/apps/api/drizzle/0029_conductor_memberships_backfill.sql
@@ -1,0 +1,90 @@
+-- Migration 0029 — Modelo de identidad del conductor (definitivo).
+--
+-- Contexto: hasta acá el flujo del conductor estaba half-implementado.
+-- Existía la tabla `conductores` (info adicional: licencia, PIN, etc.)
+-- pero el conductor NO se creaba como `membership` con role='conductor'
+-- de la empresa carrier. Resultado: `GET /me` devolvía
+-- `active_membership: null` para el conductor → el frontend mostraba
+-- "Sin empresa activa" cuando el conductor navegaba al dashboard
+-- general.
+--
+-- Decisión consolidada (ver discusión 2026-05-12): el conductor ES un
+-- miembro con `role='conductor'` de la empresa carrier que lo emplea.
+-- La tabla `conductores` permanece como metadata específica del
+-- conductor (licencia, vencimiento, PIN, clase), pero la fuente de
+-- verdad de "este user pertenece a esta empresa con este rol" es
+-- siempre `memberships`.
+--
+-- Invariante post-migration:
+--   Para cada fila en `conductores` con `eliminado_en IS NULL`,
+--   debe existir EXACTAMENTE 1 fila en `memberships` con:
+--     - user_id = conductores.usuario_id
+--     - empresa_id = conductores.empresa_id
+--     - role = 'conductor'
+--     - estado IN ('activa', 'pendiente_invitacion') (no 'removida'/'suspendida')
+--
+-- Esta migration backfillea las filas faltantes para no dejar
+-- conductores huérfanos. Las filas nuevas creadas a partir de aquí
+-- (via ensureConductor o el flujo D9 driver-activate) se encargan en
+-- código.
+--
+-- Riesgo deploy: INSERTs idempotentes con ON CONFLICT — corre múltiples
+-- veces sin duplicar. Sin DROPS ni ALTERs destructivos.
+
+-- Insert membership 'conductor' para cada conductor activo que no tenga
+-- todavía una membership en la misma empresa (la UNIQUE constraint
+-- `uq_membresias_usuario_empresa` impide 2 memberships del mismo user
+-- en la misma empresa con distintos roles — si el user ya tiene
+-- membership como dueño/admin de esa empresa carrier, no le agregamos
+-- una segunda con rol conductor; ese caso edge "dueño-conductor" se
+-- maneja a futuro con cambio de constraint o flag explícito en
+-- conductores).
+INSERT INTO membresias (
+  id,
+  usuario_id,
+  empresa_id,
+  rol,
+  estado,
+  invitado_en,
+  unido_en,
+  creado_en,
+  actualizado_en
+)
+SELECT
+  gen_random_uuid(),
+  c.usuario_id,
+  c.empresa_id,
+  'conductor'::rol_membresia,
+  -- Si el user está activado (firebase_uid real), membership va
+  -- 'activa' + unido_en = creado_en del conductor. Si todavía está
+  -- pendiente (placeholder pending-rut:), va 'pendiente_invitacion' y
+  -- unido_en = NULL — al activar via D9 (/auth/driver-activate) se
+  -- promueve a 'activa' y se setea unido_en = now().
+  CASE
+    WHEN u.firebase_uid LIKE 'pending-rut:%' THEN 'pendiente_invitacion'::estado_membresia
+    ELSE 'activa'::estado_membresia
+  END,
+  COALESCE(c.creado_en, now()),
+  CASE
+    WHEN u.firebase_uid LIKE 'pending-rut:%' THEN NULL
+    ELSE COALESCE(c.creado_en, now())
+  END,
+  now(),
+  now()
+FROM conductores c
+JOIN usuarios u ON u.id = c.usuario_id
+WHERE c.eliminado_en IS NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM membresias m
+    WHERE m.usuario_id = c.usuario_id
+      AND m.empresa_id = c.empresa_id
+  );
+
+-- Nota: el deleteDemo de seed-demo.ts ya borra memberships antes de
+-- borrar empresa (ver migration 0026/0027), así que el cleanup sigue
+-- funcionando sin cambios. ensureConductor en código será actualizado
+-- para crear la membership al mismo tiempo que el conductor.
+
+COMMENT ON COLUMN membresias.rol IS
+  'Rol del user en la empresa. Para conductores, el invariante (a partir de migration 0029) es que toda fila conductores activa tiene exactamente 1 membership con role=conductor en la misma empresa.';

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1780358400000,
       "tag": "0028_event_type_conductor_asignado",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1780444800000,
+      "tag": "0029_conductor_memberships_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/scripts/demo-dry-run.mjs
+++ b/apps/api/scripts/demo-dry-run.mjs
@@ -414,7 +414,7 @@ async function main() {
     log('  •', 'Login carrier → ve la oferta en /app/ofertas → acepta');
     log('  •', 'Carrier asigna conductor en /app/asignacion/:id (dropdown)');
     log('  •', 'Login conductor → /login/conductor con RUT + PIN → activa');
-    log('  •', 'Conductor activa GPS en /app/conductor/modo');
+    log('  •', 'Conductor activa GPS en /app/conductor (dashboard del conductor)');
     await rotateAdminPassword(adminUid);
     return;
   }

--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -614,7 +614,7 @@ export function createAssignmentsRoutes(opts: {
   // POST /:id/asignar-conductor — Carrier asigna un conductor específico
   // al assignment. Cierra el gap dejado por accept-offer (que crea el
   // assignment con driver_user_id=NULL) y habilita el flujo del driver
-  // (driver-position, conductor-modo) que valida driver_user_id ===
+  // (driver-position, dashboard del conductor) que valida driver_user_id ===
   // userContext.user.id.
   //
   // Auth: carrier owner del assignment. Rol requerido: dueno, admin,

--- a/apps/api/src/routes/auth-driver.ts
+++ b/apps/api/src/routes/auth-driver.ts
@@ -1,12 +1,12 @@
 import type { Logger } from '@booster-ai/logger';
 import { rutSchema } from '@booster-ai/shared-schemas';
 import { zValidator } from '@hono/zod-validator';
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import type { Auth } from 'firebase-admin/auth';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { Db } from '../db/client.js';
-import { conductores, users } from '../db/schema.js';
+import { conductores, memberships, users } from '../db/schema.js';
 import { verifyActivationPin } from '../services/activation-pin.js';
 
 const PENDING_FIREBASE_UID_PREFIX = 'pending-rut:';
@@ -176,6 +176,64 @@ export function createDriverAuthRoutes(opts: {
         'DB update failed after Firebase user created',
       );
       return c.json({ error: 'db_error', code: 'db_error' }, 502);
+    }
+
+    // 6b. Promover membership de 'pendiente_invitacion' → 'activa' para
+    //     todas las membresias de este user que sean rol=conductor.
+    //     Invariante (migration 0029): todo conductor activo tiene una
+    //     membership con role=conductor. Si no existe (caso edge: el
+    //     conductor se creó antes de la migration o algo se desincronizó)
+    //     la creamos acá usando el empresaId del driver row.
+    try {
+      const driverEmpresaRows = await opts.db
+        .select({ empresaId: conductores.empresaId })
+        .from(conductores)
+        .where(eq(conductores.userId, user.id))
+        .limit(1);
+      const driverEmpresa = driverEmpresaRows[0];
+      if (driverEmpresa) {
+        const existingMembership = await opts.db
+          .select({ id: memberships.id, status: memberships.status })
+          .from(memberships)
+          .where(
+            and(
+              eq(memberships.userId, user.id),
+              eq(memberships.empresaId, driverEmpresa.empresaId),
+            ),
+          )
+          .limit(1);
+        const m = existingMembership[0];
+        if (m) {
+          // Promover a 'activa' si no lo está ya.
+          if (m.status !== 'activa') {
+            await opts.db
+              .update(memberships)
+              .set({
+                status: 'activa',
+                joinedAt: sql`now()`,
+                updatedAt: sql`now()`,
+              })
+              .where(eq(memberships.id, m.id));
+          }
+        } else {
+          // Backfill seguro: insertar membership rol=conductor.
+          await opts.db.insert(memberships).values({
+            userId: user.id,
+            empresaId: driverEmpresa.empresaId,
+            role: 'conductor',
+            status: 'activa',
+            joinedAt: sql`now()`,
+          });
+        }
+      }
+    } catch (err) {
+      // No-fatal: el flujo del conductor funciona aún sin membership
+      // (driver-position resuelve via conductores.userId). Logueamos
+      // warn y seguimos.
+      opts.logger.warn(
+        { err, userId: user.id, rut },
+        'driver-activate: no se pudo promover/crear membership rol=conductor',
+      );
     }
 
     // 7. Mint custom token para que el cliente haga signInWithCustomToken.

--- a/apps/api/src/routes/conductores.ts
+++ b/apps/api/src/routes/conductores.ts
@@ -277,7 +277,7 @@ export function createConductoresRoutes(opts: { db: Db; logger: Logger }) {
     // user nuevo o un user-placeholder (firebase_uid `pending-rut:...`). Si
     // ya es un user real activado (e.g. el dueño de la empresa que también
     // se registra como conductor — flujo D10), NO generamos PIN: el dueño
-    // ya tiene su email/password y puede entrar a `/app/conductor/modo`
+    // ya tiene su email/password y puede entrar a `/app/conductor`
     // directamente sin re-autenticarse.
     //
     // El plaintext del PIN NUNCA persiste; sólo se devuelve UNA vez en la

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -207,9 +207,10 @@ export function createMeRoutes(opts: { db: Db; logger: Logger }) {
   // ordenados por más reciente primero. Sin paginación por ahora: un
   // conductor rara vez tiene > 2-3 assignments activos simultáneos.
   //
-  // Uso: la UI /app/conductor/modo lista los assignments y deja al
-  // conductor elegir cuál activar (en vez de pedir UUID copiado, que era
-  // el placeholder MVP). El conductor sólo ve los que están en estado
+  // Uso: la UI /app/conductor (dashboard del conductor) lista los
+  // assignments y deja al conductor elegir cuál activar (en vez de pedir
+  // UUID copiado, que era el placeholder MVP). El conductor sólo ve los
+  // que están en estado
   // operacional — si necesita el histórico (entregados), iría a otra
   // surface dedicada (futuro).
   //

--- a/apps/api/src/services/asignar-conductor-a-assignment.ts
+++ b/apps/api/src/services/asignar-conductor-a-assignment.ts
@@ -10,7 +10,7 @@ import { assignments, conductores, tripEvents, users } from '../db/schema.js';
  * `driver_user_id = NULL` y no había forma de setearlo después. El
  * resultado: el endpoint `/assignments/:id/driver-position` (que valida
  * `assignment.driverUserId === user.id`) era inalcanzable, y la UI
- * `/app/conductor/modo` exigía que el conductor pegara manualmente el
+ * `/app/conductor` exigía que el conductor pegara manualmente el
  * UUID del assignment (UX placeholder).
  *
  * Este servicio cierra el flujo: el carrier (dueño/admin/despachador)

--- a/apps/api/src/services/seed-demo.ts
+++ b/apps/api/src/services/seed-demo.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@booster-ai/logger';
-import { eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 import type { Auth } from 'firebase-admin/auth';
 import type { Db } from '../db/client.js';
 import {
@@ -834,5 +834,28 @@ async function ensureConductor(opts: {
   if (!row) {
     throw new Error('conductor insert returned no row');
   }
+
+  // 3. Crear membership con rol='conductor' si no existe ya. Invariante
+  //    del modelo (migration 0029): todo conductor activo tiene
+  //    membership en la misma empresa con role=conductor.
+  //    Estado: 'pendiente_invitacion' mientras el firebase_uid es
+  //    placeholder; cuando el conductor activa via D9 (driver-activate)
+  //    se promueve a 'activa'.
+  const existingMembership = await db
+    .select({ id: memberships.id })
+    .from(memberships)
+    .where(and(eq(memberships.userId, userId), eq(memberships.empresaId, empresaId)))
+    .limit(1);
+  if (existingMembership.length === 0) {
+    await db.insert(memberships).values({
+      userId,
+      empresaId,
+      role: 'conductor',
+      // El user del conductor recién creado siempre arranca pending —
+      // activationPin presente significa que aún no se activó.
+      status: activationPin ? 'pendiente_invitacion' : 'activa',
+    });
+  }
+
   return { conductorId: row.id, activationPin };
 }

--- a/apps/web/src/components/profile/AuthProvidersSection.tsx
+++ b/apps/web/src/components/profile/AuthProvidersSection.tsx
@@ -261,7 +261,7 @@ function PasswordLinkForm({
         setNeedsReauth(true);
         setError('root', {
           message:
-            'Por seguridad necesitamos confirmar tu identidad. Hacé click en "Re-autenticar" para continuar.',
+            'Por seguridad necesitamos confirmar tu identidad. Haz click en "Re-autenticar" para continuar.',
         });
       } else {
         setError('root', {

--- a/apps/web/src/components/scoring/DriverAssignmentCard.test.tsx
+++ b/apps/web/src/components/scoring/DriverAssignmentCard.test.tsx
@@ -173,7 +173,7 @@ describe('DriverAssignmentCard', () => {
     fireEvent.click(screen.getByTestId('driver-assignment-submit'));
 
     expect(
-      await screen.findByText(/No tenés permiso para asignar conductores/),
+      await screen.findByText(/No tienes permiso para asignar conductores/),
     ).toBeInTheDocument();
   });
 
@@ -215,7 +215,7 @@ describe('DriverAssignmentCard', () => {
         />
       </Wrapper>,
     );
-    expect(await screen.findByText(/No tenés conductores activos/)).toBeInTheDocument();
+    expect(await screen.findByText(/No tienes conductores activos/)).toBeInTheDocument();
     // Y NO se muestra el form (no se debería poder asignar).
     expect(screen.queryByTestId('driver-assignment-select')).toBeNull();
   });

--- a/apps/web/src/components/scoring/DriverAssignmentCard.tsx
+++ b/apps/web/src/components/scoring/DriverAssignmentCard.tsx
@@ -9,7 +9,7 @@ import { ApiError, api } from '../../lib/api-client.js';
  * Antes de este componente, los assignments se creaban con
  * driver_user_id=NULL y no había forma de setearlo después → el endpoint
  * `/assignments/:id/driver-position` era inalcanzable y la UI
- * /app/conductor/modo exigía pegar el UUID manualmente.
+ * /app/conductor exigía pegar el UUID manualmente.
  *
  * Ahora el carrier (rol dueno/admin/despachador) elige uno de sus
  * conductores activos del dropdown y lo asocia con un click. El backend
@@ -135,13 +135,13 @@ export function DriverAssignmentCard({
 
           {conductoresQ.isError && (
             <div className="mt-3 rounded-md border border-danger-200 bg-danger-50 p-2 text-danger-700 text-xs">
-              No pudimos cargar la lista de conductores. Recargá la página.
+              No pudimos cargar la lista de conductores. Recarga la página.
             </div>
           )}
 
           {!conductoresQ.isLoading && !conductoresQ.isError && conductoresActivos.length === 0 && (
             <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-2 text-amber-900 text-xs">
-              No tenés conductores activos. Creá uno en{' '}
+              No tienes conductores activos. Crea uno en{' '}
               <a href="/app/conductores/nuevo" className="underline">
                 Conductores
               </a>{' '}
@@ -211,7 +211,7 @@ export function DriverAssignmentCard({
 function humanizeAsignarError(err: unknown): string {
   if (err instanceof ApiError) {
     if (err.code === 'forbidden_role') {
-      return 'No tenés permiso para asignar conductores. Pedile a un usuario dueño o admin que lo haga.';
+      return 'No tienes permiso para asignar conductores. Pídele a un usuario dueño o admin que lo haga.';
     }
     if (err.code === 'driver_not_in_carrier') {
       return 'El conductor elegido no pertenece a tu empresa.';

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -8,7 +8,8 @@ import { CargaTrackRoute } from './routes/carga-track.js';
 import { CargasDetalleRoute, CargasListRoute, CargasNuevoRoute } from './routes/cargas.js';
 import { CertificadosRoute } from './routes/certificados.js';
 import { CobraHoyHistorialRoute } from './routes/cobra-hoy-historial.js';
-import { ConductorModoRoute } from './routes/conductor-modo.js';
+import { ConductorConfiguracionRoute } from './routes/conductor-configuracion.js';
+import { ConductorDashboardRoute } from './routes/conductor.js';
 import {
   ConductoresDetalleRoute,
   ConductoresListRoute,
@@ -98,14 +99,24 @@ const perfilRoute = createRoute({
   component: PerfilRoute,
 });
 
-// Phase 4 PR-K8 — onboarding del Modo Conductor. Una sola pantalla con
-// 4 cards (autoplay coaching, permisos mic+GPS, comandos de voz,
-// explainer). Hub centralizado para que el conductor habilite y entienda
-// las features voice-first de K1-K7. Layout `/app/*` autenticado.
-const conductorModoRoute = createRoute({
+// Dashboard del conductor — vista principal post-login del conductor
+// (rol='conductor'). Lista de servicios asignados + alerta preventiva
+// de WhatsApp + reporte GPS móvil + acceso a configuración.
+// La empresa de transporte NO ve esta vista; tiene su propia surface.
+const conductorDashboardRoute = createRoute({
   getParentRoute: () => rootRoute,
-  path: '/app/conductor/modo',
-  component: ConductorModoRoute,
+  path: '/app/conductor',
+  component: ConductorDashboardRoute,
+});
+
+// Configuración del Modo Conductor — solo permisos del navegador, audio
+// coaching, comandos de voz, "cómo funciona". El conductor entra aquí
+// la primera vez (forzado si no tiene permisos) o vía el ícono de
+// engranaje desde el dashboard. URL canónica: /app/conductor/configuracion.
+const conductorConfiguracionRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/app/conductor/configuracion',
+  component: ConductorConfiguracionRoute,
 });
 
 const adminDispositivosRoute = createRoute({
@@ -310,7 +321,8 @@ const routeTree = rootRoute.addChildren([
   appRoute,
   ofertasRoute,
   perfilRoute,
-  conductorModoRoute,
+  conductorDashboardRoute,
+  conductorConfiguracionRoute,
   adminDispositivosRoute,
   vehiculosListRoute,
   vehiculosNuevoRoute,

--- a/apps/web/src/routes/admin-cobra-hoy.tsx
+++ b/apps/web/src/routes/admin-cobra-hoy.tsx
@@ -135,7 +135,7 @@ function AdminCobraHoyPage({ me }: { me: MeOnboarded }) {
               <EmptyState
                 icon={<Banknote className="h-10 w-10" aria-hidden />}
                 title="No hay adelantos con este filtro"
-                description="Cuando los transportistas soliciten pronto pago verás las solicitudes acá para aprobar, desembolsar o cobrar."
+                description="Cuando los transportistas soliciten pronto pago verás las solicitudes aquí para aprobar, desembolsar o cobrar."
               />
             </div>
           )}
@@ -273,7 +273,7 @@ function AdelantoRow({ adelanto }: { adelanto: AdelantoAdminRow }) {
                 </button>
                 {transicionM.isError && (
                   <span role="alert" className="text-danger-700 text-sm">
-                    No pudimos aplicar la transición. Revisá los logs.
+                    No pudimos aplicar la transición. Revisa los logs.
                   </span>
                 )}
               </div>

--- a/apps/web/src/routes/app.test.tsx
+++ b/apps/web/src/routes/app.test.tsx
@@ -23,7 +23,7 @@ vi.mock('../components/ProtectedRoute.js', () => ({
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
-  // D9 — el dashboard renderiza <Navigate to="/app/conductor/modo" /> cuando
+  // D9 — el dashboard renderiza <Navigate to="/app/conductor" /> cuando
   // el rol activo es conductor. Stub que no crashea en tests sin router real.
   Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
 }));
@@ -90,21 +90,6 @@ describe('AppRoute', () => {
     expect(screen.getByText(/Ofertas activas/)).toBeInTheDocument();
   });
 
-  it('carrier → muestra card "Modo Conductor" linkeada a /app/conductor/modo', () => {
-    providedContext = { kind: 'onboarded', me: makeMe('dueno', true, false) };
-    renderWithQueryClient(<AppRoute />);
-    const link = screen.getByTestId('dashboard-link-modo-conductor');
-    expect(link).toBeInTheDocument();
-    // TanStack Link mock pasa `to` como atributo (no `href`).
-    expect(link).toHaveAttribute('to', '/app/conductor/modo');
-  });
-
-  it('shipper (no carrier) → NO muestra card "Modo Conductor"', () => {
-    providedContext = { kind: 'onboarded', me: makeMe('dueno', false, true) };
-    renderWithQueryClient(<AppRoute />);
-    expect(screen.queryByTestId('dashboard-link-modo-conductor')).not.toBeInTheDocument();
-  });
-
   it('shipper → muestra card "Crear carga"', () => {
     providedContext = { kind: 'onboarded', me: makeMe('dueno', false, true) };
     renderWithQueryClient(<AppRoute />);
@@ -121,18 +106,19 @@ describe('AppRoute', () => {
   });
 
   it('no admin → no muestra admin dispositivos', () => {
-    // D9: rol conductor ahora redirige a /app/conductor/modo, así que en
-    // vez de chequear el dashboard original chequeamos que el Navigate
-    // stub aparezca y que "Dispositivos pendientes" NO esté.
+    // D9: rol conductor ahora redirige a /app/conductor (dashboard del
+    // conductor), así que en vez de chequear el dashboard carrier
+    // chequeamos que el Navigate stub aparezca y que "Dispositivos
+    // pendientes" NO esté.
     providedContext = { kind: 'onboarded', me: makeMe('despachador') };
     renderWithQueryClient(<AppRoute />);
     expect(screen.queryByText(/Dispositivos pendientes/)).not.toBeInTheDocument();
   });
 
-  it('rol conductor → redirige a /app/conductor/modo (D9 surface guard)', () => {
+  it('rol conductor → redirige a /app/conductor (D9 surface guard)', () => {
     providedContext = { kind: 'onboarded', me: makeMe('conductor') };
     renderWithQueryClient(<AppRoute />);
-    expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app/conductor/modo');
+    expect(screen.getByTestId('navigate')).toHaveAttribute('data-to', '/app/conductor');
     // El dashboard original NO debería renderizarse.
     expect(screen.queryByText('Bienvenido a Booster')).not.toBeInTheDocument();
   });

--- a/apps/web/src/routes/app.tsx
+++ b/apps/web/src/routes/app.tsx
@@ -4,7 +4,6 @@ import {
   Banknote,
   Building2,
   Bus,
-  Headphones,
   Leaf,
   MapPinned,
   Package,
@@ -60,11 +59,12 @@ function AppDashboard({ me }: { me: MeOnboarded }) {
 
   // D9 — Driver surface guard. Si el rol activo es 'conductor', el user
   // no debería ver el dashboard carrier (ofertas/vehículos/cargas).
-  // Redirigimos a /app/conductor/modo (su único hub). Excepción: si el
-  // mismo user tiene OTRA membership donde es dueño/admin/etc., puede
-  // hacer switch desde Layout y vuelve al dashboard carrier normalmente.
+  // Redirigimos a /app/conductor (su único hub: dashboard con servicios
+  // asignados + alerta WhatsApp + reporte GPS). Excepción: si el mismo
+  // user tiene OTRA membership donde es dueño/admin/etc., puede hacer
+  // switch desde Layout y vuelve al dashboard carrier normalmente.
   if (myRole === 'conductor') {
-    return <Navigate to="/app/conductor/modo" />;
+    return <Navigate to="/app/conductor" />;
   }
 
   // D11 — Stakeholder surface guard. Si el rol activo es stakeholder,
@@ -173,33 +173,6 @@ function AppDashboard({ me }: { me: MeOnboarded }) {
                 <div className="font-medium text-neutral-900">Conductores</div>
                 <div className="text-neutral-600 text-sm">
                   Crea, edita y monitorea licencias y vencimientos de los conductores de tu empresa.
-                </div>
-              </div>
-            </div>
-            <ArrowRight className="h-5 w-5 text-neutral-400" aria-hidden />
-          </Link>
-
-          {/* Phase 4 PR-K8 — entrypoint al Modo Conductor desde el
-                  dashboard principal. Ya existían links desde /app/ofertas
-                  y /app/perfil, pero el dashboard es la primera surface
-                  post-login: el carrier merece descubrirlo acá. */}
-          <Link
-            to="/app/conductor/modo"
-            className="mt-3 flex items-center justify-between rounded-lg border border-neutral-200 bg-white p-5 shadow-sm transition hover:border-primary-500 hover:shadow-md"
-            data-testid="dashboard-link-modo-conductor"
-          >
-            <div className="flex items-center gap-4">
-              <div
-                className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-600"
-                aria-hidden
-              >
-                <Headphones className="h-5 w-5" />
-              </div>
-              <div>
-                <div className="font-medium text-neutral-900">Modo Conductor</div>
-                <div className="text-neutral-600 text-sm">
-                  Audio coaching, comandos de voz y permisos del navegador. Configura una vez antes
-                  de manejar.
                 </div>
               </div>
             </div>

--- a/apps/web/src/routes/carga-track.tsx
+++ b/apps/web/src/routes/carga-track.tsx
@@ -118,7 +118,7 @@ function CargaTrackPage() {
           ) : tripQ.isLoading ? null : (
             <div className="text-center text-neutral-600 text-sm">
               Esta carga todavía no tiene transportista asignado. Cuando un carrier acepte la
-              oferta, vas a ver su vehículo acá en tiempo real.
+              oferta, verás su vehículo aquí en tiempo real.
             </div>
           )
         }

--- a/apps/web/src/routes/cargas.tsx
+++ b/apps/web/src/routes/cargas.tsx
@@ -1432,7 +1432,7 @@ function CargaDetallePage({ me }: { me: MeOnboarded }) {
                 {!tripQ.data.metrics.certificate_issued_at &&
                   tripQ.data.trip_request.status === 'entregado' && (
                     <div className="rounded-md bg-amber-50 px-3 py-2 text-amber-900 text-xs sm:col-span-2">
-                      Generando certificado de huella de carbono. Recargá en unos segundos.
+                      Generando certificado de huella de carbono. Recarga en unos segundos.
                     </div>
                   )}
               </div>

--- a/apps/web/src/routes/certificados.tsx
+++ b/apps/web/src/routes/certificados.tsx
@@ -228,7 +228,7 @@ function CertificadosPage({ me }: { me: MeOnboarded }) {
 
           <p className="mt-4 text-neutral-500 text-xs">
             Cada certificado se firma con RSA 4096 / SHA-256 (PKCS#1 v1.5) vía Google Cloud KMS.
-            Verificá la firma de cualquier certificado en{' '}
+            Verifica la firma de cualquier certificado en{' '}
             <code>
               api.boosterchile.com/certificates/{'{'}código{'}'}/verify
             </code>

--- a/apps/web/src/routes/cobra-hoy-historial.tsx
+++ b/apps/web/src/routes/cobra-hoy-historial.tsx
@@ -70,7 +70,7 @@ function HistorialPage({ me }: { me: MeOnboarded }) {
       {featureDisabled && (
         <output className="mt-6 block rounded-md border border-neutral-200 bg-neutral-50 p-4 text-neutral-700 text-sm">
           La opción de pronto pago todavía no está activa en este entorno. Cuando se habilite, verás
-          acá el historial de tus solicitudes.
+          aquí el historial de tus solicitudes.
         </output>
       )}
 

--- a/apps/web/src/routes/conductor-configuracion.test.tsx
+++ b/apps/web/src/routes/conductor-configuracion.test.tsx
@@ -3,6 +3,19 @@ import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MeResponse } from '../hooks/use-me.js';
 
+/**
+ * Tests del route `/app/conductor/configuracion`.
+ *
+ * Este surface es la **configuración** del Modo Conductor: permisos
+ * mic/GPS, audio coaching automático, lista de comandos de voz,
+ * explainer del flujo. NO incluye reporte GPS (eso vive en
+ * `/app/conductor`, el dashboard).
+ *
+ * Antecedente: estos tests son el port del antiguo
+ * `conductor-modo.test.tsx`, quitando las assertions del GPS reporter
+ * inline (movidas a `conductor.test.tsx`).
+ */
+
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 type ProtectedContext =
   | { kind: 'onboarded'; me: MeOnboarded }
@@ -19,14 +32,6 @@ vi.mock('../components/ProtectedRoute.js', () => ({
 
 vi.mock('@tanstack/react-router', () => ({
   Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
-}));
-
-vi.mock('../components/Layout.js', () => ({
-  Layout: ({ children, title }: { children: ReactNode; title: string }) => (
-    <div data-testid="layout" data-title={title}>
-      {children}
-    </div>
-  ),
 }));
 
 const queryDriverPermissionsSpy = vi.fn();
@@ -47,24 +52,7 @@ vi.mock('../services/coaching-voice.js', () => ({
   saveAutoplayPreference: (v: boolean) => saveAutoplayPreferenceSpy(v),
 }));
 
-// Mock api-client para que el flujo "lista de asignaciones" en
-// MobileGpsReporterCard pueda ser controlado por test. Por defecto
-// devuelve lista vacía (el conductor sin asignaciones), pero los tests
-// específicos pueden override.
-const apiGetSpy = vi.fn();
-vi.mock('../lib/api-client.js', async () => {
-  const actual =
-    await vi.importActual<typeof import('../lib/api-client.js')>('../lib/api-client.js');
-  return {
-    ...actual,
-    api: {
-      ...actual.api,
-      get: (...args: unknown[]) => apiGetSpy(...args),
-    },
-  };
-});
-
-const { ConductorModoRoute } = await import('./conductor-modo.js');
+const { ConductorConfiguracionRoute } = await import('./conductor-configuracion.js');
 
 function makeMe(): MeOnboarded {
   return {
@@ -88,26 +76,22 @@ beforeEach(() => {
   vi.clearAllMocks();
   loadAutoplayPreferenceSpy.mockReturnValue(false);
   queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
-  // Default: el driver no tiene asignaciones activas. Tests específicos
-  // pueden mockear con assignments populados.
-  apiGetSpy.mockResolvedValue({ assignments: [] });
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('ConductorModoRoute', () => {
+describe('ConductorConfiguracionRoute', () => {
   it('contexto no onboarded → no renderiza', () => {
     providedContext = { kind: 'unmanaged' };
-    const { container } = render(<ConductorModoRoute />);
+    const { container } = render(<ConductorConfiguracionRoute />);
     expect(container.querySelector('[data-testid="autoplay-card"]')).toBeNull();
   });
 
-  it('contexto onboarded → renderiza las 4 cards', async () => {
+  it('contexto onboarded → renderiza las 4 cards de configuración', async () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
-    render(<ConductorModoRoute />);
-    expect(screen.getByTestId('layout')).toHaveAttribute('data-title', 'Modo Conductor');
+    render(<ConductorConfiguracionRoute />);
     expect(screen.getByTestId('autoplay-card')).toBeInTheDocument();
     expect(screen.getByTestId('permissions-card')).toBeInTheDocument();
     expect(screen.getByTestId('voice-commands-card')).toBeInTheDocument();
@@ -115,10 +99,24 @@ describe('ConductorModoRoute', () => {
     await waitFor(() => expect(queryDriverPermissionsSpy).toHaveBeenCalled());
   });
 
+  it('header tiene flecha de vuelta a /app/conductor', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorConfiguracionRoute />);
+    const backLink = screen.getByLabelText(/Volver al panel del conductor/i);
+    expect(backLink).toHaveAttribute('to', '/app/conductor');
+  });
+
+  it('botón "Listo, volver al panel" navega a /app/conductor', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorConfiguracionRoute />);
+    const doneLink = screen.getByText(/Listo, volver al panel/);
+    expect(doneLink).toHaveAttribute('to', '/app/conductor');
+  });
+
   it('autoplay toggle persiste vía saveAutoplayPreference', () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
     loadAutoplayPreferenceSpy.mockReturnValue(false);
-    render(<ConductorModoRoute />);
+    render(<ConductorConfiguracionRoute />);
     const toggle = screen.getByTestId('autoplay-toggle') as HTMLInputElement;
     expect(toggle.checked).toBe(false);
     fireEvent.click(toggle);
@@ -126,10 +124,18 @@ describe('ConductorModoRoute', () => {
     expect(toggle.checked).toBe(true);
   });
 
+  it('autoplay inicial cargado desde localStorage refleja en toggle', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    loadAutoplayPreferenceSpy.mockReturnValue(true);
+    render(<ConductorConfiguracionRoute />);
+    const toggle = screen.getByTestId('autoplay-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+
   it('estado inicial granted muestra pill "Activado" sin botón Permitir', async () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
     queryDriverPermissionsSpy.mockResolvedValue({ mic: 'granted', geo: 'granted' });
-    render(<ConductorModoRoute />);
+    render(<ConductorConfiguracionRoute />);
     await waitFor(() => expect(screen.getByTestId('mic-granted-pill')).toBeInTheDocument());
     expect(screen.getByTestId('geo-granted-pill')).toBeInTheDocument();
     expect(screen.queryByTestId('mic-request-btn')).not.toBeInTheDocument();
@@ -139,7 +145,7 @@ describe('ConductorModoRoute', () => {
   it('estado denied muestra instrucción de habilitar en settings', async () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
     queryDriverPermissionsSpy.mockResolvedValue({ mic: 'denied', geo: 'denied' });
-    render(<ConductorModoRoute />);
+    render(<ConductorConfiguracionRoute />);
     await waitFor(() => expect(screen.getByTestId('mic-denied-help')).toBeInTheDocument());
     expect(screen.getByTestId('geo-denied-help')).toBeInTheDocument();
   });
@@ -148,7 +154,7 @@ describe('ConductorModoRoute', () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
     queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
     requestMicrophonePermissionSpy.mockResolvedValue('granted');
-    render(<ConductorModoRoute />);
+    render(<ConductorConfiguracionRoute />);
     await waitFor(() => expect(screen.getByTestId('mic-request-btn')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('mic-request-btn'));
     await waitFor(() => expect(requestMicrophonePermissionSpy).toHaveBeenCalled());
@@ -159,105 +165,29 @@ describe('ConductorModoRoute', () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
     queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
     requestGeolocationPermissionSpy.mockResolvedValue('granted');
-    render(<ConductorModoRoute />);
+    render(<ConductorConfiguracionRoute />);
     await waitFor(() => expect(screen.getByTestId('geo-request-btn')).toBeInTheDocument());
     fireEvent.click(screen.getByTestId('geo-request-btn'));
     await waitFor(() => expect(requestGeolocationPermissionSpy).toHaveBeenCalled());
     await waitFor(() => expect(screen.getByTestId('geo-granted-pill')).toBeInTheDocument());
   });
 
-  it('muestra los 4 comandos de voz con sus frases', () => {
+  it('muestra los 4 comandos de voz con sus frases canónicas', () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
-    render(<ConductorModoRoute />);
+    render(<ConductorConfiguracionRoute />);
     expect(screen.getByTestId('voice-cmd-aceptar_oferta')).toBeInTheDocument();
     expect(screen.getByTestId('voice-cmd-confirmar_entrega')).toBeInTheDocument();
     expect(screen.getByTestId('voice-cmd-marcar_incidente')).toBeInTheDocument();
     expect(screen.getByTestId('voice-cmd-cancelar')).toBeInTheDocument();
-    // Phrase wrapper actually contains the canonical phrase.
     expect(screen.getAllByText(/"aceptar oferta"/i).length).toBeGreaterThanOrEqual(1);
   });
 
   it('muestra explainer del flujo en how-it-works card', () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
-    render(<ConductorModoRoute />);
+    render(<ConductorConfiguracionRoute />);
     expect(screen.getByTestId('how-it-works-card')).toBeInTheDocument();
     expect(screen.getByText(/detección de vehículo parado/i)).toBeInTheDocument();
     expect(screen.getByText(/doble confirmación/i)).toBeInTheDocument();
     expect(screen.getByText(/Ley 18\.290/i)).toBeInTheDocument();
-  });
-
-  it('autoplay inicial cargado desde localStorage refleja en toggle', () => {
-    providedContext = { kind: 'onboarded', me: makeMe() };
-    loadAutoplayPreferenceSpy.mockReturnValue(true);
-    render(<ConductorModoRoute />);
-    const toggle = screen.getByTestId('autoplay-toggle') as HTMLInputElement;
-    expect(toggle.checked).toBe(true);
-  });
-
-  describe('GPS reporter — lista de asignaciones (reemplaza pegar UUID)', () => {
-    const sampleAssignment = {
-      id: 'asg-123-456',
-      status: 'asignado',
-      trip: {
-        id: 'trip-1',
-        tracking_code: 'BOO-ABC123',
-        status: 'asignado',
-        origin: { address_raw: 'Av. Pajaritos 1234, Maipú', region_code: 'XIII' },
-        destination: { address_raw: 'Av. Brasil 2345, Valparaíso', region_code: 'V' },
-        cargo_type: 'carga_seca',
-        cargo_weight_kg: 5000,
-        pickup_window_start: null,
-        pickup_window_end: null,
-      },
-      carrier_empresa: { id: 'emp-c', legal_name: 'Transportes Demo Sur S.A.' },
-      vehicle: { id: 'veh-1', plate: 'DEMO01' },
-    };
-
-    it('sin asignaciones activas → muestra estado vacío explicativo', async () => {
-      providedContext = { kind: 'onboarded', me: makeMe() };
-      apiGetSpy.mockResolvedValue({ assignments: [] });
-      render(<ConductorModoRoute />);
-      expect(
-        await screen.findByText(/No tenés asignaciones activas en este momento/),
-      ).toBeInTheDocument();
-    });
-
-    it('con asignaciones → lista con tracking, ruta, carga y vehículo', async () => {
-      providedContext = { kind: 'onboarded', me: makeMe() };
-      apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
-      render(<ConductorModoRoute />);
-      expect(await screen.findByText('BOO-ABC123')).toBeInTheDocument();
-      expect(
-        screen.getByText(/Av\. Pajaritos 1234, Maipú → Av\. Brasil 2345, Valparaíso/),
-      ).toBeInTheDocument();
-      expect(screen.getByText(/Transportes Demo Sur S\.A\./)).toBeInTheDocument();
-      expect(screen.getByText('DEMO01')).toBeInTheDocument();
-    });
-
-    it('asignación única → se pre-selecciona automáticamente', async () => {
-      providedContext = { kind: 'onboarded', me: makeMe() };
-      apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
-      render(<ConductorModoRoute />);
-      const card = await screen.findByTestId(`gps-reporter-assignment-${sampleAssignment.id}`);
-      // El estilo selected aplica clases bg-primary-50.
-      expect(card.className).toMatch(/bg-primary-50/);
-    });
-
-    it('click en una asignación la selecciona', async () => {
-      providedContext = { kind: 'onboarded', me: makeMe() };
-      const second = {
-        ...sampleAssignment,
-        id: 'asg-999',
-        trip: { ...sampleAssignment.trip, tracking_code: 'BOO-XYZ' },
-      };
-      apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment, second] });
-      render(<ConductorModoRoute />);
-      const card2 = await screen.findByTestId('gps-reporter-assignment-asg-999');
-      fireEvent.click(card2);
-      // Ahora la segunda card debería estar resaltada.
-      await waitFor(() => {
-        expect(card2.className).toMatch(/bg-primary-50/);
-      });
-    });
   });
 });

--- a/apps/web/src/routes/conductor-configuracion.tsx
+++ b/apps/web/src/routes/conductor-configuracion.tsx
@@ -12,11 +12,8 @@ import {
   Volume2,
 } from 'lucide-react';
 import { type ReactNode, useEffect, useState } from 'react';
-import { Layout } from '../components/Layout.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
-import { useDriverPositionReporter } from '../hooks/use-driver-position-reporter.js';
 import type { MeResponse } from '../hooks/use-me.js';
-import { ApiError, api } from '../lib/api-client.js';
 import { loadAutoplayPreference, saveAutoplayPreference } from '../services/coaching-voice.js';
 import {
   type PermissionState,
@@ -29,8 +26,8 @@ import {
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 
 /**
- * /app/conductor/modo — onboarding y configuración del **Modo Conductor**
- * (Phase 4 PR-K8).
+ * /app/conductor/configuracion — configuración del **Modo Conductor**
+ * (refactor del antiguo /app/conductor/modo, Phase 4 PR-K8).
  *
  * Cierre del ciclo Phase 4 voice-first: K1-K7 implementaron features
  * voice (auto-play coaching, comandos para confirmar entrega, marcar
@@ -65,20 +62,20 @@ type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
  * onboarding + troubleshooting + transparencia de qué requiere Booster.
  */
 
-export function ConductorModoRoute() {
+export function ConductorConfiguracionRoute() {
   return (
     <ProtectedRoute meRequirement="require-onboarded">
       {(ctx) => {
         if (ctx.kind !== 'onboarded') {
           return null;
         }
-        return <ConductorModoPage me={ctx.me} />;
+        return <ConductorConfiguracionPage me={ctx.me} />;
       }}
     </ProtectedRoute>
   );
 }
 
-function ConductorModoPage({ me }: { me: MeOnboarded }) {
+function ConductorConfiguracionPage({ me: _me }: { me: MeOnboarded }) {
   const [autoplayEnabled, setAutoplayEnabled] = useState(() => loadAutoplayPreference());
   const [permissions, setPermissions] = useState<PermissionState>({
     mic: 'unknown',
@@ -133,23 +130,32 @@ function ConductorModoPage({ me }: { me: MeOnboarded }) {
   }
 
   return (
-    <Layout me={me} title="Modo Conductor">
-      <div className="mx-auto max-w-3xl px-4 py-8 sm:px-6">
-        <Link
-          to="/app"
-          className="mb-4 inline-flex items-center gap-1 text-neutral-600 text-sm transition hover:text-neutral-900"
-        >
-          <ArrowLeft className="h-4 w-4" aria-hidden />
-          Volver al inicio
-        </Link>
+    <div className="flex min-h-screen flex-col bg-neutral-50">
+      <header className="border-neutral-200 border-b bg-white">
+        <div className="mx-auto flex max-w-3xl items-center gap-3 px-4 py-3 sm:px-6">
+          <Link
+            to="/app/conductor"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-neutral-600 transition hover:bg-neutral-100"
+            aria-label="Volver al panel del conductor"
+          >
+            <ArrowLeft className="h-5 w-5" aria-hidden />
+          </Link>
+          <div>
+            <h1 className="font-semibold text-base text-neutral-900">
+              Configuración del Modo Conductor
+            </h1>
+            <p className="text-neutral-500 text-xs">Ajustes que se guardan en este dispositivo</p>
+          </div>
+        </div>
+      </header>
 
-        <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">Modo Conductor</h1>
-        <p className="mt-2 max-w-xl text-neutral-600 text-sm">
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-6 sm:px-6 sm:py-8">
+        <p className="max-w-xl text-neutral-600 text-sm">
           Configura una sola vez antes de manejar. Activamos audio, voz y GPS para que puedas operar
           la app sin tocar la pantalla mientras conduces.
         </p>
 
-        <div className="mt-8 space-y-4">
+        <div className="mt-6 space-y-4">
           <AutoplayCard enabled={autoplayEnabled} onChange={handleAutoplayToggle} />
           <PermissionsCard
             permissions={permissions}
@@ -158,219 +164,20 @@ function ConductorModoPage({ me }: { me: MeOnboarded }) {
             requestingMic={requestingMic}
             requestingGeo={requestingGeo}
           />
-          <MobileGpsReporterCard geoPermission={permissions.geo} />
           <VoiceCommandsReferenceCard />
           <HowItWorksCard />
         </div>
-      </div>
-    </Layout>
-  );
-}
 
-// ---------------------------------------------------------------------------
-// D2 — Card: Reporte GPS móvil para vehículos SIN Teltonika
-// ---------------------------------------------------------------------------
-
-interface DriverAssignment {
-  id: string;
-  status: string;
-  trip: {
-    id: string;
-    tracking_code: string;
-    status: string;
-    origin: { address_raw: string; region_code: string | null };
-    destination: { address_raw: string; region_code: string | null };
-    cargo_type: string;
-    cargo_weight_kg: number | null;
-    pickup_window_start: string | null;
-    pickup_window_end: string | null;
-  };
-  carrier_empresa: { id: string; legal_name: string | null };
-  vehicle: { id: string; plate: string | null } | null;
-}
-
-function MobileGpsReporterCard({ geoPermission }: { geoPermission: PermissionStatus }) {
-  // Estado de la lista de asignaciones activas del conductor logueado.
-  // Se carga al montar; el conductor elige una en vez de pegar UUID.
-  const [assignments, setAssignments] = useState<DriverAssignment[]>([]);
-  const [loadingAssignments, setLoadingAssignments] = useState(false);
-  const [assignmentsError, setAssignmentsError] = useState<string | null>(null);
-  const [selectedAssignmentId, setSelectedAssignmentId] = useState<string>('');
-  const reporter = useDriverPositionReporter();
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: cargar una sola
-  // vez al montar el componente.
-  useEffect(() => {
-    let cancelled = false;
-    setLoadingAssignments(true);
-    setAssignmentsError(null);
-    api
-      .get<{ assignments: DriverAssignment[] }>('/me/assignments')
-      .then((res) => {
-        if (cancelled) {
-          return;
-        }
-        setAssignments(res.assignments);
-        // Pre-seleccionar si hay una sola asignación activa.
-        if (res.assignments.length === 1) {
-          setSelectedAssignmentId(res.assignments[0]?.id ?? '');
-        }
-      })
-      .catch((err) => {
-        if (cancelled) {
-          return;
-        }
-        const msg =
-          err instanceof ApiError
-            ? err.status === 404
-              ? 'No encontramos tu cuenta en el sistema.'
-              : `${err.status}: ${err.message}`
-            : (err as Error).message;
-        setAssignmentsError(msg);
-      })
-      .finally(() => {
-        if (!cancelled) {
-          setLoadingAssignments(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const canStart =
-    geoPermission === 'granted' && selectedAssignmentId.trim().length > 0 && !reporter.isWatching;
-
-  return (
-    <section
-      aria-label="Reporte GPS móvil"
-      className="rounded-lg border border-neutral-200 bg-white p-5"
-      data-testid="gps-reporter-card"
-    >
-      <div className="flex items-start gap-3">
-        <Navigation className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
-        <div className="flex-1">
-          <h2 className="font-semibold text-base text-neutral-900">
-            Reporte GPS móvil (sin Teltonika)
-          </h2>
-          <p className="mt-1 text-neutral-600 text-sm">
-            Si tu vehículo no tiene equipo Teltonika instalado, podemos seguir tu trayecto usando el
-            GPS de tu teléfono. Elegí cuál asignación querés reportar.
-          </p>
-
-          {geoPermission !== 'granted' && (
-            <div className="mt-3 rounded-md border border-amber-200 bg-amber-50 p-2 text-amber-900 text-xs">
-              Habilita el permiso GPS arriba antes de iniciar el reporte.
-            </div>
-          )}
-
-          {loadingAssignments && (
-            <div className="mt-3 text-neutral-500 text-sm">Cargando tus asignaciones…</div>
-          )}
-
-          {assignmentsError && (
-            <div className="mt-3 rounded-md border border-danger-200 bg-danger-50 p-2 text-danger-700 text-xs">
-              No pudimos cargar tus asignaciones: {assignmentsError}
-            </div>
-          )}
-
-          {!loadingAssignments && !assignmentsError && assignments.length === 0 && (
-            <div className="mt-3 rounded-md border border-neutral-200 bg-neutral-50 p-3 text-neutral-600 text-sm">
-              No tenés asignaciones activas en este momento. Cuando tu carrier te asigne un viaje,
-              aparecerá acá.
-            </div>
-          )}
-
-          {assignments.length > 0 && (
-            <div className="mt-3 space-y-2">
-              <div className="text-neutral-700 text-xs uppercase tracking-wide">
-                Tus asignaciones activas
-              </div>
-              <ul className="space-y-2" data-testid="gps-reporter-assignment-list">
-                {assignments.map((a) => {
-                  const isSelected = selectedAssignmentId === a.id;
-                  return (
-                    <li key={a.id}>
-                      <button
-                        type="button"
-                        onClick={() => setSelectedAssignmentId(a.id)}
-                        disabled={reporter.isWatching}
-                        className={`w-full rounded-md border p-3 text-left transition disabled:opacity-50 ${
-                          isSelected
-                            ? 'border-primary-500 bg-primary-50'
-                            : 'border-neutral-200 hover:bg-neutral-50'
-                        }`}
-                        data-testid={`gps-reporter-assignment-${a.id}`}
-                      >
-                        <div className="flex items-center justify-between gap-2">
-                          <div className="font-mono text-neutral-500 text-xs">
-                            {a.trip.tracking_code}
-                          </div>
-                          <div className="text-neutral-500 text-xs">
-                            {a.vehicle?.plate ?? 'Sin patente'}
-                          </div>
-                        </div>
-                        <div className="mt-1 text-neutral-900 text-sm">
-                          {a.trip.origin.address_raw} → {a.trip.destination.address_raw}
-                        </div>
-                        <div className="mt-1 text-neutral-500 text-xs">
-                          {a.trip.cargo_type} ·{' '}
-                          {a.trip.cargo_weight_kg
-                            ? `${a.trip.cargo_weight_kg.toLocaleString('es-CL')} kg`
-                            : 'peso no declarado'}{' '}
-                          · {a.carrier_empresa.legal_name ?? 'Carrier'}
-                        </div>
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          )}
-
-          <div className="mt-3">
-            {reporter.isWatching ? (
-              <button
-                type="button"
-                onClick={() => reporter.stop()}
-                className="w-full rounded-md bg-danger-600 px-4 py-2 font-medium text-sm text-white hover:bg-danger-700"
-                data-testid="gps-reporter-stop"
-              >
-                Detener reporte
-              </button>
-            ) : (
-              <button
-                type="button"
-                onClick={() => reporter.start(selectedAssignmentId.trim())}
-                disabled={!canStart}
-                className="w-full rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white hover:bg-primary-700 disabled:opacity-50"
-                data-testid="gps-reporter-start"
-              >
-                Iniciar reporte de la asignación seleccionada
-              </button>
-            )}
-          </div>
-
-          {reporter.isWatching && (
-            <div className="mt-3 rounded-md bg-success-50 px-3 py-2 text-success-700 text-sm">
-              Reportando posición en vivo · {reporter.pointsSent} puntos enviados
-              {reporter.lastPosition && (
-                <div className="mt-1 font-mono text-xs">
-                  {reporter.lastPosition.latitude.toFixed(5)},{' '}
-                  {reporter.lastPosition.longitude.toFixed(5)}
-                </div>
-              )}
-            </div>
-          )}
-
-          {reporter.lastError && (
-            <div className="mt-3 rounded-md border border-danger-200 bg-danger-50 p-2 text-danger-700 text-xs">
-              {reporter.lastError}
-            </div>
-          )}
+        <div className="mt-8 flex justify-end">
+          <Link
+            to="/app/conductor"
+            className="inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white hover:bg-primary-700"
+          >
+            Listo, volver al panel
+          </Link>
         </div>
-      </div>
-    </section>
+      </main>
+    </div>
   );
 }
 

--- a/apps/web/src/routes/conductor.test.tsx
+++ b/apps/web/src/routes/conductor.test.tsx
@@ -1,0 +1,260 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { MeResponse } from '../hooks/use-me.js';
+
+/**
+ * Tests del route `/app/conductor` (dashboard del conductor).
+ *
+ * Superficie principal del conductor logueado. Contiene:
+ *   - Header con full name + ícono engranaje (navega a configuración).
+ *   - Banner sticky de seguridad (no usar WhatsApp manejando).
+ *   - Lista de servicios asignados con GPS reporter inline.
+ *   - Empty state amable cuando el carrier no le ha asignado nada.
+ *
+ * Los tests de configuración (permisos, voice commands, autoplay) viven
+ * en `conductor-configuracion.test.tsx`. Acá nos enfocamos en el flujo
+ * operativo del driver.
+ */
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+type ProtectedContext =
+  | { kind: 'onboarded'; me: MeOnboarded }
+  | { kind: 'pre-onboarding'; me: Extract<MeResponse, { needs_onboarding: true }> }
+  | { kind: 'unmanaged' };
+
+let providedContext: ProtectedContext = { kind: 'unmanaged' };
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: (ctx: ProtectedContext) => ReactNode }) => (
+    <>{children(providedContext)}</>
+  ),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+const queryDriverPermissionsSpy = vi.fn();
+vi.mock('../services/driver-mode-permissions.js', () => ({
+  queryDriverPermissions: (...args: unknown[]) => queryDriverPermissionsSpy(...args),
+}));
+
+const reporterStartSpy = vi.fn();
+const reporterStopSpy = vi.fn();
+let reporterState = {
+  isWatching: false,
+  lastPosition: null as { latitude: number; longitude: number; timestamp: string } | null,
+  lastError: null as string | null,
+  pointsSent: 0,
+  start: reporterStartSpy,
+  stop: reporterStopSpy,
+};
+
+vi.mock('../hooks/use-driver-position-reporter.js', () => ({
+  useDriverPositionReporter: () => reporterState,
+}));
+
+const apiGetSpy = vi.fn();
+vi.mock('../lib/api-client.js', async () => {
+  const actual =
+    await vi.importActual<typeof import('../lib/api-client.js')>('../lib/api-client.js');
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      get: (...args: unknown[]) => apiGetSpy(...args),
+    },
+  };
+});
+
+const { ConductorDashboardRoute } = await import('./conductor.js');
+
+function makeMe(): MeOnboarded {
+  return {
+    needs_onboarding: false,
+    user: {
+      id: 'u',
+      email: 'driver@boosterchile.invalid',
+      full_name: 'Pedro Conductor',
+      phone: '+56912345678',
+      whatsapp_e164: '+56912345678',
+      rut: '12.345.678-9',
+      is_platform_admin: false,
+      status: 'activo',
+    },
+    memberships: [],
+    active_membership: null,
+  } as unknown as MeOnboarded;
+}
+
+const sampleAssignment = {
+  id: 'asg-123-456',
+  status: 'asignado',
+  trip: {
+    id: 'trip-1',
+    tracking_code: 'BOO-ABC123',
+    status: 'asignado',
+    origin: { address_raw: 'Av. Pajaritos 1234, Maipú', region_code: 'XIII' },
+    destination: { address_raw: 'Av. Brasil 2345, Valparaíso', region_code: 'V' },
+    cargo_type: 'carga_seca',
+    cargo_weight_kg: 5000,
+    pickup_window_start: null,
+    pickup_window_end: null,
+  },
+  carrier_empresa: { id: 'emp-c', legal_name: 'Transportes Demo Sur S.A.' },
+  vehicle: { id: 'veh-1', plate: 'DEMO01' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  reporterState = {
+    isWatching: false,
+    lastPosition: null,
+    lastError: null,
+    pointsSent: 0,
+    start: reporterStartSpy,
+    stop: reporterStopSpy,
+  };
+  queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
+  apiGetSpy.mockResolvedValue({ assignments: [] });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ConductorDashboardRoute', () => {
+  it('contexto no onboarded → no renderiza dashboard', () => {
+    providedContext = { kind: 'unmanaged' };
+    const { container } = render(<ConductorDashboardRoute />);
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('header muestra full_name del usuario y link a configuración', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorDashboardRoute />);
+    expect(screen.getByText('Pedro Conductor')).toBeInTheDocument();
+    expect(screen.getByText('Conductor')).toBeInTheDocument();
+    const cogLink = screen.getByTestId('link-configuracion-conductor');
+    expect(cogLink).toHaveAttribute('to', '/app/conductor/configuracion');
+  });
+
+  it('banner sticky de WhatsApp es visible siempre (no oculto en config)', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorDashboardRoute />);
+    expect(screen.getByText(/No uses WhatsApp manejando/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Booster te avisa por audio cuando hay algo importante/i),
+    ).toBeInTheDocument();
+  });
+
+  it('sin servicios → empty state amable, NO crash', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    apiGetSpy.mockResolvedValue({ assignments: [] });
+    render(<ConductorDashboardRoute />);
+    expect(await screen.findByText(/No tienes servicios asignados/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Cuando tu empresa de transporte te asigne un viaje/i),
+    ).toBeInTheDocument();
+  });
+
+  it('un servicio → muestra "Tu próximo servicio" (singular) con detalles', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
+    render(<ConductorDashboardRoute />);
+    expect(await screen.findByText('Tu próximo servicio')).toBeInTheDocument();
+    expect(screen.getByText('BOO-ABC123')).toBeInTheDocument();
+    expect(screen.getByText(/Av\. Pajaritos 1234, Maipú/)).toBeInTheDocument();
+    expect(screen.getByText(/Av\. Brasil 2345, Valparaíso/)).toBeInTheDocument();
+    expect(screen.getByText('DEMO01')).toBeInTheDocument();
+  });
+
+  it('múltiples servicios → muestra "Tus servicios asignados" (plural)', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    apiGetSpy.mockResolvedValue({
+      assignments: [
+        sampleAssignment,
+        {
+          ...sampleAssignment,
+          id: 'asg-999',
+          trip: { ...sampleAssignment.trip, tracking_code: 'BOO-XYZ789' },
+        },
+      ],
+    });
+    render(<ConductorDashboardRoute />);
+    expect(await screen.findByText('Tus servicios asignados')).toBeInTheDocument();
+    expect(screen.getByText('BOO-ABC123')).toBeInTheDocument();
+    expect(screen.getByText('BOO-XYZ789')).toBeInTheDocument();
+  });
+
+  it('GPS reporter botón "Iniciar" está disabled si geoPermission ≠ granted', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
+    queryDriverPermissionsSpy.mockResolvedValue({ mic: 'prompt', geo: 'prompt' });
+    render(<ConductorDashboardRoute />);
+    const startBtn = await screen.findByTestId('gps-start');
+    expect(startBtn).toBeDisabled();
+    expect(
+      screen.getByText(/Para activar el reporte GPS, primero habilita el permiso de ubicación/i),
+    ).toBeInTheDocument();
+  });
+
+  it('GPS reporter "Iniciar" está habilitado cuando geo=granted y no watching', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
+    queryDriverPermissionsSpy.mockResolvedValue({ mic: 'granted', geo: 'granted' });
+    render(<ConductorDashboardRoute />);
+    const startBtn = await screen.findByTestId('gps-start');
+    await waitFor(() => expect(startBtn).not.toBeDisabled());
+    fireEvent.click(startBtn);
+    expect(reporterStartSpy).toHaveBeenCalledWith(sampleAssignment.id);
+  });
+
+  it('GPS reporter watching=true muestra contador + botón Detener', async () => {
+    reporterState = {
+      ...reporterState,
+      isWatching: true,
+      pointsSent: 42,
+    };
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
+    queryDriverPermissionsSpy.mockResolvedValue({ mic: 'granted', geo: 'granted' });
+    render(<ConductorDashboardRoute />);
+    expect(await screen.findByText(/42 puntos enviados/)).toBeInTheDocument();
+    const stopBtn = screen.getByTestId('gps-stop');
+    fireEvent.click(stopBtn);
+    expect(reporterStopSpy).toHaveBeenCalled();
+  });
+
+  it('error 404 de /me/assignments → mensaje amable, no stack trace', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    const { ApiError } = await import('../lib/api-client.js');
+    apiGetSpy.mockRejectedValue(new ApiError(404, 'not_found', { code: 'not_found' }));
+    render(<ConductorDashboardRoute />);
+    expect(
+      await screen.findByText(/No encontramos tu cuenta\. Vuelve a iniciar sesión/i),
+    ).toBeInTheDocument();
+  });
+
+  it('vocabulario español neutro — no "tenés/elegí/acá/querés"', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    apiGetSpy.mockResolvedValue({ assignments: [] });
+    const { container } = render(<ConductorDashboardRoute />);
+    await screen.findByText(/No tienes servicios asignados/i);
+    const text = container.textContent ?? '';
+    expect(text).not.toMatch(/\btenés\b/i);
+    expect(text).not.toMatch(/\belegí\b/i);
+    expect(text).not.toMatch(/\bquerés\b/i);
+    expect(text).not.toMatch(/\bacá\b/i);
+  });
+
+  it('vocabulario driver — usa "servicio" (no "oferta")', async () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    apiGetSpy.mockResolvedValue({ assignments: [sampleAssignment] });
+    render(<ConductorDashboardRoute />);
+    await screen.findByText('Tu próximo servicio');
+    // El driver no negocia ofertas — la palabra "oferta" no debería aparecer en su superficie.
+    expect(screen.queryByText(/\boferta(s)?\b/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/conductor.tsx
+++ b/apps/web/src/routes/conductor.tsx
@@ -1,0 +1,404 @@
+import { Link } from '@tanstack/react-router';
+import {
+  AlertTriangle,
+  ArrowRight,
+  Inbox,
+  MapPin,
+  Navigation,
+  Settings,
+  Square,
+  Truck,
+} from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { ProtectedRoute } from '../components/ProtectedRoute.js';
+import { useDriverPositionReporter } from '../hooks/use-driver-position-reporter.js';
+import type { MeResponse } from '../hooks/use-me.js';
+import { ApiError, api } from '../lib/api-client.js';
+import {
+  type PermissionStatus,
+  queryDriverPermissions,
+} from '../services/driver-mode-permissions.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+
+/**
+ * /app/conductor — Dashboard operacional del conductor.
+ *
+ * Es la **superficie principal** del conductor logueado. NO tiene
+ * configuración de permisos ni preferencias aquí: eso vive en
+ * /app/conductor/configuracion. Aquí el conductor ve solo lo que
+ * importa cuando está por manejar:
+ *
+ *   1. **Aviso sticky de seguridad** — recordatorio preventivo de no
+ *      usar WhatsApp manejando. Visible siempre, no escondido en
+ *      configuración. Booster lo avisa antes de que sea un problema.
+ *
+ *   2. **Próximo servicio asignado** — el viaje que tienes que ejecutar
+ *      ahora (origen → destino, carga, ventana de recogida, vehículo).
+ *      Botón grande "Iniciar reporte GPS" si el vehículo no tiene
+ *      Teltonika.
+ *
+ *   3. **Acceso a configuración** — icono de engranaje en la esquina,
+ *      lleva a /app/conductor/configuracion. Solo se entra ahí si
+ *      necesitas cambiar permisos del navegador o el audio coaching.
+ *
+ * Si no hay servicios asignados aún, mostramos un empty state amable:
+ * "Cuando tu empresa te asigne un viaje, aparecerá aquí."
+ *
+ * Diseño mobile-first: el conductor está en su celular, no en
+ * escritorio. Cards grandes, tipografía clara, sin barras laterales.
+ *
+ * **Lenguaje**: "servicio" para referirse al viaje asignado (el
+ * conductor no negocia ofertas — la transacción comercial es entre
+ * la empresa de transporte y el generador de carga). Español neutro
+ * latinoamericano: "tu/tienes/aquí" (no "vos/tenés/acá").
+ */
+
+interface DriverAssignment {
+  id: string;
+  status: string;
+  trip: {
+    id: string;
+    tracking_code: string;
+    status: string;
+    origin: { address_raw: string; region_code: string | null };
+    destination: { address_raw: string; region_code: string | null };
+    cargo_type: string;
+    cargo_weight_kg: number | null;
+    pickup_window_start: string | null;
+    pickup_window_end: string | null;
+  };
+  carrier_empresa: { id: string; legal_name: string | null };
+  vehicle: { id: string; plate: string | null } | null;
+}
+
+export function ConductorDashboardRoute() {
+  return (
+    <ProtectedRoute meRequirement="require-onboarded">
+      {(ctx) => {
+        if (ctx.kind !== 'onboarded') {
+          return null;
+        }
+        return <ConductorDashboardPage me={ctx.me} />;
+      }}
+    </ProtectedRoute>
+  );
+}
+
+function ConductorDashboardPage({ me }: { me: MeOnboarded }) {
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-50">
+      <ConductorHeader fullName={me.user.full_name} />
+      <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-4 sm:px-6 sm:py-6">
+        <WhatsAppSafetyBanner />
+        <AssignmentsSection />
+      </main>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Header del conductor — su propia identidad visual, sin Layout del carrier.
+// ---------------------------------------------------------------------------
+
+function ConductorHeader({ fullName }: { fullName: string }) {
+  return (
+    <header className="border-neutral-200 border-b bg-white">
+      <div className="mx-auto flex max-w-2xl items-center justify-between gap-2 px-4 py-3 sm:px-6">
+        <div className="min-w-0 flex-1">
+          <div className="text-neutral-500 text-xs">Conductor</div>
+          <div className="truncate font-semibold text-neutral-900">{fullName}</div>
+        </div>
+        <Link
+          to="/app/conductor/configuracion"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full text-neutral-600 transition hover:bg-neutral-100"
+          aria-label="Configuración del Modo Conductor"
+          data-testid="link-configuracion-conductor"
+        >
+          <Settings className="h-5 w-5" aria-hidden />
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Banner sticky de seguridad — preventivo, no oculto en configuración.
+// ---------------------------------------------------------------------------
+
+function WhatsAppSafetyBanner() {
+  return (
+    <div
+      className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm"
+      role="alert"
+    >
+      <div className="flex items-start gap-2">
+        <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" aria-hidden />
+        <div>
+          <div className="font-medium">No uses WhatsApp manejando</div>
+          <p className="mt-1 text-amber-800 text-xs leading-snug">
+            Booster te avisa por audio cuando hay algo importante. Si necesitas coordinar con tu
+            carga o destino, hazlo solo con el vehículo detenido.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sección de servicios asignados (carga + GPS reporter inline).
+// ---------------------------------------------------------------------------
+
+function AssignmentsSection() {
+  const [assignments, setAssignments] = useState<DriverAssignment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [geoPermission, setGeoPermission] = useState<PermissionStatus>('unknown');
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .get<{ assignments: DriverAssignment[] }>('/me/assignments')
+      .then((res) => {
+        if (cancelled) {
+          return;
+        }
+        setAssignments(res.assignments);
+      })
+      .catch((err) => {
+        if (cancelled) {
+          return;
+        }
+        const msg =
+          err instanceof ApiError
+            ? err.status === 404
+              ? 'No encontramos tu cuenta. Vuelve a iniciar sesión.'
+              : `Error ${err.status}: ${err.message}`
+            : (err as Error).message;
+        setError(msg);
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      });
+
+    queryDriverPermissions()
+      .then((p) => {
+        if (!cancelled) {
+          setGeoPermission(p.geo);
+        }
+      })
+      .catch(() => undefined);
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <section className="mt-6">
+        <div className="rounded-lg border border-neutral-200 bg-white p-6 text-center text-neutral-500 text-sm">
+          Cargando tus servicios…
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className="mt-6">
+        <div className="rounded-lg border border-danger-200 bg-danger-50 p-4 text-danger-700 text-sm">
+          {error}
+        </div>
+      </section>
+    );
+  }
+
+  if (assignments.length === 0) {
+    return (
+      <section className="mt-6">
+        <div className="rounded-lg border border-neutral-200 bg-white p-8 text-center">
+          <Inbox className="mx-auto h-12 w-12 text-neutral-300" aria-hidden />
+          <h2 className="mt-3 font-semibold text-base text-neutral-900">
+            No tienes servicios asignados
+          </h2>
+          <p className="mt-2 text-neutral-600 text-sm">
+            Cuando tu empresa de transporte te asigne un viaje, lo verás aquí. Mientras tanto,
+            puedes revisar tu configuración tocando el ícono de engranaje arriba.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mt-6 space-y-4">
+      <h2 className="font-semibold text-base text-neutral-900">
+        {assignments.length === 1 ? 'Tu próximo servicio' : 'Tus servicios asignados'}
+      </h2>
+      {assignments.map((a) => (
+        <AssignmentCard key={a.id} assignment={a} geoPermission={geoPermission} />
+      ))}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Card de un servicio asignado, con GPS reporter inline.
+// ---------------------------------------------------------------------------
+
+function AssignmentCard({
+  assignment,
+  geoPermission,
+}: {
+  assignment: DriverAssignment;
+  geoPermission: PermissionStatus;
+}) {
+  const reporter = useDriverPositionReporter();
+  const canStart = geoPermission === 'granted' && !reporter.isWatching;
+  const a = assignment;
+
+  return (
+    <article
+      className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm"
+      data-testid={`assignment-card-${a.id}`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="font-mono text-neutral-500 text-xs">{a.trip.tracking_code}</div>
+        {a.vehicle?.plate && (
+          <div className="rounded-md bg-neutral-100 px-2 py-0.5 font-medium text-neutral-700 text-xs">
+            <Truck className="mr-1 inline h-3 w-3" aria-hidden />
+            {a.vehicle.plate}
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 space-y-2 text-sm">
+        <div className="flex items-start gap-2">
+          <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-success-700" aria-hidden />
+          <div>
+            <div className="text-neutral-500 text-xs">Origen</div>
+            <div className="text-neutral-900">{a.trip.origin.address_raw}</div>
+          </div>
+        </div>
+        <div className="flex items-start gap-2">
+          <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-danger-700" aria-hidden />
+          <div>
+            <div className="text-neutral-500 text-xs">Destino</div>
+            <div className="text-neutral-900">{a.trip.destination.address_raw}</div>
+          </div>
+        </div>
+      </div>
+
+      <dl className="mt-3 grid grid-cols-2 gap-2 text-xs">
+        <div>
+          <dt className="text-neutral-500">Tipo de carga</dt>
+          <dd className="font-medium text-neutral-900">{a.trip.cargo_type.replace('_', ' ')}</dd>
+        </div>
+        <div>
+          <dt className="text-neutral-500">Peso</dt>
+          <dd className="font-medium text-neutral-900">
+            {a.trip.cargo_weight_kg
+              ? `${a.trip.cargo_weight_kg.toLocaleString('es-CL')} kg`
+              : 'No declarado'}
+          </dd>
+        </div>
+        {a.trip.pickup_window_start && (
+          <div className="col-span-2">
+            <dt className="text-neutral-500">Ventana de recogida</dt>
+            <dd className="font-medium text-neutral-900">
+              {formatPickupWindow(a.trip.pickup_window_start, a.trip.pickup_window_end)}
+            </dd>
+          </div>
+        )}
+      </dl>
+
+      {/* GPS reporter: si el vehículo no tiene Teltonika, el conductor
+          puede reportar posición desde el teléfono. Si tiene Teltonika,
+          esto es complementario. */}
+      <div className="mt-4 border-neutral-200 border-t pt-4">
+        <div className="flex items-center gap-2 text-neutral-700 text-xs uppercase tracking-wide">
+          <Navigation className="h-3 w-3" aria-hidden />
+          Reporte GPS
+        </div>
+        {geoPermission !== 'granted' && (
+          <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 p-2 text-amber-900 text-xs">
+            Para activar el reporte GPS, primero habilita el permiso de ubicación. Toca el ícono de
+            engranaje arriba para configurarlo.
+          </div>
+        )}
+        {reporter.isWatching ? (
+          <div className="mt-3 space-y-2">
+            <div className="rounded-md bg-success-50 px-3 py-2 text-success-700 text-sm">
+              Reportando posición en vivo · {reporter.pointsSent} puntos enviados
+            </div>
+            <button
+              type="button"
+              onClick={() => reporter.stop()}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-danger-600 px-4 py-3 font-medium text-sm text-white hover:bg-danger-700"
+              data-testid="gps-stop"
+            >
+              <Square className="h-4 w-4" aria-hidden />
+              Detener reporte
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => reporter.start(a.id)}
+            disabled={!canStart}
+            className="mt-3 inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary-600 px-4 py-3 font-medium text-sm text-white hover:bg-primary-700 disabled:opacity-50"
+            data-testid="gps-start"
+          >
+            <Navigation className="h-4 w-4" aria-hidden />
+            Iniciar reporte GPS
+          </button>
+        )}
+        {reporter.lastError && (
+          <div className="mt-2 rounded-md border border-danger-200 bg-danger-50 p-2 text-danger-700 text-xs">
+            {reporter.lastError}
+          </div>
+        )}
+      </div>
+
+      {/* Link al detalle del servicio (asignación) si quiere chat con
+          el carrier o reportar incidente. */}
+      <Link
+        to="/app/asignaciones/$id"
+        params={{ id: a.id }}
+        className="mt-3 inline-flex items-center gap-1 text-primary-700 text-sm hover:underline"
+      >
+        Ver detalle del servicio
+        <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+      </Link>
+    </article>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatPickupWindow(startIso: string, endIso: string | null): string {
+  try {
+    const start = new Date(startIso);
+    const end = endIso ? new Date(endIso) : null;
+    const fmt = new Intl.DateTimeFormat('es-CL', {
+      day: '2-digit',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    if (!end) {
+      return fmt.format(start);
+    }
+    return `${fmt.format(start)} → ${fmt.format(end)}`;
+  } catch {
+    return startIso;
+  }
+}

--- a/apps/web/src/routes/conductores.tsx
+++ b/apps/web/src/routes/conductores.tsx
@@ -1054,8 +1054,8 @@ function ActivationPinCard({
               {driverName} fue creado correctamente
             </h2>
             <p className="mt-1 text-neutral-700 text-sm">
-              RUT: <span className="font-mono">{driverRut}</span>. Ahora dale al conductor el PIN de
-              activación de abajo para que pueda ingresar a Booster con su RUT desde{' '}
+              RUT: <span className="font-mono">{driverRut}</span>. Ahora entrégale al conductor el
+              PIN de activación de abajo para que pueda ingresar a Booster con su RUT desde{' '}
               <span className="font-mono">/login/conductor</span>.
             </p>
           </div>

--- a/apps/web/src/routes/liquidaciones.tsx
+++ b/apps/web/src/routes/liquidaciones.tsx
@@ -96,7 +96,7 @@ function LiquidacionesPage({ me }: { me: MeOnboarded }) {
           <EmptyState
             icon={<FileText className="h-10 w-10" aria-hidden />}
             title="Aún no tienes liquidaciones"
-            description="Cuando un viaje entregado se procese, la liquidación aparecerá acá con el desglose y el DTE Tipo 33 de la comisión Booster."
+            description="Cuando un viaje entregado se procese, la liquidación aparecerá aquí con el desglose y el DTE Tipo 33 de la comisión Booster."
             action={
               <Link to="/app/ofertas" className={emptyStateActionClass}>
                 Ver ofertas activas

--- a/apps/web/src/routes/login-conductor.test.tsx
+++ b/apps/web/src/routes/login-conductor.test.tsx
@@ -52,7 +52,7 @@ describe('LoginConductorRoute', () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
-  it('200 + custom_token → signInWithCustomToken + navigate a /app/conductor/modo', async () => {
+  it('200 + custom_token → signInWithCustomToken + navigate a /app/conductor', async () => {
     fetchSpy.mockResolvedValueOnce(
       makeJsonResponse(200, {
         custom_token: 'tok-xyz',
@@ -67,7 +67,7 @@ describe('LoginConductorRoute', () => {
     await userEvent.click(screen.getByRole('button', { name: /Ingresar/ }));
 
     await waitFor(() => expect(signInDriverWithCustomTokenMock).toHaveBeenCalledWith('tok-xyz'));
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/app/conductor/modo' });
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/app/conductor' });
   });
 
   it('410 already_activated → fallback signInWithEmail con synthetic_email', async () => {
@@ -90,7 +90,7 @@ describe('LoginConductorRoute', () => {
         '987654',
       ),
     );
-    expect(navigateMock).toHaveBeenCalledWith({ to: '/app/conductor/modo' });
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/app/conductor' });
   });
 
   it('410 + signInWithEmail falla → "PIN o contraseña incorrectos"', async () => {

--- a/apps/web/src/routes/login-conductor.tsx
+++ b/apps/web/src/routes/login-conductor.tsx
@@ -22,7 +22,7 @@ interface AlreadyActivatedResponse {
  *
  * El frontend intenta primero `POST /auth/driver-activate` con el valor
  * como PIN. Posibles outcomes:
- *   1. 200: custom token → signInWithCustomToken → /app/conductor/modo.
+ *   1. 200: custom token → signInWithCustomToken → /app/conductor.
  *   2. 410 already_activated + synthetic_email: el user ya activó, así que
  *      fallthrough a signInWithEmail con el email sintético + el mismo valor
  *      como password.
@@ -69,7 +69,7 @@ export function LoginConductorRoute() {
       if (res.ok) {
         const body = (await res.json()) as ActivateResponse;
         await signInDriverWithCustomToken(body.custom_token);
-        void navigate({ to: '/app/conductor/modo' });
+        void navigate({ to: '/app/conductor' });
         return;
       }
 
@@ -78,7 +78,7 @@ export function LoginConductorRoute() {
         const body = (await res.json()) as AlreadyActivatedResponse;
         try {
           await signInWithEmail(body.synthetic_email, pin);
-          void navigate({ to: '/app/conductor/modo' });
+          void navigate({ to: '/app/conductor' });
           return;
         } catch (_authErr) {
           // El user ya activó pero ingresó password incorrecto.

--- a/apps/web/src/routes/ofertas.tsx
+++ b/apps/web/src/routes/ofertas.tsx
@@ -1,5 +1,4 @@
-import { Link } from '@tanstack/react-router';
-import { Headphones, Inbox, RefreshCw } from 'lucide-react';
+import { Inbox, RefreshCw } from 'lucide-react';
 import { EmptyState } from '../components/EmptyState.js';
 import { Layout } from '../components/Layout.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
@@ -52,14 +51,6 @@ function OfertasPage({ me }: { me: MeOnboarded }) {
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2 sm:shrink-0">
-          <Link
-            to="/app/conductor/modo"
-            className="inline-flex items-center gap-2 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm shadow-xs transition hover:bg-neutral-100"
-            data-testid="link-modo-conductor"
-          >
-            <Headphones className="h-4 w-4" aria-hidden />
-            Modo Conductor
-          </Link>
           <button
             type="button"
             onClick={() => offersQuery.refetch()}
@@ -95,7 +86,7 @@ function OfertasPage({ me }: { me: MeOnboarded }) {
 
       {isCarrier && offersQuery.isError && (
         <output className="mt-6 block rounded-md border border-danger-500/30 bg-danger-50 p-4 text-danger-700 text-sm">
-          No pudimos cargar las ofertas. Probá actualizar.
+          No pudimos cargar las ofertas. Intenta actualizar.
         </output>
       )}
 

--- a/apps/web/src/routes/perfil.tsx
+++ b/apps/web/src/routes/perfil.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router';
-import { ArrowLeft, Headphones } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { Layout } from '../components/Layout.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { AuthProvidersSection } from '../components/profile/AuthProvidersSection.js';
@@ -58,30 +58,6 @@ function PerfilPage({ me }: { me: MeOnboarded }) {
         <AuthProvidersSection />
 
         <TwoFactorSection initialPhoneE164={me.user.whatsapp_e164 ?? me.user.phone ?? null} />
-
-        <section
-          aria-label="Modo Conductor"
-          className="mt-8 rounded-lg border border-neutral-200 bg-white p-5"
-          data-testid="perfil-modo-conductor-section"
-        >
-          <div className="flex items-start gap-3">
-            <Headphones className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
-            <div className="flex-1">
-              <h2 className="font-semibold text-base text-neutral-900">Modo Conductor</h2>
-              <p className="mt-1 text-neutral-600 text-sm">
-                Activa audio coaching automático, gestiona permisos de micrófono y GPS, y revisa los
-                comandos de voz para operar sin tocar la pantalla mientras conduces.
-              </p>
-              <Link
-                to="/app/conductor/modo"
-                className="mt-3 inline-flex items-center gap-2 rounded-md bg-primary-600 px-3 py-2 font-medium text-sm text-white shadow-xs transition hover:bg-primary-700"
-                data-testid="link-modo-conductor-perfil"
-              >
-                Configurar modo conductor
-              </Link>
-            </div>
-          </div>
-        </section>
       </div>
     </Layout>
   );

--- a/apps/web/src/routes/platform-admin-matching.tsx
+++ b/apps/web/src/routes/platform-admin-matching.tsx
@@ -188,7 +188,7 @@ function PlatformAdminMatchingPage() {
             <div>
               <div className="font-semibold text-neutral-900">Comparar algoritmo de asignación</div>
               <div className="text-neutral-500 text-xs">
-                Probá un nuevo algoritmo de asignación sobre viajes reales antes de activarlo
+                Prueba un nuevo algoritmo de asignación sobre viajes reales antes de activarlo
               </div>
             </div>
           </div>
@@ -332,7 +332,7 @@ function RunForm({ onSubmitted }: { onSubmitted: () => void | Promise<void> }) {
         <div className="flex-1">
           <h2 className="font-semibold text-neutral-900">Lanzar una simulación</h2>
           <p className="mt-1 text-neutral-600 text-sm">
-            Sobre cuántos viajes pasados querés simular el algoritmo nuevo. Tarda menos de 30
+            Sobre cuántos viajes pasados quieres simular el algoritmo nuevo. Tarda menos de 30
             segundos para 500 viajes.
           </p>
         </div>
@@ -491,13 +491,13 @@ function RunForm({ onSubmitted }: { onSubmitted: () => void | Promise<void> }) {
  */
 function humanizeError(raw: string): string {
   if (raw.includes('403') || raw.includes('forbidden_platform_admin')) {
-    return 'Tu email no tiene permiso para acceder a esta sección. Si crees que es un error, pedile al equipo de infra que agregue tu email a la lista de administradores de plataforma.';
+    return 'Tu email no tiene permiso para acceder a esta sección. Si crees que es un error, pídele al equipo de infra que agregue tu email a la lista de administradores de plataforma.';
   }
   if (raw.includes('401')) {
-    return 'Tu sesión expiró. Recargá la página para volver a iniciar sesión.';
+    return 'Tu sesión expiró. Recarga la página para volver a iniciar sesión.';
   }
   if (raw.includes('400') || raw.toLowerCase().includes('validation')) {
-    return 'Algún valor del formulario no es válido. Revisá las fechas y el límite de viajes.';
+    return 'Algún valor del formulario no es válido. Revisa las fechas y el límite de viajes.';
   }
   if (raw.includes('500') || raw.toLowerCase().includes('backtest_failed')) {
     return `La simulación falló del lado del servidor. Detalle: ${raw}`;

--- a/apps/web/src/services/driver-position.ts
+++ b/apps/web/src/services/driver-position.ts
@@ -3,9 +3,11 @@ import { api } from '../lib/api-client.js';
 /**
  * D2 — Cliente del endpoint `POST /assignments/:id/driver-position`.
  *
- * Usado por el hook `useDriverPositionReporter` en el flujo conductor-modo:
- *   - El driver activa "Reporte GPS móvil" en /app/conductor/modo cuando
- *     opera un vehículo SIN Teltonika.
+ * Usado por el hook `useDriverPositionReporter` en el flujo del dashboard
+ * del conductor (`/app/conductor`):
+ *   - El driver toca "Iniciar reporte GPS" en /app/conductor cuando opera
+ *     un vehículo SIN Teltonika (el botón está inline en cada
+ *     assignment card).
  *   - `navigator.geolocation.watchPosition` dispara cada ~10s.
  *   - Cada disparo llama a esta función con la posición.
  *   - El backend persiste en `posiciones_movil_conductor` y los read

--- a/docs/plans/2026-05-12-identidad-universal-y-dashboard-conductor.md
+++ b/docs/plans/2026-05-12-identidad-universal-y-dashboard-conductor.md
@@ -1,0 +1,423 @@
+# Plan de implementación — Identidad universal Booster + Dashboard Conductor
+
+**Fecha**: 2026-05-12
+**Autor**: Felipe (PO) + Claude
+**Estado**: pendiente de aprobación
+**Branch base**: `feat/conductor-identity-y-dashboard` (Wave 1 ya está en este branch)
+**Referencias previas**: ADR-004, ADR-008, ADR-028, memoria `project_identity_model_decisions.md`
+
+---
+
+## Contexto
+
+Tres fuerzas convergen hoy:
+
+1. **Bug productivo**: conductores creados por el carrier no tenían `memberships` → `/me` devolvía null → frontend mostraba "Sin empresa activa". Tapado parcialmente en branch actual.
+2. **Decisión de producto** (Felipe, 2026-05-12): URL única `app.boosterchile.com`, login universal RUT + clave numérica (sin email/password), selector de **4 UI types** (Generador / Transporte / Conductor / Stakeholder, + Booster como 5° admin), empresas como "espacios de configuración" no como personas.
+3. **Demo Corfo lunes 18-may**: requiere que el flujo conductor funcione end-to-end sin parches visibles.
+
+La consigna explícita: **sin parches, soluciones definitivas, trabajar de noche si hace falta**.
+
+---
+
+## Arquitectura objetivo
+
+```
+                ┌─────────────────────────────────────────┐
+                │  app.boosterchile.com (URL ÚNICA)        │
+                │  ┌────────────────────────────────────┐ │
+                │  │  Selector: tipo de usuario        │ │
+                │  │  · Generador de carga             │ │
+                │  │  · Transporte                     │ │
+                │  │  · Conductor                      │ │
+                │  │  · Stakeholder                    │ │
+                │  │  · Booster (platform admin)       │ │
+                │  └────────────────────────────────────┘ │
+                │            ↓ RUT + clave numérica       │
+                └─────────────────────────────────────────┘
+                              │
+       ┌──────────┬──────────┼──────────┬──────────────┐
+       ↓          ↓          ↓          ↓              ↓
+  /app/cargas /app/ofertas /app/    /app/         /app/platform-
+  (shipper)  (carrier)    conductor stakeholder/  admin
+                                     zonas
+       │          │          │          │              │
+       │          │          │          │              │
+   "espacios" = empresas (configuración compartida por
+   dueño + admin + asistentes; mismo UI dentro del mismo tipo)
+       │          │          │          │              │
+       └──────────┴──────────┴──────────┴──────────────┘
+                              │
+                    ┌─────────▼──────────┐
+                    │  Backend Hono       │
+                    │  · /me              │
+                    │  · /auth/login-rut  │← NUEVO (Wave 4)
+                    │  · /auth/driver-activate (legacy, mantener)
+                    └─────────────────────┘
+```
+
+**Invariante de identidad**:
+- 1 persona = 1 `usuarios` (PK por `rut`).
+- 1 `usuarios` ↔ N `memberships` (rol específico por empresa).
+- 1 `empresa` = espacio de configuración compartido por sus memberships.
+- 1 `conductor` activo ⇒ existe `membership(rol=conductor, estado=activa)` (invariante reforzado en backend, Wave 1).
+- Stakeholder vive en `organizaciones_stakeholder` (no `empresas`).
+
+---
+
+## Mapa de waves
+
+| Wave | Alcance | PRs | Bloquea | ETA |
+|------|---------|-----|---------|-----|
+| **1** | Conductor membership + dashboard split (`/app/conductor` vs `/app/conductor/configuracion`) | 1 (branch actual) | Demo lunes | 1 día |
+| **2** | Tests del dashboard + sweep español neutro completo en surfaces driver | 1 | nada | 1 día |
+| **3** | Stakeholder organizations + auth stakeholder | 1 ADR + 2 PRs | nada (paralelo a 4) | 3 días |
+| **4** | Auth universal RUT + clave numérica (reemplaza email/password) | 1 ADR + 3 PRs | retira email/password legacy | 5 días |
+| **5** | Wake-word voice activation tipo "Hey Booster" | 1 ADR + 1 PR | requiere Wave 1 | 3 días |
+| **6** | Investigación cultural conductor chileno (gremios, modismos) — no-code | research note | informa Wave 5 + copy | 2 días paralelos |
+
+---
+
+## WAVE 1 — Conductor identity + dashboard split
+
+**Estado**: branch `feat/conductor-identity-y-dashboard` (este worktree). Falta solo PR + tests + smoke staging.
+
+### Archivos modificados/creados (ya en branch)
+
+| Archivo | Cambio |
+|---------|--------|
+| `apps/api/drizzle/0029_conductor_memberships_backfill.sql` | NUEVO — backfill `memberships(rol=conductor)` para conductores existentes |
+| `apps/api/drizzle/meta/_journal.json` | Registro de migration 0029 |
+| `apps/api/src/services/seed-demo.ts` | `ensureConductor()` crea membership automáticamente |
+| `apps/api/src/routes/auth-driver.ts` | Driver-activate promueve/crea membership al activar PIN |
+| `apps/api/src/routes/{conductores,assignments,me}.ts` | Comments actualizados con nuevo URL |
+| `apps/api/src/services/asignar-conductor-a-assignment.ts` | Comment actualizado |
+| `apps/api/scripts/demo-dry-run.mjs` | Comment actualizado |
+| `apps/web/src/routes/conductor.tsx` | NUEVO — dashboard operativo del conductor |
+| `apps/web/src/routes/conductor-configuracion.tsx` | NUEVO — config aislada (sin GPS reporter) |
+| `apps/web/src/routes/conductor-modo.{tsx,test.tsx}` | ELIMINADOS — superseded |
+| `apps/web/src/router.tsx` | Registra 2 rutas: `/app/conductor` + `/app/conductor/configuracion` |
+| `apps/web/src/routes/{app,ofertas,perfil}.tsx` | Removidos los links carrier→driver (separación de surfaces) |
+| `apps/web/src/routes/{app,login-conductor}.test.tsx` | Tests actualizados al nuevo URL |
+| `apps/web/src/routes/{login-conductor,app,ofertas}.tsx` | Redirección a `/app/conductor` |
+| `apps/web/src/services/driver-position.ts` | Comment actualizado |
+| `apps/web/src/components/scoring/DriverAssignmentCard.tsx` | Comment actualizado |
+
+### Pendiente Wave 1
+
+1. **Tests nuevos** (PR mismo):
+   - `apps/web/src/routes/conductor.test.tsx` — covers:
+     - empty state cuando `/me/assignments` devuelve []
+     - render de assignment card (origen, destino, vehículo)
+     - GPS reporter button disabled si `geoPermission !== 'granted'`
+     - Banner WhatsApp visible
+     - Click engranaje navega a `/app/conductor/configuracion`
+   - `apps/web/src/routes/conductor-configuracion.test.tsx` — port del antiguo `conductor-modo.test.tsx` quitando assertions de GPS reporter
+2. **Smoke E2E** staging tras deploy:
+   - Login carrier → crea conductor con PIN
+   - Logout
+   - `/login/conductor` con RUT + PIN
+   - Aterriza en `/app/conductor`
+   - Ve assignment card (si fue asignado previamente)
+   - Toca engranaje → ve configuración
+   - Activa permisos GPS → "Iniciar reporte" funciona
+3. **PR + merge** a main → autodeploy staging → smoke → autodeploy prod
+
+### Riesgos Wave 1
+
+| Riesgo | Mitigación |
+|--------|-----------|
+| Migration 0029 rompe DBs con conductores que YA tienen membership (dueño-conductor) | El `NOT EXISTS` clause del INSERT lo protege. Validado lógicamente; testear en staging. |
+| Conductor que tenía 2 memberships (e.g. dueño + conductor) pierde una | UNIQUE `(user_id, empresa_id)` ya bloquea esto. Caso edge documentado para Wave 4. |
+| `/app/conductor` rompe para roles no-conductor | `ProtectedRoute` con `meRequirement="require-onboarded"` ya lo gatea; pero el dashboard asume `myRole=conductor`. Añadir guard explícito que redirija no-conductores a `/app`. |
+
+### Feature flags Wave 1
+Ninguno — el split de rutas es backward-compatible con redirects.
+
+---
+
+## WAVE 2 — Tests + español neutro completo
+
+### Trigger
+Felipe identificó argentinismos en surfaces driver. Sweep completo + tests del dashboard cubren el gap de Wave 1.
+
+### Archivos a modificar
+
+| Archivo | Cambio |
+|---------|--------|
+| `apps/web/src/routes/conductor.tsx` | "acá" → "aquí" (2 instancias detectadas) |
+| `apps/web/src/components/scoring/DriverAssignmentCard.tsx` | "No tenés conductores" → "No tienes conductores"; "Creá uno" → "Crea uno"; "Pedile a un usuario" → "Pídele a un usuario" |
+| `apps/web/src/routes/platform-admin-matching.tsx` | "querés simular" → "quieres simular" |
+| `apps/web/src/routes/cobra-hoy-historial.tsx` | "acá el historial" → "aquí el historial" |
+| `apps/web/src/routes/conductor-configuracion.tsx` | Audit completo (es archivo recién copiado, puede tener argentinismos heredados) |
+
+### Test coverage Wave 2
+
+- `conductor.test.tsx` (mencionado en Wave 1, formaliza en este PR)
+- `conductor-configuracion.test.tsx`
+- Snapshot del header del conductor (logo, fullName, ícono engranaje)
+- Test de regresión: argentinismos detectados por regex en CI (script `scripts/check-spanish-neutral.sh`)
+
+### Riesgos Wave 2
+- Bajos — refactor de strings + tests.
+
+---
+
+## WAVE 3 — Stakeholder organizations
+
+### Trigger
+Felipe (2026-05-12): "me faltó incluir a los stakeholder, ayúdame con la forma de ingreso. investiga en fuentes públicas, gremios u otros…"
+
+Hoy el `stakeholder_sostenibilidad` es solo un rol de `memberships`, lo que asume que pertenece a una `empresa`. Pero un stakeholder NO es una empresa transportista ni shipper — es una organización distinta (regulador, asociación gremial, observatorio académico, ONG).
+
+### ADR nuevo: `docs/adr/034-stakeholder-organizations-y-acceso.md`
+
+Decisión:
+- Nueva entidad `organizaciones_stakeholder` (no `empresas`).
+- Campos: `id`, `nombre_legal`, `tipo` (enum: `regulador` | `gremio` | `observatorio_academico` | `ong` | `corporativo_esg`), `region_ambito`, `creado_por_admin_id`, `creado_en`, `actualizado_en`, `eliminado_en`.
+- Memberships extendidas: `memberships.organizacion_stakeholder_id` (nullable; XOR con `empresa_id`).
+- Alta solo por platform-admin (auditado en `events`).
+- Auth: mismo flow RUT + clave numérica (Wave 4) cuando esté listo; mientras tanto, email/password con allowlist de dominios institucionales (`@subtrans.gob.cl`, `@uc.cl`, etc.).
+- Datos accesibles: agregados con k-anonymity ≥ 5, scopeados por `region_ambito` de la org del stakeholder.
+
+### Migraciones
+
+- `0030_organizaciones_stakeholder.sql` — crea tabla + enum `tipo_organizacion_stakeholder`.
+- `0031_memberships_stakeholder_org.sql` — columna nullable `organizacion_stakeholder_id` + CHECK XOR.
+
+### Archivos a crear/modificar
+
+| Archivo | Cambio |
+|---------|--------|
+| `docs/adr/034-stakeholder-organizations-y-acceso.md` | NUEVO ADR |
+| `apps/api/drizzle/003{0,1}_*.sql` | Migrations |
+| `apps/api/src/db/schema.ts` | `organizacionesStakeholder` table + relations |
+| `packages/shared-schemas/src/domain/stakeholder.ts` | NUEVO — `OrganizacionStakeholderSchema`, `TipoOrganizacionStakeholder` |
+| `apps/api/src/routes/admin-stakeholder-orgs.ts` | NUEVO — CRUD restringido a platform-admin |
+| `apps/api/src/routes/me.ts` | Si membership.organizacion_stakeholder_id, popula `active_membership.organizacion_stakeholder` |
+| `apps/web/src/routes/platform-admin.tsx` | Sección "Organizaciones stakeholder" con tabla + crear |
+| `apps/web/src/routes/stakeholder-zonas.tsx` | Lee `region_ambito` desde la org y filtra |
+| `apps/api/src/services/seed-demo.ts` | Seed un stakeholder de demo (e.g. "Observatorio Logístico UC", tipo `observatorio_academico`) |
+
+### Orden de commits Wave 3
+
+1. `feat(domain): organizaciones_stakeholder schema (Wave 3 PR 1/2)`
+2. `feat(api): admin CRUD para organizaciones_stakeholder`
+3. `feat(web): UI platform-admin para crear y listar stakeholder orgs`
+4. `feat(stakeholder): zonas filtradas por region_ambito de la org`
+5. `chore(seed): seed-demo incluye observatorio stakeholder`
+
+### Riesgos Wave 3
+
+| Riesgo | Mitigación |
+|--------|-----------|
+| Memberships XOR rompe queries existentes | Migration default `empresa_id NOT NULL`, ya tiene FK; XOR aplica solo a stakeholder nuevos. |
+| Stakeholder pre-existente (rol en empresa) hay que migrarlo | Por ahora ninguno en prod. Si aparece, migration data-fix scripteada. |
+| k-anonymity ≥ 5 puede vaciar pantalla en regiones chicas | Default-fallback a "datos insuficientes" UI, no crashea. |
+
+---
+
+## WAVE 4 — Auth universal RUT + clave numérica
+
+### Trigger
+Felipe (2026-05-12): "la url app.boosterchile.com de acceso a Booster es única, en esa interfaz uno selecciona el tipo de usuario… RUT + clave numérica universal (no email/password) — aligned con mobile-first (PIN + face ID)".
+
+Este es el cambio más grande. Reemplaza el paradigma email/password de Firebase Auth con RUT + clave numérica de 6 dígitos para TODOS los roles (no solo conductor).
+
+### ADR nuevo: `docs/adr/035-auth-universal-rut-clave-numerica.md`
+
+Decisiones:
+- Toda persona se identifica por RUT (PK en `usuarios.rut`).
+- Clave de acceso: 6 dígitos numéricos (cliente puede usar PIN del dispositivo + WebAuthn / passkey en future iter).
+- Email queda como contacto opcional (notificaciones), no como credencial.
+- Firebase Auth interno sigue, pero con email sintético derivado del RUT (`<rol>+<rut>@boosterchile.invalid`) y password = clave numérica. Esto reusa el patrón de `auth-driver.ts`.
+- Migración: usuarios actuales con email/password tienen 30 días para "rotar a RUT" desde su perfil; tras eso, el email/password deja de funcionar.
+- Selector de tipo de usuario en `/login`: 5 opciones (Generador / Transporte / Conductor / Stakeholder / Booster). El backend infiere el rol disponible vía memberships del RUT; el selector solo determina la UI inicial.
+- 2FA WhatsApp sigue igual.
+
+### Migración de datos
+
+- `0032_user_clave_numerica_hash.sql` — añade `usuarios.clave_numerica_hash` (scrypt timing-safe igual que `activacion_pin_hash`).
+- Backfill: a cada usuario con `firebase_uid` real (no `pending-rut:`) le forzamos rotar clave numérica en su próximo login.
+- Eliminación de `activacion_pin_hash` se difiere hasta deprecar todos los flujos legacy.
+
+### Archivos a crear/modificar
+
+| Archivo | Cambio |
+|---------|--------|
+| `docs/adr/035-auth-universal-rut-clave-numerica.md` | NUEVO ADR |
+| `apps/api/drizzle/0032_user_clave_numerica_hash.sql` | Migration |
+| `apps/api/src/services/clave-numerica.ts` | NUEVO — hash + verify (espejo de `activation-pin.ts`) |
+| `apps/api/src/routes/auth-universal.ts` | NUEVO — `POST /auth/login-rut`, `POST /auth/rotate-clave` |
+| `apps/api/src/routes/auth-driver.ts` | Refactor: ahora es caso especial de auth-universal con `tipo=conductor` |
+| `packages/shared-schemas/src/auth.ts` | NUEVO — schemas `LoginRutSchema`, `RotateClaveSchema` |
+| `apps/web/src/routes/login.tsx` | REWRITE — selector de tipo de usuario + form RUT+clave |
+| `apps/web/src/routes/login-conductor.tsx` | DEPRECATED — redirige a `/login?tipo=conductor` (mantener 1 ciclo de release, después eliminar) |
+| `apps/web/src/hooks/use-auth.ts` | Función `signInWithRutClave(rut, clave, tipo)` |
+| `apps/web/src/components/profile/RotateClaveSection.tsx` | NUEVO — UI para rotar clave numérica |
+| `apps/api/src/services/seed-demo.ts` | Seed asigna `clave_numerica` a usuarios demo |
+
+### Orden de commits Wave 4
+
+1. `feat(auth): clave_numerica_hash + service + tests (Wave 4 PR 1/3)` — solo backend, sin cambios de UI
+2. `feat(auth): POST /auth/login-rut + endpoint admin de rotate-clave (Wave 4 PR 2/3)` — endpoint vivo pero sin uso desde UI todavía
+3. `feat(web): /login con selector tipo usuario + RUT+clave (Wave 4 PR 3/3)` — UI nueva, feature-flag `AUTH_UNIVERSAL_V1_ACTIVATED`
+
+### Feature flag Wave 4
+
+- `AUTH_UNIVERSAL_V1_ACTIVATED` (server-side + cliente):
+  - `false` → `/login` es el viejo (email/password). `/login/conductor` funciona normal.
+  - `true` → `/login` es el nuevo selector. `/login/conductor` redirige al nuevo.
+- Cliente lee desde `/me/feature-flags` (endpoint público). Cambio sin redeploy via Secret Manager → restart.
+
+### Riesgos Wave 4
+
+| Riesgo | Mitigación |
+|--------|-----------|
+| Usuarios productivos con email/password no pueden entrar | Coexistencia 30 días + email de migración con link a `/perfil/rotar-clave`. Feature flag permite rollback instantáneo. |
+| Selector tipo usuario es ambiguo (carrier que también es shipper) | El selector determina **vista inicial**, no el rol. Layout siempre muestra switcher de membresías como hoy. |
+| Pérdida de clave numérica = recovery flow | Recovery por WhatsApp OTP (Twilio) — reusa el 2FA pipeline existente. |
+| Firebase Auth quota con sintéticos | Email sintético ya implementado en auth-driver; mismo costo por usuario. |
+| Passkey / WebAuthn no soportado en browsers viejos | Mantener fallback a clave numérica siempre. |
+
+---
+
+## WAVE 5 — Wake-word voice activation
+
+### Trigger
+Felipe (2026-05-12): "el comando por voz debería activarse como Alexa o Siri".
+
+Hoy las features voice se disparan via push-to-talk explícito (botón). Cambia a always-on listening con wake-word "Hey Booster" o similar.
+
+### ADR nuevo: `docs/adr/036-wake-word-voice-driver.md`
+
+Decisiones:
+- Library: Picovoice **Porcupine** (on-device, ~700KB, gratis hasta 100 usuarios; comercial después). Alternativa Snowboy DEPRECADA, MyCroft Precise abandonada.
+- Wake-word custom: "Hey Booster" (entrenado en Picovoice Console, 24h training).
+- Always-on solo cuando vehículo detenido (≤3 km/h por 4s, igual que coaching). Cuando se mueve, mic se apaga para batería + privacidad.
+- Privacy: audio jamás sale del dispositivo. Wake-word detection es on-device. Solo tras wake-word el audio se streamea a Web Speech API para STT.
+- Costo: $20-100/mo por wake-word custom según escala.
+
+### Archivos a crear/modificar
+
+| Archivo | Cambio |
+|---------|--------|
+| `docs/adr/036-wake-word-voice-driver.md` | NUEVO ADR |
+| `apps/web/package.json` | Dep nueva: `@picovoice/porcupine-web` |
+| `apps/web/src/services/wake-word.ts` | NUEVO — wrapper Porcupine con start/stop/onWake |
+| `apps/web/src/hooks/use-wake-word.ts` | NUEVO — hook React que integra con vehicle-stopped-detector |
+| `apps/web/src/routes/conductor.tsx` | Integra wake-word: cuando suena "Hey Booster" → abre control de voice command activo |
+| `apps/web/src/routes/conductor-configuracion.tsx` | Card nuevo: "Activación por voz" con toggle on/off + estado del modelo |
+| `apps/web/public/wake-word/hey-booster.ppn` | Asset binario del modelo entrenado |
+
+### Riesgos Wave 5
+
+| Riesgo | Mitigación |
+|--------|-----------|
+| Battery drain on Android | Solo activo cuando parado (gating ya en sistema). Test en device real. |
+| False positives en conversación normal | Tuning del threshold; usuario puede desactivar por completo. |
+| Privacy concern del usuario | Banner explícito + opt-in (default OFF). Texto: "El micrófono solo escucha la frase 'Hey Booster', no se graba conversación, no sale del teléfono." |
+| Picovoice license cambia | ADR explica licencia actual; tenemos abstracción `wake-word.ts` para swap futuro. |
+
+### Feature flag Wave 5
+- `WAKE_WORD_VOICE_ACTIVATED` — default OFF, opt-in por usuario en configuración.
+
+---
+
+## WAVE 6 — Investigación cultural conductor chileno (no-code)
+
+### Trigger
+Felipe (2026-05-12): "Es importante conocer la cultura de los conductores… investiga en fuentes públicas, gremios u otros".
+
+### Deliverables
+
+| Doc | Ubicación |
+|-----|-----------|
+| Research note "Cultura conductor chileno — modismos y adherencia digital" | `docs/research/2026-05-13-cultura-conductor-chileno.md` |
+| Glosario español neutro vs chileno (qué keep, qué neutralizar) | `docs/copy-guide.md` (extend existing) |
+| Mapeo de gremios y referentes | en research note |
+
+### Fuentes a consultar (públicas)
+
+- Asociación Chilena de Empresas de Transporte de Carga (ChileTransporte)
+- Confederación Nacional de Dueños de Camiones (CNDC)
+- Subsecretaría de Transportes (Subtrans) — estudios de modos de transporte
+- Tesis y papers académicos UC + USACH sobre adherencia tecnológica en sector transporte
+- Foros y subreddits: r/chile, grupos de Facebook "Camioneros de Chile"
+- Entrevistas: 3-5 conductores reales (vía Transportes Van Oosterwyk para referidos)
+
+### Cómo informa el código
+
+- Wake-word: ¿"Hey Booster" o algo más natural? ("Oye Booster", "Booster")
+- Voice commands: frases que realmente usan al conducir vs literatura
+- Iconografía + colores: paletas que evocan confianza vs gimicky
+- UI copy: nivel de formalidad (tú vs usted en Chile depende de edad y región)
+
+### Cronograma Wave 6
+- En paralelo a Wave 1-3. NO bloquea código.
+- Resultado entra como input a Wave 5 (wake-word naming) y a refinamientos UI continuos.
+
+---
+
+## Riesgos transversales
+
+| Riesgo | Wave(s) afectadas | Mitigación |
+|--------|-------------------|------------|
+| Demo Corfo (lunes 18-may) bloqueada si Wave 1 no llega | 1 | Wave 1 ya está en branch; solo falta PR + smoke. Plan B: rollback al commit anterior si algo rompe. |
+| Cambio de auth (Wave 4) rompe sesiones activas | 4 | Feature flag + 30 días de coexistencia + recovery por WhatsApp. |
+| Picovoice quota / pricing model cambia | 5 | Abstracción permite swap. Mantener fallback push-to-talk siempre. |
+| Stakeholder org schema evoluciona post-Wave 3 (nuevos tipos) | 3 | Enum extensible via migration ALTER TYPE; no breaking. |
+
+---
+
+## Feature flags (resumen)
+
+| Flag | Default | Activado por | Wave |
+|------|---------|--------------|------|
+| `MATCHING_ALGORITHM_V2_ACTIVATED` | `true` (ya activo prod) | — | (existente) |
+| `AUTH_UNIVERSAL_V1_ACTIVATED` | `false` (rollout gradual) | Felipe via Secret Manager | 4 |
+| `WAKE_WORD_VOICE_ACTIVATED` | `false` (opt-in usuario) | Cada conductor en su configuración | 5 |
+
+---
+
+## Orden de deploy recomendado
+
+```
+2026-05-12 (hoy)    Wave 1 — PR + smoke staging + merge → prod
+2026-05-13          Wave 2 — tests + español neutro (1 PR)
+2026-05-13 a 15     Wave 6 — research en paralelo
+2026-05-13 a 16     Wave 3 — stakeholder orgs (3 PRs incrementales)
+2026-05-14 a 19     Wave 4 — auth universal (3 PRs, behind flag)
+2026-05-17 a 20     Wave 5 — wake-word voice (1 PR, opt-in)
+
+Demo Corfo lunes 18-may: necesita Wave 1 ✓ + Wave 2 ✓ + idealmente Wave 3
+                         (stakeholder en demo si Felipe quiere mostrarlo).
+                         Wave 4 + 5 NO bloquean demo.
+```
+
+---
+
+## Exit criteria del plan
+
+- [ ] Felipe aprueba waves y orden
+- [ ] ADRs 034 (stakeholder), 035 (auth universal), 036 (wake-word) escritos antes de los PRs respectivos
+- [ ] Cada wave tiene su PR con sección "Evidencia" (tests + screenshots + traces) per CLAUDE.md
+- [ ] Cada migration tiene rollback documentado
+- [ ] Feature flags declarados en Terraform antes del primer commit que los lea
+- [ ] Demo Corfo (18-may) corre verde con Wave 1 + 2 mínimo
+
+---
+
+## Decisiones cerradas (2026-05-12, aprobación Felipe)
+
+1. **Wake-word literal**: **"Oye Booster"** — natural en español de Chile, dos sílabas iniciales son fonéticamente distintas → menos falsos positivos.
+2. **Recovery de clave numérica**: WhatsApp OTP reusando pipeline 2FA existente. NO email backup (mobile-first).
+3. **URL canónica**: `app.boosterchile.com` para todos los roles. Subdominios por rol (`transporte`, `carga`, `conductor`, `stakeholder`, `admin`) son **301 redirects** al canónico con query param `?tipo=<rol>` que pre-selecciona el selector de login. No son apps separadas — single bundle, single Cloud Run, single SSO.
+4. **Excepción `admin.boosterchile.com`**: evaluar hard-separation por seguridad (IP allowlist + WAF estricto). Decisión final en ADR-035.
+5. **Plan completo aprobado hasta finalizar.** Felipe: "Apruebo el plan completo hasta terminar a la hora que sea".
+
+## Decisiones pendientes para definir dentro de las Waves
+
+1. **Stakeholder allowlist de dominios** (Wave 3): qué dominios institucionales pre-aprobamos antes de Wave 4 (`@subtrans.gob.cl`, `@uc.cl`, etc.)
+2. **Migración usuarios actuales a clave numérica** (Wave 4): forzamos rotación al login siguiente, o damos 30 días con UI nag.
+3. **Admin hard-separation** (Wave 4 ADR-035): `admin.boosterchile.com` separado o solo redirect.


### PR DESCRIPTION
## Resumen

Wave 1 del plan de identidad universal Booster + dashboard del conductor.

- **Backend**: refuerza invariante "todo conductor activo tiene membership rol=conductor" (migration 0029 + auto-creación en seed y driver-activate).
- **Frontend**: separa surface del conductor en dashboard operativo (\`/app/conductor\`) vs configuración (\`/app/conductor/configuracion\`). Carrier ya no ve UI driver.
- **Sweep español neutro**: argentinismos (tenés/elegí/querés/probá/recargá/pedile…) → forma neutra en 11 archivos.
- **Plan**: roadmap de 6 waves comprometido en \`docs/plans/2026-05-12-…\`.

Cierra el bug productivo \"Sin empresa activa\" que aparecía en logins de conductor post-creación por el carrier, y habilita el flujo end-to-end para la demo Corfo (lunes 18-may).

## Cambios principales

### Backend
- \`drizzle/0029_conductor_memberships_backfill.sql\`: backfill memberships rol=conductor para conductores existentes.
- \`services/seed-demo.ts\` (ensureConductor): crea membership automáticamente.
- \`routes/auth-driver.ts\`: tras activar PIN, promueve/crea membership rol=conductor (defensa retroactiva).

### Frontend
- NUEVO \`/app/conductor\` (\`routes/conductor.tsx\`): dashboard mobile-first del conductor con header propio (full_name + ícono engranaje → configuración), banner sticky \"no uses WhatsApp manejando\", lista de servicios asignados, GPS reporter inline en cada card. Vocabulario \"servicio\" (no \"oferta\").
- NUEVO \`/app/conductor/configuracion\` (\`routes/conductor-configuracion.tsx\`): split del antiguo \`/app/conductor/modo\`, sin GPS reporter, header con flecha de vuelta al panel.
- ELIMINADO \`conductor-modo.{tsx,test.tsx}\`.
- Surfaces carrier (\`/app\`, \`/app/ofertas\`, \`/app/perfil\`): removidos los links a \"Modo Conductor\" — el carrier no opera la UI driver (ADR-008 + modelo identidad).

### Plan
- \`docs/plans/2026-05-12-identidad-universal-y-dashboard-conductor.md\`: roadmap completo de 6 waves con:
  - Wave 1: este PR.
  - Wave 2: ya parcialmente integrado acá (tests + sweep i18n).
  - Wave 3: stakeholder organizations (ADR-034).
  - Wave 4: auth universal RUT + clave numérica (ADR-035).
  - Wave 5: wake-word \"Oye Booster\" tipo Alexa (ADR-036).
  - Wave 6: research cultural conductor chileno.
- Decisiones cerradas: URL canónica \`app.boosterchile.com\` con subdominios como 301 redirects, no apps separadas; wake-word \"Oye Booster\"; recovery de clave por WhatsApp OTP.

## Tests nuevos (24 specs)

- \`conductor.test.tsx\` (12): header, banner WhatsApp, empty state, single/multi assignment render, GPS reporter (disabled si geo≠granted, start con assignmentId correcto, watching con counter + stop), error 404 user-friendly, regex anti-argentinismos, vocabulario \"servicio\" no \"oferta\".
- \`conductor-configuracion.test.tsx\` (12): port del antiguo \`conductor-modo.test.tsx\`, sin assertions GPS reporter (movidas al test del dashboard).

## Evidencia

\`\`\`
pnpm --filter=@booster-ai/web test --run
  Test Files  88 passed (88)
       Tests  916 passed (916)     ← +24 vs main

pnpm --filter=@booster-ai/api test --run
  Test Files  70 passed (70)
       Tests  890 passed | 2 skipped (892)

pnpm --filter=@booster-ai/web typecheck    ✓
pnpm --filter=@booster-ai/api typecheck    ✓
pnpm exec biome check apps/web/src         0 errors, 15 warnings (pre-existing useSortedClasses)
\`\`\`

## Riesgos & mitigación

- **Migration 0029 en deploy**: usa \`NOT EXISTS\` clause → idempotente, no rompe conductores que ya tienen membership (caso dueño-conductor).
- **UNIQUE constraint \`(user_id, empresa_id)\`**: si un user es \*ambos\* dueño + conductor de la misma empresa, no podrá tener 2 memberships. Caso edge documentado para Wave 4 (auth universal).
- **Conductor con multiple memberships**: el dashboard asume rol=conductor; redirección desde \`/app\` ya gatea esto. Switch entre roles vía Layout sigue funcionando para usuarios multi-rol.

## Smoke E2E post-deploy (TODO antes de merge a prod)

- [ ] Login carrier → crea conductor con PIN
- [ ] Logout
- [ ] \`/login/conductor\` con RUT + PIN → activa
- [ ] Aterriza en \`/app/conductor\` (no \"Sin empresa activa\")
- [ ] Si tiene assignment, ve la card con origen/destino/vehículo
- [ ] Toca engranaje → ve configuración
- [ ] Activa GPS → botón \"Iniciar reporte\" funciona

🤖 Generated with [Claude Code](https://claude.com/claude-code)