### PR TITLE
docs(audit): cross-proyectos GCP boosterchile.com + intento deploy DR via Cloud Build

### DIFF
--- a/docs/handoff/2026-05-13-cross-projects-audit.md
+++ b/docs/handoff/2026-05-13-cross-projects-audit.md
@@ -1,0 +1,97 @@
+# Auditoría cross-proyectos GCP — boosterchile.com (organización 435506363892)
+
+**Fecha**: 2026-05-13
+**Sesión**: Claude Opus 4.7
+**Trigger**: Felipe pidió "revisar otros proyectos en GCP en el dominio boosterchile.com que estén generando costos"
+**Billing account**: `019461-C73CDE-DCE377` (CLP)
+
+## Proyectos identificados
+
+| Project ID | Display name | Created | Billing | Estado real |
+|---|---|---|---|---|
+| `booster-ai-494222` | Booster AI | 2026-04-23 | ✅ Linked | **TRL 10 actual** — ~$575/mes post-optimizaciones |
+| `big-cabinet-482101-s3` | Booster by TVO | 2025-12-23 | ✅ Linked | **Booster 2.0 legacy productivo** — ~$80-150/mes |
+| `gen-lang-client-0486421631` | Booster | 2025-12-23 | ✅ Linked | Solo Gemini API key legacy (`Booster 1.0`) — ~$0-5/mes |
+| `cs-hc-a1c2ef1734b54550be7f6005` | — | — | ❌ none | Cloud Shell session — $0 |
+| `cs-host-c104dcd149104453b58c12` | — | — | ❌ none | Cloud Shell session — $0 |
+
+## `big-cabinet-482101-s3` — análisis productivo
+
+**Recursos activos (mucha más superficie de lo esperado para un "legacy")**:
+
+- **9+ Cloud Run services** (saw1 + us-central1):
+  - `booster-api` (us-central1)
+  - `booster-backend` (saw1 + us-central1, duplicado por región)
+  - `booster-fms-python` (saw1) — fleet management ?
+  - `booster-frontend` (saw1 + us-central1) + `booster-frontend-admin/driver/fleet`
+  - `booster-landing` (us-central1)
+  - `booster-worker` (saw1)
+- **Cloud SQL**: `booster2-db-new` Postgres 16, tier `db-g1-small`, ZONAL, 10 GB
+- **2 Pub/Sub topics**: `booster-telemetry`, `device-telemetry`
+- **5 GCS buckets**: cloudbuild, frontend-prod, documents, run-sources (saw1+us)
+- **3 BigQuery datasets**: `booster_cloudrun_logs`, `booster_iot`, `booster_telemetry` (uno en `US` multi-region)
+
+**Tráfico real últimos 30d** (Cloud Monitoring):
+- `booster-backend@us-central1`: **259.184 requests** ← productivo intenso
+- `booster-landing@us-central1`: **39.474 requests**
+- `booster-backend@southamerica-west1`: 503 (estable, bajo)
+- Otros: <20 req cada uno
+- **Cloud SQL CPU avg 30d**: 7.9% (low pero sostenido)
+
+**Estimación de costo `big-cabinet-482101-s3`**: ~**USD 80-150/mes**
+- Cloud Run idle + requests: $50-100
+- Cloud SQL `db-g1-small` ZONAL: $15-25
+- BigQuery storage + queries: $5-20
+- GCS + Pub/Sub: $5-15
+
+## Hallazgos importantes
+
+### 🔴 Decisión PO requerida: ¿migrar tráfico o sunset?
+
+El repo `booster-ai` (este) se describe como **"reescritura greenfield de Booster 2.0 con cero deuda técnica desde day 0"** (per CLAUDE.md). Pero `big-cabinet-482101-s3` **sigue siendo el cliente productivo principal** — 259k req/mes en `booster-backend@us-central1`.
+
+Esto implica una de dos cosas:
+1. La migración a Booster AI todavía no ha sucedido — el tráfico sigue en Booster 2.0
+2. Booster AI sirve un caso de uso distinto y ambos siguen en paralelo
+
+**Costo continuo paralelo**: ~$655-725/mes (booster-ai $575 + big-cabinet $80-150). Si la migración va a tomar varios meses, ese costo dual se va a sumar.
+
+### 🟡 API key `Booster 1.0` en `gen-lang-client-0486421631`
+
+Otro proyecto separado con UNA API key Gemini llamada `Booster 1.0`. Probablemente usada por el frontend de Booster 2.0. Mismo problema que las eliminadas en ADR-037: sin restricción de origen + cobra al proyecto al que pertenece.
+
+**Acción**: si Booster 2.0 va a sunset, eliminar esta key + proyecto. Si sigue activo, aplicar mismo patrón ADC que ADR-037.
+
+### 🟢 Cluster DR `booster-ai-telemetry-dr` sigue inactivo
+
+El cluster DR de `booster-ai-494222` (~$130/mes) sigue sin `telemetry-tcp-gateway` desplegado. Issue #194 abierto + PR #204 con plan + esta sesión intentó deploy via Cloud Build private worker pool **pero fracasó por networking cross-region** (worker pool saw1 no llega al master DR us-central1 a pesar de `master_global_access_config=enabled`).
+
+**Nueva opción a evaluar**: crear un Cloud Run Job (o segundo worker pool) en us-central1 para correr el `kubectl apply` desde dentro del VPC peering DR.
+
+## Costos consolidados estimados
+
+| Capa | USD/mes |
+|---|---|
+| `booster-ai-494222` (post-ADR-034/035/037/038) | ~$575 |
+| `big-cabinet-482101-s3` (Booster 2.0 productivo) | ~$80-150 |
+| `gen-lang-client-0486421631` (Gemini legacy key) | ~$0-5 |
+| **TOTAL org boosterchile.com** | **~$655-730/mes** ≈ **CLP $615-685k/mes** |
+
+## Recomendaciones
+
+### Inmediato
+
+1. **Decisión PO**: ¿Booster 2.0 (`big-cabinet`) sigue siendo productivo o se va a apagar? El costo dual depende de esto.
+2. **Si sunset Booster 2.0**: agendar fecha de corte → migrar tráfico residual → `gcloud projects delete big-cabinet-482101-s3 + gen-lang-client-0486421631`.
+3. **Si sigue activo Booster 2.0**: aplicar mismo right-sizing que ADR-034 al `booster2-db-new` (db-g1-small ZONAL ya es chico) y a los Cloud Run con min_instances elevado.
+
+### Mes que viene (cuando billing export tenga datos reales)
+
+4. Re-correr esta auditoría con queries directas a `booster-ai-494222.billing_export.gcp_billing_export_v1_019461_C73CDE_DCE377` filtrado por `project.id`. Vamos a tener cifras facturadas reales por proyecto + por SKU.
+
+### Higiene de IAM (este último checks)
+
+5. Verificar que NO hay roles/owner directos a usuarios humanos en `big-cabinet-482101-s3` (anti-pattern). Usar `engineers_group` o equivalente.
+6. Validar que `gen-lang-client-0486421631` tiene billing budget alert configurado (cualquier Gemini-key leak ahí escala muy rápido).
+
+🤖 Generado por Claude Opus 4.7

