### PR TITLE
chore(infra): reducir log ingest 149GB→<50GB post-deploy DR

### DIFF
--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -32,11 +32,16 @@ resource "google_compute_subnetwork" "private" {
   }
 
   # Trivy IaC: VPC Flow Logs habilitados para audit + investigacion de
-  # incidentes (#27). Sampling 0.5 + 10-min aggregation reduce costos
-  # ~10x vs full sampling — suficiente para anomaly detection.
+  # incidentes (#27). Sampling 0.1 (10% post-DR-deploy 2026-05-13) +
+  # 15-min aggregation. Bajado desde 0.5 al detectar que post-deploy DR
+  # generaba 1.44 GB/7d solo en flow logs de saw1. 0.1 es suficiente para
+  # anomaly detection sobre tráfico estable (sub-1 RPS de Cloud Run);
+  # incidentes raros con tráfico spike se siguen viendo. Si necesitamos
+  # más resolución para investigar algo específico, subir temporalmente
+  # y volver a bajar.
   log_config {
-    aggregation_interval = "INTERVAL_10_MIN"
-    flow_sampling        = 0.5
+    aggregation_interval = "INTERVAL_15_MIN"
+    flow_sampling        = 0.1
     metadata             = "INCLUDE_ALL_METADATA"
   }
 }

--- a/infrastructure/dr-region.tf
+++ b/infrastructure/dr-region.tf
@@ -47,10 +47,11 @@ resource "google_compute_subnetwork" "dr_private" {
   private_ip_google_access = true
 
   # Trivy IaC: VPC Flow Logs habilitados (#31). Mismos parametros que la
-  # subnet primary para consistencia (10-min agg + 0.5 sampling).
+  # subnet primary (data.tf) para consistencia: 0.1 sampling + 15-min agg
+  # post-optimización de log ingest 2026-05-13.
   log_config {
-    aggregation_interval = "INTERVAL_10_MIN"
-    flow_sampling        = 0.5
+    aggregation_interval = "INTERVAL_15_MIN"
+    flow_sampling        = 0.1
     metadata             = "INCLUDE_ALL_METADATA"
   }
 }

--- a/infrastructure/logging-exclusions.tf
+++ b/infrastructure/logging-exclusions.tf
@@ -37,3 +37,32 @@ resource "google_logging_project_exclusion" "gke_control_plane_noise" {
   # No deshabilitar — esta exclusion debe estar siempre activa.
   disabled = false
 }
+
+# ---------------------------------------------------------------------------
+# k8s_cluster + k8s_node informational events — exclusion adicional
+# ---------------------------------------------------------------------------
+# Hallazgo 2026-05-13 post-deploy DR: el ingest de logs explotó de 2 GB/mes
+# (pre-deploy) a ~149 GB/mes (estimado, basado en 34.75 GB en 7 días).
+# Cobrable: 99 GB × $0.50/GB ≈ $50/mes EXTRA.
+#
+# Top contributors (7d):
+#   19.75 GB  k8s_cluster (cluster events, autopilot autoscaling, kubelet)
+#    4.88 GB  k8s_node (node health checks, kubelet logs verbose)
+#    1.44 GB  gce_subnetwork (VPC flow logs — atacado en data.tf sampling)
+#    1.78 GB  k8s_container (logs INFO de los containers — KEEP, low cost)
+#
+# Esta exclusion descarta events de severidad INFO de k8s_cluster + k8s_node.
+# WARN/ERROR/CRITICAL siguen capturándose (necesarios para alertas).
+
+resource "google_logging_project_exclusion" "k8s_info_events_noise" {
+  name        = "k8s-info-events-noise"
+  project     = google_project.booster_ai.project_id
+  description = "Hallazgo 2026-05-13: descarta INFO events de k8s_cluster + k8s_node — autoscaling, kubelet heartbeats, etc. WARN/ERROR siguen capturándose. Reduce log ingest ~80 GB/mes post-deploy DR."
+
+  filter = <<-EOT
+    (resource.type="k8s_cluster" OR resource.type="k8s_node")
+    AND severity="INFO"
+  EOT
+
+  disabled = false
+}


### PR DESCRIPTION
## Summary

Hallazgo durante optimización post-DR deploy: Cloud Logging ingest explotó de **2 GB/mes** (pre-DR) a **~149 GB/mes** estimado (basado en 34.75 GB en 7 días). Sobre free tier 50 GB → **~$50/mes cobrable extra**.

## Top contributors detectados (7d)

```
19.75 GB  k8s_cluster      (autopilot autoscaling + kubelet INFO)
 4.88 GB  k8s_node         (health checks verbosos)
 2.03 GB  gce_instance
 1.91 GB  audited_resource (audit logs)
 1.78 GB  k8s_container    (logs INFO — KEEP, low cost)
 1.45 GB  gce_instance_group_manager
 1.44 GB  gce_subnetwork   (VPC flow logs)
```

## Cambios

### 1. Nueva exclusion `k8s-info-events-noise`

Descarta `k8s_cluster` + `k8s_node` con `severity=INFO`. WARN/ERROR/CRITICAL siguen capturándose para alertas. Reduce ~25 GB/7d.

### 2. VPC flow logs sampling 0.5 → 0.1 + 10min → 15min agg

`infrastructure/data.tf` (subnet primary saw1) + `infrastructure/dr-region.tf` (subnet DR us-c1). Suficiente para anomaly detection sobre tráfico estable (<1 RPS Cloud Run); incidentes con tráfico spike se siguen viendo. Subir temporalmente si se necesita más resolución para investigación específica.

## Apply

Ya aplicado vía `terraform apply -target` (para evitar drift no relacionado: SSL cert `main` `must be replaced` causaría downtime de `api.boosterchile.com` y `app.boosterchile.com` mientras Let's Encrypt re-emite — debe aplicarse en ventana coordinada).

```
✓ Exclusion k8s-info-events-noise creada (disabled=False)
✓ Subnet booster-ai-private: flow_sampling=0.1, INTERVAL_15_MIN
✓ Subnet booster-ai-dr-private: flow_sampling=0.1, INTERVAL_15_MIN
```

## Reducción esperada

~25 GB/7d (k8s INFO) + ~3 GB/7d (flow sampling 5x menos) = **~28 GB/7d eliminados** → **~120 GB/30d**.

Estimación post-fix: ~30 GB/30d → **vuelve al free tier** (ahorro ~$50/mes).

Validable en 24-48h con nuevo `logging.googleapis.com/billing/bytes_ingested`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
