### PR TITLE
feat(wake-word): foundation Oye Booster — service stub + ADR-036 (Wave 5 PR 1/2)

### DIFF
--- a/apps/web/src/hooks/use-wake-word.ts
+++ b/apps/web/src/hooks/use-wake-word.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  type WakeWordController,
+  type WakeWordState,
+  createWakeWordController,
+} from '../services/wake-word.js';
+
+/**
+ * ADR-036 — Hook React que envuelve el `WakeWordController` y lo integra
+ * con el ciclo de vida del componente que lo monta.
+ *
+ * Responsabilidades:
+ *   - Crear el controller en mount.
+ *   - Llamar a `init()` con la access key (de env) + path al modelo.
+ *   - Suscribirse a eventos de estado para que la UI re-renderee.
+ *   - Limpiar (`destroy()`) en unmount.
+ *
+ * NO maneja:
+ *   - El gating por vehicle-stopped (eso vive en `useDriverStoppedGate`
+ *     que pause/resume este hook). Ver ADR-036 § "Activación condicionada".
+ *   - El persisted preference del toggle (eso vive en
+ *     services/coaching-voice.ts pattern, replicar acá si se decide).
+ *
+ * Estado expuesto:
+ *   - `state`: `WakeWordState` actual del controller.
+ *   - `isEnabled`: ¿el caller pidió enable()?
+ *   - `enable()` / `disable()` / `pause()` / `resume()`: pass-through.
+ *
+ * Onwake: el caller pasa la función `onWake` que se ejecutará cuando
+ * el wake-word se detecte. Debe ser idempotente y rápida (~16ms).
+ */
+
+export interface UseWakeWordResult {
+  state: WakeWordState;
+  isEnabled: boolean;
+  enable: () => void;
+  disable: () => void;
+  pause: (reason: string) => void;
+  resume: () => void;
+}
+
+export interface UseWakeWordOptions {
+  /** Si false, el hook queda inerte (no inicializa SDK). */
+  enabled: boolean;
+  /**
+   * Access key Picovoice. Provisto via env (Vite `VITE_PICOVOICE_ACCESS_KEY`).
+   * Si vacío, el controller resuelve a `'unavailable'`.
+   */
+  accessKey: string;
+  /**
+   * URL al modelo .ppn custom. Vacío hasta que tengamos
+   * `oye-booster-cl.ppn` entrenado.
+   */
+  modelPath: string;
+  /**
+   * Callback al detectar wake-word.
+   */
+  onWake: () => void;
+}
+
+export function useWakeWord(opts: UseWakeWordOptions): UseWakeWordResult {
+  const [state, setState] = useState<WakeWordState>('idle');
+  const [isEnabled, setIsEnabled] = useState(false);
+  const controllerRef = useRef<WakeWordController | null>(null);
+  const onWakeRef = useRef(opts.onWake);
+
+  // Mantener onWake fresca sin re-trigger del effect.
+  useEffect(() => {
+    onWakeRef.current = opts.onWake;
+  }, [opts.onWake]);
+
+  // Init / destroy lifecycle.
+  useEffect(() => {
+    if (!opts.enabled) {
+      return undefined;
+    }
+    let cancelled = false;
+    const controller = createWakeWordController();
+    controllerRef.current = controller;
+
+    const unsub = controller.on('state', (s) => {
+      if (!cancelled) {
+        setState(s);
+      }
+    });
+
+    void controller
+      .init({
+        accessKey: opts.accessKey,
+        modelPath: opts.modelPath,
+        onWake: () => onWakeRef.current(),
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setState('error');
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      unsub();
+      void controller.destroy();
+      controllerRef.current = null;
+    };
+  }, [opts.enabled, opts.accessKey, opts.modelPath]);
+
+  const enable = useCallback(() => {
+    setIsEnabled(true);
+    controllerRef.current?.enable();
+  }, []);
+  const disable = useCallback(() => {
+    setIsEnabled(false);
+    controllerRef.current?.disable();
+  }, []);
+  const pause = useCallback((reason: string) => {
+    controllerRef.current?.pause(reason);
+  }, []);
+  const resume = useCallback(() => {
+    controllerRef.current?.resume();
+  }, []);
+
+  return {
+    state,
+    isEnabled,
+    enable,
+    disable,
+    pause,
+    resume,
+  };
+}

--- a/apps/web/src/services/wake-word.test.ts
+++ b/apps/web/src/services/wake-word.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { type WakeWordState, createWakeWordController } from './wake-word.js';
+
+/**
+ * Tests del stub controller. Cubre la API contract para que cuando se
+ * swap con la implementación Porcupine real, los call sites sigan
+ * funcionando idéntico.
+ */
+
+describe('WakeWordController (stub Wave 5 PR 1)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('start state es "idle"', () => {
+    const c = createWakeWordController();
+    expect(c.state).toBe('idle');
+  });
+
+  it('init() con accessKey vacío → unavailable + emite error', async () => {
+    const c = createWakeWordController();
+    const states: WakeWordState[] = [];
+    c.on('state', (s) => states.push(s));
+    const errors: string[] = [];
+    c.on('error', (e) => errors.push(e.message));
+    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    expect(c.state).toBe('unavailable');
+    expect(states).toContain('unavailable');
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toMatch(/Wake-word no disponible/);
+  });
+
+  it('init() con accessKey + modelPath → todavía unavailable (PR 2 wire pendiente)', async () => {
+    const c = createWakeWordController();
+    await c.init({
+      accessKey: 'pico-key-123',
+      modelPath: '/wake-word/oye-booster-cl.ppn',
+      onWake: () => {},
+    });
+    // Stub no implementa Porcupine wire todavía — resolve unavailable
+    // hasta Wave 5 PR 2. El test futuro a invertir: esperar 'listening'.
+    expect(c.state).toBe('unavailable');
+  });
+
+  it('enable() es no-op cuando state=unavailable', async () => {
+    const c = createWakeWordController();
+    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    c.enable();
+    expect(c.state).toBe('unavailable');
+  });
+
+  it('on(state) suscribe múltiples listeners y unsubscribe limpio', async () => {
+    const c = createWakeWordController();
+    const a: WakeWordState[] = [];
+    const b: WakeWordState[] = [];
+    const unsubA = c.on('state', (s) => a.push(s));
+    c.on('state', (s) => b.push(s));
+    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    expect(a).toEqual(['unavailable']);
+    expect(b).toEqual(['unavailable']);
+    unsubA();
+    await c.destroy();
+    // Tras unsub A no debería recibir más; b sí podría si re-init, pero
+    // destroy limpió listeners.
+    expect(c.state).toBe('idle'); // destroy resetea
+  });
+
+  it('destroy() limpia state y listeners', async () => {
+    const c = createWakeWordController();
+    const states: WakeWordState[] = [];
+    c.on('state', (s) => states.push(s));
+    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    await c.destroy();
+    expect(c.state).toBe('idle');
+  });
+
+  it('listener que throw no rompe el broadcaster', async () => {
+    const c = createWakeWordController();
+    const ok: WakeWordState[] = [];
+    c.on('state', () => {
+      throw new Error('boom');
+    });
+    c.on('state', (s) => ok.push(s));
+    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    // El segundo listener debe haber recibido el estado.
+    expect(ok).toContain('unavailable');
+  });
+});

