### PR TITLE
feat(infra): limpieza dominios — apex/www al LB con redirect 301 a app, eliminar marketing placeholder

### DIFF
--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -81,7 +81,7 @@ module "service_api" {
     # Origins permitidos al api. La PWA nueva corre en https://app.${var.domain}
     # — sin esto el browser bloquea preflight OPTIONS y todas las requests
     # cross-origin desde el frontend fallan con "Failed to fetch".
-    CORS_ALLOWED_ORIGINS = "${local.public_api_url},https://${var.domain},https://marketing.${var.domain},https://app.${var.domain},https://demo.${var.domain},${local.cloud_run_api_url}"
+    CORS_ALLOWED_ORIGINS = "${local.public_api_url},https://${var.domain},https://www.${var.domain},https://app.${var.domain},https://demo.${var.domain},${local.cloud_run_api_url}"
 
     # B.8 — dispatcher de notificaciones WhatsApp post-matching.
     # El api comparte el mismo Sender (+19383365293) que el bot — Twilio
@@ -254,32 +254,16 @@ module "service_web" {
   labels = { app = "web", env = var.environment }
 }
 
-# --- apps/marketing (Next.js) ---
-module "service_marketing" {
-  source = "./modules/cloud-run-service"
-
-  project_id            = google_project.booster_ai.project_id
-  region                = var.region
-  service_name          = "booster-ai-marketing"
-  service_account_email = google_service_account.cloud_run_runtime.email
-
-  # ADR-034: tráfico real ~150 req/día (~0.002 RPS). Googlebot tolera cold start
-  # ocasional (no penaliza SEO si <30s); usuarios humanos esperan 5-10s al primer
-  # hit del día. Trade-off favorable vs $20-30/mes de min=1.
-  min_instances = 0
-  max_instances = 10
-  memory        = "512Mi"
-
-  env_vars = {
-    NODE_ENV = "production"
-  }
-
-  public = false # tráfico público entra via Global HTTPS LB (networking.tf); Cloud Run no acepta allUsers por org policy
-
-  secret_versions_ready = local.all_secret_versions_ready
-
-  labels = { app = "marketing", env = var.environment }
-}
+# NOTA: `module "service_marketing"` (Cloud Run booster-ai-marketing) fue
+# eliminado en 2026-05-13. Era un placeholder (imagen `gcr.io/cloudrun/
+# placeholder`) sin código fuente real ni IAM policy, conectado al LB via
+# backend `backend-booster-ai-marketing` y NEG marketing — tampoco recibía
+# tráfico porque DNS apex/www no apuntaban al LB. Auditoría de dominios
+# confirmó código IaC muerto.
+#
+# Reemplazo: apex/www ahora apuntan al LB y el url_map hace redirect 301
+# a app.boosterchile.com (ver path_matcher "marketing" en networking.tf).
+# Cuando exista proyecto marketing real, recrear el módulo + backend.
 
 # --- apps/matching-engine ---
 module "service_matching_engine" {

--- a/infrastructure/networking.tf
+++ b/infrastructure/networking.tf
@@ -56,6 +56,8 @@ locals {
     "api.${var.domain}",
     "app.${var.domain}",
     "demo.${var.domain}",
+    var.domain,           # apex (boosterchile.com) — landing comercial (redirect a app)
+    "www.${var.domain}",  # www  → redirect a app
   ]
 }
 
@@ -118,17 +120,6 @@ resource "google_compute_region_network_endpoint_group" "web" {
 
   cloud_run {
     service = module.service_web.name
-  }
-}
-
-resource "google_compute_region_network_endpoint_group" "marketing" {
-  name                  = "neg-booster-ai-marketing"
-  project               = google_project.booster_ai.project_id
-  region                = var.region
-  network_endpoint_type = "SERVERLESS"
-
-  cloud_run {
-    service = module.service_marketing.name
   }
 }
 
@@ -349,35 +340,6 @@ resource "google_compute_backend_service" "web" {
   }
 }
 
