### PR TITLE
feat(wake-word): UI card "Activación por voz" + banner sticky (Wave 5 PR 2 parcial)

### DIFF
--- a/apps/web/src/hooks/use-feature-flags.test.tsx
+++ b/apps/web/src/hooks/use-feature-flags.test.tsx
@@ -1,0 +1,64 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../lib/api-client.js';
+import { useFeatureFlags } from './use-feature-flags.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useFeatureFlags', () => {
+  it('devuelve los flags del backend cuando el endpoint responde', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      auth_universal_v1_activated: true,
+      wake_word_voice_activated: false,
+      matching_algorithm_v2_activated: true,
+    });
+    const Wrapper = makeWrapper();
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.flags.auth_universal_v1_activated).toBe(true);
+    expect(result.current.flags.wake_word_voice_activated).toBe(false);
+    expect(result.current.flags.matching_algorithm_v2_activated).toBe(true);
+  });
+
+  it('default conservador (todos false) si el endpoint falla', async () => {
+    vi.spyOn(api, 'get').mockRejectedValue(new Error('network down'));
+    const Wrapper = makeWrapper();
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper });
+
+    // El hook usa `retry: 1` para resilience. Esperamos hasta 5s para que
+    // el retry + fallback al estado de error ocurra (default backoff
+    // exponencial inicial es ~1s en react-query v5).
+    await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5000 });
+    expect(result.current.flags.auth_universal_v1_activated).toBe(false);
+    expect(result.current.flags.wake_word_voice_activated).toBe(false);
+    expect(result.current.flags.matching_algorithm_v2_activated).toBe(false);
+  });
+
+  it('loading inicial → flags por defecto (false) sin crash', () => {
+    vi.spyOn(api, 'get').mockReturnValue(new Promise(() => undefined)); // never resolve
+    const Wrapper = makeWrapper();
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    // Aun en loading state, debe haber un valor defaultivo seguro.
+    expect(result.current.flags.auth_universal_v1_activated).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-feature-flags.ts
+++ b/apps/web/src/hooks/use-feature-flags.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api-client.js';
+
+/**
+ * Feature flags expuestos por el backend (`GET /feature-flags`).
+ *
+ * El endpoint es público (sin auth) porque el cliente lo necesita ANTES
+ * del login para decidir qué UI renderizar (selector RUT+clave vs
+ * email/password legacy).
+ */
+export interface FeatureFlags {
+  auth_universal_v1_activated: boolean;
+  wake_word_voice_activated: boolean;
+  matching_algorithm_v2_activated: boolean;
+}
+
+const FEATURE_FLAGS_QUERY_KEY = ['feature-flags'] as const;
+
+/**
+ * Hook que carga los feature flags del backend. Se cachea agresivamente
+ * (staleTime 5 min) porque los flags rara vez cambian — un usuario
+ * raramente verá la transición; los activos se cambian via Secret
+ * Manager + Cloud Run restart.
+ *
+ * En boot:
+ *   - Render inicial muestra `flags = undefined` (loading).
+ *   - Componentes que dependan del flag pueden mostrar fallback neutro.
+ *   - Tras ~50ms el flag se resuelve y la UI se re-renderea.
+ *
+ * Si el endpoint falla (network down, backend caído), devolvemos
+ * defaults conservadores (todos false) para que la UI siga funcionando
+ * con el flow legacy.
+ */
+export function useFeatureFlags(): {
+  flags: FeatureFlags;
+  isLoading: boolean;
+  isError: boolean;
+} {
+  const query = useQuery({
+    queryKey: FEATURE_FLAGS_QUERY_KEY,
+    queryFn: async () => {
+      return api.get<FeatureFlags>('/feature-flags');
+    },
+    staleTime: 5 * 60 * 1000, // 5 min
+    gcTime: 30 * 60 * 1000, // 30 min
+    retry: 1, // si falla la 1ra vez, 1 retry; después fallback a defaults
+  });
+
+  const flags: FeatureFlags = query.data ?? {
+    auth_universal_v1_activated: false,
+    wake_word_voice_activated: false,
+    matching_algorithm_v2_activated: false,
+  };
+
+  return {
+    flags,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/apps/web/src/routes/conductor-configuracion.test.tsx
+++ b/apps/web/src/routes/conductor-configuracion.test.tsx
@@ -52,6 +52,30 @@ vi.mock('../services/coaching-voice.js', () => ({
   saveAutoplayPreference: (v: boolean) => saveAutoplayPreferenceSpy(v),
 }));
 
+// ADR-036 — el card WakeWord usa useFeatureFlags. Default flag OFF en
+// tests para que el card aparezca como "Próximamente" (la mayoría de
+// assertions existentes no tocan este card). El test dedicado al wake-word
+// card setea el flag a true.
+const useFeatureFlagsMock = vi.fn(() => ({
+  flags: {
+    auth_universal_v1_activated: false,
+    wake_word_voice_activated: false,
+    matching_algorithm_v2_activated: false,
+  },
+  isLoading: false,
+  isError: false,
+}));
+vi.mock('../hooks/use-feature-flags.js', () => ({
+  useFeatureFlags: () => useFeatureFlagsMock(),
+}));
+
+const wakeWordEnabledMock = vi.fn(() => false);
+const setWakeWordEnabledMock = vi.fn();
+vi.mock('../services/wake-word-preference.js', () => ({
+  isWakeWordEnabled: () => wakeWordEnabledMock(),
+  setWakeWordEnabled: (v: boolean) => setWakeWordEnabledMock(v),
+}));
+
 const { ConductorConfiguracionRoute } = await import('./conductor-configuracion.js');
 
 function makeMe(): MeOnboarded {
@@ -89,14 +113,59 @@ describe('ConductorConfiguracionRoute', () => {
     expect(container.querySelector('[data-testid="autoplay-card"]')).toBeNull();
   });
 
-  it('contexto onboarded → renderiza las 4 cards de configuración', async () => {
+  it('contexto onboarded → renderiza las 5 cards de configuración', async () => {
     providedContext = { kind: 'onboarded', me: makeMe() };
     render(<ConductorConfiguracionRoute />);
     expect(screen.getByTestId('autoplay-card')).toBeInTheDocument();
     expect(screen.getByTestId('permissions-card')).toBeInTheDocument();
+    expect(screen.getByTestId('wake-word-card')).toBeInTheDocument();
     expect(screen.getByTestId('voice-commands-card')).toBeInTheDocument();
     expect(screen.getByTestId('how-it-works-card')).toBeInTheDocument();
     await waitFor(() => expect(queryDriverPermissionsSpy).toHaveBeenCalled());
+  });
+
+  it('WakeWord card con flag OFF → muestra "Próximamente"', () => {
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorConfiguracionRoute />);
+    expect(screen.getByTestId('wake-word-card')).toBeInTheDocument();
+    expect(screen.getByTestId('wake-word-not-yet')).toBeInTheDocument();
+    expect(screen.queryByTestId('wake-word-toggle')).not.toBeInTheDocument();
+  });
+
+  it('WakeWord card con flag ON → toggle visible y refleja preferencia', () => {
+    useFeatureFlagsMock.mockReturnValueOnce({
+      flags: {
+        auth_universal_v1_activated: false,
+        wake_word_voice_activated: true,
+        matching_algorithm_v2_activated: false,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    wakeWordEnabledMock.mockReturnValueOnce(true);
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorConfiguracionRoute />);
+    const toggle = screen.getByTestId('wake-word-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+
+  it('WakeWord toggle click → persiste vía setWakeWordEnabled', () => {
+    useFeatureFlagsMock.mockReturnValueOnce({
+      flags: {
+        auth_universal_v1_activated: false,
+        wake_word_voice_activated: true,
+        matching_algorithm_v2_activated: false,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    wakeWordEnabledMock.mockReturnValueOnce(false);
+    providedContext = { kind: 'onboarded', me: makeMe() };
+    render(<ConductorConfiguracionRoute />);
+    const toggle = screen.getByTestId('wake-word-toggle') as HTMLInputElement;
+    expect(toggle.checked).toBe(false);
+    fireEvent.click(toggle);
+    expect(setWakeWordEnabledMock).toHaveBeenCalledWith(true);
   });
 
   it('header tiene flecha de vuelta a /app/conductor', () => {

--- a/apps/web/src/routes/conductor-configuracion.tsx
+++ b/apps/web/src/routes/conductor-configuracion.tsx
@@ -9,10 +9,12 @@ import {
   MicOff,
   Navigation,
   NavigationOff,
+  Radio,
   Volume2,
 } from 'lucide-react';
 import { type ReactNode, useEffect, useState } from 'react';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
+import { useFeatureFlags } from '../hooks/use-feature-flags.js';
 import type { MeResponse } from '../hooks/use-me.js';
 import { loadAutoplayPreference, saveAutoplayPreference } from '../services/coaching-voice.js';
 import {
@@ -22,6 +24,7 @@ import {
   requestGeolocationPermission,
   requestMicrophonePermission,
 } from '../services/driver-mode-permissions.js';
+import { isWakeWordEnabled, setWakeWordEnabled } from '../services/wake-word-preference.js';
 
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 
@@ -164,6 +167,7 @@ function ConductorConfiguracionPage({ me: _me }: { me: MeOnboarded }) {
             requestingMic={requestingMic}
             requestingGeo={requestingGeo}
           />
+          <WakeWordCard />
           <VoiceCommandsReferenceCard />
           <HowItWorksCard />
         </div>
@@ -424,6 +428,89 @@ const VOICE_COMMANDS: VoiceCommandEntry[] = [
     context: 'Si dijiste algo por error y aún no se procesó, abortas la acción.',
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Card: Activación por voz (ADR-036 — wake-word "Oye Booster")
+// ---------------------------------------------------------------------------
+
+function WakeWordCard() {
+  const { flags } = useFeatureFlags();
+  const [enabled, setEnabled] = useState(() => isWakeWordEnabled());
+  const featureLive = flags.wake_word_voice_activated;
+
+  function handleToggle(checked: boolean) {
+    setEnabled(checked);
+    setWakeWordEnabled(checked);
+  }
+
+  return (
+    <section
+      aria-label="Activación por voz"
+      className="rounded-lg border border-neutral-200 bg-white p-5"
+      data-testid="wake-word-card"
+    >
+      <div className="flex items-start gap-3">
+        <Radio className="mt-0.5 h-5 w-5 shrink-0 text-primary-700" aria-hidden />
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h2 className="font-semibold text-base text-neutral-900">Activación por voz</h2>
+            {!featureLive && (
+              <span className="inline-flex items-center rounded-md bg-neutral-100 px-2 py-0.5 font-medium text-neutral-600 text-xs">
+                Próximamente
+              </span>
+            )}
+          </div>
+          <p className="mt-1 text-neutral-600 text-sm">
+            Cuando está activo, di <strong>“Oye Booster”</strong> con el vehículo detenido y la app
+            empieza a escuchar tu comando. Sin tocar la pantalla.
+          </p>
+
+          {featureLive ? (
+            <label
+              className="mt-3 flex items-center gap-3 text-neutral-800 text-sm"
+              data-testid="wake-word-toggle-label"
+            >
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => handleToggle(e.target.checked)}
+                className="h-5 w-5 rounded border-neutral-300 text-primary-600 focus:ring-primary-500"
+                data-testid="wake-word-toggle"
+              />
+              <span className="font-medium">
+                {enabled
+                  ? 'Activado · esperando “Oye Booster” cuando estés parado'
+                  : 'Desactivado · seguir usando el botón de mic en cada acción'}
+              </span>
+            </label>
+          ) : (
+            <div
+              className="mt-3 rounded-md border border-neutral-200 bg-neutral-50 p-3 text-neutral-600 text-sm"
+              data-testid="wake-word-not-yet"
+            >
+              Estamos entrenando el reconocedor con voces chilenas. Cuando esté listo, podrás
+              activarlo desde aquí. Mientras tanto, los comandos de voz funcionan tocando el ícono
+              de micrófono.
+            </div>
+          )}
+
+          <div className="mt-3 space-y-1 text-[11px] text-neutral-500">
+            <p className="flex items-start gap-1.5">
+              <Info className="mt-px h-3 w-3 shrink-0" aria-hidden />
+              Solo escuchamos la frase “Oye Booster”. El audio se procesa en tu teléfono y no se
+              envía a Booster.
+            </p>
+            <p className="flex items-start gap-1.5">
+              <Info className="mt-px h-3 w-3 shrink-0" aria-hidden />
+              El micrófono se pausa automáticamente cuando el vehículo se mueve, cuando la pantalla
+              se apaga o cuando cambias de pestaña. Para cuidar tu batería y tu privacidad.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
 
 function VoiceCommandsReferenceCard() {
   return (

--- a/apps/web/src/routes/conductor.test.tsx
+++ b/apps/web/src/routes/conductor.test.tsx
@@ -40,6 +40,27 @@ vi.mock('../services/driver-mode-permissions.js', () => ({
   queryDriverPermissions: (...args: unknown[]) => queryDriverPermissionsSpy(...args),
 }));
 
+// ADR-036 (Wave 5) — el banner del wake-word usa useFeatureFlags. Default
+// flag OFF en tests para que el banner no aparezca y los assertions
+// existentes pasen sin cambios.
+vi.mock('../hooks/use-feature-flags.js', () => ({
+  useFeatureFlags: () => ({
+    flags: {
+      auth_universal_v1_activated: false,
+      wake_word_voice_activated: false,
+      matching_algorithm_v2_activated: false,
+    },
+    isLoading: false,
+    isError: false,
+  }),
+}));
+
+// Default mock para preference: wake-word OFF en localStorage.
+vi.mock('../services/wake-word-preference.js', () => ({
+  isWakeWordEnabled: () => false,
+  setWakeWordEnabled: vi.fn(),
+}));
+
 const reporterStartSpy = vi.fn();
 const reporterStopSpy = vi.fn();
 let reporterState = {

--- a/apps/web/src/routes/conductor.tsx
+++ b/apps/web/src/routes/conductor.tsx
@@ -4,6 +4,7 @@ import {
   ArrowRight,
   Inbox,
   MapPin,
+  Mic,
   Navigation,
   Settings,
   Square,
@@ -12,12 +13,14 @@ import {
 import { useEffect, useState } from 'react';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import { useDriverPositionReporter } from '../hooks/use-driver-position-reporter.js';
+import { useFeatureFlags } from '../hooks/use-feature-flags.js';
 import type { MeResponse } from '../hooks/use-me.js';
 import { ApiError, api } from '../lib/api-client.js';
 import {
   type PermissionStatus,
   queryDriverPermissions,
 } from '../services/driver-mode-permissions.js';
+import { isWakeWordEnabled } from '../services/wake-word-preference.js';
 
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 
@@ -91,9 +94,48 @@ function ConductorDashboardPage({ me }: { me: MeOnboarded }) {
       <ConductorHeader fullName={me.user.full_name} />
       <main className="mx-auto w-full max-w-2xl flex-1 px-4 py-4 sm:px-6 sm:py-6">
         <WhatsAppSafetyBanner />
+        <WakeWordActiveBanner />
         <AssignmentsSection />
       </main>
     </div>
+  );
+}
+
+/**
+ * ADR-036 — Banner sticky cuando el conductor activó "Oye Booster" + el
+ * feature flag global está ON. Le da al conductor feedback visible
+ * verificable de que el mic está escuchando la wake-word (privacy
+ * transparente: si no ve el banner, el mic no está activo).
+ *
+ * Cuando el banner está visible, el listener Porcupine corre solo cuando
+ * el vehículo está detenido. La integración real con el controller entra
+ * en Wave 5 PR 2 — esta UI solo refleja la preferencia del usuario.
+ */
+function WakeWordActiveBanner() {
+  const { flags } = useFeatureFlags();
+  const [enabled, setEnabled] = useState(() => isWakeWordEnabled());
+
+  // Re-evaluar cada vez que el dashboard se monta (e.g. tras volver
+  // desde /configuracion donde el conductor pudo haber tocado el toggle).
+  useEffect(() => {
+    setEnabled(isWakeWordEnabled());
+  }, []);
+
+  if (!flags.wake_word_voice_activated || !enabled) {
+    return null;
+  }
+
+  return (
+    <output
+      className="mt-3 flex items-center gap-2 rounded-md border border-primary-200 bg-primary-50 p-2 text-primary-900 text-xs"
+      data-testid="wake-word-active-banner"
+    >
+      <Mic className="h-4 w-4 shrink-0 animate-pulse" aria-hidden />
+      <span>
+        Escuchando “Oye Booster” cuando estés parado. Toca el ícono de engranaje arriba para
+        desactivar.
+      </span>
+    </output>
   );
 }
 

--- a/apps/web/src/services/wake-word-preference.test.ts
+++ b/apps/web/src/services/wake-word-preference.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { isWakeWordEnabled, setWakeWordEnabled } from './wake-word-preference.js';
+
+const KEY = 'booster:wake-word:enabled';
+
+describe('wake-word-preference', () => {
+  beforeEach(() => {
+    window.localStorage.removeItem(KEY);
+  });
+  afterEach(() => {
+    window.localStorage.removeItem(KEY);
+  });
+
+  it('default es false (sin entry en localStorage)', () => {
+    expect(isWakeWordEnabled()).toBe(false);
+  });
+
+  it('setWakeWordEnabled(true) → isWakeWordEnabled() returns true', () => {
+    setWakeWordEnabled(true);
+    expect(isWakeWordEnabled()).toBe(true);
+    expect(window.localStorage.getItem(KEY)).toBe('1');
+  });
+
+  it('setWakeWordEnabled(false) → remove entry', () => {
+    setWakeWordEnabled(true);
+    setWakeWordEnabled(false);
+    expect(isWakeWordEnabled()).toBe(false);
+    expect(window.localStorage.getItem(KEY)).toBeNull();
+  });
+
+  it('persiste a través de múltiples reads', () => {
+    setWakeWordEnabled(true);
+    expect(isWakeWordEnabled()).toBe(true);
+    expect(isWakeWordEnabled()).toBe(true);
+    expect(isWakeWordEnabled()).toBe(true);
+  });
+});

--- a/apps/web/src/services/wake-word-preference.ts
+++ b/apps/web/src/services/wake-word-preference.ts
@@ -1,0 +1,42 @@
+/**
+ * ADR-036 — Persistencia del opt-in del conductor para wake-word
+ * "Oye Booster". Patrón espejo de `coaching-voice.ts/loadAutoplayPreference`.
+ *
+ * Default OFF: el conductor ACTIVA explícitamente desde la card
+ * "Activación por voz" en /app/conductor/configuracion. Booster nunca
+ * asume permisos always-on de micrófono.
+ *
+ * El feature flag global `WAKE_WORD_VOICE_ACTIVATED` también debe ser
+ * `true` (controlado por platform-admin via Terraform). El opt-in del
+ * usuario y el flag global son AND — ambos deben estar ON para que el
+ * wake-word listener arranque.
+ */
+
+const WAKE_WORD_KEY = 'booster:wake-word:enabled';
+
+export function isWakeWordEnabled(): boolean {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return false;
+  }
+  try {
+    return window.localStorage.getItem(WAKE_WORD_KEY) === '1';
+  } catch {
+    // localStorage puede tirar SecurityError en private mode + Safari.
+    return false;
+  }
+}
+
+export function setWakeWordEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+    return;
+  }
+  try {
+    if (enabled) {
+      window.localStorage.setItem(WAKE_WORD_KEY, '1');
+    } else {
+      window.localStorage.removeItem(WAKE_WORD_KEY);
+    }
+  } catch {
+    // No-op en private mode.
+  }
+}


### PR DESCRIPTION
## Resumen

Wave 5 PR 2 (parcial) — UI completa del wake-word \"Oye Booster\". Card en \`/app/conductor/configuracion\` + banner sticky en \`/app/conductor\` cuando el conductor opt-in.

**Este PR no integra el SDK Porcupine real** — eso requiere:
1. Cuenta Picovoice + access key (env \`PICOVOICE_ACCESS_KEY\`).
2. Modelo \`oye-booster-cl.ppn\` entrenado con voces chilenas.

La UI está lista para que cuando ambos lleguen, el wire ocurre solo en \`useWakeWord\` (sin tocar UI).

## Branch base / dependencias

Este branch incluye archivos cherry-pickeados de otros PRs en flight:
- Base: \`feat/conductor-identity-y-dashboard\` (Wave 1 — PR #179).
- Cherry-pick: \`feat/wake-word-oye-booster\` (Wave 5 PR 1 — PR #183).
- Cherry-pick: \`feat/auth-universal-ui-selector\` (Wave 4 PR 2 — PR #185).

**Orden de merge recomendado**: #184 (OpenTelemetry) → #179 (Wave 1) → #183 (Wave 5 PR 1) → #185 (Wave 4 PR 2) → este PR. Tras los merges, rebase quita los archivos redundantes y este PR queda con solo la UI delta.

## Cambios

### Servicios
- \`apps/web/src/services/wake-word-preference.ts\` (NUEVO): persistencia localStorage \`booster:wake-word:enabled\`. Default OFF. Mismo patrón que \`coaching-voice.ts/loadAutoplayPreference\`.

### UI \`/app/conductor/configuracion\` (5 cards ahora)
- Nueva card \"Activación por voz\" entre PermissionsCard y VoiceCommandsReferenceCard.
- **Flag OFF**: banner \"Próximamente — estamos entrenando con voces chilenas\".
- **Flag ON**: toggle real + label de estado + privacy disclaimers (audio on-device, mic pause auto en movimiento + screen off + background tab).

### UI \`/app/conductor\` (banner sticky)
- Nuevo \`WakeWordActiveBanner\` debajo del WhatsApp banner.
- Solo visible cuando flag ON + isWakeWordEnabled() true.
- Icono Mic con \`animate-pulse\` — feedback visible verificable de privacy.

## Evidencia

\`\`\`
pnpm --filter=@booster-ai/web typecheck            ✓
pnpm --filter=@booster-ai/web test --run           933/933 ✓ (91 archivos)
                                                   +17 nuevos combinando
                                                   Wave 1 + Wave 5 PR 1 +
                                                   useFeatureFlags + wake-word UI
pnpm exec biome check                              0 errors
                                                   1 warning (pre-existing
                                                   sortClasses en otro archivo)
\`\`\`

## Privacy verificable

- **localStorage es source-of-truth**: el opt-in lo controla el cliente, no el servidor.
- **Audio on-device**: cuando ON y el listener corre (Wave 5 PR 2 wire real), Porcupine WASM detecta la wake-word sin transmitir audio. Verificable abriendo DevTools Network.
- **Banner sticky**: el conductor SIEMPRE sabe cuándo el mic está activo. Si no ve el banner, el mic está apagado.

## Próximos pasos

- **Wave 5 PR 2 wire real**: Felipe crea cuenta Picovoice + entrena \"Oye Booster\" con samples chilenos (Van Oosterwyk). Después \`pnpm add @picovoice/porcupine-web\` + reemplazar \`StubWakeWordController\` por la implementación real. UI no cambia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)