--- a/apps/web/src/services/wake-word.ts
+++ b/apps/web/src/services/wake-word.ts
@@ -1,0 +1,207 @@
+/**
+ * ADR-036 — Wake-word "Oye Booster" service wrapper.
+ *
+ * Esta capa abstrae Picovoice Porcupine para que el resto del código no
+ * dependa directamente del SDK. Permite swap del provider futuro (si
+ * cambia la decisión comercial) sin tocar los call sites.
+ *
+ * Por qué wrapper en vez de uso directo de `@picovoice/porcupine-web`:
+ *   - **Lazy loading**: el SDK es ~700 KB. Solo cargamos cuando el
+ *     usuario tiene wake-word ON. Evitamos costo en first paint para
+ *     usuarios que no lo usan (default OFF).
+ *   - **Lifecycle gating**: integramos con el stopped-detector para
+ *     auto-pause cuando el vehículo se mueve, sin que el call site
+ *     tenga que orquestar dos servicios.
+ *   - **Testability**: los call sites usan esta API; los tests mockean
+ *     este módulo en vez de Porcupine internals.
+ *   - **Privacy hook**: registramos cada start/stop para que la UI
+ *     muestre estado verificable (el conductor puede ver "mic activo /
+ *     mic pausado por movimiento" en la card).
+ *
+ * Implementación actual (Wave 5 PR 1):
+ *   - **Stub** que expone la API. La integración real con Porcupine
+ *     entra en Wave 5 PR 2 cuando tengamos:
+ *     1. Cuenta Picovoice + access key (env var
+ *        `PICOVOICE_ACCESS_KEY`).
+ *     2. Modelo `oye-booster-cl.ppn` entrenado en Picovoice Console.
+ *   - El stub registra calls + dispatcha eventos vacíos para que la UI
+ *     pueda renderizar el estado y los tests del hook puedan verificar
+ *     el wiring sin levantar el SDK pesado.
+ */
+
+export type WakeWordState =
+  | 'idle' // no iniciado
+  | 'initializing' // cargando SDK + modelo
+  | 'listening' // escuchando para "Oye Booster"
+  | 'paused' // pausado por gate (movimiento o pantalla apagada)
+  | 'detected' // wake-word recién detectado (transient ~100ms)
+  | 'unavailable' // browser no soporta (sin WebAssembly SIMD)
+  | 'error'; // falla de init o runtime
+
+export interface WakeWordEventMap {
+  state: WakeWordState;
+  detection: { timestamp: number };
+  error: { message: string };
+}
+
+export type WakeWordListener<K extends keyof WakeWordEventMap> = (
+  payload: WakeWordEventMap[K],
+) => void;
+
+/**
+ * Configuración para inicializar el wake-word listener.
+ */
+export interface WakeWordOptions {
+  /**
+   * Picovoice Access Key. Provisto via env var en build time o env-runtime.
+   * Si falta, `init()` resuelve a estado `'unavailable'`.
+   */
+  accessKey: string;
+  /**
+   * Path al modelo .ppn del wake-word custom (e.g.
+   * `/wake-word/oye-booster-cl.ppn`). En PR 1 todavía no tenemos modelo
+   * custom — se acepta vacío y cae a fallback unavailable.
+   */
+  modelPath: string;
+  /**
+   * Callback que la UI registra para reaccionar a la detección.
+   */
+  onWake: () => void;
+}
+
+/**
+ * Interface del wrapper. Implementación real swap-eable.
+ */
+export interface WakeWordController {
+  state: WakeWordState;
+  init(opts: WakeWordOptions): Promise<void>;
+  /**
+   * Marca al controller para que active el listener apenas las
+   * precondiciones se cumplan (mic granted + vehicle stopped + page
+   * visible). Es declarativo: el caller dice "quiero esto activo".
+   */
+  enable(): void;
+  /**
+   * Pausa por gate externo (vehicle moving, page hidden). NO desactiva
+   * la intención; reactiva en cuanto el gate se libera.
+   */
+  pause(reason: string): void;
+  resume(): void;
+  /**
+   * Desactiva el controller. El caller usa esto cuando el usuario
+   * apaga el toggle. Libera mic + SDK.
+   */
+  disable(): void;
+  destroy(): Promise<void>;
+  on<K extends keyof WakeWordEventMap>(event: K, fn: WakeWordListener<K>): () => void;
+}
+
+/**
+ * Implementación stub para Wave 5 PR 1. Expone la API y los eventos
+ * pero NO toca el micrófono ni carga el SDK. La integración real
+ * con Porcupine entra en PR 2 cuando el access key + modelo custom
+ * estén disponibles.
+ *
+ * El stub resuelve a `'unavailable'` siempre que `init()` se llame,
+ * porque sin access key real no hay funcionalidad real que entregar.
+ * Esto deja la UI mostrando el banner "próximamente" sin romper.
+ */
+class StubWakeWordController implements WakeWordController {
+  state: WakeWordState = 'idle';
+  private listeners = new Map<
+    keyof WakeWordEventMap,
+    Set<WakeWordListener<keyof WakeWordEventMap>>
+  >();
+  /**
+   * Callback registrado en init(). PR 1: el stub no lo dispara nunca (no
+   * hay listener real). PR 2: lo llama desde el handler de Porcupine
+   * cuando se detecte el wake-word.
+   */
+  private onWakeFn: (() => void) | null = null;
+
+  async init(opts: WakeWordOptions): Promise<void> {
+    this.onWakeFn = opts.onWake;
+    // Silencia warn TS6133 hasta PR 2 — referencia explícita.
+    void this.onWakeFn;
+    if (!opts.accessKey || !opts.modelPath) {
+      this.setState('unavailable');
+      this.emit('error', {
+        message: 'Wake-word no disponible — modelo en entrenamiento (Wave 5 PR 2).',
+      });
+      return;
+    }
+    // PR 2: cargar Porcupine acá. Por ahora marcamos unavailable.
+    this.setState('unavailable');
+  }
+
+  enable(): void {
+    if (this.state === 'unavailable') {
+      return;
+    }
+    this.setState('listening');
+  }
+
+  pause(_reason: string): void {
+    if (this.state === 'listening') {
+      this.setState('paused');
+    }
+  }
+
+  resume(): void {
+    if (this.state === 'paused') {
+      this.setState('listening');
+    }
+  }
+
+  disable(): void {
+    if (this.state !== 'unavailable') {
+      this.setState('idle');
+    }
+  }
+
+  async destroy(): Promise<void> {
+    this.listeners.clear();
+    this.onWakeFn = null;
+    this.state = 'idle';
+  }
+
+  on<K extends keyof WakeWordEventMap>(event: K, fn: WakeWordListener<K>): () => void {
+    const set = this.listeners.get(event) ?? new Set();
+    set.add(fn as WakeWordListener<keyof WakeWordEventMap>);
+    this.listeners.set(event, set);
+    return () => {
+      const s = this.listeners.get(event);
+      s?.delete(fn as WakeWordListener<keyof WakeWordEventMap>);
+    };
+  }
+
+  private setState(s: WakeWordState): void {
+    this.state = s;
+    this.emit('state', s);
+  }
+
+  private emit<K extends keyof WakeWordEventMap>(event: K, payload: WakeWordEventMap[K]): void {
+    const set = this.listeners.get(event);
+    if (!set) {
+      return;
+    }
+    for (const fn of set) {
+      try {
+        (fn as WakeWordListener<K>)(payload);
+      } catch {
+        // Swallow listener errors para no romper el broadcaster.
+      }
+    }
+  }
+}
+
+/**
+ * Factory pública. Único punto de creación. Permite swap del provider
+ * sin tocar call sites.
+ */
+export function createWakeWordController(): WakeWordController {
+  return new StubWakeWordController();
+}
+
+// Re-export del tipo public para que tests externos puedan stub.
+export type { StubWakeWordController };

