### PR TITLE
feat(stakeholder): organizaciones stakeholder + ADR-034 (Wave 3)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -248,21 +248,14 @@ const apiEnvSchema = commonEnvSchema
     GOOGLE_ROUTES_API_KEY: z.string().min(1).optional(),
 
     /**
-     * API key para Google Gemini API (Phase 3 — coaching IA).
+     * GCP project ID — Cloud Run lo setea automáticamente en runtime.
+     * Usado para construir el endpoint Vertex AI Gemini (ADR-037).
      *
-     * Server-side: la usa apps/api en `generar-coaching-viaje.ts` para
-     * generar el mensaje de coaching personalizado post-entrega.
-     *
-     * Optional: si está ausente, el coaching cae al fallback de plantilla
-     * determinística de @booster-ai/coaching-generator. El carrier
-     * recibe igual feedback útil — la diferencia es solo personalización
-     * por contexto del trip.
-     *
-     * El secret `gemini-api-key` ya existe en Secret Manager (TF
-     * security.tf). Cargar con: gcloud secrets versions add gemini-api-key
-     * --data-file=<(echo -n "AIza...").
+     * Default-required en producción; optional acá porque en tests/dev
+     * locales puede no estar definido (el coaching cae al fallback
+     * plantilla automáticamente sin generar error).
      */
-    GEMINI_API_KEY: z.string().min(1).optional(),
+    GOOGLE_CLOUD_PROJECT: z.string().min(1).optional(),
 
     /**
      * Feature flag para activar pricing v2 (ADR-030 + ADR-031).

--- a/apps/api/src/services/confirmar-entrega-viaje.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.ts
@@ -244,7 +244,7 @@ export async function confirmarEntregaViaje(opts: {
         db,
         logger,
         tripId,
-        geminiApiKey: appConfig.GEMINI_API_KEY,
+        geminiProjectId: appConfig.GOOGLE_CLOUD_PROJECT,
       });
     } catch (err) {
       logger.error(

--- a/apps/api/src/services/gemini-client.ts
+++ b/apps/api/src/services/gemini-client.ts
@@ -1,93 +1,131 @@
 import type { Logger } from '@booster-ai/logger';
+import { GoogleAuth } from 'google-auth-library';
 
 /**
- * Cliente HTTP del Gemini API (Phase 3 PR-J2).
- *
- * Usamos la REST API directamente en vez del SDK @google/generative-ai
- * por:
- *   - Cero deps adicionales (apps/api ya tiene fetch nativo).
- *   - Control fino del timeout (~10s) — el SDK no lo expone fácilmente.
- *   - Test pattern consistente con routes-api.ts (fetch mockeable).
+ * Cliente HTTP de Gemini via Vertex AI (ADR-037, migración desde ADR-anterior
+ * que usaba generativelanguage.googleapis.com con API key).
  *
  * Endpoint:
- *   POST https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent
- *   ?key=API_KEY
+ *   POST https://{LOCATION}-aiplatform.googleapis.com/v1/projects/{PROJECT}/
+ *        locations/{LOCATION}/publishers/google/models/{MODEL}:generateContent
  *
- * Diseño: este módulo expone una factoría que crea un `GenerarTextoFn`
- * compatible con la interfaz de @booster-ai/coaching-generator. El
- * caller (generar-coaching-viaje.ts) inyecta el resultado al package.
+ * Autenticación: OAuth bearer token via ADC (Application Default Credentials).
+ * En Cloud Run, ADC resuelve al Service Account del runtime (que tiene
+ * roles/aiplatform.user). En local-dev, ADC viene de `gcloud auth
+ * application-default login`.
  *
- * Errores: cualquier fallo (timeout, 4xx, 5xx, parse error) loggea WARN
- * y retorna `null`. El package coaching-generator interpreta null como
- * señal de "fallback a plantilla", que es el comportamiento deseado.
+ * Cero API keys — la key Gemini productiva queda eliminada post-deploy
+ * (ver ADR-037 sección "Apply post-merge"). Cierra el banner GCP "unrestricted
+ * API keys for generativelanguage.googleapis.com".
+ *
+ * Errores: cualquier fallo (timeout, 4xx, 5xx, parse, auth) loggea WARN y
+ * retorna null. coaching-generator interpreta null como señal de fallback
+ * a plantilla.
  */
 
 import type { GenerarTextoFn } from '@booster-ai/coaching-generator';
 
