### PR TITLE
fix(db): recover migrations skipped by Drizzle's out-of-order bug

### DIFF
--- a/apps/api/src/db/migrator.ts
+++ b/apps/api/src/db/migrator.ts
@@ -1,4 +1,8 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
 import type { Logger } from '@booster-ai/logger';
+import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { migrate } from 'drizzle-orm/node-postgres/migrator';
 import type pg from 'pg';
@@ -10,6 +14,24 @@ import * as schema from './schema.js';
  * seguro de JS Number (< 2^53) para no necesitar BigInt en la query.
  */
 const MIGRATION_LOCK_KEY = 938472561;
+
+const MIGRATIONS_FOLDER = './drizzle';
+const MIGRATIONS_SCHEMA = 'drizzle';
+const MIGRATIONS_TABLE = '__drizzle_migrations';
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface JournalFile {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
 
 /**
  * Aplica migraciones pendientes al startup, protegidas por advisory lock.
@@ -24,9 +46,31 @@ const MIGRATION_LOCK_KEY = 938472561;
  * mismo cliente (drizzle envuelve el client directamente, no el pool, así
  * el lock aplica a las queries del migrator), y liberar al final.
  *
- * Otros instances que llegan acá esperan en pg_advisory_lock hasta que el
- * primero termina. Cuando el lock libera, drizzle ve que las migraciones
- * ya están aplicadas en `__drizzle_migrations` y hace no-op.
+ * --- Validación pre-apply (ADR-pending) ---
+ *
+ * Bug detectado 2026-05-13: el migrator de Drizzle compara `lastDbMigration.created_at <
+ * migration.folderMillis` para decidir si aplica una migración. Si los timestamps del
+ * `meta/_journal.json` NO son monotónicamente crecientes vs el orden cronológico
+ * de merge a main, Drizzle skipea migraciones silenciosamente.
+ *
+ * Reproducción del incident:
+ *   - PR-A crea migrations 0030+0031 (timestamp T0)
+ *   - PR-B crea migration 0032 (timestamp T1 > T0)
+ *   - PR-B mergea primero → 0032 se aplica, lastDbMigration.created_at = T1
+ *   - PR-A mergea después → 0030+0031 tienen folderMillis = T0 < T1 → SKIPPED
+ *   - Drizzle reporta "Migrations complete" sin aplicar nada
+ *   - Columnas declaradas en schema TS pero no en BD → queries 500
+ *
+ * Fix: pre-verificamos integridad ANTES de llamar a `migrate()`:
+ *   1. Leer journal entries del disco.
+ *   2. Leer hashes ya aplicadas de `drizzle.__drizzle_migrations`.
+ *   3. Computar hash de cada migration en disco.
+ *   4. Si HAY una entry del journal cuyo hash NO esté en la BD → es pending
+ *      pero Drizzle puede skipearla → la aplicamos manualmente en transacción.
+ *
+ * Esto NO compite con `migrate()` regular — funciona como tolerancia a un bug
+ * upstream. Cuando Drizzle aplique correctamente, simplemente no encontramos
+ * pendings y `migrate()` corre como antes.
  */
 export async function runMigrations(pool: pg.Pool, logger: Logger): Promise<void> {
   const client = await pool.connect();
@@ -35,10 +79,21 @@ export async function runMigrations(pool: pg.Pool, logger: Logger): Promise<void
     await client.query('SELECT pg_advisory_lock($1)', [MIGRATION_LOCK_KEY]);
 
     const migrationDb = drizzle(client, { schema });
+
+    // 1. Drizzle normal (puede skipear out-of-order; tolerable)
     const start = Date.now();
     logger.info('Running Drizzle migrations');
-    await migrate(migrationDb, { migrationsFolder: './drizzle' });
-    logger.info({ durationMs: Date.now() - start }, 'Migrations complete');
+    await migrate(migrationDb, { migrationsFolder: MIGRATIONS_FOLDER });
+    logger.info({ durationMs: Date.now() - start }, 'Drizzle migrate() complete');
+
+    // 2. Validación + recuperación de pending out-of-order
+    const recovered = await applyOutOfOrderPending(migrationDb, logger);
+    if (recovered.length > 0) {
+      logger.warn(
+        { recovered, count: recovered.length },
+        'Recovered out-of-order pending migrations skipped by Drizzle (bug upstream)',
+      );
+    }
   } finally {
     try {
       await client.query('SELECT pg_advisory_unlock($1)', [MIGRATION_LOCK_KEY]);
@@ -47,4 +102,84 @@ export async function runMigrations(pool: pg.Pool, logger: Logger): Promise<void
     }
     client.release();
   }
+}
+
+/**
+ * Detecta migrations del journal cuyo hash NO está en `drizzle.__drizzle_migrations`
+ * y las aplica en una sola transacción. Retorna los tags aplicados.
+ *
+ * Idempotente: si nada está pending, no toca la BD.
+ */
+async function applyOutOfOrderPending(
+  // biome-ignore lint/suspicious/noExplicitAny: drizzle types
+  db: any,
+  logger: Logger,
+): Promise<string[]> {
+  const journalPath = path.join(MIGRATIONS_FOLDER, 'meta', '_journal.json');
+  if (!fs.existsSync(journalPath)) {
+    logger.warn({ journalPath }, 'Migration journal not found; skipping recovery');
+    return [];
+  }
+
+  const journal: JournalFile = JSON.parse(fs.readFileSync(journalPath, 'utf-8'));
+  const entries = journal.entries ?? [];
+  if (entries.length === 0) {
+    return [];
+  }
+
+  // Hashes ya aplicados en la BD.
+  let appliedHashes: Set<string>;
+  try {
+    const result = await db.execute(
+      sql.raw(`SELECT hash FROM "${MIGRATIONS_SCHEMA}"."${MIGRATIONS_TABLE}"`),
+    );
+    // node-postgres devuelve { rows } o ResultIterator según versión
+    const rows: Array<{ hash: string }> = result.rows ?? result;
+    appliedHashes = new Set(rows.map((r) => r.hash));
+  } catch (err) {
+    // Si la tabla no existe es porque ningún migrate ha corrido nunca; deja a Drizzle.
+    logger.debug({ err }, 'Could not read __drizzle_migrations; skipping recovery check');
+    return [];
+  }
+
+  const recovered: string[] = [];
+  for (const entry of entries) {
+    const sqlPath = path.join(MIGRATIONS_FOLDER, `${entry.tag}.sql`);
+    if (!fs.existsSync(sqlPath)) {
+      logger.warn({ tag: entry.tag, sqlPath }, 'Journal entry references missing SQL file');
+      continue;
+    }
+    const sqlContent = fs.readFileSync(sqlPath, 'utf-8');
+    const hash = crypto.createHash('sha256').update(sqlContent).digest('hex');
+
+    if (appliedHashes.has(hash)) {
+      continue; // ya aplicada
+    }
+
+    logger.warn(
+      { tag: entry.tag, hash, when: entry.when },
+      'Pending migration not in __drizzle_migrations — applying via recovery path',
+    );
+
+    // Aplicar en transacción única: SQL + INSERT del marker.
+    // Drizzle separa statements con `--> statement-breakpoint`. Replicamos.
+    const statements = sqlContent
+      .split('--> statement-breakpoint')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+
+    await db.transaction(async (tx: typeof db) => {
+      for (const stmt of statements) {
+        await tx.execute(sql.raw(stmt));
+      }
+      await tx.execute(
+        sql.raw(
+          `INSERT INTO "${MIGRATIONS_SCHEMA}"."${MIGRATIONS_TABLE}" ("hash", "created_at") VALUES ('${hash}', ${entry.when})`,
+        ),
+      );
+    });
+    recovered.push(entry.tag);
+  }
+
+  return recovered;
 }