--- a/docs/adr/036-wake-word-voice-driver.md
+++ b/docs/adr/036-wake-word-voice-driver.md
@@ -1,0 +1,140 @@
+# ADR-036 — Wake-word voice activation para el conductor ("Oye Booster")
+
+**Status**: Accepted
+**Date**: 2026-05-13
+**Decider**: Felipe Vicencio (Product Owner)
+**Related**: [ADR-008 PWA multirol](./008-pwa-multirole.md), plan `docs/plans/2026-05-12-identidad-universal-y-dashboard-conductor.md` (Wave 5), research `docs/research/2026-05-13-cultura-conductor-chileno.md`
+
+---
+
+## Contexto
+
+Felipe (2026-05-12):
+
+> "El comando por voz debería activarse como Alexa o Siri."
+
+Hoy las features voice del conductor (Phase 4: confirmar entrega, marcar incidente, aceptar oferta, cancelar) requieren **push-to-talk explícito**: el conductor tiene que mirar la pantalla, encontrar el botón de mic, tocarlo, hablar. Esto contradice la promesa "sin tocar la pantalla mientras conduces" del Modo Conductor — y para tocar el botón el conductor ya se distrajo.
+
+La solución natural: wake-word always-on que despierta el flow voice. "Oye Booster" → app empieza a escuchar el comando.
+
+## Decisión
+
+Integrar **Picovoice Porcupine** como motor de wake-word on-device. Wake-word custom **"Oye Booster"** entrenado en español neutro + dialectos chilenos. Activable opt-in desde `/app/conductor/configuracion`, default OFF.
+
+### Por qué Porcupine
+
+- **On-device**: el modelo corre en el browser (WebAssembly). El audio del wake-word NO sale del dispositivo. Privacy by design.
+- **Footprint mínimo**: ~700 KB JS + ~50 KB modelo .ppn por wake-word.
+- **Latencia**: ~50 ms de detección post-trigger.
+- **Custom wake-words**: Picovoice Console permite entrenar "Oye Booster" con 24h de training time. Costo: ~$20/mes por wake-word custom hasta cierto volumen, $99/mes para producción.
+- **Alternativas descartadas**:
+  - Snowboy: deprecada en 2020.
+  - Mycroft Precise: abandonada en 2023.
+  - Voicemod / Speechly: cloud-based, contradicen privacy.
+  - WebRTC + speech-to-text Whisper: costo cloud y latencia inaceptable.
+
+### Por qué "Oye Booster"
+
+Validado en research note 2026-05-13:
+
+- "Oye" es iniciador conversacional chileno natural.
+- Dos sílabas fonéticamente distintas → baja false positive rate.
+- No colide con Siri/Alexa/Google.
+- Pronunciable por dejos regionales (norte/centro/sur).
+
+### Activación condicionada — battery-friendly
+
+El wake-word listener consume CPU + mic constantes. Para preservar batería en conductores que operan 8–12h:
+
+- **Solo activo cuando el vehículo está detenido** (≤3 km/h por 4 s, mismo gate del audio coaching).
+- Cuando el vehículo comienza a moverse → mic pause automático.
+- Cuando la pantalla está apagada → mic pause automático.
+- Cuando el browser está en background tab → mic pause automático.
+
+### Privacy garantías
+
+Banner explícito en la primera activación + sección "Cómo funciona" en `/app/conductor/configuracion`:
+
+> Booster solo escucha la frase "Oye Booster". El audio no se graba, no sale de tu teléfono, no se envía a Booster ni a ningún servidor. Solo cuando reconocemos la frase activamos el micrófono para que dictes tu comando, y ahí sí enviamos el audio del comando a Booster para procesarlo. Puedes desactivar esto en cualquier momento desde la configuración.
+
+Esta promesa es **verificable**: Porcupine corre en WASM en el browser; no hay endpoint de transmisión de audio durante el listen. Booster puede demostrarlo abriendo DevTools Network.
+
+### Opt-in y descubrimiento
+
+- Default OFF: respetamos la decisión del conductor.
+- Toggle visible en `/app/conductor/configuracion` → card nueva "Activación por voz".
+- Onboarding: al primer login post-Wave 5, mostrar un dialog opcional "¿Activar la opción de voz? Ayuda a no tocar el celular mientras manejas." con CTA "Probar" + "No, gracias".
+- Estado persistido en localStorage (mismo patrón que `loadAutoplayPreference`).
+- Cuando ON, banner persistente en `/app/conductor` con icono de mic activo + countdown a próximo "Oye Booster".
+
+### Feature flag
+
+- `WAKE_WORD_VOICE_ACTIVATED` (server-side + cliente):
+  - `false` (default): la card "Activación por voz" en configuración aparece como "Próximamente"; toggle deshabilitado.
+  - `true`: la card está activa.
+- Cliente lo lee desde `/me/feature-flags` (mismo endpoint público que el resto de flags Wave 4).
+- Rollout staged: dev → staging por 7 días → prod.
+
+### Custom wake-word training
+
+Pendiente para producción (no bloquea PR 1):
+
+1. Crear cuenta Picovoice Console + API key (Felipe lo hace).
+2. Definir "Oye Booster" en Console.
+3. Entrenar con 24h de training time (Picovoice usa TTS sintético + augmentación).
+4. Validar accuracy con muestras propias chilenas (3 voces de Van Oosterwyk).
+5. Descargar `.ppn` model file → commitear a `apps/web/public/wake-word/oye-booster-cl.ppn`.
+
+Mientras tanto, el código se desarrolla con el modelo built-in "Bumblebee" (English) para pruebas. **NO mergeamos a prod sin el modelo custom**.
+
+---
+
+## Alternativas consideradas
+
+### Alt 1 — Reusar Web Speech API en modo continuo
+
+**Rechazada**. Web Speech API requiere user gesture cada activación de microphone permission. No es always-on real. Y en Android Chrome no funciona bien en background.
+
+### Alt 2 — Botón flotante grande siempre visible
+
+**Rechazada**. Felipe específicamente quiere "como Alexa o Siri". Botón flotante sigue requiriendo tocar la pantalla.
+
+### Alt 3 — Bluetooth headset con botón físico
+
+**Rechazada**. Asume hardware específico que no todos los conductores tienen. Bonus track para el roadmap.
+
+### Alt 4 — TensorFlow.js + entrenar wake-word nosotros
+
+**Rechazada**. Costo de ingeniería + datos de training >> $99/mes de Picovoice. No es nuestro core business.
+
+---
+
+## Consecuencias
+
+### Positivas
+
+- Driver puede operar la app realmente sin tocar la pantalla.
+- Diferenciador competitivo vs TMS chilenos (ninguno tiene wake-word hoy).
+- Privacy verificable: audio no sale del dispositivo.
+- Battery-friendly: solo activo cuando el vehículo está parado.
+
+### Negativas
+
+- Dependencia comercial con Picovoice ($99/mes + training fee del wake-word custom).
+- False positives en conversaciones casuales que mencionen "booster" (raro en contexto driver, pero posible).
+- Browsers viejos sin WebAssembly SIMD: degradación a "no wake-word" + UI hint para upgrade.
+- Costo operacional de mantener el modelo entrenado (re-train si cambia el dialecto target).
+
+### Acciones derivadas
+
+- Wave 5 PR 1 (este branch): foundation — service wrapper + hook + UI card + feature flag.
+- Wave 5 PR 2 (post-training del wake-word custom): swap modelo built-in por el custom `.ppn`.
+- Bonus Wave futura: bluetooth headset button + multiple wake-words por idioma del driver.
+
+### Costo
+
+- Picovoice license: $99/mes para producción ilimitada (Free tier es 3 usuarios activos/mes — no nos sirve).
+- Custom wake-word training: $0 (incluido en license).
+- Re-training si cambia accent target: $0 (mismo proceso self-service).
+
+Total: **~$1200/año** — pequeño vs el valor agregado al conductor.


