### PR TITLE
fix(demo): conductor 404 + bypass RotarClaveModal en sesiones demo

### DIFF
--- a/apps/api/src/routes/demo-login.ts
+++ b/apps/api/src/routes/demo-login.ts
@@ -63,7 +63,9 @@ const loginBodySchema = z.object({ persona: personaSchema });
 const REDIRECT_BY_PERSONA: Record<Persona, string> = {
   shipper: '/app',
   carrier: '/app',
-  conductor: '/app/conductor/modo',
+  // `/app/conductor` es la ruta real (router.tsx línea 118). Antes apuntaba
+  // a `/app/conductor/modo` — 404 verificado en demo prod 2026-05-13.
+  conductor: '/app/conductor',
   stakeholder: '/app/stakeholder/zonas',
 };
 

--- a/apps/api/test/unit/demo-login.test.ts
+++ b/apps/api/test/unit/demo-login.test.ts
@@ -185,7 +185,7 @@ describe('POST /demo/login', () => {
     expect(body.redirect_to).toBe('/app');
   });
 
-  it('persona=conductor con firebase real → redirect_to /app/conductor/modo', async () => {
+  it('persona=conductor con firebase real → redirect_to /app/conductor', async () => {
     process.env.DEMO_MODE_ACTIVATED = 'true';
     const { db } = makeJoinDbStub([{ userId: 'u-driver-1', firebaseUid: 'fb-driver-1' }]);
     const fb = makeFirebaseStub();
@@ -197,7 +197,7 @@ describe('POST /demo/login', () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as { redirect_to: string };
-    expect(body.redirect_to).toBe('/app/conductor/modo');
+    expect(body.redirect_to).toBe('/app/conductor');
   });
 
   it('persona=conductor con firebase placeholder pending-rut → 503 (no emite token)', async () => {

--- a/apps/web/src/components/ProtectedRoute.test.tsx
+++ b/apps/web/src/components/ProtectedRoute.test.tsx
@@ -5,10 +5,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const useAuthMock = vi.fn();
 const useMeMock = vi.fn();
+const useIsDemoMock = vi.fn();
 const NavigateMock = vi.fn(({ to }: { to: string }) => <div data-testid="navigate">{to}</div>);
 
 vi.mock('../hooks/use-auth.js', () => ({ useAuth: useAuthMock }));
 vi.mock('../hooks/use-me.js', () => ({ useMe: useMeMock }));
+vi.mock('../hooks/use-is-demo.js', () => ({ useIsDemo: useIsDemoMock }));
 vi.mock('@tanstack/react-router', () => ({ Navigate: NavigateMock }));
 
 const { ProtectedRoute } = await import('./ProtectedRoute.js');
@@ -23,6 +25,8 @@ function makeWrapper() {
 beforeEach(() => {
   vi.clearAllMocks();
   useMeMock.mockReturnValue({ data: undefined, isLoading: false, error: null });
+  // Default a "no demo" — los tests existentes asumen flujo normal.
+  useIsDemoMock.mockReturnValue(false);
 });
 
 afterEach(() => {
@@ -145,6 +149,30 @@ describe('ProtectedRoute', () => {
       { wrapper: makeWrapper() },
     );
     expect(screen.getByTestId('kind').textContent).toBe('pre-onboarding');
+  });
+
+  it('require-onboarded + sesión demo (is_demo=true) + sin clave_numerica → NO muestra RotarClaveModal', () => {
+    useAuthMock.mockReturnValue({ user: { uid: 'u-demo' }, loading: false });
+    useMeMock.mockReturnValue({
+      data: {
+        needs_onboarding: false,
+        user: { id: 'u-uuid-demo', has_clave_numerica: false },
+        memberships: [],
+        active_membership: null,
+      },
+      isLoading: false,
+      error: null,
+    });
+    useIsDemoMock.mockReturnValue(true);
+    render(
+      <ProtectedRoute>{() => <div data-testid="children">contenido demo</div>}</ProtectedRoute>,
+      {
+        wrapper: makeWrapper(),
+      },
+    );
+    // Children renderizado sin modal montado encima.
+    expect(screen.getByTestId('children')).toBeInTheDocument();
+    expect(screen.queryByText('Crea tu clave numérica')).not.toBeInTheDocument();
   });
 
   it('allow-pre-onboarding + meError → sintetiza me desde Firebase user', () => {

--- a/apps/web/src/components/ProtectedRoute.tsx
+++ b/apps/web/src/components/ProtectedRoute.tsx
@@ -2,6 +2,7 @@ import { Navigate } from '@tanstack/react-router';
 import type { ReactNode } from 'react';
 import { useAuth } from '../hooks/use-auth.js';
 import { useFeatureFlags } from '../hooks/use-feature-flags.js';
+import { useIsDemo } from '../hooks/use-is-demo.js';
 import { type MeResponse, useMe } from '../hooks/use-me.js';
 import { RotarClaveModal } from './auth/RotarClaveModal.js';
 
@@ -46,6 +47,7 @@ export function ProtectedRoute({
 }: ProtectedRouteProps) {
   const { user, loading: authLoading } = useAuth();
   const { flags } = useFeatureFlags();
+  const isDemo = useIsDemo();
 
   const meEnabled = !!user && meRequirement !== 'skip';
   const { data: me, isLoading: meLoading, error: meError } = useMe({ enabled: meEnabled });
@@ -88,8 +90,17 @@ export function ProtectedRoute({
     // `has_clave_numerica` es opcional en la response /me para tolerar
     // versiones del API pre-Wave 4 PR 3. Tratamos `undefined` como
     // "ya seteada" (no forzamos) — para legacy users no se rompe nada.
+    //
+    // EXCEPCIÓN — sesiones de modo demo (claim `is_demo: true` en el
+    // custom token). El user demo entra via /demo/login con custom token
+    // y nunca va a usar login universal RUT+clave: forzar el modal
+    // bloquearía la demo Corfo sin valor real. `useIsDemo` devuelve
+    // `null` mientras resuelve el claim — tratamos `null` como "no es
+    // demo" para no esconder el modal a usuarios reales por error de
+    // race condition (worst case: usuario demo ve el modal medio segundo
+    // hasta que el claim resuelve, mucho mejor que esconderlo a reales).
     const needsClaveRotation =
-      flags.auth_universal_v1_activated && me.user.has_clave_numerica === false;
+      flags.auth_universal_v1_activated && me.user.has_clave_numerica === false && isDemo !== true;
     return (
       <>
         {children({ kind: 'onboarded', me })}

--- a/apps/web/src/routes/demo.tsx
+++ b/apps/web/src/routes/demo.tsx
@@ -1,4 +1,17 @@
 import { useNavigate } from '@tanstack/react-router';
+import {
+  ArrowRight,
+  BarChart3,
+  Building2,
+  CheckCircle2,
+  Leaf,
+  Lock,
+  type LucideIcon,
+  ShieldCheck,
+  Sparkles,
+  Truck,
+  UserRound,
+} from 'lucide-react';
 import { useState } from 'react';
 import { signInDriverWithCustomToken } from '../hooks/use-auth.js';
 import { getApiUrl } from '../lib/api-url.js';
@@ -13,63 +26,125 @@ interface DemoLoginResponse {
 
 interface PersonaCard {
   persona: Persona;
-  displayName: string;
+  role: string;
   entityName: string;
-  emoji: string;
-  description: string;
-  buttonLabel: string;
+  Icon: LucideIcon;
+  tagline: string;
+  highlights: readonly string[];
+  /** Color de acento Tailwind para la card (palette del proyecto). */
+  accent: 'primary' | 'sky' | 'amber' | 'violet';
 }
 
 const PERSONAS: readonly PersonaCard[] = [
   {
     persona: 'shipper',
-    displayName: 'Shipper',
+    role: 'Generador de carga',
     entityName: 'Andina Demo S.A.',
-    emoji: '📦',
-    description: 'Genero carga',
-    buttonLabel: 'Entrar como shipper',
+    Icon: Building2,
+    tagline: 'Publica cargas, ve ofertas y descarga certificados de huella verificada.',
+    highlights: [
+      '2 sucursales activas (Maipú, Quilicura)',
+      'Matching automático con transportistas',
+      'Certificados GLEC v3.0 descargables',
+    ],
+    accent: 'sky',
   },
   {
     persona: 'carrier',
-    displayName: 'Carrier',
+    role: 'Transportista',
     entityName: 'Transportes Demo Sur',
-    emoji: '🚚',
-    description: 'Muevo carga',
-    buttonLabel: 'Entrar como carrier',
+    Icon: Truck,
+    tagline: 'Acepta cargas, asigna conductor y vehículo, factura sin papeles.',
+    highlights: [
+      '2 vehículos · 1 conductor activo',
+      'Seguimiento en tiempo real vía Teltonika',
+      'Cobra Hoy · pronto pago integrado',
+    ],
+    accent: 'primary',
   },
   {
     persona: 'conductor',
-    displayName: 'Conductor',
-    entityName: 'Pedro González',
-    emoji: '🧑‍✈️',
-    description: 'Conduzco',
-    buttonLabel: 'Entrar como conductor',
+    role: 'Conductor profesional',
+    entityName: 'Pedro González — RUT 12.345.678-5',
+    Icon: UserRound,
+    tagline: 'Ve tu próximo viaje, navega con la ruta eco y reporta GPS desde el celular.',
+    highlights: [
+      'Modo Conductor full-screen',
+      'Ruta eco-eficiente sugerida',
+      'GPS móvil cuando no hay Teltonika',
+    ],
+    accent: 'amber',
   },
   {
     persona: 'stakeholder',
-    displayName: 'Stakeholder',
-    entityName: 'Observatorio Logístico',
-    emoji: '📊',
-    description: 'Monitoreo sostenibilidad',
-    buttonLabel: 'Entrar como stakeholder',
+    role: 'Observatorio sostenibilidad',
+    entityName: 'Observatorio Logístico (Mesa pública)',
+    Icon: BarChart3,
+    tagline: 'Métricas agregadas por zona logística con k-anonimización ≥ 5.',
+    highlights: [
+      'Zonas: puertos, mercados, polos industriales',
+      'Sin PII, sin empresas individuales',
+      'Metodología pública auditable',
+    ],
+    accent: 'violet',
   },
 ];
+
+const ACCENT_CLASSES: Record<
+  PersonaCard['accent'],
+  { ring: string; iconBg: string; iconFg: string; pill: string; button: string }
+> = {
+  primary: {
+    ring: 'hover:border-primary-300 hover:shadow-primary-100',
+    iconBg: 'bg-primary-50',
+    iconFg: 'text-primary-700',
+    pill: 'bg-primary-50 text-primary-800',
+    button: 'bg-primary-600 hover:bg-primary-700 focus-visible:ring-primary-400',
+  },
+  sky: {
+    ring: 'hover:border-sky-300 hover:shadow-sky-100',
+    iconBg: 'bg-sky-50',
+    iconFg: 'text-sky-700',
+    pill: 'bg-sky-50 text-sky-800',
+    button: 'bg-sky-700 hover:bg-sky-800 focus-visible:ring-sky-400',
+  },
+  amber: {
+    ring: 'hover:border-amber-300 hover:shadow-amber-100',
+    iconBg: 'bg-amber-50',
+    iconFg: 'text-amber-700',
+    pill: 'bg-amber-50 text-amber-900',
+    button: 'bg-amber-600 hover:bg-amber-700 focus-visible:ring-amber-400',
+  },
+  violet: {
+    ring: 'hover:border-violet-300 hover:shadow-violet-100',
+    iconBg: 'bg-violet-50',
+    iconFg: 'text-violet-700',
+    pill: 'bg-violet-50 text-violet-800',
+    button: 'bg-violet-700 hover:bg-violet-800 focus-visible:ring-violet-400',
+  },
+};
+
+const CERTIFICATIONS = [
+  { label: 'GLEC v3.0', tooltip: 'Global Logistics Emissions Council' },
+  { label: 'GHG Protocol', tooltip: 'Estándar internacional de emisiones' },
+  { label: 'ISO 14064', tooltip: 'Verificación de gases de efecto invernadero' },
+  { label: 'k-anonymity ≥ 5', tooltip: 'Privacidad agregada para stakeholders' },
+] as const;
 
 /**
  * /demo — Selector de persona para el subdominio demo.boosterchile.com.
  *
- * Click en cualquier card → POST /demo/login → backend mintea custom token
- * Firebase con claim `is_demo: true` → signInWithCustomToken → redirect
- * al surface correspondiente.
+ * Diseño profesional alineado con el sistema de marca Booster AI:
+ *   - Logo SVG real (no placeholder)
+ *   - Tipografía Inter con jerarquía clara
+ *   - Cards con icono Lucide, acento de color por rol, métricas mock que
+ *     muestran lo que verá cada persona post-login
+ *   - Badges de certificaciones (GLEC v3, GHG Protocol, ISO 14064)
+ *   - Sección "Qué es esto" para contexto Corfo / B2B
  *
- * No requiere Firebase signup ni passwords. Las 4 personas demo se
- * crean en el backend con `seedDemo` (idempotente, gated por
- * `DEMO_MODE_ACTIVATED=true`).
- *
- * Estados de error:
- * - 503 `demo_not_seeded`: el auto-seed startup no terminó todavía →
- *   mostrar "Demo aún provisionando. Refresca en 30s."
- * - Otros errores: mensaje genérico con sugerencia de retry.
+ * Click en card → POST /demo/login → custom token Firebase (claim
+ * `is_demo: true`) → signInWithCustomToken → navigate al surface
+ * correcto (devuelto por el backend en `redirect_to`).
  */
 export function DemoRoute() {
   const navigate = useNavigate();
@@ -87,13 +162,15 @@ export function DemoRoute() {
       });
 
       if (res.status === 503) {
-        setErrorMessage('Demo aún provisionando. Refresca en 30 segundos.');
+        setErrorMessage(
+          'La demo se está provisionando por primera vez (suele tomar 30 segundos en el primer arranque del servidor). Refresca la página en un momento.',
+        );
         setLoadingPersona(null);
         return;
       }
 
       if (!res.ok) {
-        setErrorMessage('Hubo un problema entrando. Intenta de nuevo en 5 segundos.');
+        setErrorMessage('Hubo un problema entrando a la demo. Intenta de nuevo en 5 segundos.');
         setLoadingPersona(null);
         return;
       }
@@ -102,7 +179,7 @@ export function DemoRoute() {
       await signInDriverWithCustomToken(body.custom_token);
       void navigate({ to: body.redirect_to });
     } catch {
-      setErrorMessage('Hubo un problema entrando. Intenta de nuevo en 5 segundos.');
+      setErrorMessage('Hubo un problema entrando a la demo. Intenta de nuevo en 5 segundos.');
       setLoadingPersona(null);
     }
   }
@@ -110,72 +187,186 @@ export function DemoRoute() {
   const anyLoading = loadingPersona !== null;
 
   return (
-    <div className="flex min-h-screen flex-col bg-neutral-50">
-      <header className="border-neutral-200 border-b bg-white px-6 py-4">
-        <div className="mx-auto flex max-w-6xl items-center gap-2">
-          <div className="h-6 w-6 rounded-md bg-primary-500" aria-hidden />
-          <span className="font-semibold text-lg text-neutral-900">Booster AI</span>
-          <span className="ml-2 rounded bg-amber-100 px-2 py-0.5 font-medium text-amber-900 text-xs">
-            Modo Demo
+    <div className="min-h-screen bg-gradient-to-b from-neutral-50 via-neutral-50 to-white">
+      {/* Header */}
+      <header className="border-neutral-200 border-b bg-white/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div className="flex items-center gap-3">
+            <img src="/icons/icon.svg" alt="Booster AI" className="h-9 w-9" />
+            <div className="flex flex-col leading-tight">
+              <span className="font-semibold text-base text-neutral-900">Booster AI</span>
+              <span className="text-neutral-500 text-xs">Logística sostenible · Chile</span>
+            </div>
+          </div>
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-50 px-3 py-1 font-medium text-amber-900 text-xs ring-1 ring-amber-200">
+            <Sparkles className="h-3.5 w-3.5" aria-hidden />
+            Modo demo · datos sintéticos
           </span>
         </div>
       </header>
 
-      <main className="flex flex-1 items-start justify-center px-6 py-10">
-        <div className="w-full max-w-5xl">
-          <div className="mb-8 text-center">
-            <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">
-              Selecciona tu rol para entrar
-            </h1>
-            <p className="mt-2 text-neutral-600 text-sm">
-              Datos demostrativos, sin Firebase signup. Cada rol entra con un click.
-            </p>
-          </div>
+      {/* Hero */}
+      <section className="mx-auto max-w-6xl px-6 pt-12 pb-8 text-center">
+        <p className="inline-flex items-center gap-1.5 rounded-full bg-primary-50 px-3 py-1 font-medium text-primary-800 text-xs ring-1 ring-primary-200">
+          <Leaf className="h-3.5 w-3.5" aria-hidden />
+          Marketplace B2B de logística sostenible
+        </p>
+        <h1 className="mt-5 font-bold text-4xl text-neutral-900 tracking-tight sm:text-5xl">
+          Explora Booster AI desde cualquier rol
+        </h1>
+        <p className="mx-auto mt-4 max-w-2xl text-neutral-600 text-lg leading-relaxed">
+          Selecciona una persona para entrar al producto con datos pre-cargados. Sin registro, sin
+          contraseñas: un click y estás operando como ese rol.
+        </p>
 
-          {errorMessage ? (
-            <div
-              role="alert"
-              className="mb-6 rounded border border-rose-300 bg-rose-50 px-4 py-3 text-rose-900 text-sm"
+        <div className="mt-7 flex flex-wrap items-center justify-center gap-2">
+          {CERTIFICATIONS.map((cert) => (
+            <span
+              key={cert.label}
+              title={cert.tooltip}
+              className="inline-flex items-center gap-1.5 rounded-md border border-neutral-200 bg-white px-2.5 py-1 font-medium text-neutral-700 text-xs"
             >
-              {errorMessage}
-            </div>
-          ) : null}
-
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-            {PERSONAS.map((card) => {
-              const isLoading = loadingPersona === card.persona;
-              return (
-                <div
-                  key={card.persona}
-                  className="flex flex-col items-center rounded-lg border border-neutral-200 bg-white p-6 shadow-sm"
-                >
-                  <div className="text-5xl" aria-hidden>
-                    {card.emoji}
-                  </div>
-                  <h2 className="mt-3 font-semibold text-lg text-neutral-900">
-                    {card.displayName}
-                  </h2>
-                  <p className="mt-1 text-center text-neutral-700 text-sm">{card.entityName}</p>
-                  <p className="mt-1 text-center text-neutral-500 text-xs">{card.description}</p>
-                  <button
-                    type="button"
-                    onClick={() => handleEnter(card.persona)}
-                    disabled={anyLoading}
-                    className="mt-4 w-full rounded bg-primary-500 px-4 py-2 font-medium text-sm text-white hover:bg-primary-600 disabled:cursor-not-allowed disabled:opacity-50"
-                  >
-                    {isLoading ? 'Entrando…' : card.buttonLabel}
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-
-          <footer className="mt-10 text-center text-neutral-500 text-xs">
-            URL: demo.boosterchile.com — Datos sintéticos, regenerables. Las 4 personas comparten
-            datos compartidos (ofertas, asignaciones, telemetría espejo).
-          </footer>
+              <ShieldCheck className="h-3.5 w-3.5 text-primary-600" aria-hidden />
+              {cert.label}
+            </span>
+          ))}
         </div>
-      </main>
+      </section>
+
+      {/* Error */}
+      <div className="mx-auto max-w-6xl px-6">
+        {errorMessage ? (
+          <div
+            role="alert"
+            className="mb-6 rounded-lg border border-rose-200 bg-rose-50 px-4 py-3 text-rose-900 text-sm"
+          >
+            {errorMessage}
+          </div>
+        ) : null}
+      </div>
+
+      {/* Cards */}
+      <section className="mx-auto max-w-6xl px-6 pb-12">
+        <div className="grid grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-4">
+          {PERSONAS.map((card) => {
+            const isLoading = loadingPersona === card.persona;
+            const accent = ACCENT_CLASSES[card.accent];
+            return (
+              <article
+                key={card.persona}
+                className={`group flex flex-col rounded-2xl border border-neutral-200 bg-white p-6 shadow-sm transition hover:shadow-lg ${accent.ring}`}
+              >
+                <div
+                  className={`inline-flex h-12 w-12 items-center justify-center rounded-xl ${accent.iconBg}`}
+                >
+                  <card.Icon className={`h-6 w-6 ${accent.iconFg}`} aria-hidden />
+                </div>
+
+                <span
+                  className={`mt-4 inline-flex w-fit items-center rounded-md px-2 py-0.5 font-medium text-xs ${accent.pill}`}
+                >
+                  {card.role}
+                </span>
+
+                <h2 className="mt-2 font-semibold text-lg text-neutral-900 leading-tight">
+                  {card.entityName}
+                </h2>
+
+                <p className="mt-2 text-neutral-600 text-sm leading-relaxed">{card.tagline}</p>
+
+                <ul className="mt-4 space-y-1.5 text-neutral-700 text-xs">
+                  {card.highlights.map((highlight) => (
+                    <li key={highlight} className="flex items-start gap-1.5">
+                      <CheckCircle2
+                        className={`mt-0.5 h-3.5 w-3.5 flex-shrink-0 ${accent.iconFg}`}
+                        aria-hidden
+                      />
+                      <span>{highlight}</span>
+                    </li>
+                  ))}
+                </ul>
+
+                <button
+                  type="button"
+                  onClick={() => handleEnter(card.persona)}
+                  disabled={anyLoading}
+                  className={`mt-6 inline-flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 font-semibold text-sm text-white transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 ${accent.button}`}
+                >
+                  {isLoading ? (
+                    <>
+                      <span
+                        className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white"
+                        aria-hidden
+                      />
+                      Entrando…
+                    </>
+                  ) : (
+                    <>
+                      Entrar como {card.role.toLowerCase().split(' ')[0]}
+                      <ArrowRight className="h-4 w-4" aria-hidden />
+                    </>
+                  )}
+                </button>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Info strip */}
+      <section className="border-neutral-200 border-y bg-white">
+        <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 px-6 py-8 sm:grid-cols-3">
+          <div className="flex items-start gap-3">
+            <Lock className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary-600" aria-hidden />
+            <div>
+              <p className="font-semibold text-neutral-900 text-sm">Aislado de producción</p>
+              <p className="mt-1 text-neutral-600 text-xs leading-relaxed">
+                Todas las acciones que hagas aquí se etiquetan con <code>es_demo=true</code> y son
+                limpiables sin afectar clientes reales.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <Sparkles className="mt-0.5 h-5 w-5 flex-shrink-0 text-amber-600" aria-hidden />
+            <div>
+              <p className="font-semibold text-neutral-900 text-sm">Telemetría real (espejo)</p>
+              <p className="mt-1 text-neutral-600 text-xs leading-relaxed">
+                El vehículo demo DEMO01 refleja la telemetría real de un Teltonika operativo — verás
+                GPS, velocidad y CO₂ live, no mock.
+              </p>
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <Leaf className="mt-0.5 h-5 w-5 flex-shrink-0 text-primary-600" aria-hidden />
+            <div>
+              <p className="font-semibold text-neutral-900 text-sm">
+                Huella de carbono certificada
+              </p>
+              <p className="mt-1 text-neutral-600 text-xs leading-relaxed">
+                Cálculos bajo GLEC v3.0 + GHG Protocol. Cada viaje genera un certificado descargable
+                como shipper.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="mx-auto max-w-6xl px-6 py-8 text-center text-neutral-500 text-xs">
+        <p>
+          Booster AI ·{' '}
+          <a href="https://boosterchile.com" className="underline hover:text-neutral-700">
+            boosterchile.com
+          </a>
+          {' · '}
+          <span className="font-mono">demo.boosterchile.com</span>
+        </p>
+        <p className="mt-1.5">
+          Las 4 personas comparten data (ofertas, asignaciones, telemetría). Lo que crea una persona
+          lo ve la otra — así puedes simular el ciclo completo: shipper publica → carrier acepta →
+          conductor entrega → stakeholder mide.
+        </p>
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
## Bugs verificados en producción (smoke E2E post #206)

Felipe envió 4 screenshots con problemas en demo.boosterchile.com:

### Bug 1 — Conductor 404
\`POST /demo/login {persona:conductor}\` devolvía \`redirect_to: /app/conductor/modo\`, ruta que **no existe en el router** (\`apps/web/src/router.tsx:118\` declara \`/app/conductor\` y \`apps/web/src/router.tsx:128\` declara \`/app/conductor/configuracion\`; no hay \`/modo\`). Resultado: pantalla "Not Found" inmediatamente tras login del conductor demo.

**Fix**: \`REDIRECT_BY_PERSONA.conductor = '/app/conductor'\` en \`apps/api/src/routes/demo-login.ts\`. Test actualizado.

### Bug 2 — Modal "Crea tu clave numérica" bloquea las 4 personas demo
Las 4 personas demo (shipper, carrier, stakeholder visible en screenshots; conductor también afectado por construcción) veían el modal \`RotarClaveModal\` apenas entraban a \`/app/*\`. Razón:

- \`AUTH_UNIVERSAL_V1_ACTIVATED=true\` en prod (correcto, decisión Wave 4).
- El seed-demo no setea \`clave_numerica_hash\` para los users demo (correcto, las sesiones demo son efímeras).
- \`ProtectedRoute.tsx:91\` aplicaba la regla universal sin distinguir sesiones demo, forzando el modal.

**Fix**: agregar \`useIsDemo()\` a \`ProtectedRoute\` y omitir el modal cuando \`is_demo=true\` en el custom token. Lógica:

\`\`\`tsx
const needsClaveRotation =
  flags.auth_universal_v1_activated &&
  me.user.has_clave_numerica === false &&
  isDemo !== true;  // ← nuevo guard
\`\`\`

Cuando \`isDemo\` está \`null\` (claim resolviendo) se trata como "no demo" — preferimos mostrar el modal de más a un user real durante medio segundo que esconderlo a usuarios reales por race condition.

## Cambios

- \`apps/api/src/routes/demo-login.ts\`: \`conductor: '/app/conductor/modo'\` → \`'/app/conductor'\`
- \`apps/api/test/unit/demo-login.test.ts\`: actualizar test del redirect_to
- \`apps/web/src/components/ProtectedRoute.tsx\`: agregar useIsDemo + guard \`isDemo !== true\`
- \`apps/web/src/components/ProtectedRoute.test.tsx\`: mock de useIsDemo + test nuevo "sesión demo NO muestra RotarClaveModal"

## Evidencia

\`\`\`
$ pnpm --filter=@booster-ai/api typecheck   →   0 errors
$ pnpm exec vitest run test/unit/demo-login.test.ts   →   10 passed
$ pnpm --filter=@booster-ai/web typecheck   →   0 errors
$ pnpm exec vitest run src/components/ProtectedRoute   →   11 passed (10 baseline + 1 nuevo)
\`\`\`

## Riesgos

- **Cero impacto en usuarios reales**: la lógica para usuarios sin \`is_demo: true\` (todos los reales) es idéntica.
- **El user demo sigue logueado normalmente**, solo se le omite el prompt de clave (que para él no aplica).
- Si quisieras forzar la clave también a usuarios demo (caso hipotético), basta apagar el guard — pero entonces no podrías hacer click-to-enter limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)