### PR DESCRIPTION
## Summary

Fix permanente para el bug del migrator detectado durante Playwright smoke test (sesión Claude 2026-05-13). Cierra la regresión que generó `/me → 500` en producción.

## Root cause (verificado leyendo `drizzle-orm` source)

`node_modules/drizzle-orm/pg-core/dialect.js` aplica migrations así:

```js
const lastDbMigration = dbMigrations[0];
for await (const migration of migrations) {
  if (!lastDbMigration || Number(lastDbMigration.created_at) < migration.folderMillis) {
    // aplicar
  }
}
```

**Bug**: solo aplica si `timestamp > último ya aplicado`. NO valida hashes pending del journal contra `__drizzle_migrations`. Si los timestamps del `meta/_journal.json` no son monotónicamente crecientes vs el orden cronológico de merge a main, las migrations llegan out-of-order y se skipean silenciosamente.

### Reproducción real (2026-05-13)

- PR #198 (stakeholder orgs) introdujo `0030` + `0031` con `when=1780531200000/1`
- PR #186 (auth wave) introdujo `0032` con `when=1780617600000` (mayor)
- PR #186 desplegó **primero** → `lastDbMigration.created_at = 1780617600000`
- PR #198 desplegó después → `0030/0031.folderMillis < 1780617600000` → **SKIPPED**
- Log `Migrations complete` en 0ms, sin error
- `__drizzle_migrations` quedó con 31 entries (faltan 2 vs 33 del journal)
- Schema TS declara columna `organizacion_stakeholder_id` pero BD no la tiene
- `/me` 500: `column membresias.organizacion_stakeholder_id does not exist`

## Fix

`runMigrations()` ahora corre `migrate()` (Drizzle normal) y **después** `applyOutOfOrderPending()`:

1. Lee `meta/_journal.json` entries
2. Computa `sha256` de cada migration SQL en disco
3. Lee hashes aplicadas de `drizzle.__drizzle_migrations`
4. Si hay entry del journal cuyo hash NO está en la BD → aplica en transacción (statements + INSERT del marker)
5. Splits por `--> statement-breakpoint` (formato Drizzle)
6. Log `WARN` cuando recupera — alertable en monitoring

**Idempotente**: si no hay pendings, no toca la BD. Tolera Drizzle aplicando correctamente.

## Hotfix manual (ya aplicado en prod)

El 2026-05-13 ~13:00 Chile, via `cloud-sql-proxy` + `psql` desde `db-bastion`:
- Aplicaron las 2 SQL files
- INSERT en `drizzle.__drizzle_migrations`
- Servicio recuperado, `/me` responde 200

Este PR **previene** que vuelva a pasar en futuros deploys.

## Test plan

- [x] typecheck OK
- [x] biome lint OK
- [x] vitest 929 passed, 2 skipped
- [ ] Post-merge: redeploy + verificar logs del nuevo runMigrations
  ```
  "Drizzle migrate() complete"
  // si hay pendings out-of-order:
  "Recovered out-of-order pending migrations skipped by Drizzle (bug upstream)"
  ```

## Alternativa rechazada

Patchear `drizzle-orm` con un fork. Demasiado overhead — el wrapper `applyOutOfOrderPending` resuelve igual y se desactiva solo cuando Drizzle aplique correctamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
