### PR TITLE
chore(infra): worker pool us-central1 DR + cleanup secrets huérfanos ADR-037/038

### DIFF
--- a/infrastructure/cloudbuild.tf
+++ b/infrastructure/cloudbuild.tf
@@ -58,3 +58,65 @@ output "cloudbuild_worker_pool_name" {
   description = "Resource name del Cloud Build private worker pool. Pasar a `gcloud builds submit --worker-pool` o setear en options.pool.name del cloudbuild.yaml."
   value       = google_cloudbuild_worker_pool.production.id
 }
+
+# ---------------------------------------------------------------------------
+# Cloud Build worker pool en DR region (us-central1) — para deploys al
+# cluster GKE DR cuyo master internal IP (172.17.0.0/28) NO es alcanzable
+# cross-region desde saw1 a pesar de master_global_access_config=enabled.
+#
+# Sesión 2026-05-13 verificó empíricamente que el pool en saw1 falla con
+# `i/o timeout dial tcp 172.17.0.2:443` al intentar kubectl al cluster DR.
+# Un pool en la misma region elimina el cross-region peering issue.
+#
+# Costo:
+#   - e2-standard-2 en us-central1: $0.064/hr (vs $0.080 en saw1, 20% menos)
+#   - Uso esperado: ~2h/mes (deploys DR esporádicos) ≈ $0.13/mes
+#   - + IP range reservada: $0.01/mes
+#   Total: <$1/mes
+# ---------------------------------------------------------------------------
+
+# IP range para peering del pool DR. /24 = 256 IPs, suficiente para builds
+# concurrentes en DR. Distinto de 10.104.24.0 (primary pool).
+resource "google_compute_global_address" "cloudbuild_pool_range_dr" {
+  name          = "booster-cloudbuild-pool-range-dr"
+  project       = google_project.booster_ai.project_id
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 24
+  network       = google_compute_network.vpc.id
+}
+
+# Agregamos el range del pool DR al service networking connection existente
+# (private_vpc en data.tf). NO crear una connection nueva — Google solo
+# permite UNA por VPC + service. Hace un re-apply del recurso compartido.
+#
+# NOTA: data.tf:google_service_networking_connection.private_vpc tiene
+# reserved_peering_ranges = [private_services, cloudbuild_pool_range].
+# Necesita agregar cloudbuild_pool_range_dr ahí también — ver ese archivo.
+
+resource "google_cloudbuild_worker_pool" "production_dr" {
+  name     = "booster-production-pool-dr"
+  project  = google_project.booster_ai.project_id
+  location = var.dr_region # us-central1
+
+  worker_config {
+    machine_type   = "e2-standard-2"
+    disk_size_gb   = 100
+    no_external_ip = false
+  }
+
+  network_config {
+    peered_network = google_compute_network.vpc.id
+  }
+
+  depends_on = [
+    google_service_networking_connection.private_vpc,
+    google_compute_global_address.cloudbuild_pool_range_dr,
+    google_project_service.apis,
+  ]
+}
+
+output "cloudbuild_worker_pool_dr_name" {
+  description = "Resource name del Cloud Build private worker pool DR (us-central1). Usar en deploys al cluster DR via gcloud builds submit --worker-pool."
+  value       = google_cloudbuild_worker_pool.production_dr.id
+}

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -72,6 +72,10 @@ resource "google_service_networking_connection" "private_vpc" {
   reserved_peering_ranges = [
     google_compute_global_address.private_services.name,
     google_compute_global_address.cloudbuild_pool_range.name,
+    # Cloud Build pool DR (us-central1) — sesión 2026-05-13: resuelve el
+    # bloqueo de deploy DR (issue #194). Worker pool en mismo region que
+    # cluster DR evita el cross-region peering issue del master.
+    google_compute_global_address.cloudbuild_pool_range_dr.name,
   ]
 }
 

--- a/infrastructure/dr-region.tf
+++ b/infrastructure/dr-region.tf
@@ -78,11 +78,20 @@ resource "google_container_cluster" "telemetry_dr" {
     }
 
     # Cloud Build pool en south-west via cross-region peering (la VPC es
