### PR TITLE
fix(security): migrar Routes API key → ADC con X-Goog-User-Project (ADR-038)

### DIFF
--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -233,27 +233,14 @@ const apiEnvSchema = commonEnvSchema
       .optional(),
 
     /**
-     * API key para Google Routes API (Phase 1 — eco route suggestion).
-     *
-     * IMPORTANTE: esta key DEBE estar restringida a los servidores de
-     * Cloud Run del backend, NO al dominio app.boosterchile.com — Routes
-     * API se llama server-to-server, no desde el browser. La restricción
-     * en GCP Console → APIs → Credentials → "Booster Routes - API
-     * Backend" debe ser por IP o por SA, nunca HTTP referrer.
-     *
-     * Optional: si está ausente, los servicios que la usan caen al
-     * fallback de estimarDistanciaKm (tabla pre-computada Chile) y NO
-     * generan sugerencia de eco-route. Útil en dev sin quota Routes API.
-     */
-    GOOGLE_ROUTES_API_KEY: z.string().min(1).optional(),
-
-    /**
      * GCP project ID — Cloud Run lo setea automáticamente en runtime.
-     * Usado para construir el endpoint Vertex AI Gemini (ADR-037).
+     * Usado para:
+     *   - Vertex AI Gemini endpoint (ADR-037, coaching IA post-entrega).
+     *   - Header X-Goog-User-Project en Routes API via ADC (ADR-038).
      *
      * Default-required en producción; optional acá porque en tests/dev
-     * locales puede no estar definido (el coaching cae al fallback
-     * plantilla automáticamente sin generar error).
+     * locales puede no estar definido (los flows caen al fallback
+     * determinístico automáticamente sin generar error).
      */
     GOOGLE_CLOUD_PROJECT: z.string().min(1).optional(),
 

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -7,6 +7,40 @@ import {
 } from '@booster-ai/config';
 import { z } from 'zod';
 
+/**
+ * Parsea env var boolean correctamente. `z.coerce.boolean()` es un footgun
+ * — coerce-ea CUALQUIER string non-empty a `true`, incluyendo "false".
+ *
+ * Bug descubierto 2026-05-13: `WAKE_WORD_VOICE_ACTIVATED="false"` se
+ * coerce-eaba a `true`. Propagó al endpoint /feature-flags y a logic
+ * server. Mismo issue afectaba a AUTH_UNIVERSAL_V1_ACTIVATED,
+ * MATCHING_ALGORITHM_V2_ACTIVATED, FACTORING_V1_ACTIVATED,
+ * PRICING_V2_ACTIVATED.
+ *
+ * Mapea explícitamente: "true"/"1" → true, "false"/"0"/"" → false,
+ * otros (incluyendo undefined) → defaultValue.
+ */
+function booleanFlag(defaultValue: boolean) {
+  return z
+    .preprocess((v) => {
+      if (typeof v === 'boolean') {
+        return v;
+      }
+      if (typeof v !== 'string') {
+        return defaultValue;
+      }
+      const normalized = v.trim().toLowerCase();
+      if (normalized === 'true' || normalized === '1') {
+        return true;
+      }
+      if (normalized === 'false' || normalized === '0' || normalized === '') {
+        return false;
+      }
+      return defaultValue;
+    }, z.boolean())
+    .default(defaultValue);
+}
+
 const apiEnvSchema = commonEnvSchema
   .merge(databaseEnvSchema)
   .merge(redisEnvSchema)
@@ -267,7 +301,7 @@ const apiEnvSchema = commonEnvSchema
      * Override explícito: setear `PRICING_V2_ACTIVATED=false` en Cloud Run
      * env revierte la activación en segundos sin tocar BD ni código.
      */
-    PRICING_V2_ACTIVATED: z.coerce.boolean().default(process.env.NODE_ENV === 'production'),
+    PRICING_V2_ACTIVATED: booleanFlag(process.env.NODE_ENV === 'production'),
 
     /**
      * Feature flag para activar factoring v1 / "Booster Cobra Hoy"
@@ -288,7 +322,7 @@ const apiEnvSchema = commonEnvSchema
      *     queda diferido — adelantos quedan en `solicitado` hasta
      *     integración del partner.
      */
-    FACTORING_V1_ACTIVATED: z.coerce.boolean().default(process.env.NODE_ENV === 'production'),
+    FACTORING_V1_ACTIVATED: booleanFlag(process.env.NODE_ENV === 'production'),
 
     /**
      * Allowlist de emails con acceso a endpoints `/admin/cobra-hoy/*`
@@ -359,7 +393,7 @@ const apiEnvSchema = commonEnvSchema
      *   2. Backtest sobre 30d de staging — si delta favorable, flag=true en staging por 7d.
      *   3. Si métricas siguen estables, flag=true en prod.
      */
-    MATCHING_ALGORITHM_V2_ACTIVATED: z.coerce.boolean().default(false),
+    MATCHING_ALGORITHM_V2_ACTIVATED: booleanFlag(false),
 
     /**
      * ADR-035 (Wave 4) — Feature flag para activar el flow universal
@@ -378,7 +412,7 @@ const apiEnvSchema = commonEnvSchema
      *      con flag=true. Si OK, flag=true en prod.
      *   3. PR 3 (migración 30d): forzar rotación al login siguiente.
      */
-    AUTH_UNIVERSAL_V1_ACTIVATED: z.coerce.boolean().default(false),
+    AUTH_UNIVERSAL_V1_ACTIVATED: booleanFlag(false),
 
     /**
      * ADR-036 (Wave 5) — Feature flag para wake-word "Oye Booster" en
@@ -395,7 +429,7 @@ const apiEnvSchema = commonEnvSchema
      * Rollout: false en prod hasta que el modelo custom
      * `oye-booster-cl.ppn` esté entrenado con voces chilenas (Wave 5 PR 2).
      */
-    WAKE_WORD_VOICE_ACTIVATED: z.coerce.boolean().default(false),
+    WAKE_WORD_VOICE_ACTIVATED: booleanFlag(false),
 
     /**
      * ADR-033 §1 — Pesos custom para los componentes del scoring v2.

--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -49,12 +49,12 @@ export function createAssignmentsRoutes(opts: {
   logger: Logger;
   certConfig?: Partial<EmitirCertificadoConfig>;
   /**
-   * Phase 1 PR-H5 — Routes API key opcional. Si está presente, el
-   * endpoint /assignments/:id/eco-route fetches polyline desde Routes
-   * API; si no, devuelve { polyline_encoded: null, status: 'no_routes_api_key' }
-   * sin error (la página del driver sigue funcional sin mapa).
+   * GCP project ID — usado como X-Goog-User-Project en Routes API (ADR-038).
+   * Si está presente, el endpoint /assignments/:id/eco-route fetches polyline
+   * desde Routes API via ADC; si no, devuelve { polyline_encoded: null,
+   * status: 'no_routes_api_key' } sin error.
    */
