### PR TITLE
feat(stakeholder): zonas filtradas por region_ambito (Wave 3 follow-up)

### DIFF
--- a/apps/web/src/components/CompanySwitcher.tsx
+++ b/apps/web/src/components/CompanySwitcher.tsx
@@ -30,7 +30,14 @@ export function CompanySwitcher({
   onSelect,
   disabled,
 }: CompanySwitcherProps) {
-  const activas = memberships.filter((m) => m.status === 'activa');
+  // ADR-034 — el switcher solo lista memberships a empresas comerciales,
+  // no a organizaciones stakeholder. Stakeholder users tienen su propia
+  // surface (`/app/stakeholder/zonas`) y normalmente single org; no
+  // necesitan switcher acá.
+  const activas = memberships.filter(
+    (m): m is typeof m & { empresa: NonNullable<typeof m.empresa> } =>
+      m.status === 'activa' && m.empresa != null,
+  );
   const active = activas.find((m) => m.empresa.id === activeEmpresaId) ?? activas[0];
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -47,7 +47,11 @@ export function Layout({
   title: string;
   children: ReactNode;
 }) {
-  const activeEmpresaId = me.active_membership?.empresa.id ?? null;
+  // ADR-034 — empresa puede ser null cuando la membership activa es a una
+  // organización stakeholder. El Layout es shipper/carrier surface; el
+  // AppRoute redirige a stakeholders a /app/stakeholder/zonas antes de
+  // llegar acá, pero usamos chaining null-safe defensivamente.
+  const activeEmpresaId = me.active_membership?.empresa?.id ?? null;
   const [mobileOpen, setMobileOpen] = useState(false);
   const { switchTo, isPending: switchPending } = useSwitchCompany();
 

--- a/apps/web/src/hooks/use-me.ts
+++ b/apps/web/src/hooks/use-me.ts
@@ -28,6 +28,10 @@ export interface MembershipPayload {
     | 'stakeholder_sostenibilidad';
   status: 'pendiente_invitacion' | 'activa' | 'suspendida' | 'removida';
   joined_at: string | null;
+  /**
+   * Empresa de la membership. NULL cuando la membership es a una
+   * organización stakeholder (XOR — ADR-034).
+   */
   empresa: {
     id: string;
     legal_name: string;
@@ -35,7 +39,22 @@ export interface MembershipPayload {
     is_generador_carga: boolean;
     is_transportista: boolean;
     status: 'pendiente_verificacion' | 'activa' | 'suspendida';
-  };
+  } | null;
+  /**
+   * ADR-034 — Organización stakeholder de la membership. NULL cuando la
+   * membership es a una empresa (XOR). Aparece solo para users con rol
+   * `stakeholder_sostenibilidad` en una organización dada de alta por
+   * platform-admin.
+   *
+   * Opcional para tolerar respuestas pre-Wave 3 (clientes cacheados).
+   */
+  organizacion_stakeholder?: {
+    id: string;
+    nombre_legal: string;
+    tipo: 'regulador' | 'gremio' | 'observatorio_academico' | 'ong' | 'corporativo_esg';
+    region_ambito: string | null;
+    sector_ambito: string | null;
+  } | null;
 }
 
 export interface MeUser {

--- a/apps/web/src/routes/asignacion-detalle.tsx
+++ b/apps/web/src/routes/asignacion-detalle.tsx
@@ -56,7 +56,7 @@ export function AsignacionDetalleRoute() {
         if (ctx.kind !== 'onboarded') {
           return null;
         }
-        const isCarrier = ctx.me.active_membership?.empresa.is_transportista ?? false;
+        const isCarrier = ctx.me.active_membership?.empresa?.is_transportista ?? false;
         if (!isCarrier) {
           return (
             <div className="mx-auto max-w-2xl px-6 py-12">

--- a/apps/web/src/routes/cargas.tsx
+++ b/apps/web/src/routes/cargas.tsx
@@ -296,7 +296,7 @@ export function CargasListRoute() {
 }
 
 function CargasListPage({ me }: { me: MeOnboarded }) {
-  const isShipper = me.active_membership?.empresa.is_generador_carga ?? false;
+  const isShipper = me.active_membership?.empresa?.is_generador_carga ?? false;
 
   const tripsQ = useQuery({
     queryKey: ['cargas'],
@@ -617,7 +617,7 @@ export function CargasNuevoRoute() {
         if (ctx.kind !== 'onboarded') {
           return null;
         }
-        const isShipper = ctx.me.active_membership?.empresa.is_generador_carga ?? false;
+        const isShipper = ctx.me.active_membership?.empresa?.is_generador_carga ?? false;
         if (!isShipper) {
           return (
             <Layout me={ctx.me} title="Nueva carga">

--- a/apps/web/src/routes/certificados.tsx
+++ b/apps/web/src/routes/certificados.tsx
@@ -57,7 +57,7 @@ export function CertificadosRoute() {
         if (ctx.kind !== 'onboarded') {
           return null;
         }
-        const isShipper = ctx.me.active_membership?.empresa.is_generador_carga ?? false;
+        const isShipper = ctx.me.active_membership?.empresa?.is_generador_carga ?? false;
         if (!isShipper) {
           return <NoShipperPermission me={ctx.me} />;
         }

--- a/apps/web/src/routes/cobra-hoy-historial.tsx
+++ b/apps/web/src/routes/cobra-hoy-historial.tsx
@@ -25,7 +25,7 @@ export function CobraHoyHistorialRoute() {
         if (ctx.kind !== 'onboarded') {
           return null;
         }
-        const isCarrier = ctx.me.active_membership?.empresa.is_transportista ?? false;
+        const isCarrier = ctx.me.active_membership?.empresa?.is_transportista ?? false;
         if (!isCarrier) {
           return <NoCarrierPermission />;
         }

--- a/apps/web/src/routes/liquidaciones.tsx
+++ b/apps/web/src/routes/liquidaciones.tsx
@@ -33,7 +33,7 @@ export function LiquidacionesRoute() {
         if (ctx.kind !== 'onboarded') {
           return null;
         }
-        const isCarrier = ctx.me.active_membership?.empresa.is_transportista ?? false;
+        const isCarrier = ctx.me.active_membership?.empresa?.is_transportista ?? false;
         if (!isCarrier) {
           return <NoCarrierPermission />;
         }

--- a/apps/web/src/routes/stakeholder-zonas.test.tsx
+++ b/apps/web/src/routes/stakeholder-zonas.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { filterZonasByRegion } from './stakeholder-zonas.js';
+
+const ZONAS = [
+  {
+    id: 'a',
+    nombre: 'A',
+    region: 'V',
+    region_iso: 'CL-VS',
+    tipo: 'puerto',
+    demo_viajes_30d: 1,
+    demo_co2e_kg: 1,
+    demo_horario_pico: 'x',
+  },
+  {
+    id: 'b',
+    nombre: 'B',
+    region: 'V',
+    region_iso: 'CL-VS',
+    tipo: 'puerto',
+    demo_viajes_30d: 1,
+    demo_co2e_kg: 1,
+    demo_horario_pico: 'x',
+  },
+  {
+    id: 'c',
+    nombre: 'C',
+    region: 'XIII',
+    region_iso: 'CL-RM',
+    tipo: 'mercado_abastos',
+    demo_viajes_30d: 1,
+    demo_co2e_kg: 1,
+    demo_horario_pico: 'x',
+  },
+  {
+    id: 'd',
+    nombre: 'D',
+    region: 'I',
+    region_iso: 'CL-TA',
+    tipo: 'zona_franca',
+    demo_viajes_30d: 1,
+    demo_co2e_kg: 1,
+    demo_horario_pico: 'x',
+  },
+] as Parameters<typeof filterZonasByRegion>[0];
+
+describe('filterZonasByRegion (ADR-034)', () => {
+  it('region_ambito null → devuelve todas (ámbito nacional)', () => {
+    expect(filterZonasByRegion(ZONAS, null)).toHaveLength(4);
+  });
+
+  it('region_ambito undefined → devuelve todas', () => {
+    expect(filterZonasByRegion(ZONAS, undefined)).toHaveLength(4);
+  });
+
+  it('region_ambito CL-VS → solo Valparaíso', () => {
+    const result = filterZonasByRegion(ZONAS, 'CL-VS');
+    expect(result).toHaveLength(2);
+    expect(result.every((z) => z.region_iso === 'CL-VS')).toBe(true);
+  });
+
+  it('region_ambito CL-RM → solo Metropolitana', () => {
+    const result = filterZonasByRegion(ZONAS, 'CL-RM');
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe('c');
+  });
+
+  it('region_ambito sin matches → array vacío', () => {
+    const result = filterZonasByRegion(ZONAS, 'CL-XX');
+    expect(result).toHaveLength(0);
+  });
+});

--- a/apps/web/src/routes/stakeholder-zonas.tsx
+++ b/apps/web/src/routes/stakeholder-zonas.tsx
@@ -1,3 +1,4 @@
+import { STAKEHOLDER_ORG_TYPE_LABEL } from '@booster-ai/shared-schemas';
 import { Link, Navigate } from '@tanstack/react-router';
 import { ArrowLeft, Building2, Info, MapPin, Shield, TrendingUp } from 'lucide-react';
 import type { ReactNode } from 'react';
@@ -36,6 +37,12 @@ interface ZonaPredefinida {
   id: string;
   nombre: string;
   region: string;
+  /**
+   * Código ISO 3166-2:CL (e.g. `CL-VS`, `CL-RM`). Usado para filtrar las
+   * zonas mostradas por el ámbito declarado de la organización stakeholder
+   * (ADR-034 — `organizacion_stakeholder.region_ambito`).
+   */
+  region_iso: string;
   tipo: 'puerto' | 'mercado_abastos' | 'polo_industrial' | 'zona_franca';
   /**
    * Datos demo en este sprint — la próxima iteración pulla esto del API
@@ -52,6 +59,7 @@ const ZONAS_DEMO: ZonaPredefinida[] = [
     id: 'puerto-valparaiso',
     nombre: 'Puerto Valparaíso',
     region: 'V Valparaíso',
+    region_iso: 'CL-VS',
     tipo: 'puerto',
     demo_viajes_30d: 1247,
     demo_co2e_kg: 312_400,
@@ -61,6 +69,7 @@ const ZONAS_DEMO: ZonaPredefinida[] = [
     id: 'puerto-san-antonio',
     nombre: 'Puerto San Antonio',
     region: 'V Valparaíso',
+    region_iso: 'CL-VS',
     tipo: 'puerto',
     demo_viajes_30d: 1893,
     demo_co2e_kg: 478_900,
@@ -70,6 +79,7 @@ const ZONAS_DEMO: ZonaPredefinida[] = [
     id: 'mercado-lo-valledor',
     nombre: 'Mercado Lo Valledor',
     region: 'XIII Metropolitana',
+    region_iso: 'CL-RM',
     tipo: 'mercado_abastos',
     demo_viajes_30d: 2104,
     demo_co2e_kg: 89_300,
@@ -79,6 +89,7 @@ const ZONAS_DEMO: ZonaPredefinida[] = [
     id: 'polo-quilicura',
     nombre: 'Polo industrial Quilicura',
     region: 'XIII Metropolitana',
+    region_iso: 'CL-RM',
     tipo: 'polo_industrial',
     demo_viajes_30d: 856,
     demo_co2e_kg: 167_200,
@@ -88,12 +99,31 @@ const ZONAS_DEMO: ZonaPredefinida[] = [
     id: 'zofri-iquique',
     nombre: 'Zona Franca Iquique',
     region: 'I Tarapacá',
+    region_iso: 'CL-TA',
     tipo: 'zona_franca',
     demo_viajes_30d: 425,
     demo_co2e_kg: 198_500,
     demo_horario_pico: '08:00 – 12:00',
   },
 ];
+
+/**
+ * Filtra las zonas según el ámbito geográfico de la organización
+ * stakeholder. NULL `region_ambito` = ámbito nacional → todas las zonas
+ * visibles. Cualquier otro valor filtra a las que matchean.
+ *
+ * Sin región matcheante: devuelve array vacío. El caller debe mostrar
+ * estado "No hay zonas en el ámbito de tu organización".
+ */
+export function filterZonasByRegion(
+  zonas: ZonaPredefinida[],
+  regionAmbito: string | null | undefined,
+): ZonaPredefinida[] {
+  if (!regionAmbito) {
+    return zonas;
+  }
+  return zonas.filter((z) => z.region_iso === regionAmbito);
+}
 
 const TIPO_LABEL: Record<ZonaPredefinida['tipo'], string> = {
   puerto: 'Puerto',
@@ -128,6 +158,12 @@ export function StakeholderZonasRoute() {
 }
 
 function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
+  // ADR-034 — el active_membership de un stakeholder apunta a una
+  // `organizacion_stakeholder` (no a una `empresa`). Extraemos el scope
+  // declarado para filtrar las zonas mostradas.
+  const org = me.active_membership?.organizacion_stakeholder ?? null;
+  const zonasVisibles = filterZonasByRegion(ZONAS_DEMO, org?.region_ambito);
+
   return (
     <Layout me={me} title="Zonas de impacto">
       <div className="flex items-center gap-3">
@@ -157,6 +193,33 @@ function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
         </div>
       </header>
 
+      {/* ADR-034 — Contexto de la organización stakeholder del usuario.
+          Muestra a qué organización pertenece y cuál es su ámbito de
+          datos (regional / sectorial / nacional). Esto da transparencia:
+          el stakeholder ve por qué algunas zonas no aparecen (filtro). */}
+      {org && (
+        <div
+          className="mt-6 flex flex-wrap items-center gap-3 rounded-md border border-violet-200 bg-violet-50/50 p-4 text-sm"
+          data-testid="stakeholder-org-context"
+        >
+          <Building2 className="h-4 w-4 shrink-0 text-violet-700" aria-hidden />
+          <div className="text-violet-900">
+            <span className="font-semibold">{org.nombre_legal}</span>{' '}
+            <span className="text-violet-700 text-xs">
+              · {STAKEHOLDER_ORG_TYPE_LABEL[org.tipo]}
+            </span>
+          </div>
+          <div className="ml-auto flex flex-wrap items-center gap-2 text-violet-700 text-xs">
+            <span className="rounded bg-violet-100 px-2 py-0.5">
+              Ámbito: {org.region_ambito ? `Región ${org.region_ambito}` : 'Nacional'}
+            </span>
+            {org.sector_ambito && (
+              <span className="rounded bg-violet-100 px-2 py-0.5">Sector: {org.sector_ambito}</span>
+            )}
+          </div>
+        </div>
+      )}
+
       <div className="mt-6 rounded-md border border-amber-200 bg-amber-50/60 p-4 text-sm">
         <div className="flex items-start gap-2 text-amber-900">
           <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
@@ -169,15 +232,34 @@ function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
       </div>
 
       <section className="mt-8">
-        <h2 className="font-semibold text-neutral-900 text-xl">Zonas monitoreadas</h2>
+        <h2 className="font-semibold text-neutral-900 text-xl">
+          {org?.region_ambito ? `Zonas monitoreadas en ${org.region_ambito}` : 'Zonas monitoreadas'}
+        </h2>
         <p className="mt-1 text-neutral-600 text-sm">
-          Selecciona una zona para drill-down a flujos por hora, tipo de carga y mix de combustible.
+          {org?.region_ambito
+            ? `Tu organización tiene ámbito regional ${org.region_ambito}. Solo ves zonas dentro de esa región.`
+            : 'Selecciona una zona para drill-down a flujos por hora, tipo de carga y mix de combustible.'}
         </p>
-        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {ZONAS_DEMO.map((z) => (
-            <ZonaCard key={z.id} zona={z} />
-          ))}
-        </div>
+
+        {zonasVisibles.length === 0 ? (
+          <div
+            className="mt-4 rounded-md border border-neutral-200 bg-white p-6 text-center text-neutral-600 text-sm"
+            data-testid="stakeholder-zonas-empty"
+          >
+            <Info className="mx-auto h-8 w-8 text-neutral-300" aria-hidden />
+            <p className="mt-2">
+              No hay zonas dentro del ámbito de tu organización
+              {org?.region_ambito && ` (${org.region_ambito})`}. Pídele a Booster que extienda el
+              ámbito o agregue zonas nuevas si tu organización las necesita.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+            {zonasVisibles.map((z) => (
+              <ZonaCard key={z.id} zona={z} />
+            ))}
+          </div>
+        )}
       </section>
 
       <section className="mt-10 rounded-lg border border-neutral-200 bg-white p-5">


### PR DESCRIPTION
## Resumen

Cierra el loop del PR #180 (ADR-034) llevando el \`region_ambito\` de la organización stakeholder al filtrado real de \`/app/stakeholder/zonas\`. Hasta este PR el campo se almacenaba pero no afectaba la UI.

**Branch base**: \`feat/stakeholder-organizations\` (PR #180).

## Cambios

### UI con scope visible
- Header agrega banner violeta con: nombre legal de la organización + tipo humano + chips "Ámbito: Región CL-XX" o "Nacional" + "Sector: <slug>" si setado.
- Lista de zonas filtrada por \`region_iso\` matcheando \`region_ambito\`. Si NULL = ámbito nacional → todas las zonas visibles.
- Estado vacío amable cuando filtro deja 0 zonas.

### Type safety
- \`MembershipPayload.empresa\` se hace nullable (XOR con \`organizacion_stakeholder\` — ADR-034 ya lo declaraba en backend, faltaba TS).
- Nuevo \`organizacion_stakeholder?: {...} | null\` opcional.

### Defensive null-safety
- Layout, CompanySwitcher, asignacion-detalle, cargas, certificados, cobra-hoy-historial, liquidaciones: \`?\` chaining donde antes asumían \`empresa\` non-null. AppRoute redirige stakeholders antes de llegar, pero el check es correcto.
- CompanySwitcher filtra explícitamente \`empresa != null\` — solo lista empresas comerciales.

### Tests
- 5 specs nuevos para \`filterZonasByRegion\`: null/undefined → todas, ISO matcheante → subset, sin match → vacío.

## Evidencia

\`\`\`
pnpm --filter=@booster-ai/web typecheck            ✓
pnpm --filter=@booster-ai/web test --run           913/913 ✓ (88 archivos)
                                                   +5 nuevos stakeholder-zonas.test
pnpm exec biome check                              0 errors
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)