-resource "google_compute_backend_service" "marketing" {
-  name                  = "backend-booster-ai-marketing"
-  project               = google_project.booster_ai.project_id
-  protocol              = "HTTPS"
-  load_balancing_scheme = "EXTERNAL_MANAGED"
-  security_policy       = google_compute_security_policy.waf.id
-
-  # CDN habilitado para marketing site (SEO + performance)
-  enable_cdn = true
-  cdn_policy {
-    cache_mode                   = "CACHE_ALL_STATIC"
-    default_ttl                  = 3600
-    client_ttl                   = 3600
-    max_ttl                      = 86400
-    negative_caching             = true
-    serve_while_stale            = 86400
-    signed_url_cache_max_age_sec = 0
-  }
-
-  backend {
-    group = google_compute_region_network_endpoint_group.marketing.id
-  }
-
-  log_config {
-    enable      = true
-    sample_rate = 1.0
-  }
-}
-
 resource "google_compute_backend_service" "whatsapp_bot" {
   name                  = "backend-booster-ai-whatsapp-bot"
   project               = google_project.booster_ai.project_id
@@ -400,9 +362,12 @@ resource "google_compute_backend_service" "whatsapp_bot" {
 # =============================================================================
 
 resource "google_compute_url_map" "main" {
-  name            = "booster-ai-url-map"
-  project         = google_project.booster_ai.project_id
-  default_service = google_compute_backend_service.marketing.id # apex + www → marketing
+  name    = "booster-ai-url-map"
+  project = google_project.booster_ai.project_id
+  # Default service para hosts/paths sin match explícito. Apuntamos al
+  # backend web (PWA) que tiene su propio 404 controlado por TanStack
+  # Router. Antes era el backend marketing que era un placeholder vacío.
+  default_service = google_compute_backend_service.web.id
 
   host_rule {
     hosts        = ["api.${var.domain}"]
@@ -452,9 +417,20 @@ resource "google_compute_url_map" "main" {
     default_service = google_compute_backend_service.web.id
   }
 
+  # apex (boosterchile.com) + www.boosterchile.com — redirect 301 a
+  # app.boosterchile.com mientras no exista un landing comercial dedicado.
+  # Reversible: cuando haya proyecto marketing real, cambiar
+  # `default_url_redirect` por `default_service` apuntando al nuevo
+  # backend. NO usamos backend marketing porque era placeholder vacío
+  # (eliminado en este PR).
   path_matcher {
-    name            = "marketing"
-    default_service = google_compute_backend_service.marketing.id
+    name = "marketing"
+    default_url_redirect {
+      host_redirect          = "app.${var.domain}"
+      redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+      strip_query            = false
+      https_redirect         = true
+    }
   }
 }
 
@@ -531,28 +507,39 @@ resource "google_compute_global_forwarding_rule" "http_redirect" {
 # Fase 1/5: confirmar en admin.google.com → Apps → Gmail → Authenticate
 # email antes del corte de NS.
 
-# === Booster 2.0 — preservar destinos legacy ===
-# Apex apunta a las IPs de AWS Global Accelerator (Booster 2.0 landing).
+# === apex + www: migrados al LB de Booster AI ===
+#
+# Histórico hasta 2026-05-13:
+#   apex → A 13.248.243.5, 76.223.105.230 (AWS GA, GoDaddy Website Builder
+#          Booster 2.0 con landing "Próximo lanzamiento")
+#   www  → CNAME ghs.googlehosted.com (Google Sites Booster 2.0, 503)
+#
+# Auditoría de dominios identificó que Booster AI ya está live (api/app/
+# demo operativos) pero el primer punto de contacto comercial seguía
+# sirviendo content de Booster 2.0/legacy inconsistente con la marca
+# actual. El servicio Cloud Run `booster-ai-marketing` además era un
+# placeholder vacío (`gcr.io/cloudrun/placeholder`), código IaC muerto.
+#
+# Decisión: apex + www apuntan al LB. El URL map de Booster AI hace
+# redirect 301 a app.boosterchile.com mientras no exista un landing
+# comercial dedicado. Reversible cuando haya proyecto marketing real:
+# basta cambiar el url_redirect por backend_service.
 resource "google_dns_record_set" "apex" {
   name         = "${var.domain}."
   project      = google_project.booster_ai.project_id
   managed_zone = google_dns_managed_zone.main.name
   type         = "A"
   ttl          = 3600
-  rrdatas = [
-    "13.248.243.5",
-    "76.223.105.230",
-  ]
+  rrdatas      = [google_compute_global_address.lb_ipv4.address]
 }
 
-# www → Google Sites (Booster 2.0)
 resource "google_dns_record_set" "www" {
   name         = "www.${var.domain}."
   project      = google_project.booster_ai.project_id
   managed_zone = google_dns_managed_zone.main.name
-  type         = "CNAME"
+  type         = "A"
   ttl          = 3600
-  rrdatas      = ["ghs.googlehosted.com."]
+  rrdatas      = [google_compute_global_address.lb_ipv4.address]
 }
 
 # app → Cloud Run booster-ai-web vía Global HTTPS LB.


### PR DESCRIPTION
## Auditoría de dominios

Estado pre-PR de los 8 subdominios de \`boosterchile.com\`:

| Subdominio | Estado pre-PR | Acción |
|---|---|---|
| \`api.*\` | ✅ LB → Cloud Run api | Sin cambios |
| \`app.*\` | ✅ LB → Cloud Run web | Sin cambios |
| \`demo.*\` | ✅ LB → Cloud Run web (modo demo) | Sin cambios |
| \`telemetry.*\` | ✅ GKE codec8 plain TCP 5027 | Sin cambios (ya en IaC) |
| \`telemetry-tls.*\` | ✅ GKE TLS TCP 5061 | Sin cambios |
| \`telemetry-dr.*\` | ✅ DR del gateway TLS | Sin cambios |
| **\`boosterchile.com\`** (apex) | ❌ AWS GA → GoDaddy \"Próximo lanzamiento\" Booster 1.0/2.0 | **Migrado al LB + redirect 301** |
| **\`www.boosterchile.com\`** | ❌ CNAME ghs → 503 huérfano | **Migrado al LB + redirect 301** |

## Cambios consolidados

### DNS (Cloud DNS)
- \`apex\`: A 13.248.243.5, 76.223.105.230 (AWS GA GoDaddy) → A 34.36.187.195 (LB Booster AI)
- \`www\`: CNAME ghs.googlehosted.com → A 34.36.187.195

### Cert managed
- Agregados a \`local.cert_domains\`: \`boosterchile.com\` (apex) + \`www.boosterchile.com\`
- Cert nuevo: \`booster-ai-cert-47e8c1ae\` (regenerado vía \`random_id.cert_suffix\` con \`create_before_destroy\`)
- Estado actual: **PROVISIONING** para los 5 dominios (api, app, demo, apex, www). 10–60 min real, hasta 24h worst case.

### URL map (LB)
- \`path_matcher \"marketing\"\` cambia de \`default_service = backend.marketing\` a \`default_url_redirect\` con HTTP 301 → \`https://app.boosterchile.com\`
- \`default_service\` del url_map pasa de backend.marketing a backend.web (404 controlado por TanStack Router)

### Eliminados (placeholder vacío sin tráfico)
- \`module \"service_marketing\"\` (Cloud Run con imagen \`gcr.io/cloudrun/placeholder\`)
- \`google_compute_backend_service.marketing\`
- \`google_compute_region_network_endpoint_group.marketing\`

### CORS API
- Remueve \`https://marketing.boosterchile.com\` (subdominio que no existe)
- Agrega \`https://www.boosterchile.com\` (ahora bajo el LB)

## Evidencia (aplicado en producción pre-merge)

\`\`\`
$ terraform validate                              ✅
$ terraform apply step 1 (DNS only, target)       ✅ — apex+www → LB IP
$ gcloud dns record-sets list ...                 ✅ — confirmado A 34.36.187.195
$ terraform apply step 2 (cert + url_map + clean) ✅ (después de update url_map target)
$ gcloud run services list | grep marketing       ELIMINADO
$ gcloud compute backend-services list | marketing ELIMINADO
$ gcloud compute network-endpoint-groups list | mk ELIMINADO
\`\`\`

## Reversibilidad

Si necesitas un proyecto marketing real en el futuro:

1. Recrear \`module \"service_marketing\"\` con el código fuente real (Next.js, etc).
2. Crear NEG + backend_service apuntando a ese Cloud Run.
3. En \`url_map\` cambiar \`path_matcher \"marketing\"\` de \`default_url_redirect\` a \`default_service\` apuntando al backend nuevo.

El \`host_rule\` para apex+www y el path_matcher por nombre quedan intactos — el cambio es mínimo.

## Pendientes manuales (no bloqueante)

1. **Eliminar el sitio GoDaddy Website Builder** desde la consola GoDaddy del usuario. El binding queda huérfano sin tráfico tras el corte DNS, pero conviene desactivarlo por aseo.
2. **Validar redirects 301** cuando el cert llegue a ACTIVE (~30 min):
   \`\`\`
   curl -sSI https://boosterchile.com/      →  301 Location: https://app.boosterchile.com/
   curl -sSI https://www.boosterchile.com/  →  301 Location: https://app.boosterchile.com/
   \`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)