--- a/infrastructure/k8s/cloudbuild-dr-check.yaml
+++ b/infrastructure/k8s/cloudbuild-dr-check.yaml
@@ -1,0 +1,34 @@
+# Cloud Build pipeline minimal: verificar acceso al cluster DR + estado
+# cert-manager. Si pasa, validamos que el deploy real (cloudbuild-dr-deploy.yaml)
+# tiene todo lo necesario.
+
+steps:
+  - id: check
+    name: gcr.io/cloud-builders/kubectl
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euxo pipefail
+        export CLOUDSDK_COMPUTE_REGION=us-central1
+        export CLOUDSDK_CONTAINER_USE_APPLICATION_DEFAULT_CREDENTIALS=true
+        gcloud container clusters get-credentials booster-ai-telemetry-dr \
+          --location=us-central1 \
+          --project=booster-ai-494222 \
+          --internal-ip
+        echo "--- nodes ---"
+        kubectl get nodes
+        echo "--- cert-manager status ---"
+        kubectl get ns cert-manager 2>&1 || echo "(cert-manager namespace NOT FOUND)"
+        kubectl get deployment -n cert-manager cert-manager 2>&1 || echo "(cert-manager deployment NOT FOUND)"
+        echo "--- existing namespaces ---"
+        kubectl get ns
+        echo "--- existing clusterissuers ---"
+        kubectl get clusterissuer 2>&1 || echo "(no clusterissuers)"
+
+options:
+  pool:
+    name: projects/booster-ai-494222/locations/southamerica-west1/workerPools/booster-production-pool
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 300s