### PR DESCRIPTION
## Resumen

Wave 5 PR 1 — fundación del wake-word \"Oye Booster\" para conductores. Define contrato del controller + hook React + tests + ADR-036, **sin integrar el SDK Porcupine real**. Eso entra en PR 2 cuando esté:

1. **Cuenta Picovoice** + access key (env var \`PICOVOICE_ACCESS_KEY\`) — Felipe registra.
2. **Modelo \`oye-booster-cl.ppn\`** entrenado en Picovoice Console con voces chilenas (referidos por Van Oosterwyk — research note 2026-05-13).

## ADR

[ADR-036 — Wake-word voice driver](https://github.com/boosterchile/booster-ai/blob/feat/wake-word-oye-booster/docs/adr/036-wake-word-voice-driver.md): on-device Porcupine + activo solo con vehículo detenido + opt-in default OFF + privacy verifiable.

## Cambios

### Stub controller (Wave 5 PR 1)
- \`apps/web/src/services/wake-word.ts\` (NUEVO): \`WakeWordController\` interface + \`StubWakeWordController\`. API contract estable. State machine: \`idle / initializing / listening / paused / detected / unavailable / error\`.
- \`apps/web/src/hooks/use-wake-word.ts\` (NUEVO): hook React que envuelve el controller con lifecycle del componente.
- \`apps/web/src/services/wake-word.test.ts\` (NUEVO): 7 specs del contrato (init unavailable sin key, multi-listener, listener errors no rompen broadcaster, destroy limpio).
- ADR-036 con alternativas consideradas (Web Speech API, TensorFlow.js, Bluetooth) y costo planeado (~\$99/mes).

## Evidencia

\`\`\`
pnpm --filter=@booster-ai/web typecheck        ✓
pnpm --filter=@booster-ai/web test --run       915/915 ✓ (88 archivos)
                                               +7 nuevos: wake-word.test
pnpm exec biome check                          0 errors
\`\`\`

## Diseño verificable de privacy

- **On-device**: Porcupine corre en WASM en el browser. El audio del wake-word NO sale del dispositivo.
- **Verificable**: el conductor abre DevTools Network y NO ve ningún POST de audio durante el listening — solo se envía el audio del comando **después** de detectar \"Oye Booster\".
- **Battery gate**: listener pause automático cuando el vehículo se mueve (≥3 km/h), cuando la pantalla está apagada, o cuando la tab está en background.
- **Opt-in**: default OFF. Banner explícito al primer enable.

## Próximos pasos (PR 2)

1. Felipe crea Picovoice account + define \"Oye Booster\" en Console.
2. Coordinar samples de voz chilena de Van Oosterwyk (3 conductores, ~5 min de audio cada uno).
3. Upload + entrenamiento 24h. Resultado: \`oye-booster-cl.ppn\`.
4. Commitear modelo a \`apps/web/public/wake-word/oye-booster-cl.ppn\`.
5. Wire real con \`@picovoice/porcupine-web\`.
6. UI: card \"Activación por voz\" en \`/app/conductor/configuracion\` + banner sticky en \`/app/conductor\` cuando ON.
7. Feature flag \`WAKE_WORD_VOICE_ACTIVATED\` server + cliente.

## Riesgos & mitigación

- **API contract estable swap-eable**: si Picovoice cambia de licencia/pricing, podemos cambiar el provider (TensorFlow.js + entrenar propio) sin tocar call sites — solo \`createWakeWordController()\`.
- **Stub resuelve unavailable siempre**: la UI debe mostrar \"próximamente\" en este estado, pero la UI entra en PR 2 — no hay UX visible al usuario en este merge.
- **Sin dependencias nuevas en \`package.json\`**: este PR no añade Picovoice SDK aún. \`@picovoice/porcupine-web\` entra en PR 2 junto con el modelo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)