### PR TITLE
feat(auth): UI selector universal + endpoint /feature-flags (Wave 4 PR 2/3)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -394,6 +394,23 @@ const apiEnvSchema = commonEnvSchema
     AUTH_UNIVERSAL_V1_ACTIVATED: z.coerce.boolean().default(false),
 
     /**
+     * ADR-036 (Wave 5) — Feature flag para wake-word "Oye Booster" en
+     * el conductor. Default OFF. Cuando `true`:
+     *   - La card "Activación por voz" en /app/conductor/configuracion
+     *     es activa (toggle real, no "próximamente").
+     *   - El usuario puede opt-in para que su PWA escuche el wake-word
+     *     "Oye Booster" cuando el vehículo está detenido.
+     *
+     * El listener Porcupine es on-device (WASM); el audio del wake-word
+     * NO sale del teléfono. Solo cuando se detecta la frase, el audio
+     * del comando subsecuente se envía a Booster para procesar.
+     *
+     * Rollout: false en prod hasta que el modelo custom
+     * `oye-booster-cl.ppn` esté entrenado con voces chilenas (Wave 5 PR 2).
+     */
+    WAKE_WORD_VOICE_ACTIVATED: z.coerce.boolean().default(false),
+
+    /**
      * ADR-033 §1 — Pesos custom para los componentes del scoring v2.
      * JSON con shape `{ capacidad: number; backhaul: number;
      * reputacion: number; tier: number }`. Suma debe ser ≈ 1.0

--- a/apps/api/src/routes/feature-flags.ts
+++ b/apps/api/src/routes/feature-flags.ts
@@ -1,0 +1,39 @@
+import type { Logger } from '@booster-ai/logger';
+import { Hono } from 'hono';
+import { config as appConfig } from '../config.js';
+
+/**
+ * Endpoint público `GET /feature-flags`.
+ *
+ * ADR-035 (Wave 4) + ADR-036 (Wave 5) — el cliente necesita conocer
+ * qué flags están activos ANTES de decidir qué UI renderizar. Por eso
+ * este endpoint NO requiere Firebase auth: el cliente lo llama en boot
+ * para resolver qué pantalla mostrar en `/login`.
+ *
+ * Trust boundary: los valores son booleanos derivados de env vars
+ * controladas por platform-admin via Secret Manager / Terraform. El
+ * usuario no puede modificarlos. Exponerlos públicamente NO crea
+ * superficie de ataque adicional (lo único que se filtra es el roadmap
+ * de features, info pública).
+ *
+ * Shape:
+ *   {
+ *     auth_universal_v1_activated: boolean,
+ *     wake_word_voice_activated: boolean,
+ *     matching_algorithm_v2_activated: boolean
+ *   }
+ */
+export function createFeatureFlagsRoutes(opts: { logger: Logger }) {
+  const app = new Hono();
+
+  app.get('/', (c) => {
+    opts.logger.debug({}, 'feature-flags: read');
+    return c.json({
+      auth_universal_v1_activated: appConfig.AUTH_UNIVERSAL_V1_ACTIVATED,
+      wake_word_voice_activated: appConfig.WAKE_WORD_VOICE_ACTIVATED,
+      matching_algorithm_v2_activated: appConfig.MATCHING_ALGORITHM_V2_ACTIVATED,
+    });
+  });
+
+  return app;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -24,6 +24,7 @@ import { createCobraHoyAssignmentsRoutes, createCobraHoyMeRoutes } from './route
 import { createConductoresRoutes } from './routes/conductores.js';
 import { createCumplimientoRoutes, createDocumentosRoutes } from './routes/documentos.js';
 import { createEmpresaRoutes } from './routes/empresas.js';
+import { createFeatureFlagsRoutes } from './routes/feature-flags.js';
 import { createHealthRouter } from './routes/health.js';
 import { createMeConsentsRoutes } from './routes/me-consents.js';
 import { createMeLiquidacionesRoutes } from './routes/me-liquidaciones.js';
@@ -127,6 +128,12 @@ export function createServer(opts: CreateServerOptions): Hono {
         : {}),
     }),
   );
+
+  // Public route — GET /feature-flags (ADR-035 + ADR-036).
+  // El cliente lo llama en boot para decidir qué UI renderizar en
+  // /login (selector RUT+clave vs email/password legacy). NO requiere
+  // auth porque la decisión de UI ocurre ANTES del login.
+  app.route('/feature-flags', createFeatureFlagsRoutes({ logger }));
 
   // Phase 5 PR-L1 — Public tracking del shipper / consignee. NO auth:
   // la defensa es la opacidad del token UUID v4 (122 bits, no enumerable).