--- a/infrastructure/k8s/cloudbuild-dr-deploy.yaml
+++ b/infrastructure/k8s/cloudbuild-dr-deploy.yaml
@@ -1,0 +1,161 @@
+# Cloud Build pipeline para deployar telemetry-tcp-gateway en el cluster DR
+# (us-central1). Cierra issue #194.
+#
+# Por qué Cloud Build private worker pool y NO kubectl desde laptop:
+#   El cluster DR tiene `master_authorized_networks_config` restringido. El
+#   pool de Cloud Build privado YA ESTÁ en la allowlist (ver
+#   `infrastructure/dr-region.tf` master_authorized_networks_config). Esto
+#   evita tener que abrir el master al internet ni montar IAP tunnels.
+#
+# Run:
+#   gcloud builds submit --no-source \
+#     --config=infrastructure/k8s/cloudbuild-dr-deploy.yaml \
+#     --region=southamerica-west1 \
+#     --project=booster-ai-494222
+#
+# Pre-requisitos (idempotentes — el pipeline los verifica):
+#   - Imagen `telemetry-tcp-gateway:bootstrap` taggeada en Artifact Registry
+#   - cert-manager instalado en el cluster DR (si falta, install via helm)
+#   - ClusterIssuer `letsencrypt-prod` aplicado en el cluster DR
+
+steps:
+  # ----------------------------------------------------------------------
+  # 1. Get kubectl credentials del cluster DR (internal endpoint via VPC peering)
+  # ----------------------------------------------------------------------
+  - id: get-credentials-dr
+    name: gcr.io/cloud-builders/kubectl
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euxo pipefail
+        gcloud container clusters get-credentials booster-ai-telemetry-dr \
+          --location=us-central1 \
+          --project=booster-ai-494222 \
+          --internal-ip
+        kubectl get nodes
+
+  # ----------------------------------------------------------------------
+  # 2. Verify cert-manager + install si falta (idempotente)
+  # ----------------------------------------------------------------------
+  - id: ensure-cert-manager
+    name: alpine/helm:3.16.3
+    entrypoint: sh
+    args:
+      - -c
+      - |
+        set -eux
+        # Copy kubeconfig del step previo
+        cp -r /workspace/.kube ~/.kube 2>/dev/null || true
+        export KUBECONFIG=~/.kube/config
+
+        if kubectl get namespace cert-manager 2>/dev/null; then
+          echo "cert-manager namespace exists, checking deployment..."
+          if kubectl get deployment -n cert-manager cert-manager 2>/dev/null; then
+            echo "cert-manager already installed, skipping helm install"
+            exit 0
+          fi
+        fi
+
+        echo "Installing cert-manager via helm..."
+        helm repo add jetstack https://charts.jetstack.io
+        helm repo update
+        helm install cert-manager jetstack/cert-manager \
+          --namespace cert-manager --create-namespace \
+          --set crds.enabled=true \
+          --set serviceAccount.annotations."iam\.gke\.io/gcp-service-account"="cert-manager-cloud-dns@booster-ai-494222.iam.gserviceaccount.com" \
+          --wait --timeout=5m
+
+        # Annotation post-install para Workload Identity binding (terraform
+        # ya bindeó el GCP SA — falta solo la annotation en el K8s SA).
+        kubectl annotate serviceaccount cert-manager \
+          --namespace cert-manager \
+          iam.gke.io/gcp-service-account=cert-manager-cloud-dns@booster-ai-494222.iam.gserviceaccount.com \
+          --overwrite
+
+  # ----------------------------------------------------------------------
+  # 3. Apply ClusterIssuer (letsencrypt-prod) — pre-req del Certificate
+  # ----------------------------------------------------------------------
+  - id: apply-issuers
+    name: gcr.io/cloud-builders/kubectl
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euxo pipefail
+        kubectl apply -f infrastructure/k8s/cert-manager-issuers.yaml
+        # ClusterIssuer Ready check (puede tomar ~30s)
+        for i in $$(seq 1 30); do
+          if kubectl get clusterissuer letsencrypt-prod -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep -q True; then
+            echo "ClusterIssuer Ready"
+            break
+          fi
+          echo "Waiting for ClusterIssuer Ready... ($$i/30)"
+          sleep 5
+        done
+
+  # ----------------------------------------------------------------------
+  # 4. Apply Certificate (cert-dr.yaml) — cert-manager hace DNS-01 challenge
+  # ----------------------------------------------------------------------
+  - id: apply-cert-dr
+    name: gcr.io/cloud-builders/kubectl
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euxo pipefail
+        # Crear namespace antes (el manifest del gateway lo crea pero el cert
+        # va al mismo namespace y se aplica primero).
+        kubectl create namespace telemetry --dry-run=client -o yaml | kubectl apply -f -
+        kubectl apply -f infrastructure/k8s/cert-dr.yaml
+        echo "Cert applied — DNS-01 challenge en curso (puede tomar ~2-5min)"
+
+  # ----------------------------------------------------------------------
+  # 5. Apply telemetry-tcp-gateway-dr.yaml (Deployment + Service + SA)
+  # ----------------------------------------------------------------------
+  - id: apply-gateway-dr
+    name: gcr.io/cloud-builders/kubectl
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euxo pipefail
+        kubectl apply -f infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
+        echo "Rollout watch (max 5min)..."
+        kubectl rollout status deployment/telemetry-tcp-gateway \
+          --namespace=telemetry --timeout=300s
+
+  # ----------------------------------------------------------------------
+  # 6. Verificar Service obtuvo el loadBalancerIP esperado
+  # ----------------------------------------------------------------------
+  - id: verify-service
+    name: gcr.io/cloud-builders/kubectl
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -euxo pipefail
+        for i in $$(seq 1 30); do
+          IP=$$(kubectl get svc -n telemetry telemetry-tcp-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+          if [ "$$IP" = "136.116.208.86" ]; then
+            echo "Service LoadBalancer IP correcto: $$IP"
+            break
+          fi
+          echo "Waiting for LoadBalancer IP... current=$$IP expected=136.116.208.86 ($$i/30)"
+          sleep 10
+        done
+
+        # Final status snapshot
+        kubectl get pods,svc,certificate -n telemetry
+
+options:
+  # Usar el private worker pool — está en master_authorized_networks_config
+  # del cluster DR, así puede llegar al master vía VPC peering.
+  pool:
+    name: projects/booster-ai-494222/locations/southamerica-west1/workerPools/booster-production-pool
+  logging: CLOUD_LOGGING_ONLY
+  # machine_type viene del worker_config del pool (e2-standard-2 según
+  # infrastructure/cloudbuild.tf) — Cloud Build no permite override aquí.
+
+# Timeout total del pipeline (15 min — incluye DNS challenge + LB provisioning)
+timeout: 900s


### PR DESCRIPTION
## Summary

Dos entregables en el mismo PR (ambos detectados en la misma sesión):

### 1. Auditoría cross-proyectos org `boosterchile.com`

Descubre que `big-cabinet-482101-s3` (Booster 2.0 legacy) **sigue siendo productivo** con 259k req/mes en `booster-backend@us-central1`. Costo dual con Booster AI: **~$655-730/mes total** (booster-ai $575 + big-cabinet $80-150).

**Decisión PO pendiente**: ¿sunset Booster 2.0 o seguir paralelo con right-sizing?

Adicional: `gen-lang-client-0486421631` tiene una API key Gemini legacy (`Booster 1.0`) sin restricción de origen — mismo problema que ADR-037.

### 2. Intento deploy DR via Cloud Build private pool (issue #194)

Creé `cloudbuild-dr-check.yaml` + `cloudbuild-dr-deploy.yaml` para correr `kubectl apply` desde el Cloud Build private worker pool (que está allowlisted en `master_authorized_networks` del cluster DR). También tagué la imagen `:bootstrap` requerida por el manifest.

**Resultado**: bloqueado por networking cross-region. Worker pool en saw1 NO logra TCP handshake al master del cluster DR us-central1 (`172.17.0.2:443`) a pesar de `master_global_access_config=enabled`. Mismo síntoma que el bastion vía IAP de la sesión anterior.

**Próximo paso (no realizable en sesión Claude)**: segundo worker pool en us-central1 o Cloud Run Job en us-central1 dentro de la subnet DR.

## Cambios

- `docs/handoff/2026-05-13-cross-projects-audit.md` (nuevo) — auditoría completa cross-org
- `infrastructure/k8s/cloudbuild-dr-deploy.yaml` (nuevo) — pipeline deploy DR (preparado, no funcional por bloqueo networking)
- `infrastructure/k8s/cloudbuild-dr-check.yaml` (nuevo) — pipeline mínimo de verificación de acceso

## Estado de sesión

| Acción | Estado |
|---|---|
| Bug Drizzle migrator (PR #205) | ✅ Mergeado |
| Cross-projects audit | ✅ Documentado |
| DR deploy intento | ⏸ Bloqueado por networking |
| Cleanup IAM grants temporales | ✅ Revocados |
| Tag `:bootstrap` | ✅ Persiste para próximo intento |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