-const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
+/** Timeout total del HTTP call (ms). Incluye latencia de obtener access token. */
+const TIMEOUT_MS = 12_000;
 
-/** Timeout total del HTTP call (ms). Si Gemini tarda más, fallback. */
-const TIMEOUT_MS = 10_000;
-
-/** Modelo default. Override via opts del crear cliente. */
+/** Modelo default. Override via opts. */
 const DEFAULT_MODEL = 'gemini-1.5-flash';
 
+/**
+ * Región Vertex AI. `southamerica-east1` (São Paulo) tiene latencia ~80ms
+ * desde Santiago, vs ~150ms para us-central1. Modelo gemini-1.5-flash
+ * disponible en saw1-east, confirmado en docs de Vertex AI (2026-Q2).
+ */
+const DEFAULT_LOCATION = 'southamerica-east1';
+
+/**
+ * Singleton de GoogleAuth — instanciar una vez por proceso evita el
+ * overhead de descubrir credenciales en cada request. El cliente cachea
+ * el access token internamente y lo renueva antes de expirar.
+ */
+const authClient = new GoogleAuth({
+  scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+});
+
 export interface CreateGeminiGenFnOpts {
-  apiKey: string;
+  /**
+   * GCP project ID. En Cloud Run viene de GOOGLE_CLOUD_PROJECT env var.
+   * Requerido para construir el endpoint Vertex AI.
+   */
+  projectId: string;
+  /** Región Vertex AI. Default: southamerica-east1. */
+  location?: string;
   /** Modelo Gemini. Default: gemini-1.5-flash (cheap, rápido). */
   model?: string;
-  /**
-   * Inyectable para tests. Default: global fetch.
-   */
+  /** Inyectable para tests. Default: global fetch. */
   fetchImpl?: typeof fetch;
   logger?: Logger;
 }
 
 /**
- * Crea una `GenerarTextoFn` que llama a Gemini API. El package
+ * Crea una GenerarTextoFn que llama a Gemini via Vertex AI. El package
  * coaching-generator la consume sin saber del HTTP underlying.
  */
 export function createGeminiGenFn(opts: CreateGeminiGenFnOpts): GenerarTextoFn {
-  const { apiKey, model = DEFAULT_MODEL, fetchImpl = fetch, logger } = opts;
+  const {
+    projectId,
+    location = DEFAULT_LOCATION,
+    model = DEFAULT_MODEL,
+    fetchImpl = fetch,
+    logger,
+  } = opts;
+
+  const endpoint =
+    `https://${location}-aiplatform.googleapis.com/v1/` +
+    `projects/${projectId}/locations/${location}/` +
+    `publishers/google/models/${model}:generateContent`;
 
   return async ({ systemPrompt, userPrompt }) => {
-    const url = `${GEMINI_API_BASE}/${model}:generateContent?key=${encodeURIComponent(apiKey)}`;
-
-    const body = {
-      systemInstruction: {
-        parts: [{ text: systemPrompt }],
-      },
-      contents: [
-        {
-          role: 'user',
-          parts: [{ text: userPrompt }],
-        },
-      ],
-      generationConfig: {
-        // Temperature 0.2 para casi-determinismo manteniendo variedad
-        // mínima en wording (0 estricto a veces da output muy seco).
-        temperature: 0.2,
-        maxOutputTokens: 200, // ~280 chars target + slack
-        topK: 40,
-        topP: 0.95,
-      },
-      // Safety: bloquear solo high-severity. Coaching tiene tono
-      // neutral; no necesitamos bloqueo médico/sexual paranoico.
-      safetySettings: [
-        { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
-        { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH' },
-        { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
-        { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
-      ],
-    };
-
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
     try {
-      const response = await fetchImpl(url, {
+      // ADC: en Cloud Run resuelve al SA del runtime (workload identity).
+      // En local-dev, a las creds de `gcloud auth application-default login`.
+      const client = await authClient.getClient();
+      const tokenResponse = await client.getAccessToken();
+      const accessToken = tokenResponse.token;
+
+      if (!accessToken) {
+        logger?.warn({ model }, 'ADC sin access token, fallback a plantilla');
+        return null;
+      }
+
+      const body = {
+        systemInstruction: {
+          parts: [{ text: systemPrompt }],
+        },
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: userPrompt }],
+          },
+        ],
+        generationConfig: {
+          temperature: 0.2,
+          maxOutputTokens: 200,
+          topK: 40,
+          topP: 0.95,
+        },
+        safetySettings: [
+          { category: 'HARM_CATEGORY_HARASSMENT', threshold: 'BLOCK_ONLY_HIGH' },
+          { category: 'HARM_CATEGORY_HATE_SPEECH', threshold: 'BLOCK_ONLY_HIGH' },
+          { category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT', threshold: 'BLOCK_ONLY_HIGH' },
+          { category: 'HARM_CATEGORY_DANGEROUS_CONTENT', threshold: 'BLOCK_ONLY_HIGH' },
+        ],
+      };
+
+      const response = await fetchImpl(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify(body),
         signal: controller.signal,
       });
@@ -99,8 +137,9 @@ export function createGeminiGenFn(opts: CreateGeminiGenFnOpts): GenerarTextoFn {
             httpStatus: response.status,
             errBody: errBody.slice(0, 300),
             model,
+            location,
           },
-          'Gemini API non-2xx, fallback a plantilla',
+          'Vertex AI Gemini non-2xx, fallback a plantilla',
         );
         return null;
       }
@@ -114,23 +153,21 @@ export function createGeminiGenFn(opts: CreateGeminiGenFnOpts): GenerarTextoFn {
 
       const candidate = json.candidates?.[0];
       if (!candidate) {
-        logger?.warn({ model }, 'Gemini API sin candidates, fallback a plantilla');
+        logger?.warn({ model }, 'Vertex AI sin candidates, fallback a plantilla');
         return null;
       }
 
-      // finishReason ≠ 'STOP' indica que Gemini fue truncado o bloqueado
-      // por safety. En esos casos no usamos el output parcial.
       if (candidate.finishReason && candidate.finishReason !== 'STOP') {
         logger?.warn(
           { finishReason: candidate.finishReason, model },
-          'Gemini API finish reason inesperado, fallback a plantilla',
+          'Vertex AI finish reason inesperado, fallback a plantilla',
         );
         return null;
       }
 
       const text = candidate.content?.parts?.[0]?.text?.trim();
       if (!text || text.length === 0) {
-        logger?.warn({ model }, 'Gemini API devolvió texto vacío, fallback a plantilla');
+        logger?.warn({ model }, 'Vertex AI devolvió texto vacío, fallback a plantilla');
         return null;
       }
 
@@ -140,8 +177,9 @@ export function createGeminiGenFn(opts: CreateGeminiGenFnOpts): GenerarTextoFn {
         {
           err: err instanceof Error ? err.message : String(err),
           model,
+          location,
         },
-        'Gemini API fetch error, fallback a plantilla',
+        'Vertex AI Gemini fetch error, fallback a plantilla',
       );
       return null;
     } finally {

--- a/apps/api/src/services/generar-coaching-viaje.ts
+++ b/apps/api/src/services/generar-coaching-viaje.ts
@@ -16,8 +16,9 @@ import { createGeminiGenFn } from './gemini-client.js';
  *   1. Cargar metricas_viaje del trip — necesitamos behavior_score y
  *      breakdown ya computados (PR-I4) como input al coaching.
  *   2. Construir ParametrosCoaching con los datos del trip + breakdown.
- *   3. Llamar a generarCoachingConduccion con Gemini wrapper (si hay
- *      GEMINI_API_KEY) o sin él (fallback plantilla).
+ *   3. Llamar a generarCoachingConduccion con Gemini wrapper (Vertex AI
+ *      via ADC, ADR-037) o fallback plantilla si geminiEnabled=false o
+ *      Vertex AI falla.
  *   4. Persistir coaching en metricas_viaje (mensaje + foco + fuente +
  *      modelo + timestamp).
  *
@@ -51,13 +52,13 @@ export async function generarCoachingViaje(opts: {
   logger: Logger;
   tripId: string;
   /**
-   * GEMINI_API_KEY del config. Si está presente, se usa Gemini API.
-   * Si no, fallback a plantilla determinística (sin AI). Optional —
-   * el caller decide si la pasa según config.
+   * GCP project ID — usado para construir el endpoint Vertex AI Gemini
+   * (ADR-037). Si está presente, intenta Gemini via ADC; sino, plantilla
+   * determinística. Optional — el caller decide.
    */
-  geminiApiKey?: string | undefined;
+  geminiProjectId?: string | undefined;
 }): Promise<GenerarCoachingResult> {
-  const { db, logger, tripId, geminiApiKey } = opts;
+  const { db, logger, tripId, geminiProjectId } = opts;
 
   // Cargar trip + metricas + assignment para construir el contexto.
   const tripRows = await db.select().from(trips).where(eq(trips.id, tripId)).limit(1);
@@ -125,9 +126,12 @@ export async function generarCoachingViaje(opts: {
     },
   };
 
-  // Construir genFn solo si hay API key. Sin key → undefined → el
-  // package va directo a plantilla.
-  const genFn = geminiApiKey ? createGeminiGenFn({ apiKey: geminiApiKey, logger }) : undefined;
+  // Construir genFn solo si hay projectId (Vertex AI necesita el project
+  // ID para construir el endpoint). Sin él → undefined → el package va
+  // directo a plantilla.
+  const genFn = geminiProjectId
+    ? createGeminiGenFn({ projectId: geminiProjectId, logger })
+    : undefined;
 
   const result: ResultadoCoaching = await generarCoachingConduccion(params, {
     ...(genFn ? { genFn } : {}),

--- a/docs/adr/037-vertex-ai-adc-gemini-migration.md
+++ b/docs/adr/037-vertex-ai-adc-gemini-migration.md
@@ -1,0 +1,140 @@
+# ADR 037 — Migración Gemini API key → Vertex AI con ADC
+
+**Estado**: Aceptado
+**Fecha**: 2026-05-13
+**Autor**: Claude (Opus 4.7) + Felipe Vicencio
+**Cierra issue**: [#195](https://github.com/boosterchile/booster-ai/issues/195)
+**Relacionado**: ADR-035 (auditoría que destapó el banner)
+
+---
+
+## Contexto
+
+Cloud Console mostró banner crítico durante la habilitación del billing export (2026-05-13):
+
+> *"Action Required: One or more projects enabled with Gemini API (generativelanguage.googleapis.com) have unrestricted API keys. To prevent unauthorized usage and costs, restrict these keys or switch to Authorization keys."*
+
+Inventario de keys al momento:
+
+| Key | UID | Service | Origen restriction |
+|---|---|---|---|
+| `Booster Gemini - API Backend` | `a5a60db7-0dc4-43c2-b08a-bb21e7834c2d` | generativelanguage | **ninguna** ← lo que el banner reclama |
+| `Booster Routes - API Backend` | `e091850a-d5ea-4941-bcf0-8f966032b58b` | routes | ninguna |
+| `Booster Maps - Web (PWA)` | `eb016256-c055-42f8-a3ce-c60749b50cbe` | addressvalidation | referrer `app.boosterchile.com/*` ✅ |
+
+El backend `booster-ai-api` (Cloud Run) usa la key Gemini desde `apps/api/src/services/gemini-client.ts` para generar el coaching post-entrega de cada trip (Phase 3 PR-J2). El bot WhatsApp tenía un binding del mismo secret pero **no se usa en código** — binding huérfano.
+
+## Riesgo
+
+- **Costo**: una key filtrada genera tráfico Gemini cobrado a la cuenta. Gemini 1.5 Flash ≈ USD 0.075/M input + 0.30/M output tokens. Pro: 1.25 / 5. Filtración fácil → cientos de USD/mes.
+- **Seguridad**: la key pasa por Cloud Run env vars + Secret Manager + logs eventuales + dumps. La `service-restriction = generativelanguage.googleapis.com` limita el daño a Gemini API, pero igual hay superficie de ataque.
+- **Compliance TRL 10**: API keys hardcoded para uso backend son anti-pattern. Vertex AI / ADC es el camino oficial GCP para servidores.
+
+---
+
+## Decisión
+
+Migrar `apps/api/src/services/gemini-client.ts` a **Vertex AI Gemini API** con autenticación via **Application Default Credentials** (ADC).
+
+### Cambios
+
+1. **`gemini-client.ts`** — refactor completo:
+   - Quita parámetro `apiKey`. Recibe `projectId` (+ `location` opcional).
+   - Endpoint: `https://{location}-aiplatform.googleapis.com/v1/projects/{project}/locations/{location}/publishers/google/models/{model}:generateContent`
+   - Auth: singleton `GoogleAuth` de `google-auth-library` (ya estaba en deps). En cada request obtiene access token via ADC y lo pone en header `Authorization: Bearer ...`.
+   - Region: `southamerica-east1` (São Paulo) — latencia ~80ms desde Santiago, vs ~150ms us-central1. Modelo `gemini-1.5-flash` confirmado disponible.
+   - Body, safety settings, timeout, fallback a null: idénticos al cliente previo.
+
+2. **`generar-coaching-viaje.ts`** — callsite:
+   - Parámetro `geminiApiKey?` renombrado a `geminiProjectId?`.
+   - `createGeminiGenFn({ projectId, logger })` en vez de `{ apiKey, logger }`.
+
+3. **`confirmar-entrega-viaje.ts`** — pasa `geminiProjectId: appConfig.GOOGLE_CLOUD_PROJECT` en lugar de `geminiApiKey: appConfig.GEMINI_API_KEY`.
+
+4. **`config.ts`** — schema:
+   - Elimina `GEMINI_API_KEY: z.string().optional()`.
+   - Agrega `GOOGLE_CLOUD_PROJECT: z.string().optional()` (Cloud Run lo setea automáticamente).
+
+5. **`infrastructure/compute.tf`** — env vars de Cloud Run:
+   - Elimina `GEMINI_API_KEY = ...` del `service_api` y del `service_whatsapp_bot` (binding huérfano).
+   - `GOOGLE_CLOUD_PROJECT = var.project_id` ya estaba en `common_env_vars`.
+
+### IAM — sin cambios necesarios
+
+El SA `booster-cloudrun-sa@booster-ai-494222.iam.gserviceaccount.com` ya tiene `roles/aiplatform.user` (verificado vía `gcloud projects get-iam-policy`). Vertex AI Gemini se llama bajo ese rol.
+
+### Secret Manager — sin cambios en este ADR
+
+El secret `gemini-api-key` queda en Secret Manager (no se borra del .tf de `security.tf`) como artefacto histórico para eventual rollback rápido. **Pero la API key real se elimina** post-apply para que el secret quede como string vacío inerte. Quitar el secret de Terraform es trabajo cosmético de otro PR.
+
+---
+
+## Apply post-merge
+
+```bash
+# 1. terraform apply para sacar GEMINI_API_KEY del Cloud Run
+cd infrastructure/
+export TF_VAR_billing_account="019461-C73CDE-DCE377"
+terraform apply
+
+# 2. Smoke test del coaching (verificar que Vertex AI responde)
+#    Trigger: confirmar-entrega de un trip en demo seed; el dashboard
+#    debería mostrar coaching con fuente=gemini (no plantilla).
+
+# 3. Eliminar la API key productiva
+gcloud services api-keys delete \
+  a5a60db7-0dc4-43c2-b08a-bb21e7834c2d \
+  --project=booster-ai-494222 \
+  --location=global \
+  --quiet
+
+# 4. Verificar que el banner desaparece (≤24h)
+```
+
+## Validación post-apply
+
+- [ ] `gcloud run services describe booster-ai-api ... --format="value(spec.template.spec.containers[0].env[].name)"` ya no incluye `GEMINI_API_KEY`
+- [ ] `gcloud services api-keys list --project=booster-ai-494222` no muestra `Booster Gemini - API Backend`
+- [ ] Smoke test del flow coaching: invocar `POST /admin/seed/demo` + simular confirmar-entrega de un trip + verificar en `metricas_viaje.coaching_fuente = 'gemini'`
+- [ ] `gcloud logging read "resource.type=cloud_run_revision AND severity>=WARNING" --limit=10` no muestra errores nuevos de auth en gemini-client
+- [ ] Banner GCP "unrestricted API keys" desaparece (≤24h, posible 24-48h)
+
+---
+
+## Consecuencias
+
+### Positivas
+
+- ✅ Cierra el banner GCP de "unrestricted API keys" (security + compliance TRL 10).
+- ✅ Sin API keys hardcoded — auth via workload identity (best practice).
+- ✅ Sin rotaciones manuales de keys en el futuro.
+- ✅ Latencia mejorada: `southamerica-east1` (~80ms) vs Gemini API global default (~150-200ms).
+- ✅ Quota tracking por proyecto/SA en Cloud Console (más granular que API key).
+
+### Negativas
+
+- Cold start ligeramente mayor (~50-100ms adicionales por el primer `getAccessToken()` — el token se cachea después).
+- Tests locales del backend ahora requieren `gcloud auth application-default login` para invocar Gemini. Para tests unitarios con mock fetch, sin cambio.
+
+### Reversibilidad
+
+- `git revert` del PR + `terraform apply` vuelve al estado previo en <10 min. La API key original se puede recrear (con la misma restricción de servicio) si necesario.
+- El secret `gemini-api-key` en Secret Manager queda intacto, permitiendo cargar una key nueva sin tocar Terraform.
+
+---
+
+## Pendientes no resueltos por este ADR
+
+1. **`Booster Routes - API Backend`** (key `e091850a-...`) también sin restricción de origen. Mismo fix recomendado: usar ADC con `roles/serviceusage.routesViewer` o equivalente. Issue separado.
+2. **`Browser key (Firebase)`** — auto-creada por Firebase. Su scheme es distinto (browser-side); el banner no la flagea pero podría agregarse referrer restriction.
+3. **Secret `gemini-api-key` en Secret Manager** — eliminar el resource Terraform de `security.tf` cuando se confirme estabilidad de Vertex AI (1 sprint post-merge).
+
+---
+
+## Referencias
+
+- [Vertex AI Gemini docs](https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini)
+- [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)
+- [google-auth-library Node.js](https://github.com/googleapis/google-auth-library-nodejs)
+- Issue [#195](https://github.com/boosterchile/booster-ai/issues/195) — security trigger
+- ADR-035 — auditoría que destapó el banner

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -176,14 +176,13 @@ module "service_api" {
     # estimarDistanciaKm (tabla pre-computada Chile) sin romper nada.
     GOOGLE_ROUTES_API_KEY = google_secret_manager_secret.secrets["google-routes-api-key"].secret_id
 
-    # Phase 3 PR-J2 — Gemini API key para coaching IA post-entrega.
-    # Server-side; el api la usa en generar-coaching-viaje.ts para
-    # llamar a Gemini REST API. Si la key está con placeholder o
-    # ausente, generarCoachingConduccion cae al fallback de plantilla
-    # determinística — el carrier sigue recibiendo coaching útil.
-    # El secret ya existe en security.tf; este binding lo expone como
-    # env var GEMINI_API_KEY al api Cloud Run (apps/api lee via config.ts).
-    GEMINI_API_KEY = google_secret_manager_secret.secrets["gemini-api-key"].secret_id
+    # ADR-037: GEMINI_API_KEY eliminada. apps/api ahora usa Vertex AI con
+    # ADC (workload identity del SA cloud_run_runtime, que ya tiene
+    # roles/aiplatform.user). El secret gemini-api-key del Secret Manager
+    # queda como artefacto histórico — la API key real se elimina con
+    # `gcloud services api-keys delete a5a60db7-0dc4-43c2-b08a-bb21e7834c2d`
+    # post-apply de este cambio. Cierra el banner GCP "unrestricted API keys
+    # for generativelanguage.googleapis.com".
   })
 
   vpc_connector = google_vpc_access_connector.serverless.id
@@ -452,7 +451,8 @@ module "service_whatsapp_bot" {
   secrets = {
     TWILIO_ACCOUNT_SID = google_secret_manager_secret.secrets["twilio-account-sid"].secret_id
     TWILIO_AUTH_TOKEN  = google_secret_manager_secret.secrets["twilio-auth-token"].secret_id
-    GEMINI_API_KEY     = google_secret_manager_secret.secrets["gemini-api-key"].secret_id
+    # ADR-037: GEMINI_API_KEY eliminada. El bot WhatsApp no usa Gemini en
+    # código — era binding huérfano.
   }
 
   # Necesario para llegar a Redis (172.25.0.4) que vive en VPC privado.


### PR DESCRIPTION
## Resumen

Wave 3 del plan de identidad universal — entidad `organizaciones_stakeholder` paralela a `empresas` (no hija) + extensión de memberships con CHECK XOR + CRUD admin + UI platform-admin + seed demo actualizado.

## ADR

[ADR-034 — Stakeholder Organizations](https://github.com/boosterchile/booster-ai/blob/feat/stakeholder-organizations/docs/adr/034-stakeholder-organizations.md): un stakeholder NO es una empresa transportista ni generadora; merece entidad propia con scope geográfico/sectorial declarado para el routing de datos agregados (k-anonimidad ≥ 5).

## Cambios principales

### Schema + migrations
- \`0030_organizaciones_stakeholder.sql\`: tabla nueva con tipo (regulador / gremio / observatorio_academico / ong / corporativo_esg), region_ambito (ISO 3166-2:CL), sector_ambito (slug).
- \`0031_memberships_stakeholder_org.sql\`: nullable \`empresa_id\` + nueva columna \`organizacion_stakeholder_id\` + CHECK XOR.
- \`apps/api/src/db/schema.ts\`: tablas Drizzle equivalentes con check XOR.

### Backend
- \`apps/api/src/routes/admin-stakeholder-orgs.ts\` (NUEVO): CRUD restringido a allowlist platform-admin. GET / | POST / | GET /:id (con miembros) | POST /:id/invitar | DELETE /:id (soft).
- \`apps/api/src/routes/me.ts\`: payload extendido con \`organizacion_stakeholder XOR empresa\` en cada membership; 2 queries (empresa + stakeholder-org), ambos cubiertos por índices.
- \`apps/api/src/services/seed-demo.ts\`: \`ensureMembership\` XOR enforce; crea \"Observatorio Logístico Demo\" tipo academic scope CL-RM + transporte-carga; \`deleteDemo\` limpia orgs y users huérfanos.

### Frontend
- \`apps/web/src/routes/platform-admin.tsx\`: sección \`StakeholderOrgsSection\` con listado + form de creación (nombre, tipo, región opcional ISO, sector opcional slug). Usa Zod schemas del package compartido.

### Shared schemas
- \`packages/shared-schemas/src/domain/organizacion-stakeholder.ts\` (NUEVO): \`OrganizacionStakeholder\`, \`StakeholderOrgType\`, \`crearOrganizacionStakeholderSchema\`, \`invitarMiembroOrgStakeholderSchema\`, \`STAKEHOLDER_ORG_TYPE_LABEL\` para UI bilingüe.

## Evidencia

\`\`\`
pnpm --filter=@booster-ai/api typecheck        ✓
pnpm --filter=@booster-ai/web typecheck        ✓
pnpm --filter=@booster-ai/api test --run       890/890 ✓ + 2 skipped (70 archivos)
pnpm --filter=@booster-ai/web test --run       908/908 ✓ (87 archivos)
pnpm exec biome check                          0 errors, 1 warning (pre-existing)
\`\`\`

## Riesgos & mitigación

- **Migration 0031 hace \`empresa_id\` nullable** — el CHECK XOR defiende. Idempotente: rows existentes pasan (todos tienen \`empresa_id NOT NULL\` y \`organizacion_stakeholder_id IS NULL\`).
- **2 queries en /me** — performance impact mínimo, memberships es pequeño por user; cubiertos por índices \`idx_membresias_usuario\` y \`idx_membresias_org_stakeholder\`.
- **Test mock me-profile.test.ts** — actualizado para 2 innerJoins; el caso típico (user sin stakeholder membership) devuelve [] en el 2do.
- **Auth stakeholder pre-Wave 4** — sigue siendo email/password manual (admin crea desde UI). Post-Wave 4 pasa al flow universal RUT+clave con allowlist por dominio para mandantes internacionales sin RUT chileno.

## Próximos pasos

- Wave 4 (auth universal RUT+clave) usa este modelo: \`usuarios.rut = NULL\` permitido SOLO para users con stakeholder membership de tipo \`corporativo_esg\`.
- Surface \`/app/stakeholder/zonas\` (skeleton existente) consumirá \`active_membership.organizacion_stakeholder.region_ambito\` para filtrar zonas en el próximo PR del programa stakeholder.

## Smoke E2E post-deploy (TODO)

- [ ] Login platform-admin
- [ ] Crear org \"Observatorio UC Movilidad\" tipo academic scope CL-RM
- [ ] Lista refresca con la nueva org
- [ ] Invitar miembro con RUT + email + nombre → user placeholder + membership pendiente
- [ ] Seed-demo crea org + asigna stakeholder demo
- [ ] Clean-demo borra org + miembros sin huérfanos

🤖 Generated with [Claude Code](https://claude.com/claude-code)