### PR TITLE
feat(brand): logo Booster real (boo|boo) al lado del nombre en toda la app

### DIFF
--- a/apps/web/public/icons/icon.svg
+++ b/apps/web/public/icons/icon.svg
@@ -2,35 +2,36 @@
   <title>Booster AI</title>
   <!--
     Símbolo "boo / boo" en grilla 2 filas × 3 columnas.
-    Columna 1: dos "b" stilizadas como anillos con cola descendente.
+    Columna 1: dos "b" estilizadas (anillo + cola vertical en el lado izquierdo).
     Columnas 2 y 3: cuatro "o" como anillos circulares.
     El "o" de la fila inferior, columna central, es el acento verde brillante.
 
-    Paleta:
+    Paleta canónica del símbolo Booster:
       Azul marino: #1F2D5C
       Verde acento: #1FD75C
 
-    Fondo blanco a sangrado completo.
-  -->
-  <rect width="512" height="512" fill="#ffffff"/>
+    Trazo grueso (40) calibrado para legibilidad en tamaños chicos
+    (32-48 px en headers / tabs / favicons).
 
-  <!-- Grid: 6 anillos. Centro de cada anillo: x ∈ {128, 256, 384}, y ∈ {176, 336}.
-       Radio del anillo: 64. Ancho del trazo: 28. -->
-  <g fill="none" stroke="#1F2D5C" stroke-width="28">
+    Fondo transparente (sin <rect>) para que el ícono se adapte a
+    fondos claros y oscuros del producto.
+  -->
+
+  <g fill="none" stroke="#1F2D5C" stroke-width="40" stroke-linecap="round">
     <!-- Fila superior: b - o - o -->
-    <!-- "b": círculo con tail vertical en el lado izquierdo -->
-    <line x1="80"  y1="80"  x2="80"  y2="176"/>
-    <circle cx="128" cy="176" r="64"/>
-    <circle cx="256" cy="176" r="64"/>
-    <circle cx="384" cy="176" r="64"/>
+    <!-- "b": cola vertical izquierda + anillo derecho -->
+    <line x1="72" y1="60" x2="72" y2="172"/>
+    <circle cx="136" cy="176" r="68"/>
+    <circle cx="272" cy="176" r="68"/>
+    <circle cx="408" cy="176" r="68"/>
 
     <!-- Fila inferior: b - o(verde) - o -->
-    <line x1="80"  y1="240" x2="80"  y2="336"/>
-    <circle cx="128" cy="336" r="64"/>
-    <!-- "o" central inferior va aparte (verde) -->
-    <circle cx="384" cy="336" r="64"/>
+    <line x1="72" y1="224" x2="72" y2="336"/>
+    <circle cx="136" cy="340" r="68"/>
+    <!-- o central inferior va aparte (verde acento) -->
+    <circle cx="408" cy="340" r="68"/>
   </g>
 