-  routesApiKey?: string | undefined;
+  routesProjectId?: string | undefined;
 }) {
   const app = new Hono();
 
@@ -268,7 +268,7 @@ export function createAssignmentsRoutes(opts: {
       logger: opts.logger,
       assignmentId,
       empresaId,
-      ...(opts.routesApiKey ? { routesApiKey: opts.routesApiKey } : {}),
+      ...(opts.routesProjectId ? { routesProjectId: opts.routesProjectId } : {}),
     });
     if (result.kind === 'not_found') {
       return c.json({ error: 'assignment_not_found', code: 'assignment_not_found' }, 404);

--- a/apps/api/src/routes/offers.ts
+++ b/apps/api/src/routes/offers.ts
@@ -205,7 +205,7 @@ export function createOfferRoutes(opts: {
         logger: opts.logger,
         offerId,
         empresaId: active.empresa.id,
-        routesApiKey: config.GOOGLE_ROUTES_API_KEY,
+        routesProjectId: config.GOOGLE_CLOUD_PROJECT,
       });
       return c.json({
         trip_request_id: preview.tripId,

--- a/apps/api/src/routes/public-tracking.ts
+++ b/apps/api/src/routes/public-tracking.ts
@@ -25,12 +25,12 @@ export function createPublicTrackingRoutes(opts: {
   db: Db;
   logger: Logger;
   /**
-   * Phase 5 PR-L2c — Routes API key opcional. Si presente, el ETA del
-   * tracking público se calcula con distancia por carretera real al
-   * destino exacto (vs centroide regional). Si ausente o el call falla,
-   * fallback transparente al método de PR-L2b.
+   * GCP project ID para X-Goog-User-Project en Routes API (ADR-038).
+   * Si presente, ETA del tracking público se calcula con distancia por
+   * carretera real al destino exacto (vs centroide regional). Fallback
+   * transparente al método de PR-L2b si ausente o si el call falla.
    */
-  routesApiKey?: string | undefined;
+  routesProjectId?: string | undefined;
 }) {
   const app = new Hono();
 
@@ -41,7 +41,7 @@ export function createPublicTrackingRoutes(opts: {
       db: opts.db,
       logger: opts.logger,
       token,
-      ...(opts.routesApiKey ? { routesApiKey: opts.routesApiKey } : {}),
+      ...(opts.routesProjectId ? { routesProjectId: opts.routesProjectId } : {}),
     });
 
     if (result.status === 'not_found') {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -142,16 +142,16 @@ export function createServer(opts: CreateServerOptions): Hono {
   // El handler restringe los datos expuestos (plate parcial, sin
   // driver name, telemetría sólo <30min).
   //
-  // Phase 5 PR-L2c — si GOOGLE_ROUTES_API_KEY está configurada, el ETA
-  // del tracking se calcula con Routes API (distancia real por carretera
-  // al destino exacto). Sin la key, fallback transparente al ETA al
-  // centroide regional (PR-L2b).
+  // ADR-038: Routes API via ADC. Pasamos GOOGLE_CLOUD_PROJECT en lugar
+  // de API key — el SA del runtime se autentica via workload identity, y
+  // el projectId va en X-Goog-User-Project. Si la env var está ausente,
+  // fallback transparente al ETA al centroide regional (PR-L2b).
   app.route(
     '/public/tracking',
     createPublicTrackingRoutes({
       db: opts.db,
       logger,
-      ...(config.GOOGLE_ROUTES_API_KEY ? { routesApiKey: config.GOOGLE_ROUTES_API_KEY } : {}),
+      ...(config.GOOGLE_CLOUD_PROJECT ? { routesProjectId: config.GOOGLE_CLOUD_PROJECT } : {}),
     }),
   );
 
@@ -289,10 +289,10 @@ export function createServer(opts: CreateServerOptions): Hono {
       db: opts.db,
       logger,
       certConfig,
-      // Phase 1 PR-H5 — Routes API key para que GET /assignments/:id/eco-route
-      // pueda devolver la polyline. Sin esta key, el endpoint devuelve
-      // polyline_encoded=null con status='no_routes_api_key' (no error).
-      ...(config.GOOGLE_ROUTES_API_KEY ? { routesApiKey: config.GOOGLE_ROUTES_API_KEY } : {}),
+      // ADR-038: Routes API via ADC. GOOGLE_CLOUD_PROJECT va como
+      // X-Goog-User-Project. Sin él, GET /assignments/:id/eco-route
+      // devuelve polyline_encoded=null con status='no_routes_api_key'.
+      ...(config.GOOGLE_CLOUD_PROJECT ? { routesProjectId: config.GOOGLE_CLOUD_PROJECT } : {}),
     });
     const chatRouter = createChatRoutes({
       db: opts.db,

--- a/apps/api/src/services/calcular-metricas-viaje.ts
+++ b/apps/api/src/services/calcular-metricas-viaje.ts
@@ -112,7 +112,7 @@ async function obtenerDistanciaKm(opts: {
   origenRegionCode: string | null;
   destinoRegionCode: string | null;
   fuelType: string | null;
-  routesApiKey: string | undefined;
+  routesProjectId: string | undefined;
   logger: Logger;
 }): Promise<number> {
   const {
@@ -121,15 +121,15 @@ async function obtenerDistanciaKm(opts: {
     origenRegionCode,
     destinoRegionCode,
     fuelType,
-    routesApiKey,
+    routesProjectId,
     logger,
   } = opts;
 
-  if (routesApiKey) {
+  if (routesProjectId) {
     try {
       const emissionType = fuelType ? mapFuelToEmissionType(fuelType) : undefined;
       const routes = await computeRoutes({
-        apiKey: routesApiKey,
+        projectId: routesProjectId,
         origin: origenDireccion,
         destination: destinoDireccion,
         emissionType,
@@ -166,13 +166,13 @@ export async function calcularMetricasEstimadas(opts: {
   tripId: string;
   vehicleId: string | null;
   /**
-   * GOOGLE_ROUTES_API_KEY del config. Si está presente, se usa Routes API
-   * para distancia precisa. Si no, se cae al fallback de estimarDistanciaKm.
-   * Optional: el caller decide si la pasa o no (en dev sin quota la omite).
+   * GCP project ID — header X-Goog-User-Project para Routes API (ADR-038).
+   * Si presente, se usa Routes API via ADC para distancia precisa.
+   * Si no, fallback a estimarDistanciaKm.
    */
-  routesApiKey?: string | undefined;
+  routesProjectId?: string | undefined;
 }): Promise<CalcularMetricasResult> {
-  const { db, logger, tripId, vehicleId, routesApiKey } = opts;
+  const { db, logger, tripId, vehicleId, routesProjectId } = opts;
 
   // (1) Lectura de trip + vehicle FUERA de la transacción. Esto permite
   // hacer el HTTP a Routes API sin extender el lock de la tx (que sería
@@ -197,7 +197,7 @@ export async function calcularMetricasEstimadas(opts: {
     origenRegionCode: trip.originRegionCode,
     destinoRegionCode: trip.destinationRegionCode,
     fuelType: veh?.fuelType ?? null,
-    routesApiKey,
+    routesProjectId,
     logger,
   });
 

--- a/apps/api/src/services/compute-route-eta.ts
+++ b/apps/api/src/services/compute-route-eta.ts
@@ -58,8 +58,11 @@ export interface ComputeRouteEtaInput {
   avgSpeedKmh: number | null;
   /** ETA en minutos del fallback (PR-L2b centroide). Devolvemos esto si Routes API no aplica. */
   fallbackEtaMinutes: number | null;
-  /** API key del Routes API. Si undefined/empty, usamos fallback directo. */
-  routesApiKey: string | undefined;
+  /**
+   * GCP project ID para X-Goog-User-Project en Routes API (ADR-038).
+   * Si undefined/empty, usamos fallback directo sin llamar a Routes API.
+   */
+  routesProjectId: string | undefined;
   /** Inyectable para tests. Default: import dinámico de fetch global. */
   fetchImpl?: typeof fetch | undefined;
   /** Inyectable para tests. Default: in-memory module singleton. */
@@ -167,7 +170,7 @@ export async function computeRouteEta(input: ComputeRouteEtaInput): Promise<Comp
     destinationAddress,
     avgSpeedKmh,
     fallbackEtaMinutes,
-    routesApiKey,
+    routesProjectId,
     fetchImpl,
     cacheStore = defaultCache,
     nowMs = Date.now(),
@@ -176,7 +179,7 @@ export async function computeRouteEta(input: ComputeRouteEtaInput): Promise<Comp
   // Early returns: si nos faltan inputs críticos, devolvemos el fallback
   // sin tocar Routes API. Esto incluye los casos donde el fallback
   // también es null (NO_ETA_STATUSES, sin posición, etc.).
-  if (!routesApiKey) {
+  if (!routesProjectId) {
     return { etaMinutes: fallbackEtaMinutes, source: pickFallbackSource(fallbackEtaMinutes) };
   }
   if (currentLat === null || currentLng === null) {
@@ -206,7 +209,7 @@ export async function computeRouteEta(input: ComputeRouteEtaInput): Promise<Comp
     // lo interpreta como punto exacto sin geocoding.
     const origin = `${currentLat},${currentLng}`;
     const routes = await computeRoutes({
-      apiKey: routesApiKey,
+      projectId: routesProjectId,
       origin,
       destination: destinationAddress,
       computeAlternatives: false,

--- a/apps/api/src/services/eco-route-preview.ts
+++ b/apps/api/src/services/eco-route-preview.ts
@@ -124,9 +124,14 @@ export async function generarEcoPreview(opts: {
   offerId: string;
   /** Empresa del carrier que está pidiendo el preview (validación de ownership). */
   empresaId: string;
-  routesApiKey?: string | undefined;
+  /**
+   * GCP project ID — usado para construir el header X-Goog-User-Project
+   * en el call a Routes API (ADR-038, migración desde API key a ADC).
+   * Si está ausente, skip Routes API y cae a tabla_chile.
+   */
+  routesProjectId?: string | undefined;
 }): Promise<EcoRoutePreview> {
-  const { db, logger, offerId, empresaId, routesApiKey } = opts;
+  const { db, logger, offerId, empresaId, routesProjectId } = opts;
 
   // (1) Cargar offer + trip + vehicle en una sola query con joins.
   const rows = await db
@@ -159,11 +164,11 @@ export async function generarEcoPreview(opts: {
   let dataSource: DataSourcePreview = 'tabla_chile';
   let polylineEncoded: string | null = null;
 
-  if (routesApiKey) {
+  if (routesProjectId) {
     try {
       const emissionType = veh?.fuelType ? mapFuelToEmissionType(veh.fuelType) : undefined;
       const routes = await computeRoutes({
-        apiKey: routesApiKey,
+        projectId: routesProjectId,
         origin: trip.originAddressRaw,
         destination: trip.destinationAddressRaw,
         emissionType,

--- a/apps/api/src/services/get-assignment-eco-route.ts
+++ b/apps/api/src/services/get-assignment-eco-route.ts
@@ -70,9 +70,10 @@ export async function getAssignmentEcoRoute(opts: {
   logger: Logger;
   assignmentId: string;
   empresaId: string;
-  routesApiKey?: string | undefined;
+  /** GCP project ID — header X-Goog-User-Project para Routes API (ADR-038). */
+  routesProjectId?: string | undefined;
 }): Promise<GetAssignmentEcoRouteResult> {
-  const { db, logger, assignmentId, empresaId, routesApiKey } = opts;
+  const { db, logger, assignmentId, empresaId, routesProjectId } = opts;
 
   // Cargar assignment + trip en una query (origin/destination addresses
   // + polyline cacheada PR-H5b).
@@ -114,7 +115,7 @@ export async function getAssignmentEcoRoute(opts: {
     };
   }
 
-  if (!routesApiKey) {
+  if (!routesProjectId) {
     return {
       kind: 'ok',
       data: {
@@ -128,7 +129,7 @@ export async function getAssignmentEcoRoute(opts: {
 
   try {
     const routes = await computeRoutes({
-      apiKey: routesApiKey,
+      projectId: routesProjectId,
       origin: row.originAddress,
       destination: row.destinationAddress,
       computeAlternatives: false,

--- a/apps/api/src/services/get-public-tracking.ts
+++ b/apps/api/src/services/get-public-tracking.ts
@@ -154,13 +154,14 @@ export async function getPublicTracking(opts: {
   logger: Logger;
   token: string;
   /**
-   * Phase 5 PR-L2c — si está presente, calculamos el ETA con Routes API
-   * (distancia real por carretera al destino exacto). Si está ausente
-   * o el call falla, fallback al ETA de centroide regional (PR-L2b).
+   * GCP project ID para X-Goog-User-Project en Routes API (ADR-038).
+   * Si presente, ETA se calcula con distancia real por carretera al
+   * destino exacto. Fallback al ETA de centroide regional (PR-L2b) si
+   * ausente o el call falla.
    */
-  routesApiKey?: string | undefined;
+  routesProjectId?: string | undefined;
 }): Promise<PublicTrackingResult> {
-  const { db, logger, token, routesApiKey } = opts;
+  const { db, logger, token, routesProjectId } = opts;
 
   // Validar formato UUID antes de query — si no parece UUID, no
   // pegamos la DB (defensa contra scanning).
@@ -253,7 +254,7 @@ export async function getPublicTracking(opts: {
   });
 
   // Phase 5 PR-L2c — upgrade a Routes API on-demand. Si trip está activo
-  // y hay posición + avgSpeed + routesApiKey + destinationAddress,
+  // y hay posición + avgSpeed + routesProjectId + destinationAddress,
   // pedimos a Routes API la distancia real por carretera al destino y
   // recalculamos con el avgSpeed del vehículo. Cache de 5min + grid 0.01°
   // evita hammering. Fallback automático al centroide si algo falla.
@@ -267,7 +268,7 @@ export async function getPublicTracking(opts: {
       destinationAddress: row.destAddr,
       avgSpeedKmh: progress.avg_speed_kmh_last_15min,
       fallbackEtaMinutes,
-      routesApiKey,
+      routesProjectId,
     });
     etaMinutes = routeEtaResult.etaMinutes;
     logger.debug(

--- a/apps/api/src/services/offer-actions.ts
+++ b/apps/api/src/services/offer-actions.ts
@@ -220,11 +220,10 @@ export async function acceptOffer(opts: {
           logger,
           tripId: result.assignment.tripId,
           vehicleId: result.assignment.vehicleId || null,
-          // ADR-028 PR-H2: si hay GOOGLE_ROUTES_API_KEY, calcularMetricas
-          // usa Routes API para distancia (más precisa, traffic-aware) en
-          // vez de la tabla pre-computada Chile. Si no hay key (dev sin
-          // quota), cae al fallback automáticamente.
-          routesApiKey: config.GOOGLE_ROUTES_API_KEY,
+          // ADR-038: Routes API via ADC. GOOGLE_CLOUD_PROJECT activa la
+          // llamada (distancia más precisa, traffic-aware). Si está ausente,
+          // fallback a la tabla pre-computada Chile.
+          routesProjectId: config.GOOGLE_CLOUD_PROJECT,
         });
         logger.info(
           {
@@ -270,7 +269,7 @@ export async function acceptOffer(opts: {
           db,
           logger,
           assignmentId: result.assignment.id,
-          ...(config.GOOGLE_ROUTES_API_KEY ? { routesApiKey: config.GOOGLE_ROUTES_API_KEY } : {}),
+          ...(config.GOOGLE_CLOUD_PROJECT ? { routesProjectId: config.GOOGLE_CLOUD_PROJECT } : {}),
         });
       } catch (err) {
         logger.error(

--- a/apps/api/src/services/persist-eco-route-polyline.ts
+++ b/apps/api/src/services/persist-eco-route-polyline.ts
@@ -40,11 +40,11 @@ export async function persistEcoRoutePolyline(opts: {
   db: Db;
   logger: Logger;
   assignmentId: string;
-  routesApiKey?: string | undefined;
+  routesProjectId?: string | undefined;
 }): Promise<PersistEcoRoutePolylineResult> {
-  const { db, logger, assignmentId, routesApiKey } = opts;
+  const { db, logger, assignmentId, routesProjectId } = opts;
 
-  if (!routesApiKey) {
+  if (!routesProjectId) {
     return { attempted: false, persisted: false, reason: 'no_routes_api_key' };
   }
 
@@ -71,7 +71,7 @@ export async function persistEcoRoutePolyline(opts: {
   let polylineEncoded: string | null = null;
   try {
     const routes = await computeRoutes({
-      apiKey: routesApiKey,
+      projectId: routesProjectId,
       origin: row.originAddress,
       destination: row.destinationAddress,
       computeAlternatives: false,

--- a/apps/api/src/services/routes-api.ts
+++ b/apps/api/src/services/routes-api.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@booster-ai/logger';
+import { GoogleAuth } from 'google-auth-library';
 
 /**
  * Cliente del Google Routes API (Phase 1 — eco route suggestion).
@@ -6,20 +7,34 @@ import type { Logger } from '@booster-ai/logger';
  * Endpoint: POST https://routes.googleapis.com/directions/v2:computeRoutes
  * Docs: https://developers.google.com/maps/documentation/routes/compute_route_directions
  *
- * Diseño:
+ * Diseño (ADR-038, migración desde API key):
+ *   - Autenticación: OAuth bearer token via ADC (Application Default
+ *     Credentials). En Cloud Run, ADC resuelve al SA del runtime (que
+ *     tiene roles/serviceusage.serviceUsageConsumer, suficiente para
+ *     Routes API + header X-Goog-User-Project).
+ *   - Cero API keys — cierra el banner GCP "unrestricted API keys" en la
+ *     parte Routes API.
  *   - Función pura (toma `fetch` inyectable para tests).
  *   - Devuelve estructura normalizada que oculta detalles del wire
  *     protocol de Google (microliters → liters, distanceMeters → km).
  *   - Acepta direcciones como strings (Routes API geocodifica internamente).
- *     Cuando agreguemos lat/lng a `viajes`, se podrá pasar coordenadas
- *     directamente sin geocoding extra (más barato).
  *
  * Costo: ~$5 USD por 1000 requests con extras computations habilitados.
  *
- * Restricción de la API key (configurada en GCP Console):
- *   - Por IP del egress de Cloud Run (preferido) o por SA token.
- *   - NUNCA por HTTP referrer (Routes API es server-side).
+ * Quota tracking: por projectId via header X-Goog-User-Project. La cuota
+ * de Routes API se factura al proyecto cuyo SA hace el token, NO al
+ * proyecto del SA — por eso el header es obligatorio para que GCP sepa
+ * a quién cobrar.
  */
+
+/**
+ * Singleton de GoogleAuth — una instancia por proceso evita el overhead
+ * de descubrir credenciales en cada request. El cliente cachea access
+ * tokens internamente y los renueva antes de expirar.
+ */
+const authClient = new GoogleAuth({
+  scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+});
 
 /** Tipos de combustible aceptados por Routes API. Espejo de
  *  google.routes.v2.VehicleEmissionType. */
@@ -45,8 +60,14 @@ export interface RouteSuggestion {
 }
 
 export interface ComputeRoutesParams {
-  /** API key con restricción server-side (no HTTP referrer). */
-  apiKey: string;
+  /**
+   * GCP project ID que se factura por las llamadas. En Cloud Run viene
+   * de la env var GOOGLE_CLOUD_PROJECT (auto-seteada). Se pasa como
+   * header X-Goog-User-Project para que Routes API sepa a quién cobrar
+   * la cuota (el SA hace el token, pero el proyecto del header recibe
+   * el cargo).
+   */
+  projectId: string;
   /** Origen — dirección textual (Routes API la geocodifica). */
   origin: string;
   /** Destino — dirección textual. */
@@ -99,7 +120,7 @@ const ROUTES_API_URL = 'https://routes.googleapis.com/directions/v2:computeRoute
  */
 export async function computeRoutes(params: ComputeRoutesParams): Promise<RouteSuggestion[]> {
   const {
-    apiKey,
+    projectId,
     origin,
     destination,
     emissionType,
@@ -134,13 +155,33 @@ export async function computeRoutes(params: ComputeRoutesParams): Promise<RouteS
     .filter(Boolean)
     .join(',');
 
+  // ADC: en Cloud Run resuelve al SA del runtime (workload identity).
+  // En local-dev, a las creds de `gcloud auth application-default login`.
+  let accessToken: string | null | undefined;
+  try {
+    const client = await authClient.getClient();
+    const tokenResponse = await client.getAccessToken();
+    accessToken = tokenResponse.token;
+  } catch (err) {
+    logger?.error({ err, origin, destination }, 'Routes API: ADC token error');
+    throw new RoutesApiError(
+      `ADC token error calling Routes API: ${err instanceof Error ? err.message : 'unknown'}`,
+      'auth_error',
+      null,
+    );
+  }
+  if (!accessToken) {
+    throw new RoutesApiError('ADC returned no access token for Routes API', 'auth_error', null);
+  }
+
   let response: Response;
   try {
     response = await fetchImpl(ROUTES_API_URL, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Goog-Api-Key': apiKey,
+        Authorization: `Bearer ${accessToken}`,
+        'X-Goog-User-Project': projectId,
         'X-Goog-FieldMask': fieldMask,
       },
       body: JSON.stringify(body),

--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -1,3 +1,24 @@
+import { vi } from 'vitest';
+
+// ADR-038: routes-api.ts y gemini-client.ts usan `new GoogleAuth(...)` a
+// nivel de módulo. En CI no hay ADC ni internet — `getAccessToken()` lanza
+// y los tests que indirectamente ejercitan estos clientes fallan. Mock
+// global con `importOriginal` para preservar OAuth2Client/JWT/otros exports
+// usados por otras dependencias (pg auth helpers, firebase-admin, etc.).
+vi.mock('google-auth-library', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('google-auth-library')>();
+  class MockGoogleAuth {
+    async getClient() {
+      return {
+        async getAccessToken() {
+          return { token: 'test-access-token' };
+        },
+      };
+    }
+  }
+  return { ...actual, GoogleAuth: MockGoogleAuth };
+});
+
 // Stub env vars antes que cualquier test importe módulos que evalúan config.
 // El `parseEnv` de packages/config llama process.exit(1) si fallan los Zod
 // schemas — sin estos defaults, vitest aborta el suite con

--- a/apps/api/test/unit/calcular-metricas-viaje.test.ts
+++ b/apps/api/test/unit/calcular-metricas-viaje.test.ts
@@ -362,13 +362,13 @@ describe('calcularMetricasEstimadas — Routes API integration', () => {
       logger: noopLogger,
       tripId: TRIP_ID,
       vehicleId: VEH_ID,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(result.emisiones.distanciaKm).toBe(137.4);
     expect(computeRoutes).toHaveBeenCalledWith(
       expect.objectContaining({
-        apiKey: 'test-key',
+        projectId: 'test-project',
         emissionType: 'DIESEL',
       }),
     );
@@ -386,7 +386,7 @@ describe('calcularMetricasEstimadas — Routes API integration', () => {
       logger: noopLogger,
       tripId: TRIP_ID,
       vehicleId: null,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(result.emisiones.distanciaKm).toBeGreaterThan(0);
@@ -405,7 +405,7 @@ describe('calcularMetricasEstimadas — Routes API integration', () => {
       logger: noopLogger,
       tripId: TRIP_ID,
       vehicleId: null,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(result.emisiones.distanciaKm).toBeGreaterThan(0);
@@ -426,7 +426,7 @@ describe('calcularMetricasEstimadas — Routes API integration', () => {
       logger: noopLogger,
       tripId: TRIP_ID,
       vehicleId: null,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(result.emisiones.distanciaKm).toBeGreaterThan(0);
@@ -468,7 +468,7 @@ describe('calcularMetricasEstimadas — Routes API integration', () => {
         logger: noopLogger,
         tripId: TRIP_ID,
         vehicleId: VEH_ID,
-        routesApiKey: 'test-key',
+        routesProjectId: 'test-project',
       });
     }
     expect(computeRoutes).toHaveBeenCalledTimes(fuelCases.length);

--- a/apps/api/test/unit/compute-route-eta.test.ts
+++ b/apps/api/test/unit/compute-route-eta.test.ts
@@ -87,7 +87,7 @@ const baseInput = (over: Partial<ComputeRouteEtaInput> = {}): ComputeRouteEtaInp
   destinationAddress: 'Av Ejemplo 123, Concepción',
   avgSpeedKmh: 60,
   fallbackEtaMinutes: 500,
-  routesApiKey: 'fake-key',
+  routesProjectId: 'test-project',
   ...over,
 });
 
@@ -99,7 +99,7 @@ beforeEach(() => {
 describe('computeRouteEta — fallback paths (no Routes API call)', () => {
   it('sin routesApiKey → devuelve fallback con source=centroide', async () => {
     const fetchImpl = vi.fn() as unknown as typeof fetch;
-    const res = await computeRouteEta(baseInput({ routesApiKey: undefined, fetchImpl }));
+    const res = await computeRouteEta(baseInput({ routesProjectId: undefined, fetchImpl }));
     expect(res).toEqual({ etaMinutes: 500, source: 'centroide' });
     expect(fetchImpl).not.toHaveBeenCalled();
   });
@@ -132,7 +132,7 @@ describe('computeRouteEta — fallback paths (no Routes API call)', () => {
 
   it('fallback null preservado como unavailable', async () => {
     const res = await computeRouteEta(
-      baseInput({ routesApiKey: undefined, fallbackEtaMinutes: null }),
+      baseInput({ routesProjectId: undefined, fallbackEtaMinutes: null }),
     );
     expect(res).toEqual({ etaMinutes: null, source: 'unavailable' });
   });

--- a/apps/api/test/unit/eco-route-preview.test.ts
+++ b/apps/api/test/unit/eco-route-preview.test.ts
@@ -243,7 +243,7 @@ describe('generarEcoPreview — Routes API path', () => {
       logger: noopLogger,
       offerId: OFFER_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(result.dataSource).toBe('routes_api');
@@ -254,7 +254,7 @@ describe('generarEcoPreview — Routes API path', () => {
     expect(result.polylineEncoded).toBe('abc123');
     expect(computeRoutes).toHaveBeenCalledWith(
       expect.objectContaining({
-        apiKey: 'test-key',
+        projectId: 'test-project',
         emissionType: 'DIESEL',
         origin: TRIP_BASE.originAddressRaw,
         destination: TRIP_BASE.destinationAddressRaw,
@@ -305,7 +305,7 @@ describe('generarEcoPreview — Routes API path', () => {
       logger: noopLogger,
       offerId: OFFER_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
     expect(result.dataSource).toBe('routes_api');
     expect(result.polylineEncoded).toBeNull();
@@ -330,7 +330,7 @@ describe('generarEcoPreview — Routes API path', () => {
       logger: noopLogger,
       offerId: OFFER_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(result.dataSource).toBe('tabla_chile');
@@ -357,7 +357,7 @@ describe('generarEcoPreview — Routes API path', () => {
       logger: noopLogger,
       offerId: OFFER_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(result.dataSource).toBe('tabla_chile');
@@ -384,7 +384,7 @@ describe('generarEcoPreview — Routes API path', () => {
       logger: noopLogger,
       offerId: OFFER_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(result.dataSource).toBe('tabla_chile');
@@ -411,7 +411,7 @@ describe('generarEcoPreview — Routes API path', () => {
       logger: noopLogger,
       offerId: OFFER_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'test-key',
+      routesProjectId: 'test-project',
     });
 
     expect(computeRoutes).toHaveBeenCalledWith(
@@ -453,7 +453,7 @@ describe('generarEcoPreview — mapFuelToEmissionType branches', () => {
         logger: noopLogger,
         offerId: OFFER_ID,
         empresaId: EMPRESA_ID,
-        routesApiKey: 'test-key',
+        routesProjectId: 'test-project',
       });
 
       expect(computeRoutes).toHaveBeenCalledWith(

--- a/apps/api/test/unit/gemini-client.test.ts
+++ b/apps/api/test/unit/gemini-client.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createGeminiGenFn } from '../../src/services/gemini-client.js';
+
+// google-auth-library mockeada globalmente en test/setup.ts (ADR-038).
+
+function makeFetchOkWithText(text: string): typeof fetch {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      candidates: [
+        {
+          content: { parts: [{ text }] },
+          finishReason: 'STOP',
+        },
+      ],
+    }),
+    text: async () => '',
+  })) as unknown as typeof fetch;
+}
+
+function makeFetchError(status: number, body = '{"error":"..."}'): typeof fetch {
+  return vi.fn(async () => ({
+    ok: false,
+    status,
+    json: async () => ({}),
+    text: async () => body,
+  })) as unknown as typeof fetch;
+}
+
+describe('createGeminiGenFn — happy path', () => {
+  it('llama a Vertex AI endpoint con Authorization Bearer + projectId path', async () => {
+    const fetchSpy = makeFetchOkWithText('Coaching message ejemplo');
+    const genFn = createGeminiGenFn({
+      projectId: 'booster-ai-test',
+      fetchImpl: fetchSpy,
+    });
+
+    const out = await genFn({
+      systemPrompt: 'Eres un coach',
+      userPrompt: 'Dame feedback',
+    });
+
+    expect(out).toBe('Coaching message ejemplo');
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    const calls = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls;
+    const url = calls[0]?.[0] as string;
+    expect(url).toContain('aiplatform.googleapis.com');
+    expect(url).toContain('projects/booster-ai-test/locations/southamerica-east1');
+    expect(url).toContain(':generateContent');
+    const init = calls[0]?.[1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-access-token');
+  });
+
+  it('body incluye systemInstruction + contents + generationConfig + safetySettings', async () => {
+    const fetchSpy = makeFetchOkWithText('ok');
+    const genFn = createGeminiGenFn({
+      projectId: 'p',
+      fetchImpl: fetchSpy,
+    });
+    await genFn({ systemPrompt: 'SYS', userPrompt: 'USER' });
+
+    const init = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body.systemInstruction).toEqual({ parts: [{ text: 'SYS' }] });
+    expect((body.contents as unknown[])[0]).toEqual({
+      role: 'user',
+      parts: [{ text: 'USER' }],
+    });
+    expect((body.generationConfig as Record<string, unknown>).temperature).toBe(0.2);
+    expect((body.safetySettings as unknown[]).length).toBe(4);
+  });
+
+  it('override de location y model se reflejan en la URL', async () => {
+    const fetchSpy = makeFetchOkWithText('ok');
+    const genFn = createGeminiGenFn({
+      projectId: 'p',
+      location: 'us-central1',
+      model: 'gemini-2.0-flash',
+      fetchImpl: fetchSpy,
+    });
+    await genFn({ systemPrompt: 'S', userPrompt: 'U' });
+
+    const url = (fetchSpy as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as string;
+    expect(url).toContain('us-central1-aiplatform.googleapis.com');
+    expect(url).toContain('models/gemini-2.0-flash:generateContent');
+  });
+});
+
+describe('createGeminiGenFn — fallback paths (devuelven null)', () => {
+  it('non-2xx response → null', async () => {
+    const fetchImpl = makeFetchError(500, '{"error":"backend"}');
+    const genFn = createGeminiGenFn({ projectId: 'p', fetchImpl });
+    const out = await genFn({ systemPrompt: 'S', userPrompt: 'U' });
+    expect(out).toBeNull();
+  });
+
+  it('response sin candidates → null', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ candidates: [] }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+    const genFn = createGeminiGenFn({ projectId: 'p', fetchImpl });
+    const out = await genFn({ systemPrompt: 'S', userPrompt: 'U' });
+    expect(out).toBeNull();
+  });
+
+  it('finishReason ≠ STOP → null (safety block o truncation)', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        candidates: [
+          {
+            content: { parts: [{ text: 'partial' }] },
+            finishReason: 'SAFETY',
+          },
+        ],
+      }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+    const genFn = createGeminiGenFn({ projectId: 'p', fetchImpl });
+    const out = await genFn({ systemPrompt: 'S', userPrompt: 'U' });
+    expect(out).toBeNull();
+  });
+
+  it('texto vacío en candidate → null', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: '   ' }] }, finishReason: 'STOP' }],
+      }),
+      text: async () => '',
+    })) as unknown as typeof fetch;
+    const genFn = createGeminiGenFn({ projectId: 'p', fetchImpl });
+    const out = await genFn({ systemPrompt: 'S', userPrompt: 'U' });
+    expect(out).toBeNull();
+  });
+
+  it('fetch throw (network error) → null', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('ECONNRESET');
+    }) as unknown as typeof fetch;
+    const genFn = createGeminiGenFn({ projectId: 'p', fetchImpl });
+    const out = await genFn({ systemPrompt: 'S', userPrompt: 'U' });
+    expect(out).toBeNull();
+  });
+});

--- a/apps/api/test/unit/get-assignment-eco-route.test.ts
+++ b/apps/api/test/unit/get-assignment-eco-route.test.ts
@@ -126,7 +126,7 @@ describe('getAssignmentEcoRoute', () => {
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'fake-key', // present pero NO debe usarse
+      routesProjectId: 'test-project', // present pero NO debe usarse
     });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {
@@ -154,7 +154,7 @@ describe('getAssignmentEcoRoute', () => {
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'fake-key',
+      routesProjectId: 'test-project',
     });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {
@@ -179,7 +179,7 @@ describe('getAssignmentEcoRoute', () => {
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'fake-key',
+      routesProjectId: 'test-project',
     });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {
@@ -192,7 +192,7 @@ describe('getAssignmentEcoRoute', () => {
     }
     expect(computeRoutes).toHaveBeenCalledWith(
       expect.objectContaining({
-        apiKey: 'fake-key',
+        projectId: 'test-project',
         origin: validRow.originAddress,
         destination: validRow.destinationAddress,
         computeAlternatives: false,
@@ -208,7 +208,7 @@ describe('getAssignmentEcoRoute', () => {
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'fake-key',
+      routesProjectId: 'test-project',
     });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {
@@ -227,7 +227,7 @@ describe('getAssignmentEcoRoute', () => {
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'fake-key',
+      routesProjectId: 'test-project',
     });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {
@@ -245,7 +245,7 @@ describe('getAssignmentEcoRoute', () => {
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'fake-key',
+      routesProjectId: 'test-project',
     });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {
@@ -268,7 +268,7 @@ describe('getAssignmentEcoRoute', () => {
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'fake-key',
+      routesProjectId: 'test-project',
     });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {
@@ -285,7 +285,7 @@ describe('getAssignmentEcoRoute', () => {
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
       empresaId: EMPRESA_ID,
-      routesApiKey: 'fake-key',
+      routesProjectId: 'test-project',
     });
     expect(result.kind).toBe('ok');
     if (result.kind === 'ok') {

--- a/apps/api/test/unit/persist-eco-route-polyline.test.ts
+++ b/apps/api/test/unit/persist-eco-route-polyline.test.ts
@@ -98,7 +98,7 @@ describe('persistEcoRoutePolyline', () => {
       db,
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
-      routesApiKey: 'fake',
+      routesProjectId: 'test-project',
     });
     expect(result).toEqual({
       attempted: true,
@@ -117,7 +117,7 @@ describe('persistEcoRoutePolyline', () => {
       db,
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
-      routesApiKey: 'fake',
+      routesProjectId: 'test-project',
     });
     expect(result).toEqual({ attempted: true, persisted: true });
     expect(updateSpy).toHaveBeenCalledTimes(1);
@@ -130,7 +130,7 @@ describe('persistEcoRoutePolyline', () => {
       db,
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
-      routesApiKey: 'fake',
+      routesProjectId: 'test-project',
     });
     expect(result.reason).toBe('route_empty');
     expect(result.persisted).toBe(false);
@@ -146,7 +146,7 @@ describe('persistEcoRoutePolyline', () => {
       db,
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
-      routesApiKey: 'fake',
+      routesProjectId: 'test-project',
     });
     expect(result.reason).toBe('route_empty');
     expect(updateSpy).not.toHaveBeenCalled();
@@ -165,7 +165,7 @@ describe('persistEcoRoutePolyline', () => {
       db,
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
-      routesApiKey: 'fake',
+      routesProjectId: 'test-project',
     });
     expect(result.reason).toBe('routes_api_failed');
     expect(result.persisted).toBe(false);
@@ -179,7 +179,7 @@ describe('persistEcoRoutePolyline', () => {
       db,
       logger: noopLogger as never,
       assignmentId: ASSIGNMENT_ID,
-      routesApiKey: 'fake',
+      routesProjectId: 'test-project',
     });
     expect(result.reason).toBe('routes_api_failed');
     expect(updateSpy).not.toHaveBeenCalled();

--- a/apps/api/test/unit/routes-api.test.ts
+++ b/apps/api/test/unit/routes-api.test.ts
@@ -1,35 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
-
-// Mock de google-auth-library con vi.hoisted: garantiza que el mock se
-// inicialice antes del import del módulo testeado (vital con coverage
-// instrumentation, donde el orden de evaluación cambia y un vi.mock al
-// medio del archivo no siempre se hoist).
-//
-// En CI no hay ADC disponible (no Cloud Run, no `gcloud auth
-// application-default login`), pero routes-api.ts llama getAccessToken()
-// en cada request. Devolvemos un token fake para ejercitar la lógica de
-// fetch/parse sin tocar ADC real.
-// `GoogleAuth` se usa con `new`, así que el mock debe ser una clase real
-// (arrow function no es constructable). Devuelve siempre el mismo objeto
-// con getClient → getAccessToken cuyo .token es 'test-access-token'.
-vi.mock('google-auth-library', () => {
-  class MockGoogleAuth {
-    async getClient() {
-      return {
-        async getAccessToken() {
-          return { token: 'test-access-token' };
-        },
-      };
-    }
-  }
-  return { GoogleAuth: MockGoogleAuth };
-});
-
 import {
   type RouteSuggestion,
   RoutesApiError,
   computeRoutes,
 } from '../../src/services/routes-api.js';
+
+// google-auth-library está mockeada globalmente en test/setup.ts (ADR-038).
 
 /**
  * Tests del cliente Routes API (Phase 1 — eco route suggestion).

--- a/apps/api/test/unit/routes-api.test.ts
+++ b/apps/api/test/unit/routes-api.test.ts
@@ -1,4 +1,18 @@
 import { describe, expect, it, vi } from 'vitest';
+
+// Mock de google-auth-library: en CI no hay ADC disponible (no Cloud Run,
+// no `gcloud auth application-default login`), pero el cliente production
+// llama getAccessToken() en cada request. Devolvemos un token fake para
+// que los tests del cliente puedan ejercitar la lógica de fetch/parse sin
+// tocar ADC real.
+vi.mock('google-auth-library', () => ({
+  GoogleAuth: vi.fn().mockImplementation(() => ({
+    getClient: vi.fn().mockResolvedValue({
+      getAccessToken: vi.fn().mockResolvedValue({ token: 'test-access-token' }),
+    }),
+  })),
+}));
+
 import {
   type RouteSuggestion,
   RoutesApiError,
@@ -50,7 +64,7 @@ describe('computeRoutes — request body', () => {
     })) as unknown as typeof fetch;
 
     await computeRoutes({
-      apiKey: 'AIzaTest',
+      projectId: 'test-project',
       origin: 'Av. Apoquindo 5400, Las Condes',
       destination: 'Calle 1 Norte 123, Concepción',
       fetchImpl: fetchSpy,
@@ -76,7 +90,7 @@ describe('computeRoutes — request body', () => {
     })) as unknown as typeof fetch;
 
     await computeRoutes({
-      apiKey: 'AIzaTest',
+      projectId: 'test-project',
       origin: 'A',
       destination: 'B',
       emissionType: 'DIESEL',
@@ -103,7 +117,7 @@ describe('computeRoutes — request body', () => {
     })) as unknown as typeof fetch;
 
     await computeRoutes({
-      apiKey: 'AIzaTest',
+      projectId: 'test-project',
       origin: 'A',
       destination: 'B',
       fetchImpl: fetchSpy,
@@ -126,7 +140,7 @@ describe('computeRoutes — request body', () => {
     })) as unknown as typeof fetch;
 
     await computeRoutes({
-      apiKey: 'k',
+      projectId: 'test-project',
       origin: 'A',
       destination: 'B',
       computeAlternatives: true,
@@ -152,7 +166,7 @@ describe('computeRoutes — response parsing', () => {
     });
 
     const routes = await computeRoutes({
-      apiKey: 'k',
+      projectId: 'test-project',
       origin: 'A',
       destination: 'B',
       fetchImpl,
@@ -181,7 +195,7 @@ describe('computeRoutes — response parsing', () => {
     });
 
     const [r] = await computeRoutes({
-      apiKey: 'k',
+      projectId: 'test-project',
       origin: 'A',
       destination: 'B',
       emissionType: 'DIESEL',
@@ -201,7 +215,7 @@ describe('computeRoutes — response parsing', () => {
     });
 
     const routes = await computeRoutes({
-      apiKey: 'k',
+      projectId: 'test-project',
       origin: 'A',
       destination: 'B',
       computeAlternatives: true,
@@ -217,7 +231,7 @@ describe('computeRoutes — response parsing', () => {
   it('response sin rutas → [] (no throw)', async () => {
     const fetchImpl = makeFetchOk({}); // sin field "routes"
     const routes = await computeRoutes({
-      apiKey: 'k',
+      projectId: 'test-project',
       origin: 'A',
       destination: 'B',
       fetchImpl,
@@ -230,7 +244,7 @@ describe('computeRoutes — response parsing', () => {
       routes: [{}], // ruta sin nada
     });
     const [r] = await computeRoutes({
-      apiKey: 'k',
+      projectId: 'test-project',
       origin: 'A',
       destination: 'B',
       fetchImpl,
@@ -249,7 +263,7 @@ describe('computeRoutes — errores HTTP', () => {
     const fetchImpl = makeFetchError(400, 'Origin not parseable');
     await expect(
       computeRoutes({
-        apiKey: 'k',
+        projectId: 'test-project',
         origin: 'invalid',
         destination: 'B',
         fetchImpl,
@@ -265,7 +279,7 @@ describe('computeRoutes — errores HTTP', () => {
     for (const status of [401, 403]) {
       const fetchImpl = makeFetchError(status);
       await expect(
-        computeRoutes({ apiKey: 'wrong', origin: 'A', destination: 'B', fetchImpl }),
+        computeRoutes({ projectId: 'test-project', origin: 'A', destination: 'B', fetchImpl }),
       ).rejects.toMatchObject({ code: 'auth_error', httpStatus: status });
     }
   });
@@ -273,14 +287,14 @@ describe('computeRoutes — errores HTTP', () => {
   it('429 → quota_exceeded', async () => {
     const fetchImpl = makeFetchError(429);
     await expect(
-      computeRoutes({ apiKey: 'k', origin: 'A', destination: 'B', fetchImpl }),
+      computeRoutes({ projectId: 'test-project', origin: 'A', destination: 'B', fetchImpl }),
     ).rejects.toMatchObject({ code: 'quota_exceeded', httpStatus: 429 });
   });
 
   it('500 → unknown', async () => {
     const fetchImpl = makeFetchError(500);
     await expect(
-      computeRoutes({ apiKey: 'k', origin: 'A', destination: 'B', fetchImpl }),
+      computeRoutes({ projectId: 'test-project', origin: 'A', destination: 'B', fetchImpl }),
     ).rejects.toMatchObject({ code: 'unknown', httpStatus: 500 });
   });
 
@@ -290,7 +304,7 @@ describe('computeRoutes — errores HTTP', () => {
     }) as unknown as typeof fetch;
 
     await expect(
-      computeRoutes({ apiKey: 'k', origin: 'A', destination: 'B', fetchImpl }),
+      computeRoutes({ projectId: 'test-project', origin: 'A', destination: 'B', fetchImpl }),
     ).rejects.toMatchObject({
       code: 'network_error',
       httpStatus: null,

--- a/apps/api/test/unit/routes-api.test.ts
+++ b/apps/api/test/unit/routes-api.test.ts
@@ -1,17 +1,29 @@
 import { describe, expect, it, vi } from 'vitest';
 
-// Mock de google-auth-library: en CI no hay ADC disponible (no Cloud Run,
-// no `gcloud auth application-default login`), pero el cliente production
-// llama getAccessToken() en cada request. Devolvemos un token fake para
-// que los tests del cliente puedan ejercitar la lógica de fetch/parse sin
-// tocar ADC real.
-vi.mock('google-auth-library', () => ({
-  GoogleAuth: vi.fn().mockImplementation(() => ({
-    getClient: vi.fn().mockResolvedValue({
-      getAccessToken: vi.fn().mockResolvedValue({ token: 'test-access-token' }),
-    }),
-  })),
-}));
+// Mock de google-auth-library con vi.hoisted: garantiza que el mock se
+// inicialice antes del import del módulo testeado (vital con coverage
+// instrumentation, donde el orden de evaluación cambia y un vi.mock al
+// medio del archivo no siempre se hoist).
+//
+// En CI no hay ADC disponible (no Cloud Run, no `gcloud auth
+// application-default login`), pero routes-api.ts llama getAccessToken()
+// en cada request. Devolvemos un token fake para ejercitar la lógica de
+// fetch/parse sin tocar ADC real.
+// `GoogleAuth` se usa con `new`, así que el mock debe ser una clase real
+// (arrow function no es constructable). Devuelve siempre el mismo objeto
+// con getClient → getAccessToken cuyo .token es 'test-access-token'.
+vi.mock('google-auth-library', () => {
+  class MockGoogleAuth {
+    async getClient() {
+      return {
+        async getAccessToken() {
+          return { token: 'test-access-token' };
+        },
+      };
+    }
+  }
+  return { GoogleAuth: MockGoogleAuth };
+});
 
 import {
   type RouteSuggestion,

--- a/docs/adr/038-routes-api-adc-migration.md
+++ b/docs/adr/038-routes-api-adc-migration.md
@@ -1,0 +1,150 @@
+# ADR 038 — Migración Routes API key → ADC (X-Goog-User-Project)
+
+**Estado**: Aceptado
+**Fecha**: 2026-05-13
+**Autor**: Claude (Opus 4.7) + Felipe Vicencio
+**Relacionado**: ADR-037 (Gemini API key → Vertex AI ADC, mismo patrón)
+
+---
+
+## Contexto
+
+Después de cerrar el banner GCP de Gemini API key con ADR-037, la auditoría dejó pendiente un segundo cabo suelto: **`Booster Routes - API Backend`** (UID `e091850a-d5ea-4941-bcf0-8f966032b58b`) — API key del Routes API también sin restricción de origen.
+
+Inventario al iniciar:
+
+| Key | Service | Origen restriction | Acción |
+|---|---|---|---|
+| ~~`Booster Gemini - API Backend`~~ | ~~generativelanguage~~ | ~~ninguna~~ | **eliminada ADR-037** ✓ |
+| `Booster Routes - API Backend` | routes | **ninguna** ← esta | ← este ADR |
+| `Booster Maps - Web (PWA)` | addressvalidation | referrer ✓ | mantener |
+| `Browser key (Firebase)` | firebasedatabase | n/a | mantener (Firebase la maneja) |
+
+El backend `booster-ai-api` usa la key Routes API en múltiples flows:
+- `services/routes-api.ts` (cliente HTTP)
+- `services/calcular-metricas-viaje.ts` (distancia precisa post-asignación)
+- `services/eco-route-preview.ts` (preview de eco-ruta para shipper)
+- `services/compute-route-eta.ts` (ETA real para tracking público)
+- `services/persist-eco-route-polyline.ts` (cache polyline post-accept)
+- `services/get-assignment-eco-route.ts` (endpoint del driver)
+- `services/get-public-tracking.ts` (tracking público sin auth)
+- `services/offer-actions.ts` (orquestación post-accept)
+
+## Decisión
+
+Validado empíricamente que **Routes API acepta OAuth bearer token con header `X-Goog-User-Project`** (curl test directo respondió `OK — distance=120531m duration=5111s` para Santiago → Valparaíso).
+
+Migrar el cliente al mismo patrón de ADR-037 (Vertex AI Gemini):
+- `Authorization: Bearer {ADC access token}` (en lugar de `X-Goog-Api-Key`)
+- `X-Goog-User-Project: {GCP project ID}` (para que GCP sepa a qué proyecto facturar la quota)
+
+### Cambios
+
+#### Código (12 archivos)
+
+| Archivo | Cambio |
+|---|---|
+| `apps/api/src/services/routes-api.ts` | Singleton `GoogleAuth` (scope cloud-platform) + bearer token + `X-Goog-User-Project` header. `apiKey` → `projectId` en `ComputeRoutesParams`. |
+| `apps/api/src/services/calcular-metricas-viaje.ts` | `routesApiKey` → `routesProjectId` (param y firma) |
+| `apps/api/src/services/eco-route-preview.ts` | Idem |
+| `apps/api/src/services/compute-route-eta.ts` | Idem |
+| `apps/api/src/services/persist-eco-route-polyline.ts` | Idem |
+| `apps/api/src/services/get-assignment-eco-route.ts` | Idem |
+| `apps/api/src/services/get-public-tracking.ts` | Idem |
+| `apps/api/src/services/offer-actions.ts` | Pasa `config.GOOGLE_CLOUD_PROJECT` en lugar de `config.GOOGLE_ROUTES_API_KEY` |
+| `apps/api/src/routes/offers.ts` | Idem |
+| `apps/api/src/routes/assignments.ts` | Idem |
+| `apps/api/src/routes/public-tracking.ts` | Idem |
+| `apps/api/src/server.ts` | Idem (2 callsites: public-tracking + assignments) |
+| `apps/api/src/config.ts` | Quita `GOOGLE_ROUTES_API_KEY` del schema (el `GOOGLE_CLOUD_PROJECT` ya estaba post-ADR-037) |
+
+#### Tests (5 archivos, ~20 reemplazos)
+
+Tests unitarios actualizados: `routesApiKey` → `routesProjectId`, `apiKey` → `projectId` en assertions de `computeRoutes`. Resultado: **921 passed, 0 failed, 2 skipped**.
+
+#### Infra (1 archivo)
+
+| Archivo | Cambio |
+|---|---|
+| `infrastructure/compute.tf` | Elimina `GOOGLE_ROUTES_API_KEY = ...` del env del `service_api`. |
+
+#### IAM — sin cambios necesarios
+
+El SA `booster-cloudrun-sa@booster-ai-494222.iam.gserviceaccount.com` ya tiene `roles/serviceusage.serviceUsageConsumer` (verificado vía `gcloud projects get-iam-policy`). Eso es suficiente para usar Routes API con `X-Goog-User-Project`.
+
+---
+
+## Apply post-merge (3 pasos)
+
+```bash
+# 1. terraform apply (saca GOOGLE_ROUTES_API_KEY del Cloud Run env)
+cd infrastructure/
+export TF_VAR_billing_account="019461-C73CDE-DCE377"
+terraform apply
+
+# 2. Smoke test: trigger un flow Routes API
+#    (ej. POST /carrier/offers/:id/accept o GET /assignments/:id/eco-route)
+#    Verificar log "distancia obtenida via Routes API" sin auth_error.
+
+# 3. Eliminar la API key
+gcloud services api-keys delete \
+  e091850a-d5ea-4941-bcf0-8f966032b58b \
+  --project=booster-ai-494222 \
+  --location=global \
+  --quiet
+```
+
+## Validación post-apply
+
+- [ ] `gcloud run services describe booster-ai-api ...` ya no incluye env `GOOGLE_ROUTES_API_KEY`
+- [ ] `gcloud services api-keys list --project=booster-ai-494222` no muestra `Booster Routes - API Backend`
+- [ ] Smoke test: aceptar una oferta de demo seed → `metricas_viaje.distancia_km` proviene de Routes API (no de `estimarDistanciaKm` Chile)
+- [ ] `gcloud logging read` no muestra errores de auth en `routes-api.ts`
+
+---
+
+## Consecuencias
+
+### Positivas
+
+- ✅ Cierra completamente el tema de API keys del proyecto (excepto `Booster Maps - Web (PWA)` que ya está bien restringida con referrer, y la Firebase auto-creada).
+- ✅ Sin rotaciones manuales de keys de Routes en el futuro.
+- ✅ Quota tracking por proyecto/SA via X-Goog-User-Project.
+
+### Negativas
+
+- Cold start ligeramente mayor (~50-100ms adicionales por el primer `getAccessToken()` — cacheado después).
+- Tests locales requieren `gcloud auth application-default login` para invocar Routes API real. Para tests unitarios con mock fetch, sin cambio (los tests siguen pasando 921/921).
+
+### Reversibilidad
+
+`git revert` del PR + `terraform apply` vuelve al estado previo en <10 min. La API key se puede recrear desde Cloud Console si necesario.
+
+---
+
+## Pendientes que NO resuelve este PR
+
+- Eliminar el secret `google-routes-api-key` de `infrastructure/security.tf` (cosmético, 1 sprint post-merge una vez validada estabilidad).
+- `Browser key (auto created by Firebase)` — auto-creada y manejada por Firebase, fuera del scope.
+
+---
+
+## Estado API keys post este ADR
+
+| Key | Estado |
+|---|---|
+| ~~`Booster Gemini - API Backend`~~ | **eliminada** (ADR-037) ✓ |
+| ~~`Booster Routes - API Backend`~~ | **eliminada** (ADR-038, este) ✓ |
+| `Booster Maps - Web (PWA)` | mantener (referrer-restricted, browser-side) |
+| `Browser key (Firebase auto)` | mantener (Firebase la gestiona) |
+
+Banner GCP "unrestricted API keys" debe desaparecer dentro de 24h post-delete.
+
+---
+
+## Referencias
+
+- ADR-037 — mismo patrón ADC para Gemini API
+- [Routes API auth options](https://developers.google.com/maps/documentation/routes/authentication)
+- [X-Goog-User-Project header](https://cloud.google.com/apis/docs/system-parameters)
+- `docs/audits/gcp-costs-2026-05-13.md` — auditoría que destapó las keys

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -189,20 +189,17 @@ module "service_api" {
     WEBPUSH_VAPID_PUBLIC_KEY  = google_secret_manager_secret.secrets["webpush-vapid-public-key"].secret_id
     WEBPUSH_VAPID_PRIVATE_KEY = google_secret_manager_secret.secrets["webpush-vapid-private-key"].secret_id
 
-    # Phase 1 (ADR-028) — Google Routes API key para eco-route suggestion.
-    # Server-side; el api la usa al confirmar oferta y al consultar
-    # GET /offers/:id/eco-preview. Si está con placeholder
-    # ROTATE_ME_GOOGLE_ROUTES_API_KEY, el servicio cae al fallback de
-    # estimarDistanciaKm (tabla pre-computada Chile) sin romper nada.
-    GOOGLE_ROUTES_API_KEY = google_secret_manager_secret.secrets["google-routes-api-key"].secret_id
-
-    # ADR-037: GEMINI_API_KEY eliminada. apps/api ahora usa Vertex AI con
-    # ADC (workload identity del SA cloud_run_runtime, que ya tiene
-    # roles/aiplatform.user). El secret gemini-api-key del Secret Manager
-    # queda como artefacto histórico — la API key real se elimina con
-    # `gcloud services api-keys delete a5a60db7-0dc4-43c2-b08a-bb21e7834c2d`
-    # post-apply de este cambio. Cierra el banner GCP "unrestricted API keys
-    # for generativelanguage.googleapis.com".
+    # ADR-038: GOOGLE_ROUTES_API_KEY eliminada. apps/api ahora autentica
+    # contra Routes API con ADC + header X-Goog-User-Project (el SA del
+    # runtime tiene roles/serviceusage.serviceUsageConsumer, suficiente).
+    # El secret google-routes-api-key queda en Secret Manager como
+    # artefacto histórico — la API key real se elimina con
+    # `gcloud services api-keys delete e091850a-d5ea-4941-bcf0-8f966032b58b`
+    # post-apply.
+    #
+    # ADR-037: GEMINI_API_KEY eliminada con el mismo patrón (Vertex AI +
+    # ADC con roles/aiplatform.user). API key Booster Gemini ya eliminada
+    # post-apply de PR #196.
   })
 
   vpc_connector = google_vpc_access_connector.serverless.id


### PR DESCRIPTION
## Summary

Segunda fase de la migración a ADC iniciada con [ADR-037](docs/adr/037-vertex-ai-adc-gemini-migration.md) (Gemini). Cierra completamente el banner GCP "unrestricted API keys" del proyecto.

ADR: [`docs/adr/038-routes-api-adc-migration.md`](docs/adr/038-routes-api-adc-migration.md)

## Cambios

### Código (12 archivos)

| Archivo | Cambio |
|---|---|
| `apps/api/src/services/routes-api.ts` | Singleton `GoogleAuth` + bearer token + `X-Goog-User-Project`. `apiKey` → `projectId` en `ComputeRoutesParams` |
| `services/calcular-metricas-viaje.ts` | `routesApiKey` → `routesProjectId` |
| `services/eco-route-preview.ts` | idem |
| `services/compute-route-eta.ts` | idem |
| `services/persist-eco-route-polyline.ts` | idem |
| `services/get-assignment-eco-route.ts` | idem |
| `services/get-public-tracking.ts` | idem |
| `services/offer-actions.ts` | pasa `config.GOOGLE_CLOUD_PROJECT` |
| `routes/offers.ts` | idem |
| `routes/assignments.ts` | idem |
| `routes/public-tracking.ts` | idem |
| `server.ts` (2 callsites) | idem |
| `config.ts` | quita `GOOGLE_ROUTES_API_KEY` del schema |

### Tests (5 archivos, ~20 reemplazos)

- `routesApiKey` → `routesProjectId` en inputs
- `apiKey` → `projectId` en assertions de `computeRoutes`
- **921 passed, 0 failed, 2 skipped** ✅

### Infra (1 archivo)

- `infrastructure/compute.tf` — elimina `GOOGLE_ROUTES_API_KEY` del env del `service_api`

### IAM sin cambios

El SA `booster-cloudrun-sa@...` ya tiene `roles/serviceusage.serviceUsageConsumer` (suficiente para Routes API + header `X-Goog-User-Project`).

## Verificación previa: Routes API SÍ acepta OAuth/ADC

```
$ curl -X POST -H "Authorization: Bearer $(gcloud auth print-access-token)" \
       -H "X-Goog-User-Project: booster-ai-494222" \
       -H "X-Goog-FieldMask: routes.distanceMeters,routes.duration" \
       -d '{"origin": {"address": "Santiago"}, "destination": {"address": "Valparaíso"}, "travelMode": "DRIVE"}' \
       https://routes.googleapis.com/directions/v2:computeRoutes

OK — distance=120531m duration=5111s
```

## Apply post-merge (3 pasos)

```bash
# 1. terraform apply (quita GOOGLE_ROUTES_API_KEY del Cloud Run env)
cd infrastructure/
export TF_VAR_billing_account="019461-C73CDE-DCE377"
terraform apply

# 2. Smoke test: aceptar oferta demo → verificar metricas_viaje.distancia_km
#    viene de Routes API (no estimarDistanciaKm).

# 3. Eliminar la API key
gcloud services api-keys delete \
  e091850a-d5ea-4941-bcf0-8f966032b58b \
  --project=booster-ai-494222 \
  --location=global --quiet
```

## Estado API keys post-merge

| Key | Estado |
|---|---|
| ~~`Booster Gemini - API Backend`~~ | **eliminada (ADR-037)** ✓ |
| ~~`Booster Routes - API Backend`~~ | **eliminada (este, ADR-038)** ✓ |
| `Booster Maps - Web (PWA)` | mantener (referrer-restricted) |
| `Browser key (Firebase auto)` | mantener (Firebase la gestiona) |

Banner GCP "unrestricted API keys" debe desaparecer ≤24h post-delete.

## Test plan

### Pre-merge
- [x] typecheck OK
- [x] biome lint OK
- [x] vitest 921/921 PASS

### Post-merge
- [ ] `terraform apply` ejecuta limpio
- [ ] `gcloud run services describe booster-ai-api ...` sin `GOOGLE_ROUTES_API_KEY`
- [ ] Smoke test Routes API funcional (aceptar oferta → distancia precisa)
- [ ] `gcloud services api-keys delete e091850a-d5ea-4941-bcf0-8f966032b58b`
- [ ] Banner GCP desaparece (24h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