-    # global). El DR cluster solo recibe deploys cuando hay failover —
-    # operadores manuales usan IAP, no Cloud Build automatico.
+    # global). NOTA: en la práctica este peering NO logra TCP handshake al
+    # master DR (verificado 2026-05-13 — i/o timeout). Mantenido por compat
+    # pero el deploy real usa el pool DR de abajo.
     cidr_blocks {
       cidr_block   = "${google_compute_global_address.cloudbuild_pool_range.address}/${google_compute_global_address.cloudbuild_pool_range.prefix_length}"
-      display_name = "cloudbuild-private-pool"
+      display_name = "cloudbuild-private-pool-saw1"
+    }
+
+    # Cloud Build pool DR (us-central1, MISMA region que el cluster) —
+    # solución definitiva al bloqueo de deploy DR (issue #194). Pool
+    # us-central1 alcanza el master DR sin cross-region peering issues.
+    cidr_blocks {
+      cidr_block   = "${google_compute_global_address.cloudbuild_pool_range_dr.address}/${google_compute_global_address.cloudbuild_pool_range_dr.prefix_length}"
+      display_name = "cloudbuild-private-pool-us-central1"
     }
 
     # IAP TCP forwarding para operadores accediendo al DR.

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -174,8 +174,10 @@ locals {
     # Database
     "database-url",
 
-    # Gemini / AI
-    "gemini-api-key",
+    # AI providers
+    # NOTA: gemini-api-key eliminada en ADR-037 — el backend ahora usa
+    # Vertex AI Gemini con ADC (workload identity del SA cloud_run_runtime).
+    # Cero API keys para Gemini.
     "anthropic-api-key", # por si usamos Claude como fallback en ai-provider
 
     # Maps Platform (ADR-009 del 2.0: key legacy Geocoding + Elevation)
@@ -241,27 +243,10 @@ locals {
     "webpush-vapid-public-key",
     "webpush-vapid-private-key",
 
-    # Google Routes API key (Phase 1 — eco route suggestion).
-    # Server-side ONLY: el api la usa para llamar
-    # https://routes.googleapis.com/directions/v2:computeRoutes desde
-    # Cloud Run. NO va al bundle del cliente (a diferencia de
-    # frontend-maps-key que es pública por diseño).
-    #
-    # Restricciones obligatorias en GCP Console al crear la key:
-    #   - API restriction: ONLY "Routes API" (limita blast radius)
-    #   - Application restriction: NONE inicialmente (Cloud Run egress IP
-    #     no es estática sin Cloud NAT). Si se conecta VPC connector con
-    #     egress estático, restringir por IP.
-    #   - Quota: cap a $X/mes en GCP Billing budgets para evitar abuso.
-    #
-    # Cargar el valor real con:
-    #   gcloud secrets versions add google-routes-api-key \
-    #     --data-file=<(echo -n "AIza...")
-    #
-    # El api lee config.GOOGLE_ROUTES_API_KEY; si vale el placeholder
-    # ROTATE_ME_..., el calculator cae al fallback estimarDistanciaKm
-    # automáticamente (no rompe el flujo de asignación).
-    "google-routes-api-key",
+    # NOTA: google-routes-api-key eliminada en ADR-038 — el backend ahora
+    # autentica contra Routes API con ADC + header X-Goog-User-Project (SA
+    # cloud_run_runtime tiene serviceusage.serviceUsageConsumer). Cero
+    # API keys para Routes API.
   ]
 }
 


### PR DESCRIPTION
## Summary

Solución definitiva al bloqueo del DR deploy (issue #194) + higiene de secrets huérfanos.

## Cambios

### 1. Cloud Build worker pool DR (us-central1)

- Nuevo `google_compute_global_address.cloudbuild_pool_range_dr` (/24 reservado en VPC)
- Nuevo `google_cloudbuild_worker_pool.production_dr` en `us-central1` (e2-standard-2)
- `data.tf`: range agregado a `reserved_peering_ranges` del `private_vpc`
- `dr-region.tf`: range agregado a `master_authorized_networks_config` del cluster DR

**Por qué us-central1**: el pool saw1 NO logra TCP handshake al master del cluster DR (us-central1, `172.17.0.2:443`) a pesar de `master_global_access_config=enabled` — verificado empíricamente 2026-05-13. Cross-region peering no funciona para GKE master access.

**Costo**: ~$0.064/hr × ~2h/mes = **<$1/mes** (20% más barato que saw1).

### 2. Cleanup secrets huérfanos

- ❌ `secrets["gemini-api-key"]` + `placeholder["gemini-api-key"]`
- ❌ `secrets["google-routes-api-key"]` + `placeholder["google-routes-api-key"]`

Estas API keys ya fueron eliminadas del proyecto el 2026-05-13 (ADR-037 + ADR-038). Los secrets en Secret Manager quedaron como artefactos huérfanos.

## Plan terraform

```
Plan: 2 to add, 14 to change, 4 to destroy.
```

## Test plan

### Pre-merge
- [x] terraform validate — Success
- [x] terraform plan — 2 add, 14 change, 4 destroy

### Post-merge
- [ ] terraform apply ejecuta limpio
- [ ] `gcloud builds worker-pools list --region=us-central1` muestra `booster-production-pool-dr`
- [ ] `gcloud secrets list` ya no muestra gemini-api-key ni google-routes-api-key
- [ ] Re-run cloudbuild-dr-deploy.yaml apuntando al pool DR → kubectl alcanza el master sin timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)