-  <!-- "o" acento verde brillante (centro inferior) -->
-  <circle cx="256" cy="336" r="64" fill="none" stroke="#1FD75C" stroke-width="28"/>
+  <!-- o acento verde brillante (centro inferior) -->
+  <circle cx="272" cy="340" r="68" fill="none" stroke="#1FD75C" stroke-width="40"/>
 </svg>

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -75,7 +75,7 @@ export function Layout({
             className="flex shrink-0 items-center gap-2 sm:gap-3"
             onClick={() => setMobileOpen(false)}
           >
-            <div className="h-6 w-6 rounded-md bg-primary-500" aria-hidden />
+            <img src="/icons/icon.svg" alt="" aria-hidden className="h-7 w-7" />
             <span className="whitespace-nowrap font-semibold text-lg text-neutral-900">
               Booster AI
             </span>

--- a/apps/web/src/routes/demo.tsx
+++ b/apps/web/src/routes/demo.tsx
@@ -192,7 +192,7 @@ export function DemoRoute() {
       <header className="border-neutral-200 border-b bg-white/80 backdrop-blur">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
           <div className="flex items-center gap-3">
-            <img src="/icons/icon.svg" alt="Booster AI" className="h-9 w-9" />
+            <img src="/icons/icon.svg" alt="Booster AI" className="h-11 w-11" />
             <div className="flex flex-col leading-tight">
               <span className="font-semibold text-base text-neutral-900">Booster AI</span>
               <span className="text-neutral-500 text-xs">Logística sostenible · Chile</span>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -151,7 +151,7 @@ export function LoginRoute() {
     <div className="flex min-h-screen flex-col bg-neutral-50">
       <header className="border-neutral-200 border-b bg-white px-6 py-4">
         <div className="mx-auto flex max-w-6xl items-center gap-2">
-          <div className="h-6 w-6 rounded-md bg-primary-500" aria-hidden />
+          <img src="/icons/icon.svg" alt="" aria-hidden className="h-7 w-7" />
           <span className="font-semibold text-lg text-neutral-900">Booster AI</span>
         </div>
       </header>

--- a/apps/web/src/routes/onboarding.tsx
+++ b/apps/web/src/routes/onboarding.tsx
@@ -33,7 +33,7 @@ function OnboardingPage({ me }: { me: MeNeedsOnboarding }) {
     <div className="flex min-h-screen flex-col bg-neutral-50">
       <header className="border-neutral-200 border-b bg-white px-6 py-4">
         <div className="mx-auto flex max-w-6xl items-center gap-2">
-          <div className="h-6 w-6 rounded-md bg-primary-500" aria-hidden />
+          <img src="/icons/icon.svg" alt="" aria-hidden className="h-7 w-7" />
           <span className="font-semibold text-lg text-neutral-900">Booster AI</span>
         </div>
       </header>


### PR DESCRIPTION
## Contexto

Felipe envió el logo canónico de Booster (símbolo \"boo|boo\" con el \"o\" central inferior en verde acento). El SVG en \`apps/web/public/icons/icon.svg\` ya tenía la geometría correcta pero con trazo delgado y padding mayor — se veía flaco al lado del wordmark \"Booster AI\" en headers de 24–48 px y NO se estaba usando en 3 de los 4 lugares donde aparece el wordmark.

## Cambios

### 1. \`apps/web/public/icons/icon.svg\` — refinado

- \`stroke-width\` 28 → **40** (anillos prominentes a tamaños chicos)
- Radio 64 → **68**, posicionado más compacto
- \`stroke-linecap=\"round\"\` en las \"b\" para suavizar terminaciones
- \`<rect>\` de fondo blanco removido → ahora **transparente** (respeta light/dark del contenedor)

### 2. Reemplazo del placeholder verde cuadrado por el SVG real

Antes:

\`\`\`tsx
<div className=\"h-6 w-6 rounded-md bg-primary-500\" aria-hidden />
\`\`\`

Después:

\`\`\`tsx
<img src=\"/icons/icon.svg\" alt=\"\" aria-hidden className=\"h-7 w-7\" />
\`\`\`

Aplicado en:
- \`apps/web/src/components/Layout.tsx\` (header app — todas las páginas \`/app/*\`)
- \`apps/web/src/routes/login.tsx\` (pantalla login)
- \`apps/web/src/routes/onboarding.tsx\` (wizard onboarding)

### 3. \`apps/web/src/routes/demo.tsx\` — logo más prominente

h-9 w-9 → **h-11 w-11** en la landing del demo (mayor presencia visual).

## Validación

\`\`\`
$ pnpm --filter=@booster-ai/web typecheck   →   0 errors
\`\`\`

## Lugares donde se verá el logo nuevo post-deploy

| Surface | URL | Tamaño |
|---|---|---|
| Demo landing | demo.boosterchile.com/demo | h-11 (44px) |
| App header | app.boosterchile.com/app/* | h-7 (28px) |
| Login | app.boosterchile.com/login | h-7 (28px) |
| Onboarding | app.boosterchile.com/onboarding | h-7 (28px) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)