--- a/apps/api/test/unit/feature-flags.test.ts
+++ b/apps/api/test/unit/feature-flags.test.ts
@@ -1,0 +1,58 @@
+import { Hono } from 'hono';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.SERVICE_NAME = 'booster-ai-api';
+  process.env.SERVICE_VERSION = '0.0.0-test';
+  process.env.LOG_LEVEL = 'error';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.REDIS_HOST = 'localhost';
+  process.env.CORS_ALLOWED_ORIGINS = 'http://localhost:5173';
+  process.env.FIREBASE_PROJECT_ID = 'test';
+  process.env.API_AUDIENCE = 'https://api.boosterchile.com';
+  process.env.ALLOWED_CALLER_SA = 'caller@booster-ai.iam.gserviceaccount.com';
+});
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as Parameters<
+  typeof import('../../src/routes/feature-flags.js').createFeatureFlagsRoutes
+>[0]['logger'];
+
+describe('GET /feature-flags (ADR-035 + ADR-036)', () => {
+  it('devuelve los tres flags como booleanos', async () => {
+    const { createFeatureFlagsRoutes } = await import('../../src/routes/feature-flags.js');
+    const app = new Hono();
+    app.route('/feature-flags', createFeatureFlagsRoutes({ logger: noopLogger }));
+
+    const res = await app.request('/feature-flags');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+
+    expect(body).toHaveProperty('auth_universal_v1_activated');
+    expect(body).toHaveProperty('wake_word_voice_activated');
+    expect(body).toHaveProperty('matching_algorithm_v2_activated');
+    expect(typeof body.auth_universal_v1_activated).toBe('boolean');
+    expect(typeof body.wake_word_voice_activated).toBe('boolean');
+    expect(typeof body.matching_algorithm_v2_activated).toBe('boolean');
+  });
+
+  it('no requiere auth (público)', async () => {
+    const { createFeatureFlagsRoutes } = await import('../../src/routes/feature-flags.js');
+    const app = new Hono();
+    app.route('/feature-flags', createFeatureFlagsRoutes({ logger: noopLogger }));
+
+    // Sin headers de auth.
+    const res = await app.request('/feature-flags');
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/web/src/components/login/LoginUniversal.test.tsx
+++ b/apps/web/src/components/login/LoginUniversal.test.tsx
@@ -1,0 +1,170 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests del LoginUniversal (ADR-035 — Wave 4 PR 2).
+ *
+ * Cubre:
+ *   - Selector visible cuando no hay query param tipo.
+ *   - Pre-selección desde ?tipo=transporte
+ *   - Form RUT + clave numérica
+ *   - Validación de RUT inválido y clave no-6-dígitos
+ *   - 200 → custom_token → signInUniversalWithCustomToken + navigate /app
+ *   - 401 → mensaje "RUT o clave incorrectos"
+ *   - 410 needs_rotation → vista de rotación con link a legacy
+ */
+
+const navigateMock = vi.fn();
+const useSearchMock = vi.fn(() => ({}));
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigateMock,
+  useSearch: () => useSearchMock(),
+}));
+
+const signInUniversalWithCustomTokenMock = vi.fn();
+vi.mock('../../hooks/use-auth.js', () => ({
+  signInUniversalWithCustomToken: signInUniversalWithCustomTokenMock,
+}));
+
+vi.mock('../../lib/api-url.js', () => ({
+  getApiUrl: () => 'http://test',
+}));
+
+const { LoginUniversal } = await import('./LoginUniversal.js');
+
+const fetchSpy = vi.fn();
+
+function makeJsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useSearchMock.mockReturnValue({});
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('LoginUniversal', () => {
+  it('sin ?tipo → renderiza selector con las 5 opciones', () => {
+    render(<LoginUniversal />);
+    expect(screen.getByTestId('login-universal-selector')).toBeInTheDocument();
+    expect(screen.getByTestId('login-tipo-carga')).toBeInTheDocument();
+    expect(screen.getByTestId('login-tipo-transporte')).toBeInTheDocument();
+    expect(screen.getByTestId('login-tipo-conductor')).toBeInTheDocument();
+    expect(screen.getByTestId('login-tipo-stakeholder')).toBeInTheDocument();
+    expect(screen.getByTestId('login-tipo-booster')).toBeInTheDocument();
+  });
+
+  it('click en tipo Transporte → muestra form', async () => {
+    render(<LoginUniversal />);
+    await userEvent.click(screen.getByTestId('login-tipo-transporte'));
+    expect(screen.getByTestId('login-universal-form')).toBeInTheDocument();
+    // El label del form usa la etiqueta humana del tipo.
+    expect(screen.getByText('Transporte')).toBeInTheDocument();
+  });
+
+  it('?tipo=conductor en URL → entra directo al form pre-seleccionado', () => {
+    useSearchMock.mockReturnValue({ tipo: 'conductor' });
+    render(<LoginUniversal />);
+    expect(screen.getByTestId('login-universal-form')).toBeInTheDocument();
+    expect(screen.getByText('Conductor')).toBeInTheDocument();
+  });
+
+  it('RUT mal formado → muestra error sin llamar fetch', async () => {
+    render(<LoginUniversal />);
+    await userEvent.click(screen.getByTestId('login-tipo-conductor'));
+    await userEvent.type(screen.getByTestId('login-rut-input'), 'no-es-rut');
+    await userEvent.type(screen.getByTestId('login-clave-input'), '123456');
+    await userEvent.click(screen.getByTestId('login-submit'));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('clave de 5 dígitos no se acepta (input maxLength=6 + filter numérico)', async () => {
+    render(<LoginUniversal />);
+    await userEvent.click(screen.getByTestId('login-tipo-conductor'));
+    const claveInput = screen.getByTestId('login-clave-input') as HTMLInputElement;
+    await userEvent.type(claveInput, 'abc'); // letras filtradas
+    expect(claveInput.value).toBe('');
+    await userEvent.type(claveInput, '1234567'); // 7 dígitos → corta a 6
+    expect(claveInput.value).toBe('123456');
+  });
+
+  it('200 + custom_token → signInUniversalWithCustomToken + navigate a /app', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeJsonResponse(200, {
+        custom_token: 'tok-abc',
+        synthetic_email: 'users+11111111@boosterchile.invalid',
+        auth_method: 'rut_clave',
+      }),
+    );
+    signInUniversalWithCustomTokenMock.mockResolvedValueOnce({ uid: 'fb-1' });
+
+    render(<LoginUniversal />);
+    await userEvent.click(screen.getByTestId('login-tipo-transporte'));
+    fireEvent.change(screen.getByTestId('login-rut-input'), {
+      target: { value: '11.111.111-1' },
+    });
+    fireEvent.change(screen.getByTestId('login-clave-input'), { target: { value: '123456' } });
+    await userEvent.click(screen.getByTestId('login-submit'));
+
+    await waitFor(() => expect(signInUniversalWithCustomTokenMock).toHaveBeenCalledWith('tok-abc'));
+    expect(navigateMock).toHaveBeenCalledWith({ to: '/app' });
+  });
+
+  it('401 → mensaje "RUT o clave incorrectos"', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeJsonResponse(401, { error: 'invalid_credentials', code: 'invalid_credentials' }),
+    );
+
+    render(<LoginUniversal />);
+    await userEvent.click(screen.getByTestId('login-tipo-conductor'));
+    await userEvent.type(screen.getByTestId('login-rut-input'), '11.111.111-1');
+    fireEvent.change(screen.getByTestId('login-clave-input'), { target: { value: '654321' } });
+    await userEvent.click(screen.getByTestId('login-submit'));
+
+    await waitFor(() => expect(screen.getByText(/RUT o clave incorrectos/i)).toBeInTheDocument());
+    expect(signInUniversalWithCustomTokenMock).not.toHaveBeenCalled();
+  });
+
+  it('410 needs_rotation → renderiza vista de rotación con link a legacy', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeJsonResponse(410, {
+        error: 'needs_rotation',
+        code: 'needs_rotation',
+        message: 'Tu cuenta todavía no tiene clave.',
+      }),
+    );
+
+    render(<LoginUniversal />);
+    await userEvent.click(screen.getByTestId('login-tipo-carga'));
+    fireEvent.change(screen.getByTestId('login-rut-input'), {
+      target: { value: '11.111.111-1' },
+    });
+    fireEvent.change(screen.getByTestId('login-clave-input'), { target: { value: '123456' } });
+    await userEvent.click(screen.getByTestId('login-submit'));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Tu cuenta todavía no tiene clave/i)).toBeInTheDocument(),
+    );
+    const legacyLink = screen.getByTestId('needs-rotation-go-legacy');
+    expect(legacyLink).toHaveAttribute('href', '/login?legacy=1');
+  });
+
+  it('botón "Cambiar tipo de usuario" en form vuelve al selector', async () => {
+    render(<LoginUniversal />);
+    await userEvent.click(screen.getByTestId('login-tipo-stakeholder'));
+    expect(screen.getByTestId('login-universal-form')).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId('login-back-to-selector'));
+    expect(screen.getByTestId('login-universal-selector')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/login/LoginUniversal.tsx
+++ b/apps/web/src/components/login/LoginUniversal.tsx
@@ -1,0 +1,437 @@
+import {
+  USER_TYPE_HINT_LABEL,
+  type UserTypeHint,
+  loginRutSchema,
+  rutSchema,
+} from '@booster-ai/shared-schemas';
+import { useNavigate, useSearch } from '@tanstack/react-router';
+import {
+  ArrowRight,
+  Building2,
+  KeyRound,
+  Loader2,
+  Package,
+  ShieldCheck,
+  Truck,
+  Users,
+} from 'lucide-react';
+import { type FormEvent, useEffect, useState } from 'react';
+import { signInUniversalWithCustomToken } from '../../hooks/use-auth.js';
+import { getApiUrl } from '../../lib/api-url.js';
+
+/**
+ * ADR-035 — Login universal RUT + clave numérica (Wave 4 PR 2).
+ *
+ * Surface única para todos los roles. Dos pasos:
+ *
+ *   1. **Selector tipo usuario**: 5 botones (Generador de carga /
+ *      Transporte / Conductor / Stakeholder / Booster). El selector
+ *      determina la **vista inicial** post-login, NO el rol — el rol
+ *      sigue viniendo de memberships del user.
+ *
+ *   2. **Form RUT + clave**: con el tipo preseleccionado, el usuario
+ *      ingresa su RUT chileno + 6 dígitos. Backend valida con scrypt
+ *      timing-safe contra `usuarios.clave_numerica_hash`.
+ *
+ * Subdominios (transporte.boosterchile.com, conductor.boosterchile.com,
+ * etc.) son 301 redirects al canónico con `?tipo=<rol>` que pre-selecciona
+ * el botón correspondiente.
+ *
+ * El tipo "Booster" (platform admin) requiere allowlist server-side
+ * adicional. Si un user sin allowlist elige "Booster", el AppRoute lo
+ * redirigirá a su surface real post-login.
+ *
+ * NeedsRotation: si el backend responde 410 (user sin clave seteada),
+ * mostramos un mensaje guiando al usuario a usar su método anterior
+ * (Google / email+password legacy) para activar su clave. La UI de
+ * rotación entra en Wave 4 PR 3.
+ */
+
+type UniversalLoginSearch = {
+  tipo?: UserTypeHint;
+};
+
+interface ActivateResponse {
+  custom_token: string;
+  synthetic_email: string;
+  auth_method: 'rut_clave';
+}
+
+interface NeedsRotationResponse {
+  error: 'needs_rotation';
+  code: 'needs_rotation';
+  message: string;
+}
+
+type Step = 'selector' | 'form' | 'needs-rotation';
+
+interface UserTypeOption {
+  value: UserTypeHint;
+  label: string;
+  description: string;
+  Icon: typeof Truck;
+}
+
+const USER_TYPE_OPTIONS: UserTypeOption[] = [
+  {
+    value: 'carga',
+    label: USER_TYPE_HINT_LABEL.carga,
+    description: 'Genero cargas y necesito transportistas.',
+    Icon: Package,
+  },
+  {
+    value: 'transporte',
+    label: USER_TYPE_HINT_LABEL.transporte,
+    description: 'Tengo una empresa de transporte de carga.',
+    Icon: Truck,
+  },
+  {
+    value: 'conductor',
+    label: USER_TYPE_HINT_LABEL.conductor,
+    description: 'Soy conductor de un vehículo de carga.',
+    Icon: Users,
+  },
+  {
+    value: 'stakeholder',
+    label: USER_TYPE_HINT_LABEL.stakeholder,
+    description: 'Audito datos agregados (regulador, gremio, ONG).',
+    Icon: Building2,
+  },
+  {
+    value: 'booster',
+    label: USER_TYPE_HINT_LABEL.booster,
+    description: 'Soy parte del equipo Booster.',
+    Icon: ShieldCheck,
+  },
+];
+
+export function LoginUniversal() {
+  const navigate = useNavigate();
+  // Tanstack Router type-safe — esta route todavía no declara search params;
+  // leemos lo que venga manualmente desde la URL como fallback compatible.
+  const search = (useSearch({ strict: false }) ?? {}) as UniversalLoginSearch;
+  const preselectedTipo = search.tipo;
+
+  const [step, setStep] = useState<Step>(preselectedTipo ? 'form' : 'selector');
+  const [tipo, setTipo] = useState<UserTypeHint | null>(preselectedTipo ?? null);
+  const [rut, setRut] = useState('');
+  const [clave, setClave] = useState('');
+  const [rutError, setRutError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Si el query param cambia (e.g. user navega entre subdominios), update tipo.
+  useEffect(() => {
+    if (preselectedTipo && preselectedTipo !== tipo) {
+      setTipo(preselectedTipo);
+      setStep('form');
+    }
+  }, [preselectedTipo, tipo]);
+
+  function handleSelectTipo(t: UserTypeHint) {
+    setTipo(t);
+    setStep('form');
+    setRut('');
+    setClave('');
+    setRutError(null);
+    setSubmitError(null);
+  }
+
+  function handleBackToSelector() {
+    setStep('selector');
+    setTipo(null);
+    setRut('');
+    setClave('');
+    setRutError(null);
+    setSubmitError(null);
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setRutError(null);
+    setSubmitError(null);
+
+    const rutParsed = rutSchema.safeParse(rut);
+    if (!rutParsed.success) {
+      setRutError(rutParsed.error.issues[0]?.message ?? 'RUT inválido');
+      return;
+    }
+    const cleanRut = rutParsed.data;
+
+    if (!/^\d{6}$/.test(clave)) {
+      setSubmitError('La clave debe ser exactamente 6 dígitos.');
+      return;
+    }
+
+    const bodyParsed = loginRutSchema.safeParse({ rut: cleanRut, clave, tipo: tipo ?? undefined });
+    if (!bodyParsed.success) {
+      setSubmitError('Datos inválidos. Verifica RUT y clave.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const res = await fetch(`${getApiUrl()}/auth/login-rut`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(bodyParsed.data),
+      });
+
+      if (res.ok) {
+        const body = (await res.json()) as ActivateResponse;
+        await signInUniversalWithCustomToken(body.custom_token);
+        void navigate({ to: '/app' });
+        return;
+      }
+
+      if (res.status === 410) {
+        const body = (await res.json()) as NeedsRotationResponse;
+        setSubmitError(body.message);
+        setStep('needs-rotation');
+        return;
+      }
+
+      if (res.status === 401) {
+        setSubmitError('RUT o clave incorrectos. Verifica e intenta de nuevo.');
+        return;
+      }
+
+      if (res.status === 400) {
+        setSubmitError('Datos inválidos. Verifica RUT y clave.');
+        return;
+      }
+
+      setSubmitError(`Error inesperado (${res.status}). Intenta de nuevo.`);
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : 'Error al conectar con el servidor.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (step === 'selector') {
+    return <SelectorView onSelect={handleSelectTipo} />;
+  }
+
+  if (step === 'needs-rotation') {
+    return <NeedsRotationView onBack={handleBackToSelector} message={submitError} />;
+  }
+
+  return (
+    <FormView
+      tipo={tipo}
+      rut={rut}
+      clave={clave}
+      rutError={rutError}
+      submitError={submitError}
+      submitting={submitting}
+      onChangeRut={setRut}
+      onChangeClave={setClave}
+      onSubmit={handleSubmit}
+      onBack={handleBackToSelector}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Selector — 5 botones de tipo de usuario
+// ---------------------------------------------------------------------------
+
+function SelectorView({ onSelect }: { onSelect: (t: UserTypeHint) => void }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50 p-4">
+      <div
+        className="w-full max-w-2xl rounded-lg border border-neutral-200 bg-white p-6 shadow-sm"
+        data-testid="login-universal-selector"
+      >
+        <div className="text-center">
+          <h1 className="font-bold text-2xl text-neutral-900 tracking-tight">
+            Bienvenido a Booster
+          </h1>
+          <p className="mt-2 text-neutral-600 text-sm">
+            ¿Cómo te identificas en Booster? Elige una opción para continuar.
+          </p>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+          {USER_TYPE_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => onSelect(opt.value)}
+              className="flex items-start gap-3 rounded-lg border border-neutral-200 bg-white p-4 text-left transition hover:border-primary-500 hover:bg-primary-50"
+              data-testid={`login-tipo-${opt.value}`}
+            >
+              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-primary-100 text-primary-700">
+                <opt.Icon className="h-5 w-5" aria-hidden />
+              </div>
+              <div>
+                <div className="font-semibold text-neutral-900">{opt.label}</div>
+                <div className="mt-0.5 text-neutral-600 text-xs">{opt.description}</div>
+              </div>
+            </button>
+          ))}
+        </div>
+
+        <p className="mt-6 text-center text-neutral-500 text-xs">
+          Tu acceso usa RUT + clave numérica. Lo mismo que tu app de banco.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Form — RUT + clave (paso 2)
+// ---------------------------------------------------------------------------
+
+interface FormViewProps {
+  tipo: UserTypeHint | null;
+  rut: string;
+  clave: string;
+  rutError: string | null;
+  submitError: string | null;
+  submitting: boolean;
+  onChangeRut: (v: string) => void;
+  onChangeClave: (v: string) => void;
+  onSubmit: (e: FormEvent) => void;
+  onBack: () => void;
+}
+
+function FormView(props: FormViewProps) {
+  const label = props.tipo ? USER_TYPE_HINT_LABEL[props.tipo] : 'Ingresar';
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50 p-4">
+      <div className="w-full max-w-md rounded-lg border border-neutral-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-primary-50 text-primary-700">
+            <KeyRound className="h-5 w-5" aria-hidden />
+          </div>
+          <div>
+            <div className="text-neutral-500 text-xs">Ingresar como</div>
+            <h1 className="font-semibold text-neutral-900">{label}</h1>
+          </div>
+        </div>
+
+        <form
+          onSubmit={props.onSubmit}
+          noValidate
+          className="mt-6 space-y-4"
+          data-testid="login-universal-form"
+        >
+          <label className="flex flex-col gap-1">
+            <span className="font-medium text-neutral-700 text-sm">RUT</span>
+            <input
+              type="text"
+              autoComplete="username"
+              inputMode="numeric"
+              value={props.rut}
+              onChange={(e) => props.onChangeRut(e.target.value)}
+              className="rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              placeholder="12.345.678-9"
+              data-testid="login-rut-input"
+            />
+            {props.rutError && (
+              <span className="text-danger-700 text-xs" role="alert">
+                {props.rutError}
+              </span>
+            )}
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="font-medium text-neutral-700 text-sm">Clave (6 dígitos)</span>
+            <input
+              type="password"
+              autoComplete="current-password"
+              inputMode="numeric"
+              maxLength={6}
+              value={props.clave}
+              onChange={(e) => props.onChangeClave(e.target.value.replace(/\D/g, ''))}
+              className="rounded-md border border-neutral-300 px-3 py-2 text-center font-mono text-lg tracking-widest focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
+              placeholder="••••••"
+              data-testid="login-clave-input"
+            />
+            <span className="text-neutral-500 text-xs">
+              Si nunca configuraste tu clave, usa tu método anterior una vez para activarla.
+            </span>
+          </label>
+
+          {props.submitError && (
+            <div
+              className="rounded-md border border-danger-200 bg-danger-50 p-2 text-danger-700 text-sm"
+              role="alert"
+            >
+              {props.submitError}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={props.submitting}
+            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary-600 px-4 py-3 font-medium text-sm text-white hover:bg-primary-700 disabled:opacity-50"
+            data-testid="login-submit"
+          >
+            {props.submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+                Ingresando…
+              </>
+            ) : (
+              <>
+                Ingresar
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </>
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={props.onBack}
+            className="block w-full text-center text-neutral-500 text-xs hover:text-neutral-700"
+            data-testid="login-back-to-selector"
+          >
+            Cambiar tipo de usuario
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// NeedsRotation — guía al usuario a setear su primera clave (PR 3 wire UI)
+// ---------------------------------------------------------------------------
+
+function NeedsRotationView({ onBack, message }: { onBack: () => void; message: string | null }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-neutral-50 p-4">
+      <div className="w-full max-w-md rounded-lg border border-amber-200 bg-amber-50 p-6 shadow-sm">
+        <h1 className="font-semibold text-amber-900 text-lg">Configura tu clave numérica</h1>
+        <p className="mt-2 text-amber-800 text-sm">
+          {message ??
+            'Tu cuenta todavía no tiene una clave numérica. Necesitamos que la actives una sola vez.'}
+        </p>
+        <p className="mt-3 text-amber-700 text-sm">
+          Inicia sesión con tu método anterior (Google o email + contraseña) y te guiaremos para
+          crear tu nueva clave de 6 dígitos. Después podrás usarla siempre.
+        </p>
+        <div className="mt-4 flex flex-col gap-2">
+          <a
+            href="/login?legacy=1"
+            className="inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary-600 px-4 py-2 font-medium text-sm text-white hover:bg-primary-700"
+            data-testid="needs-rotation-go-legacy"
+          >
+            Usar método anterior
+          </a>
+          <button
+            type="button"
+            onClick={onBack}
+            className="text-center text-neutral-500 text-sm hover:text-neutral-700"
+          >
+            Cambiar tipo de usuario
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -108,6 +108,18 @@ export async function signInDriverWithCustomToken(customToken: string): Promise<
 }
 
 /**
+ * ADR-035 — Login universal con custom token devuelto por
+ * `POST /auth/login-rut`. Reemplaza a `signInWithEmail` cuando el flag
+ * `auth_universal_v1_activated=true`. Funciona para cualquier rol
+ * (shipper / carrier / conductor / stakeholder / booster admin) — el
+ * tipo de UI inicial post-login lo determina el AppRoute via /me.
+ */
+export async function signInUniversalWithCustomToken(customToken: string): Promise<User> {
+  const result = await signInWithCustomToken(firebaseAuth, customToken);
+  return result.user;
+}
+
+/**
  * Registro nuevo con email + password. Setea displayName si se provee.
  *
  * Lanza FirebaseError si el email ya existe (auth/email-already-in-use),

--- a/apps/web/src/hooks/use-feature-flags.test.tsx
+++ b/apps/web/src/hooks/use-feature-flags.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../lib/api-client.js';
+import { useFeatureFlags } from './use-feature-flags.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useFeatureFlags', () => {
+  it('devuelve los flags del backend cuando el endpoint responde', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      auth_universal_v1_activated: true,
+      wake_word_voice_activated: false,
+      matching_algorithm_v2_activated: true,
+    });
+    const Wrapper = makeWrapper();
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.flags.auth_universal_v1_activated).toBe(true);
+    expect(result.current.flags.wake_word_voice_activated).toBe(false);
+    expect(result.current.flags.matching_algorithm_v2_activated).toBe(true);
+  });
+
+  it('default conservador (todos false) si el endpoint falla', async () => {
+    vi.spyOn(api, 'get').mockRejectedValue(new Error('network down'));
+    const Wrapper = makeWrapper();
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper });
+
+    // El hook usa `retry: 1` para resilience. Esperamos hasta 5s para que
+    // el retry + fallback al estado de error ocurra (default backoff
+    // exponencial inicial es ~1s en react-query v5).
+    await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5000 });
+    expect(result.current.flags.auth_universal_v1_activated).toBe(false);
+    expect(result.current.flags.wake_word_voice_activated).toBe(false);
+    expect(result.current.flags.matching_algorithm_v2_activated).toBe(false);
+  });
+
+  it('loading inicial → flags por defecto (false) sin crash', () => {
+    vi.spyOn(api, 'get').mockReturnValue(new Promise(() => undefined)); // never resolve
+    const Wrapper = makeWrapper();
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    // Aun en loading state, debe haber un valor defaultivo seguro.
+    expect(result.current.flags.auth_universal_v1_activated).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-feature-flags.ts
+++ b/apps/web/src/hooks/use-feature-flags.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api-client.js';
+
+/**
+ * Feature flags expuestos por el backend (`GET /feature-flags`).
+ *
+ * El endpoint es público (sin auth) porque el cliente lo necesita ANTES
+ * del login para decidir qué UI renderizar (selector RUT+clave vs
+ * email/password legacy).
+ */
+export interface FeatureFlags {
+  auth_universal_v1_activated: boolean;
+  wake_word_voice_activated: boolean;
+  matching_algorithm_v2_activated: boolean;
+}
+
+const FEATURE_FLAGS_QUERY_KEY = ['feature-flags'] as const;
+
+/**
+ * Hook que carga los feature flags del backend. Se cachea agresivamente
+ * (staleTime 5 min) porque los flags rara vez cambian — un usuario
+ * raramente verá la transición; los activos se cambian via Secret
+ * Manager + Cloud Run restart.
+ *
+ * En boot:
+ *   - Render inicial muestra `flags = undefined` (loading).
+ *   - Componentes que dependan del flag pueden mostrar fallback neutro.
+ *   - Tras ~50ms el flag se resuelve y la UI se re-renderea.
+ *
+ * Si el endpoint falla (network down, backend caído), devolvemos
+ * defaults conservadores (todos false) para que la UI siga funcionando
+ * con el flow legacy.
+ */
+export function useFeatureFlags(): {
+  flags: FeatureFlags;
+  isLoading: boolean;
+  isError: boolean;
+} {
+  const query = useQuery({
+    queryKey: FEATURE_FLAGS_QUERY_KEY,
+    queryFn: async () => {
+      return api.get<FeatureFlags>('/feature-flags');
+    },
+    staleTime: 5 * 60 * 1000, // 5 min
+    gcTime: 30 * 60 * 1000, // 30 min
+    retry: 1, // si falla la 1ra vez, 1 retry; después fallback a defaults
+  });
+
+  const flags: FeatureFlags = query.data ?? {
+    auth_universal_v1_activated: false,
+    wake_word_voice_activated: false,
+    matching_algorithm_v2_activated: false,
+  };
+
+  return {
+    flags,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/apps/web/src/lib/api-url.ts
+++ b/apps/web/src/lib/api-url.ts
@@ -1,0 +1,15 @@
+/**
+ * Devuelve la URL base del API.
+ *
+ * En dev se inyecta via `VITE_API_URL` (e.g. `http://localhost:3000`).
+ * En producción, si se usa path relativo via reverse proxy (mismo dominio),
+ * la env queda vacía y el cliente arma URLs relativas como `/auth/login-rut`.
+ *
+ * Útil principalmente para endpoints PRE-auth donde el `api-client.ts`
+ * (que agrega `Authorization: Bearer <firebase-id-token>` automáticamente)
+ * NO aplica — el usuario todavía no tiene sesión.
+ */
+export function getApiUrl(): string {
+  const apiUrl = import.meta.env.VITE_API_URL;
+  return typeof apiUrl === 'string' ? apiUrl : '';
+}

--- a/apps/web/src/routes/login-conductor.tsx
+++ b/apps/web/src/routes/login-conductor.tsx
@@ -4,6 +4,7 @@ import { Headphones } from 'lucide-react';
 import { type FormEvent, useState } from 'react';
 import { FormField, inputClass as fieldInputClass } from '../components/FormField.js';
 import { signInDriverWithCustomToken, signInWithEmail } from '../hooks/use-auth.js';
+import { getApiUrl } from '../lib/api-url.js';
 
 interface ActivateResponse {
   custom_token: string;
@@ -192,9 +193,4 @@ export function LoginConductorRoute() {
  * fetch directo (no `api.post`) porque el endpoint NO requiere Firebase
  * ID token — el conductor todavía no tiene sesión.
  */
-function getApiUrl(): string {
-  // VITE_API_URL puede no estar definida en producción si se usa el path
-  // relativo via reverse proxy. En ese caso usamos string vacía.
-  const apiUrl = import.meta.env.VITE_API_URL;
-  return typeof apiUrl === 'string' ? apiUrl : '';
-}
+// `getApiUrl` movido a `../lib/api-url.ts` (reusado por LoginUniversal Wave 4).

--- a/apps/web/src/routes/login.test.tsx
+++ b/apps/web/src/routes/login.test.tsx
@@ -15,9 +15,28 @@ vi.mock('../hooks/use-auth.js', () => ({
 }));
 
 const navigateMock = vi.fn();
+const useSearchMock = vi.fn(() => ({}));
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => navigateMock,
+  useSearch: () => useSearchMock(),
   Navigate: ({ to }: { to: string }) => <div data-testid="navigate" data-to={to} />,
+}));
+
+// ADR-035 Wave 4 PR 2 — el LoginRoute lee `auth_universal_v1_activated`
+// via useFeatureFlags(). Por default mockeamos el flag OFF para que estos
+// tests sigan validando el flow legacy (Google + email/password). Los
+// tests del flow universal están en `components/login/LoginUniversal.test.tsx`.
+const useFeatureFlagsMock = vi.fn(() => ({
+  flags: {
+    auth_universal_v1_activated: false,
+    wake_word_voice_activated: false,
+    matching_algorithm_v2_activated: false,
+  },
+  isLoading: false,
+  isError: false,
+}));
+vi.mock('../hooks/use-feature-flags.js', () => ({
+  useFeatureFlags: () => useFeatureFlagsMock(),
 }));
 
 const { LoginRoute } = await import('./login.js');

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,9 +1,10 @@
-import { Navigate, useNavigate } from '@tanstack/react-router';
+import { Navigate, useNavigate, useSearch } from '@tanstack/react-router';
 import type { FirebaseError } from 'firebase/app';
 import { LogIn, Mail } from 'lucide-react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { FormField, inputClass } from '../components/FormField.js';
+import { LoginUniversal } from '../components/login/LoginUniversal.js';
 import {
   requestPasswordReset,
   signInWithEmail,
@@ -11,6 +12,7 @@ import {
   signUpWithEmail,
   useAuth,
 } from '../hooks/use-auth.js';
+import { useFeatureFlags } from '../hooks/use-feature-flags.js';
 
 type Mode = 'sign-in' | 'sign-up' | 'reset';
 
@@ -23,19 +25,34 @@ interface LoginFormValues {
 const EMPTY_VALUES: LoginFormValues = { name: '', email: '', password: '' };
 
 /**
- * /login — pantalla de autenticación con tres flows:
- *   - Google sign-in (popup)
- *   - Email + password (sign in / sign up)
- *   - Password reset (email con link de Firebase)
+ * /login — pantalla de autenticación.
+ *
+ * ADR-035 (Wave 4) — dual flow basado en feature flag:
+ *   - Si `auth_universal_v1_activated=true`: renderiza `<LoginUniversal>`
+ *     con selector tipo usuario + form RUT + clave numérica.
+ *   - Si `auth_universal_v1_activated=false` (default): legacy flow
+ *     con Google + email/password + password reset.
+ *
+ * Escape hatch: `?legacy=1` en la URL fuerza el flow legacy aunque el
+ * flag esté ON. Usado por `LoginUniversal` cuando el user necesita
+ * rotar su clave numérica desde su método anterior (Wave 4 PR 3 wire).
  *
  * Tras login exitoso → /app, que decide via /me si va a /onboarding o
  * directo al dashboard según `needs_onboarding`.
  */
 export function LoginRoute() {
   const { user, loading } = useAuth();
+  const { flags } = useFeatureFlags();
+  // biome-ignore lint/suspicious/noExplicitAny: search params del legacy escape hatch sin type strict.
+  const search = (useSearch({ strict: false }) ?? {}) as { legacy?: string };
   const navigate = useNavigate();
   const [mode, setMode] = useState<Mode>('sign-in');
   const [resetSent, setResetSent] = useState(false);
+
+  // Si el flag está ON y el user NO forzó legacy, ruta al flow universal.
+  // Re-evaluamos esto tras `user`/loading checks debajo para mantener la
+  // semántica del legacy (Navigate to /app si ya logueado).
+  const useUniversalFlow = flags.auth_universal_v1_activated && search.legacy !== '1';
 
   const {
     register,
@@ -58,6 +75,10 @@ export function LoginRoute() {
 
   if (user) {
     return <Navigate to="/app" />;
+  }
+
+  if (useUniversalFlow) {
+    return <LoginUniversal />;
   }
 
   async function handleGoogleSignIn() {

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -131,6 +131,26 @@ module "service_api" {
     MATCHING_ALGORITHM_V2_ACTIVATED = tostring(var.matching_algorithm_v2_activated)
     MATCHING_V2_WEIGHTS_JSON        = var.matching_v2_weights_json
 
+    # ADR-035 (Wave 4) — Auth universal RUT + clave numérica. Default
+    # `false` mantiene el flow legacy email/password. Cuando `true`,
+    # `/login` muestra selector de tipo usuario + form RUT+clave para
+    # todos los roles (no solo conductor).
+    #
+    # Rollout staged:
+    #   1. PR 1 (foundation backend): flag=false default. Endpoint vivo
+    #      sin uso desde UI.
+    #   2. PR 2 (este PR — UI selector): flag=false default. Activar en
+    #      staging para validar smoke E2E. Si OK, activar en prod.
+    #   3. PR 3 (migración 30d): forzar rotación al login siguiente de
+    #      usuarios con email/password legacy.
+    AUTH_UNIVERSAL_V1_ACTIVATED = tostring(var.auth_universal_v1_activated)
+
+    # ADR-036 (Wave 5) — Wake-word "Oye Booster" para conductor. Default
+    # `false`. Activar SOLO después de entrenar el modelo custom con
+    # voces chilenas (Wave 5 PR 2). El conductor además debe opt-in en
+    # su configuración (default OFF en localStorage).
+    WAKE_WORD_VOICE_ACTIVATED = tostring(var.wake_word_voice_activated)
+
     # Allowlist de operadores Booster que pueden entrar a /admin/* del API
     # y /app/platform-admin/* de la PWA. CSV de emails (lower-cased en
     # comparison). Sin esta env var nadie es admin — el código defaultea

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -305,6 +305,44 @@ variable "matching_v2_weights_json" {
 }
 
 # ---------------------------------------------------------------------------
+# ADR-035 Wave 4 — Auth universal RUT + clave numérica
+# ---------------------------------------------------------------------------
+# Cuando `true`, `/login` muestra selector de tipo usuario + form RUT +
+# clave numérica para todos los roles. Default `false` mantiene el flow
+# legacy (Google + email/password + reset).
+#
+# Rollout staged:
+#   1. PR 1 (foundation backend): flag=false default. Endpoint
+#      /auth/login-rut vivo pero sin uso del UI.
+#   2. PR 2 (UI selector): flag=false default. Activar en staging para
+#      smoke E2E. Si OK, activar en prod.
+#   3. PR 3 (migración 30d): forzar rotación al login siguiente de
+#      usuarios con email/password legacy.
+#
+# Flip es reversible sin redeploy de código.
+variable "auth_universal_v1_activated" {
+  description = "Activa el flow universal RUT + clave numérica (ADR-035). false = legacy email/password."
+  type        = bool
+  default     = false
+}
+
+# ---------------------------------------------------------------------------
+# ADR-036 Wave 5 — Wake-word "Oye Booster"
+# ---------------------------------------------------------------------------
+# Cuando `true`, la card "Activación por voz" en
+# /app/conductor/configuracion es activa (toggle real, no
+# "próximamente"). El conductor debe además opt-in para que la PWA
+# escuche el wake-word "Oye Booster".
+#
+# Mantener `false` en prod hasta que el modelo custom `oye-booster-cl.ppn`
+# esté entrenado con voces chilenas vía Picovoice Console (Wave 5 PR 2).
+variable "wake_word_voice_activated" {
+  description = "Activa wake-word \"Oye Booster\" en /app/conductor (ADR-036)."
+  type        = bool
+  default     = false
+}
+
+# ---------------------------------------------------------------------------
 # Platform admin allowlist
 # ---------------------------------------------------------------------------
 # Emails (CSV) que pueden acceder a /app/platform-admin/* en la PWA y a


### PR DESCRIPTION
## Resumen

Wave 4 PR 2 — UI completa del flow universal RUT + clave numérica detrás del feature flag \`AUTH_UNIVERSAL_V1_ACTIVATED\`. Default OFF mantiene el flow legacy email/password intacto. PR self-contained (no requiere Wave 4 PR 1 mergeado primero — el endpoint \`/auth/login-rut\` viene incluido como dependencia del branch).

**Branch base**: \`feat/auth-universal-rut-clave\` (Wave 4 PR 1) → este branch \`feat/auth-universal-ui-selector\`.

## Cambios principales

### Backend
- \`apps/api/src/routes/feature-flags.ts\` (NUEVO): endpoint público \`GET /feature-flags\` con los 3 flags. Sin auth — el cliente lo necesita ANTES del login.
- \`apps/api/src/config.ts\`: añade \`WAKE_WORD_VOICE_ACTIVATED\` (preparación Wave 5).
- \`apps/api/src/server.ts\`: wire \`/feature-flags\` como public route.

### Frontend
- \`apps/web/src/hooks/use-feature-flags.ts\` (NUEVO): hook con cache 5min via TanStack Query. Defaults conservadores (todos false) si endpoint falla.
- \`apps/web/src/components/login/LoginUniversal.tsx\` (NUEVO): 2 pasos:
  1. **Selector** de tipo usuario (5 botones: Generador / Transporte / Conductor / Stakeholder / Booster).
  2. **Form** RUT + clave numérica (6 dígitos, input password con filter numérico + maxLength).
- \`apps/web/src/routes/login.tsx\`: dual flow basado en flag. Escape hatch \`?legacy=1\` para forzar legacy aunque flag esté ON (usado por la vista needs-rotation).
- \`apps/web/src/lib/api-url.ts\` (NUEVO): helper \`getApiUrl()\` extraído para reuso entre flows pre-auth.
- \`apps/web/src/hooks/use-auth.ts\`: alias \`signInUniversalWithCustomToken\`.

### Terraform
- \`infrastructure/variables.tf\`: declara \`auth_universal_v1_activated\` + \`wake_word_voice_activated\`, ambos default false.
- \`infrastructure/compute.tf\`: wired al Cloud Run env vars.

### Casos cubiertos
- **Pre-selección desde subdominio**: \`?tipo=<rol>\` salta el selector y entra al form. Soporta \`transporte.boosterchile.com → app.boosterchile.com/login?tipo=transporte\`.
- **401 invalid_credentials**: mensaje genérico (sin enumerar RUT existente vs clave incorrecta).
- **410 needs_rotation**: vista que guía al usuario a \`/login?legacy=1\` para activar su clave con su método anterior.

## Evidencia

\`\`\`
pnpm --filter=@booster-ai/api typecheck            ✓
pnpm --filter=@booster-ai/web typecheck            ✓
pnpm --filter=@booster-ai/api test --run           913/913 ✓ + 2 skipped
                                                   +2 nuevos: feature-flags
pnpm --filter=@booster-ai/web test --run           920/920 ✓
                                                   +12 nuevos:
                                                     - 9 LoginUniversal
                                                     - 3 useFeatureFlags
pnpm exec biome check                              0 errors
\`\`\`

## Próximo paso (Wave 4 PR 3)

UI + backend para SETEAR la clave numérica durante la sesión legacy:
1. Endpoint \`POST /me/clave-numerica\` que verifica firebase id token + setea \`clave_numerica_hash\`.
2. Componente que post-login legacy detecta \`needs_rotation\` y muestra modal forzado para crear clave.
3. Tras setear → next login funciona con flow universal.

## Riesgos

- **Subdominios**: \`transporte.boosterchile.com\` etc. no están configurados en DNS aún. El query param \`?tipo=<rol>\` funciona en \`app.boosterchile.com\` directamente. Setup DNS post-merge cuando Felipe quiera activar.
- **Default OFF**: el código de Wave 4 PR 2 está completamente inerte hasta que Felipe haga flip de \`AUTH_UNIVERSAL_V1_ACTIVATED=true\` via tfvars + apply. Reversible sin redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)