### PR TITLE
chore(auth): activar AUTH_UNIVERSAL_V1_ACTIVATED en prod (default true)

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -323,7 +323,12 @@ variable "matching_v2_weights_json" {
 variable "auth_universal_v1_activated" {
   description = "Activa el flow universal RUT + clave numérica (ADR-035). false = legacy email/password."
   type        = bool
-  default     = false
+  # Activado por Felipe (PO) 2026-05-13 tras merge de Waves 4 PR 1-3.
+  # El cambio enciende el selector RUT+clave + modal forzado de rotación
+  # para usuarios legacy en su próximo login. Flip reversible sin
+  # redeploy de código — setear a `false` y `terraform apply` revierte
+  # al flow legacy en segundos.
+  default = true
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Resumen

Activa el flag \`AUTH_UNIVERSAL_V1_ACTIVATED\` en producción cambiando el default de la variable Terraform de \`false\` a \`true\`. El próximo \`terraform apply\` propaga el flip a Cloud Run.

## Pre-requisitos de merge

**Este PR NO debe mergearse antes de que estos estén en main:**

- [ ] [#184](https://github.com/boosterchile/booster-ai/pull/184) — bump @opentelemetry/* (desbloquea CI)
- [ ] [#181](https://github.com/boosterchile/booster-ai/pull/181) — Wave 4 PR 1 (backend foundation)
- [ ] [#185](https://github.com/boosterchile/booster-ai/pull/185) — Wave 4 PR 2 (UI selector + /feature-flags)
- [ ] [#187](https://github.com/boosterchile/booster-ai/pull/187) — Wave 4 PR 3 (modal rotación + endpoint)

Si este PR mergea sin las 3 dependencias, el frontend rompe:
- Sin #181: \`POST /auth/login-rut\` no existe → 404 desde cliente.
- Sin #185: el frontend no tiene UI nueva (flag activo sin efecto visible).
- Sin #187: usuarios legacy quedan en loop needs_rotation sin forma de setear clave.

## Qué cambia post-merge + apply

- **Usuarios nuevos**: registro con RUT + clave directamente.
- **Usuarios legacy con Google**: entran con Google → ProtectedRoute detecta \`has_clave_numerica=false\` → modal forzado → crean clave → próximo login va por flow universal.
- **Usuarios legacy con email/password**: idem (entran via \`/login?legacy=1\` una vez).
- **Stakeholders** (post-Wave 3): mismo modal de rotación; auth universal funciona para todos los roles.

## Rollback

Setear \`default = false\` + commit + \`terraform apply\`. Reversión instantánea (Cloud Run respawn ~30s).

## WAKE_WORD_VOICE_ACTIVATED queda en false

Picovoice Console respondió \"Thank you for your interest\" — el modelo custom \"Oye Booster\" sigue en aprobación. Cuando llegue el access key y el modelo entrenado, se activará en un PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)