### PR TITLE
feat: Site Settings Editor (ADR-039) — editar marca y copy sin redeploy

### DIFF
--- a/apps/api/drizzle/0033_configuracion_sitio.sql
+++ b/apps/api/drizzle/0033_configuracion_sitio.sql
@@ -1,0 +1,78 @@
+-- ADR-039 — Site Settings Runtime Configuration
+--
+-- Tabla `configuracion_sitio` para configuración editable de marca y copy
+-- desde el admin UI sin redeploy. Versionada (una fila por publicación
+-- + drafts). Singleton sobre `publicada=true` para que el endpoint público
+-- siempre tenga UNA versión vigente.
+
+CREATE TABLE IF NOT EXISTS "configuracion_sitio" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"version" integer NOT NULL,
+	"config" jsonb NOT NULL,
+	"publicada" boolean DEFAULT false NOT NULL,
+	"nota_publicacion" text,
+	"creado_por_email" text NOT NULL,
+	"creado_en" timestamp with time zone DEFAULT now() NOT NULL
+);
+
+-- Singleton: solo UNA fila con publicada=true a la vez.
+CREATE UNIQUE INDEX IF NOT EXISTS "configuracion_sitio_publicada_unique"
+	ON "configuracion_sitio" ("publicada") WHERE "publicada" = true;
+
+-- Versiones ordenadas por fecha (history más reciente primero).
+CREATE INDEX IF NOT EXISTS "configuracion_sitio_creado_idx"
+	ON "configuracion_sitio" ("creado_en" DESC);
+
+-- Seed inicial con los valores hardcoded de produción al momento de
+-- introducir esta feature (post PR #216 — propuesta de valor + logo
+-- canónico + botones verde Booster). Fuente de verdad: `DEFAULT_SITE_CONFIG`
+-- en packages/shared-schemas/src/site-settings.ts (mantener sincronizado).
+INSERT INTO "configuracion_sitio" ("version", "config", "publicada", "nota_publicacion", "creado_por_email")
+VALUES (
+	1,
+	'{
+		"identity": {
+			"logo_alt": "Booster AI"
+		},
+		"hero": {
+			"headline_line1": "Transporta más,",
+			"headline_line2": "impacta menos.",
+			"subhead": "Marketplace B2B de logística sostenible para Chile. Conecta generadores de carga con transportistas, optimiza retornos vacíos y certifica huella de carbono bajo GLEC v3.0.",
+			"microcopy": "Explora la demo desde cualquier rol — un click, sin registro."
+		},
+		"certifications": ["GLEC v3.0", "GHG Protocol", "ISO 14064", "k-anonymity ≥ 5"],
+		"persona_cards": [
+			{
+				"persona": "shipper",
+				"role": "Generador de carga",
+				"entity_name": "Andina Demo S.A.",
+				"tagline": "Publica cargas, ve ofertas y descarga certificados de huella verificada.",
+				"highlights": ["2 sucursales activas (Maipú, Quilicura)", "Matching automático con transportistas", "Certificados GLEC v3.0 descargables"]
+			},
+			{
+				"persona": "carrier",
+				"role": "Transportista",
+				"entity_name": "Transportes Demo Sur",
+				"tagline": "Acepta cargas, asigna conductor y vehículo, factura sin papeles.",
+				"highlights": ["2 vehículos · 1 conductor activo", "Seguimiento en tiempo real vía Teltonika", "Cobra Hoy · pronto pago integrado"]
+			},
+			{
+				"persona": "conductor",
+				"role": "Conductor profesional",
+				"entity_name": "Pedro González",
+				"tagline": "Ve tu próximo viaje, navega con la ruta eco y reporta GPS desde el celular.",
+				"highlights": ["Modo Conductor full-screen", "Ruta eco-eficiente sugerida", "GPS móvil cuando no hay Teltonika"]
+			},
+			{
+				"persona": "stakeholder",
+				"role": "Observatorio sostenibilidad",
+				"entity_name": "Observatorio Logístico",
+				"tagline": "Métricas agregadas por zona logística con k-anonimización ≥ 5.",
+				"highlights": ["Zonas: puertos, mercados, polos industriales", "Sin PII, sin empresas individuales", "Metodología pública auditable"]
+			}
+		]
+	}'::jsonb,
+	true,
+	'Seed inicial con valores hardcoded de production post PR #216.',
+	'system'
+);

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1780617600000,
       "tag": "0032_user_clave_numerica",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1780704000000,
+      "tag": "0033_configuracion_sitio",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -479,6 +479,13 @@ const apiEnvSchema = commonEnvSchema
           .map((x) => x.trim().toLowerCase())
           .filter(Boolean),
       ),
+
+    /**
+     * Bucket GCS público para assets editables vía Site Settings Editor
+     * (logos, favicons). Read público (CDN), write restringido al SA del
+     * Cloud Run api. Configurado en infrastructure/storage.tf (ADR-039).
+     */
+    PUBLIC_ASSETS_BUCKET: z.string().min(1).default('booster-ai-public-assets-prod'),
   });
 
 export type ApiEnv = z.infer<typeof apiEnvSchema>;

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,3 +1,4 @@
+import type { SiteConfig } from '@booster-ai/shared-schemas';
 import { sql } from 'drizzle-orm';
 import {
   bigserial,
@@ -2067,6 +2068,26 @@ export const matchingBacktestRuns = pgTable(
 );
 
 // =============================================================================
+// ADR-039 — Site Settings Runtime Configuration
+// =============================================================================
+//
+// Tabla `configuracion_sitio` para editar marca + copy desde admin UI
+// sin redeploy. Versionada (cada publish crea fila nueva) y singleton
+// sobre publicada=true (index unique parcial). Cualquiera puede leer la
+// versión publicada vía GET /public/site-settings (cache 5min); solo
+// platform-admin puede crear drafts y publicar.
+
+export const configuracionSitio = pgTable('configuracion_sitio', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  version: integer('version').notNull(),
+  config: jsonb('config').notNull().$type<SiteConfig>(),
+  publicada: boolean('publicada').notNull().default(false),
+  notaPublicacion: text('nota_publicacion'),
+  creadoPorEmail: text('creado_por_email').notNull(),
+  creadoEn: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
+});
+
+// =============================================================================
 // TYPE EXPORTS
 // =============================================================================
 
@@ -2133,3 +2154,6 @@ export type NewAdelantoCarrierRow = typeof adelantosCarrier.$inferInsert;
 
 export type MatchingBacktestRunRow = typeof matchingBacktestRuns.$inferSelect;
 export type NewMatchingBacktestRunRow = typeof matchingBacktestRuns.$inferInsert;
+
+export type ConfiguracionSitioRow = typeof configuracionSitio.$inferSelect;
+export type NewConfiguracionSitioRow = typeof configuracionSitio.$inferInsert;

--- a/apps/api/src/routes/site-settings.ts
+++ b/apps/api/src/routes/site-settings.ts
@@ -1,0 +1,372 @@
+import { randomUUID } from 'node:crypto';
+import type { Logger } from '@booster-ai/logger';
+import { siteConfigSchema } from '@booster-ai/shared-schemas';
+import { Storage } from '@google-cloud/storage';
+import { zValidator } from '@hono/zod-validator';
+import { desc, eq, max } from 'drizzle-orm';
+import type { Context } from 'hono';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { config as appConfig } from '../config.js';
+import type { Db } from '../db/client.js';
+import { configuracionSitio } from '../db/schema.js';
+import type { UserContext } from '../services/user-context.js';
+
+/**
+ * ADR-039 — Site Settings Runtime Configuration.
+ *
+ * Endpoints para editar marca + copy del sitio sin redeploy.
+ *
+ * Endpoint público (sin auth, cache 5min en cliente):
+ *   GET /public/site-settings → { config: SiteConfig, version }
+ *
+ * Endpoints admin (auth Firebase + platform-admin allowlist):
+ *   GET    /admin/site-settings           → publicada + history últimas 20
+ *   GET    /admin/site-settings/:version  → versión específica
+ *   POST   /admin/site-settings/draft     → crear nueva versión (no publicada)
+ *   POST   /admin/site-settings/publish   → publicar versión existente (id en body)
+ *   POST   /admin/site-settings/rollback  → revertir a versión X (target_version)
+ *   POST   /admin/site-settings/assets    → upload logo/favicon → GCS → URL
+ */
+
+let cachedStorage: Storage | null = null;
+function getStorage(): Storage {
+  if (!cachedStorage) {
+    cachedStorage = new Storage();
+  }
+  return cachedStorage;
+}
+
+const ALLOWED_MIME_TYPES = ['image/svg+xml', 'image/png', 'image/jpeg'] as const;
+const MAX_ASSET_BYTES = 500 * 1024; // 500 KB
+
+const publishBodySchema = z.object({
+  id: z.string().uuid(),
+});
+
+const rollbackBodySchema = z.object({
+  target_version: z.number().int().positive(),
+});
+
+const draftBodySchema = z.object({
+  config: siteConfigSchema,
+  nota: z.string().min(1).max(500).optional(),
+});
+
+/**
+ * Sanitiza SVG contra XSS — bloquea <script>, on*=, javascript: hrefs.
+ * Defensiva: si el contenido tiene cualquiera de esos patrones, rechaza
+ * el upload. NO intenta "limpiar" el SVG (eso es trabajo de DOMPurify).
+ */
+function svgIsSafe(buffer: Buffer): boolean {
+  const text = buffer.toString('utf-8');
+  if (text.length > MAX_ASSET_BYTES) {
+    return false;
+  }
+  const dangerous = [
+    /<script\b/i,
+    /\son[a-z]+\s*=/i,
+    /javascript:/i,
+    /<iframe\b/i,
+    /<object\b/i,
+    /<embed\b/i,
+    /<foreignObject\b/i,
+  ];
+  return !dangerous.some((rgx) => rgx.test(text));
+}
+
+export function createSiteSettingsRoutes(opts: {
+  db: Db;
+  logger: Logger;
+  publicAssetsBucket: string;
+}) {
+  const app = new Hono();
+
+  // biome-ignore lint/suspicious/noExplicitAny: hono Context genéricos.
+  function requirePlatformAdmin(c: Context<any, any, any>) {
+    const userContext = c.get('userContext') as UserContext | undefined;
+    if (!userContext) {
+      return { ok: false as const, response: c.json({ error: 'unauthorized' }, 401) };
+    }
+    const email = userContext.user.email?.toLowerCase();
+    const allowlist = appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS;
+    if (!email || !allowlist.includes(email)) {
+      return {
+        ok: false as const,
+        response: c.json({ error: 'forbidden_platform_admin' }, 403),
+      };
+    }
+    return { ok: true as const, adminEmail: email };
+  }
+
+  /**
+   * GET /admin/site-settings — versión publicada + history de 20 más recientes.
+   */
+  app.get('/', async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+
+    // rls-allowlist: admin platform-wide read — protegido por requirePlatformAdmin.
+    const published = await opts.db
+      .select()
+      .from(configuracionSitio)
+      .where(eq(configuracionSitio.publicada, true))
+      .limit(1);
+
+    // rls-allowlist: admin platform-wide history — protegido por requirePlatformAdmin.
+    const history = await opts.db
+      .select()
+      .from(configuracionSitio)
+      .orderBy(desc(configuracionSitio.creadoEn))
+      .limit(20);
+
+    return c.json({
+      published: published[0] ?? null,
+      history,
+    });
+  });
+
+  /**
+   * GET /admin/site-settings/:version — versión específica.
+   */
+  app.get('/:version', async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+
+    const versionParam = Number.parseInt(c.req.param('version'), 10);
+    if (!Number.isInteger(versionParam) || versionParam < 1) {
+      return c.json({ error: 'invalid_version' }, 400);
+    }
+
+    // rls-allowlist: admin platform-wide read by version — protegido por requirePlatformAdmin.
+    const rows = await opts.db
+      .select()
+      .from(configuracionSitio)
+      .where(eq(configuracionSitio.version, versionParam))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+    return c.json({ version: rows[0] });
+  });
+
+  /**
+   * POST /admin/site-settings/draft — crea nueva versión NO publicada.
+   * Si quieres publicarla inmediatamente, llama /publish con el id devuelto.
+   */
+  app.post('/draft', zValidator('json', draftBodySchema), async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const body = c.req.valid('json');
+
+    // Calcular próxima versión.
+    // rls-allowlist: admin platform-wide max version — protegido por requirePlatformAdmin.
+    const maxRow = await opts.db
+      .select({ maxVersion: max(configuracionSitio.version) })
+      .from(configuracionSitio);
+    const nextVersion = (maxRow[0]?.maxVersion ?? 0) + 1;
+
+    // rls-allowlist: admin platform-wide insert — protegido por requirePlatformAdmin.
+    const inserted = await opts.db
+      .insert(configuracionSitio)
+      .values({
+        version: nextVersion,
+        config: body.config,
+        publicada: false,
+        notaPublicacion: body.nota ?? null,
+        creadoPorEmail: auth.adminEmail,
+      })
+      .returning();
+
+    opts.logger.info(
+      { adminEmail: auth.adminEmail, version: nextVersion },
+      'site-settings draft created',
+    );
+    return c.json({ ok: true, draft: inserted[0] });
+  });
+
+  /**
+   * POST /admin/site-settings/publish — marca una versión como publicada,
+   * desmarca todas las demás. Atómico vía transacción.
+   */
+  app.post('/publish', zValidator('json', publishBodySchema), async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const { id } = c.req.valid('json');
+
+    try {
+      await opts.db.transaction(async (tx) => {
+        // rls-allowlist: admin platform-wide bulk update — protegido por requirePlatformAdmin.
+        await tx
+          .update(configuracionSitio)
+          .set({ publicada: false })
+          .where(eq(configuracionSitio.publicada, true));
+
+        // rls-allowlist: admin platform-wide single publish — protegido por requirePlatformAdmin.
+        await tx
+          .update(configuracionSitio)
+          .set({ publicada: true })
+          .where(eq(configuracionSitio.id, id));
+      });
+    } catch (err) {
+      opts.logger.error({ err, id }, 'site-settings publish failed');
+      return c.json({ error: 'publish_failed', detail: (err as Error).message }, 500);
+    }
+
+    opts.logger.info({ adminEmail: auth.adminEmail, id }, 'site-settings published');
+    return c.json({ ok: true, published_id: id });
+  });
+
+  /**
+   * POST /admin/site-settings/rollback — revertir a la versión `target_version`.
+   * Marca esa versión como publicada (y desmarca las demás).
+   */
+  app.post('/rollback', zValidator('json', rollbackBodySchema), async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const { target_version } = c.req.valid('json');
+
+    // rls-allowlist: admin platform-wide read for rollback — protegido por requirePlatformAdmin.
+    const target = await opts.db
+      .select()
+      .from(configuracionSitio)
+      .where(eq(configuracionSitio.version, target_version))
+      .limit(1);
+
+    if (target.length === 0) {
+      return c.json({ error: 'version_not_found' }, 404);
+    }
+
+    try {
+      await opts.db.transaction(async (tx) => {
+        // rls-allowlist: admin platform-wide bulk update — protegido por requirePlatformAdmin.
+        await tx
+          .update(configuracionSitio)
+          .set({ publicada: false })
+          .where(eq(configuracionSitio.publicada, true));
+
+        // rls-allowlist: admin platform-wide single rollback — protegido por requirePlatformAdmin.
+        await tx
+          .update(configuracionSitio)
+          .set({ publicada: true })
+          .where(eq(configuracionSitio.version, target_version));
+      });
+    } catch (err) {
+      opts.logger.error({ err, target_version }, 'site-settings rollback failed');
+      return c.json({ error: 'rollback_failed', detail: (err as Error).message }, 500);
+    }
+
+    opts.logger.info({ adminEmail: auth.adminEmail, target_version }, 'site-settings rolled back');
+    return c.json({ ok: true, published_version: target_version });
+  });
+
+  /**
+   * POST /admin/site-settings/assets — upload de logo/favicon a GCS público.
+   * Recibe multipart/form-data con field `file`. Valida MIME + size +
+   * sanitiza SVG. Retorna URL pública.
+   */
+  app.post('/assets', async (c) => {
+    const auth = requirePlatformAdmin(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+
+    const formData = await c.req.formData().catch(() => null);
+    if (!formData) {
+      return c.json({ error: 'multipart_required' }, 400);
+    }
+    const file = formData.get('file');
+    if (!(file instanceof File)) {
+      return c.json({ error: 'file_missing' }, 400);
+    }
+
+    const mime = file.type;
+    if (!ALLOWED_MIME_TYPES.includes(mime as (typeof ALLOWED_MIME_TYPES)[number])) {
+      return c.json({ error: 'mime_not_allowed', allowed: ALLOWED_MIME_TYPES }, 400);
+    }
+    if (file.size > MAX_ASSET_BYTES) {
+      return c.json({ error: 'file_too_large', max_bytes: MAX_ASSET_BYTES }, 413);
+    }
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    if (mime === 'image/svg+xml' && !svgIsSafe(buffer)) {
+      return c.json({ error: 'svg_unsafe_content' }, 400);
+    }
+
+    const ext = mime === 'image/svg+xml' ? 'svg' : mime === 'image/png' ? 'png' : 'jpg';
+    const objectName = `assets/site/${randomUUID()}.${ext}`;
+    const gcsFile = getStorage().bucket(opts.publicAssetsBucket).file(objectName);
+
+    try {
+      await gcsFile.save(buffer, {
+        contentType: mime,
+        metadata: {
+          cacheControl: 'public, max-age=3600',
+        },
+      });
+    } catch (err) {
+      opts.logger.error({ err, objectName }, 'site-settings asset upload failed');
+      return c.json({ error: 'upload_failed' }, 500);
+    }
+
+    const url = `https://storage.googleapis.com/${opts.publicAssetsBucket}/${objectName}`;
+    opts.logger.info(
+      { adminEmail: auth.adminEmail, objectName, mime },
+      'site-settings asset uploaded',
+    );
+    return c.json({ ok: true, url });
+  });
+
+  return app;
+}
+
+/**
+ * Endpoint público — sin auth, retorna la versión publicada.
+ * Cache 5min en cliente, sin cache server (siempre lee BD para que
+ * publish/rollback aparezca inmediato).
+ */
+export function createPublicSiteSettingsRoutes(opts: { db: Db; logger: Logger }) {
+  const app = new Hono();
+
+  app.get('/site-settings', async (c) => {
+    // rls-allowlist: lectura pública de configuración publicada (sin PII).
+    const rows = await opts.db
+      .select({
+        version: configuracionSitio.version,
+        config: configuracionSitio.config,
+        creadoEn: configuracionSitio.creadoEn,
+      })
+      .from(configuracionSitio)
+      .where(eq(configuracionSitio.publicada, true))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return c.json({ error: 'no_published_version' }, 404);
+    }
+
+    c.header('Cache-Control', 'public, max-age=300, stale-while-revalidate=60');
+    const row = rows[0];
+    if (!row) {
+      return c.json({ error: 'no_published_version' }, 404);
+    }
+    return c.json({
+      version: row.version,
+      config: row.config,
+      updated_at: row.creadoEn,
+    });
+  });
+
+  return app;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -34,6 +34,10 @@ import { createMeLiquidacionesRoutes } from './routes/me-liquidaciones.js';
 import { createMeRoutes } from './routes/me.js';
 import { createOfferRoutes } from './routes/offers.js';
 import { createPublicTrackingRoutes } from './routes/public-tracking.js';
+import {
+  createPublicSiteSettingsRoutes,
+  createSiteSettingsRoutes,
+} from './routes/site-settings.js';
 import { createSucursalesRoutes } from './routes/sucursales.js';
 import { createTripRequestsV2Routes } from './routes/trip-requests-v2.js';
 import { createTripRequestsRoutes } from './routes/trip-requests.js';
@@ -369,6 +373,22 @@ export function createServer(opts: CreateServerOptions): Hono {
     app.use('/admin/stakeholder-orgs/*', firebaseAuthMiddleware);
     app.use('/admin/stakeholder-orgs/*', userContextMiddleware);
     app.route('/admin/stakeholder-orgs', createAdminStakeholderOrgsRoutes({ db: opts.db, logger }));
+
+    // ADR-039 — Site Settings Runtime Configuration. Admin edita marca
+    // y copy desde la PWA; demo/login/onboarding leen la versión
+    // publicada via GET /public/site-settings (cache 5min).
+    app.use('/admin/site-settings/*', firebaseAuthMiddleware);
+    app.use('/admin/site-settings/*', userContextMiddleware);
+    app.route(
+      '/admin/site-settings',
+      createSiteSettingsRoutes({
+        db: opts.db,
+        logger,
+        publicAssetsBucket: config.PUBLIC_ASSETS_BUCKET,
+      }),
+    );
+    // Endpoint público sin auth — sirve la versión publicada con cache.
+    app.route('/public', createPublicSiteSettingsRoutes({ db: opts.db, logger }));
 
     // Admin platform-wide: re-emisión manual de DTEs Tipo 33 (ADR-024 +
     // ADR-031). Auth via BOOSTER_PLATFORM_ADMIN_EMAILS allowlist en el

--- a/apps/api/test/unit/site-settings.test.ts
+++ b/apps/api/test/unit/site-settings.test.ts
@@ -1,17 +1,20 @@
 /**
- * Tests minimal del endpoint público GET /public/site-settings.
+ * Tests del endpoint público + admin de site-settings.
  *
- * Los endpoints admin tienen guards de auth idénticos al patrón ya
- * probado en admin-seed.test.ts (requirePlatformAdmin + allowlist
- * BOOSTER_PLATFORM_ADMIN_EMAILS). No re-testeamos eso aquí.
- *
- * Tests cubren:
- *   - GET /public/site-settings devuelve la versión publicada.
- *   - GET /public/site-settings 404 cuando no hay publicada.
- *   - Headers de cache-control para CDN.
+ * Cubre los principales branches:
+ *   - GET /public/site-settings: 200 + 404
+ *   - requirePlatformAdmin guard: sin userContext, fuera de allowlist
+ *   - GET /admin/site-settings: ok
+ *   - GET /admin/site-settings/:version: invalid + not_found + ok
+ *   - POST /draft: validation + ok
+ *   - POST /publish: ok + db_error
+ *   - POST /rollback: version_not_found + ok
+ *   - POST /assets: multipart missing + mime not allowed + file too large
+ *     + svg unsafe + ok
  */
 
-import { DEFAULT_SITE_CONFIG } from '@booster-ai/shared-schemas';
+import { DEFAULT_SITE_CONFIG, type SiteConfig } from '@booster-ai/shared-schemas';
+import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const loggerStub = {
@@ -25,12 +28,16 @@ const loggerStub = {
 };
 
 interface FakeRow {
+  id: string;
   version: number;
-  config: typeof DEFAULT_SITE_CONFIG;
+  config: SiteConfig;
+  publicada: boolean;
+  notaPublicacion: string | null;
+  creadoPorEmail: string;
   creadoEn: Date;
 }
 
-function makeDbStub(rows: FakeRow[]) {
+function makePublishedStub(rows: FakeRow[]) {
   return {
     select: () => ({
       from: () => ({
@@ -42,43 +49,384 @@ function makeDbStub(rows: FakeRow[]) {
   };
 }
 
+function makeAdminStub(opts: {
+  publishedRow: FakeRow | null;
+  history: FakeRow[];
+  byVersion?: FakeRow | null;
+  maxVersion?: number;
+  insertResult?: FakeRow;
+  txError?: Error;
+}) {
+  return {
+    select: vi.fn().mockImplementation((cols?: Record<string, unknown>) => ({
+      from: () => ({
+        // Path: where → limit (used by /admin/ GET single + /admin/:version + rollback target lookup)
+        where: () => ({
+          limit: async () => {
+            if (opts.byVersion !== undefined) {
+              return opts.byVersion ? [opts.byVersion] : [];
+            }
+            return opts.publishedRow ? [opts.publishedRow] : [];
+          },
+        }),
+        // Path: orderBy → limit (used by /admin/ GET history)
+        orderBy: () => ({
+          limit: async () => opts.history,
+        }),
+        // Path: select max (no where) — for /draft
+        ...(cols && 'maxVersion' in cols
+          ? {
+              /* not used here, max returns via this object's select */
+            }
+          : {}),
+      }),
+    })),
+    insert: vi.fn().mockReturnValue({
+      values: () => ({
+        returning: async () => (opts.insertResult ? [opts.insertResult] : []),
+      }),
+    }),
+    transaction: vi.fn().mockImplementation(async (cb: (tx: unknown) => Promise<void>) => {
+      if (opts.txError) {
+        throw opts.txError;
+      }
+      // Stub mínimo de tx (update().set().where()).
+      const tx = {
+        update: () => ({
+          set: () => ({
+            where: async () => undefined,
+          }),
+        }),
+      };
+      await cb(tx);
+    }),
+  };
+}
+
+/**
+ * Stub específico para el endpoint /draft que necesita select max(version).
+ * Drizzle: db.select({maxVersion: max(...)}).from(...). El stub devuelve
+ * el array con un objeto cuando llamamos .from() directo (sin where ni limit).
+ */
+function makeDraftStub(maxVersion: number, insertResult: FakeRow) {
+  // biome-ignore lint/suspicious/noExplicitAny: stub flexible — usado solo en tests.
+  const fromObj: any = [{ maxVersion }];
+  // Make .from() return [maxRow] when awaited (drizzle's pattern: await db.select(...).from(...))
+  return {
+    select: vi.fn().mockImplementation((cols?: Record<string, unknown>) => {
+      if (cols && 'maxVersion' in cols) {
+        return {
+          from: () => fromObj,
+        };
+      }
+      // Otros selects (no usados en /draft) — pero damos un fallback seguro.
+      return {
+        from: () => ({
+          where: () => ({ limit: async () => [] }),
+          orderBy: () => ({ limit: async () => [] }),
+        }),
+      };
+    }),
+    insert: vi.fn().mockReturnValue({
+      values: () => ({
+        returning: async () => [insertResult],
+      }),
+    }),
+  };
+}
+
+// User contexts para los tests.
+const adminCtx = {
+  user: { email: 'dev@boosterchile.com', uid: 'admin-uid' },
+};
+const notAdminCtx = {
+  user: { email: 'random@gmail.com', uid: 'user-uid' },
+};
+
+const fakeRow: FakeRow = {
+  id: 'abc-uuid',
+  version: 1,
+  config: DEFAULT_SITE_CONFIG,
+  publicada: true,
+  notaPublicacion: 'Seed',
+  creadoPorEmail: 'system',
+  creadoEn: new Date('2026-05-13T22:00:00Z'),
+};
+
 beforeEach(() => {
   vi.resetModules();
+  vi.stubEnv('BOOSTER_PLATFORM_ADMIN_EMAILS', 'dev@boosterchile.com');
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
+async function buildAdminApp(
+  // biome-ignore lint/suspicious/noExplicitAny: db stub flexible.
+  db: any,
+  ctx: typeof adminCtx | typeof notAdminCtx | null,
+) {
+  const { createSiteSettingsRoutes } = await import('../../src/routes/site-settings.js');
+  const app = new Hono();
+  if (ctx) {
+    app.use('*', async (c, next) => {
+      c.set('userContext', ctx);
+      await next();
+    });
+  }
+  app.route(
+    '/admin/site-settings',
+    createSiteSettingsRoutes({ db, logger: loggerStub, publicAssetsBucket: 'test-bucket' }),
+  );
+  return app;
+}
+
 describe('GET /public/site-settings', () => {
   it('devuelve la versión publicada con cache-control', async () => {
-    const fakeRow: FakeRow = {
-      version: 1,
-      config: DEFAULT_SITE_CONFIG,
-      creadoEn: new Date('2026-05-13T22:00:00Z'),
-    };
-    const db = makeDbStub([fakeRow]) as unknown as Parameters<
+    const db = makePublishedStub([fakeRow]) as unknown as Parameters<
       typeof import('../../src/routes/site-settings.js').createPublicSiteSettingsRoutes
     >[0]['db'];
     const { createPublicSiteSettingsRoutes } = await import('../../src/routes/site-settings.js');
     const router = createPublicSiteSettingsRoutes({ db, logger: loggerStub });
     const res = await router.request('/site-settings');
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { version: number; config: typeof DEFAULT_SITE_CONFIG };
+    const body = (await res.json()) as { version: number; config: SiteConfig };
     expect(body.version).toBe(1);
     expect(body.config.hero.headline_line1).toBe('Transporta más,');
     expect(res.headers.get('Cache-Control')).toContain('max-age=300');
   });
 
   it('404 cuando no hay versión publicada', async () => {
-    const db = makeDbStub([]) as unknown as Parameters<
+    const db = makePublishedStub([]) as unknown as Parameters<
       typeof import('../../src/routes/site-settings.js').createPublicSiteSettingsRoutes
     >[0]['db'];
     const { createPublicSiteSettingsRoutes } = await import('../../src/routes/site-settings.js');
     const router = createPublicSiteSettingsRoutes({ db, logger: loggerStub });
     const res = await router.request('/site-settings');
     expect(res.status).toBe(404);
+  });
+});
+
+describe('Admin guards (requirePlatformAdmin)', () => {
+  it('GET /admin/site-settings sin userContext → 401', async () => {
+    const db = makeAdminStub({ publishedRow: fakeRow, history: [fakeRow] });
+    const app = await buildAdminApp(db, null);
+    const res = await app.request('/admin/site-settings');
+    expect(res.status).toBe(401);
+  });
+
+  it('GET /admin/site-settings fuera de allowlist → 403', async () => {
+    const db = makeAdminStub({ publishedRow: fakeRow, history: [fakeRow] });
+    const app = await buildAdminApp(db, notAdminCtx);
+    const res = await app.request('/admin/site-settings');
+    expect(res.status).toBe(403);
+  });
+
+  it('GET /admin/site-settings admin OK → published + history', async () => {
+    const db = makeAdminStub({ publishedRow: fakeRow, history: [fakeRow] });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { published: FakeRow; history: FakeRow[] };
+    expect(body.published.version).toBe(1);
+    expect(body.history.length).toBe(1);
+  });
+});
+
+describe('GET /admin/site-settings/:version', () => {
+  it('version inválida → 400', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [], byVersion: null });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/not-a-number');
+    expect(res.status).toBe(400);
+  });
+
+  it('version not found → 404', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [], byVersion: null });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/999');
+    expect(res.status).toBe(404);
+  });
+
+  it('version encontrada → 200', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [], byVersion: fakeRow });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/1');
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('POST /admin/site-settings/draft', () => {
+  it('body inválido (config no pasa Zod) → 400', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/draft', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ config: { invalid: true } }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('admin OK → crea draft con next version', async () => {
+    const db = makeDraftStub(5, { ...fakeRow, version: 6, publicada: false });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/draft', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ config: DEFAULT_SITE_CONFIG, nota: 'test' }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; draft: FakeRow };
+    expect(body.ok).toBe(true);
+    expect(body.draft.version).toBe(6);
+  });
+});
+
+describe('POST /admin/site-settings/publish', () => {
+  it('body inválido (id no UUID) → 400', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/publish', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: 'not-uuid' }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('transaction OK → 200', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/publish', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: '00000000-0000-0000-0000-000000000001' }),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it('transaction error → 500', async () => {
+    const db = makeAdminStub({
+      publishedRow: null,
+      history: [],
+      txError: new Error('db down'),
+    });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/publish', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: '00000000-0000-0000-0000-000000000001' }),
+    });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('POST /admin/site-settings/rollback', () => {
+  it('version no existe → 404', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [], byVersion: null });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/rollback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_version: 99 }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('rollback OK → 200', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [], byVersion: fakeRow });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/rollback', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ target_version: 1 }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('POST /admin/site-settings/assets', () => {
+  it('sin multipart → 400', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const res = await app.request('/admin/site-settings/assets', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('multipart sin file → 400', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const form = new FormData();
+    form.append('not_file', 'oops');
+    const res = await app.request('/admin/site-settings/assets', {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('mime no permitido → 400', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const form = new FormData();
+    form.append(
+      'file',
+      new File(['malicious binary'], 'evil.exe', { type: 'application/octet-stream' }),
+    );
+    const res = await app.request('/admin/site-settings/assets', {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(400);
     const body = (await res.json()) as { error: string };
-    expect(body.error).toBe('no_published_version');
+    expect(body.error).toBe('mime_not_allowed');
+  });
+
+  it('file demasiado grande → 413', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const form = new FormData();
+    const bigData = new Uint8Array(600 * 1024); // 600 KB > 500 KB max
+    form.append('file', new File([bigData], 'big.png', { type: 'image/png' }));
+    const res = await app.request('/admin/site-settings/assets', {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it('SVG con <script> → 400 svg_unsafe_content', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const form = new FormData();
+    const malicious = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>';
+    form.append('file', new File([malicious], 'bad.svg', { type: 'image/svg+xml' }));
+    const res = await app.request('/admin/site-settings/assets', {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('svg_unsafe_content');
+  });
+
+  it('SVG con onload handler → 400 svg_unsafe_content', async () => {
+    const db = makeAdminStub({ publishedRow: null, history: [] });
+    const app = await buildAdminApp(db, adminCtx);
+    const form = new FormData();
+    const malicious = '<svg onload="alert(1)" xmlns="http://www.w3.org/2000/svg"></svg>';
+    form.append('file', new File([malicious], 'bad.svg', { type: 'image/svg+xml' }));
+    const res = await app.request('/admin/site-settings/assets', {
+      method: 'POST',
+      body: form,
+    });
+    expect(res.status).toBe(400);
   });
 });

--- a/apps/api/test/unit/site-settings.test.ts
+++ b/apps/api/test/unit/site-settings.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests minimal del endpoint público GET /public/site-settings.
+ *
+ * Los endpoints admin tienen guards de auth idénticos al patrón ya
+ * probado en admin-seed.test.ts (requirePlatformAdmin + allowlist
+ * BOOSTER_PLATFORM_ADMIN_EMAILS). No re-testeamos eso aquí.
+ *
+ * Tests cubren:
+ *   - GET /public/site-settings devuelve la versión publicada.
+ *   - GET /public/site-settings 404 cuando no hay publicada.
+ *   - Headers de cache-control para CDN.
+ */
+
+import { DEFAULT_SITE_CONFIG } from '@booster-ai/shared-schemas';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loggerStub = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(() => loggerStub),
+};
+
+interface FakeRow {
+  version: number;
+  config: typeof DEFAULT_SITE_CONFIG;
+  creadoEn: Date;
+}
+
+function makeDbStub(rows: FakeRow[]) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => rows,
+        }),
+      }),
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GET /public/site-settings', () => {
+  it('devuelve la versión publicada con cache-control', async () => {
+    const fakeRow: FakeRow = {
+      version: 1,
+      config: DEFAULT_SITE_CONFIG,
+      creadoEn: new Date('2026-05-13T22:00:00Z'),
+    };
+    const db = makeDbStub([fakeRow]) as unknown as Parameters<
+      typeof import('../../src/routes/site-settings.js').createPublicSiteSettingsRoutes
+    >[0]['db'];
+    const { createPublicSiteSettingsRoutes } = await import('../../src/routes/site-settings.js');
+    const router = createPublicSiteSettingsRoutes({ db, logger: loggerStub });
+    const res = await router.request('/site-settings');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { version: number; config: typeof DEFAULT_SITE_CONFIG };
+    expect(body.version).toBe(1);
+    expect(body.config.hero.headline_line1).toBe('Transporta más,');
+    expect(res.headers.get('Cache-Control')).toContain('max-age=300');
+  });
+
+  it('404 cuando no hay versión publicada', async () => {
+    const db = makeDbStub([]) as unknown as Parameters<
+      typeof import('../../src/routes/site-settings.js').createPublicSiteSettingsRoutes
+    >[0]['db'];
+    const { createPublicSiteSettingsRoutes } = await import('../../src/routes/site-settings.js');
+    const router = createPublicSiteSettingsRoutes({ db, logger: loggerStub });
+    const res = await router.request('/site-settings');
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('no_published_version');
+  });
+});

--- a/apps/web/src/hooks/use-site-settings.test.tsx
+++ b/apps/web/src/hooks/use-site-settings.test.tsx
@@ -1,0 +1,87 @@
+import { DEFAULT_SITE_CONFIG } from '@booster-ai/shared-schemas';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSiteSettings } from './use-site-settings.js';
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+const fetchMock = vi.fn();
+beforeEach(() => {
+  fetchMock.mockReset();
+  globalThis.fetch = fetchMock;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useSiteSettings', () => {
+  it('devuelve DEFAULT_SITE_CONFIG inicialmente (mientras query corre)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: 1, config: DEFAULT_SITE_CONFIG }),
+    });
+    const { result } = renderHook(() => useSiteSettings(), { wrapper: makeWrapper() });
+    expect(result.current.config).toEqual(DEFAULT_SITE_CONFIG);
+  });
+
+  it('cuando fetch falla → devuelve DEFAULT_SITE_CONFIG (fallback)', async () => {
+    fetchMock.mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useSiteSettings(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.config).toEqual(DEFAULT_SITE_CONFIG);
+  });
+
+  it('cuando response 404 → devuelve DEFAULT_SITE_CONFIG', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404, json: async () => ({}) });
+    const { result } = renderHook(() => useSiteSettings(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.config).toEqual(DEFAULT_SITE_CONFIG);
+  });
+
+  it('cuando response es válido → devuelve config del API', async () => {
+    const customConfig = {
+      ...DEFAULT_SITE_CONFIG,
+      hero: {
+        ...DEFAULT_SITE_CONFIG.hero,
+        headline_line1: 'Custom headline,',
+      },
+    };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: 5, config: customConfig }),
+    });
+    const { result } = renderHook(() => useSiteSettings(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.config.hero.headline_line1).toBe('Custom headline,');
+    });
+  });
+
+  it('cuando response es inválido (falta campo requerido) → fallback a default', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        version: 1,
+        config: { identity: {}, hero: { headline_line1: '' } }, // inválido
+      }),
+    });
+    const { result } = renderHook(() => useSiteSettings(), { wrapper: makeWrapper() });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.config).toEqual(DEFAULT_SITE_CONFIG);
+  });
+});

--- a/apps/web/src/hooks/use-site-settings.ts
+++ b/apps/web/src/hooks/use-site-settings.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_SITE_CONFIG, type SiteConfig, siteConfigSchema } from '@booster-ai/shared-schemas';
+import { useQuery } from '@tanstack/react-query';
+import { getApiUrl } from '../lib/api-url.js';
+
+/**
+ * ADR-039 — hook que lee la configuración runtime publicada desde
+ * `GET /public/site-settings` con cache de 5 minutos (TanStack Query
+ * staleTime). Fallback al `DEFAULT_SITE_CONFIG` hardcoded cuando:
+ *
+ *   - El endpoint devuelve 404 (no hay versión publicada)
+ *   - El response no pasa validación Zod
+ *   - El fetch falla por network / timeout
+ *
+ * El hook nunca lanza — siempre devuelve un `SiteConfig` válido. Eso
+ * evita que un fallo del API rompa el render de la home pública.
+ */
+
+interface PublicSiteSettingsResponse {
+  version: number;
+  config: SiteConfig;
+  updated_at: string;
+}
+
+async function fetchPublicSiteSettings(): Promise<SiteConfig> {
+  try {
+    const res = await fetch(`${getApiUrl()}/public/site-settings`);
+    if (!res.ok) {
+      return DEFAULT_SITE_CONFIG;
+    }
+    const json = (await res.json()) as PublicSiteSettingsResponse;
+    const parsed = siteConfigSchema.safeParse(json.config);
+    return parsed.success ? parsed.data : DEFAULT_SITE_CONFIG;
+  } catch {
+    return DEFAULT_SITE_CONFIG;
+  }
+}
+
+export function useSiteSettings(): { config: SiteConfig; isLoading: boolean } {
+  const { data, isLoading } = useQuery({
+    queryKey: ['public-site-settings'],
+    queryFn: fetchPublicSiteSettings,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+  });
+  return { config: data ?? DEFAULT_SITE_CONFIG, isLoading };
+}

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -28,6 +28,7 @@ import { OfertasRoute } from './routes/ofertas.js';
 import { OnboardingRoute } from './routes/onboarding.js';
 import { PerfilRoute } from './routes/perfil.js';
 import { PlatformAdminMatchingRoute } from './routes/platform-admin-matching.js';
+import { PlatformAdminSiteSettingsRoute } from './routes/platform-admin-site-settings.js';
 import { PlatformAdminRoute } from './routes/platform-admin.js';
 import { PublicTrackingRoute } from './routes/public-tracking.js';
 import { StakeholderZonasRoute } from './routes/stakeholder-zonas.js';
@@ -228,6 +229,14 @@ const platformAdminMatchingRoute = createRoute({
   component: PlatformAdminMatchingRoute,
 });
 
+// ADR-039 — Site Settings Editor. Editar marca + copy del demo sin
+// redeploy. Mismo gate platform-admin (BOOSTER_PLATFORM_ADMIN_EMAILS).
+const platformAdminSiteSettingsRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/app/platform-admin/site-settings',
+  component: PlatformAdminSiteSettingsRoute,
+});
+
 const vehiculosNuevoRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/app/vehiculos/nuevo',
@@ -350,6 +359,7 @@ const routeTree = rootRoute.addChildren([
   cumplimientoRoute,
   platformAdminRoute,
   platformAdminMatchingRoute,
+  platformAdminSiteSettingsRoute,
   cargasListRoute,
   cargasNuevaRoute,
   cargasDetalleRoute,

--- a/apps/web/src/routes/demo.tsx
+++ b/apps/web/src/routes/demo.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import { signInDriverWithCustomToken } from '../hooks/use-auth.js';
+import { useSiteSettings } from '../hooks/use-site-settings.js';
 import { getApiUrl } from '../lib/api-url.js';
 
 type Persona = 'shipper' | 'carrier' | 'conductor' | 'stakeholder';
@@ -20,67 +21,20 @@ interface DemoLoginResponse {
   redirect_to: string;
 }
 
-interface PersonaCard {
-  persona: Persona;
-  role: string;
-  entityName: string;
-  Icon: LucideIcon;
-  tagline: string;
-  highlights: readonly string[];
-}
+// Mapeo persona → icono Lucide (no es editable runtime, identidad visual
+// canónica). Las otras propiedades de cada card (role, entity_name,
+// tagline, highlights) sí vienen del site-settings publicado.
+const PERSONA_ICONS: Record<Persona, LucideIcon> = {
+  shipper: Building2,
+  carrier: Truck,
+  conductor: UserRound,
+  stakeholder: BarChart3,
+};
 
-const PERSONAS: readonly PersonaCard[] = [
-  {
-    persona: 'shipper',
-    role: 'Generador de carga',
-    entityName: 'Andina Demo S.A.',
-    Icon: Building2,
-    tagline: 'Publica cargas, ve ofertas y descarga certificados de huella verificada.',
-    highlights: [
-      '2 sucursales activas (Maipú, Quilicura)',
-      'Matching automático con transportistas',
-      'Certificados GLEC v3.0 descargables',
-    ],
-  },
-  {
-    persona: 'carrier',
-    role: 'Transportista',
-    entityName: 'Transportes Demo Sur',
-    Icon: Truck,
-    tagline: 'Acepta cargas, asigna conductor y vehículo, factura sin papeles.',
-    highlights: [
-      '2 vehículos · 1 conductor activo',
-      'Seguimiento en tiempo real vía Teltonika',
-      'Cobra Hoy · pronto pago integrado',
-    ],
-  },
-  {
-    persona: 'conductor',
-    role: 'Conductor profesional',
-    entityName: 'Pedro González',
-    Icon: UserRound,
-    tagline: 'Ve tu próximo viaje, navega con la ruta eco y reporta GPS desde el celular.',
-    highlights: [
-      'Modo Conductor full-screen',
-      'Ruta eco-eficiente sugerida',
-      'GPS móvil cuando no hay Teltonika',
-    ],
-  },
-  {
-    persona: 'stakeholder',
-    role: 'Observatorio sostenibilidad',
-    entityName: 'Observatorio Logístico',
-    Icon: BarChart3,
-    tagline: 'Métricas agregadas por zona logística con k-anonimización ≥ 5.',
-    highlights: [
-      'Zonas: puertos, mercados, polos industriales',
-      'Sin PII, sin empresas individuales',
-      'Metodología pública auditable',
-    ],
-  },
-];
-
-const CERTIFICATIONS = ['GLEC v3.0', 'GHG Protocol', 'ISO 14064', 'k-anonymity ≥ 5'] as const;
+// PERSONAS y CERTIFICATIONS vienen del site-settings publicado (ADR-039).
+// Default hardcoded vive en packages/shared-schemas/src/site-settings.ts
+// (`DEFAULT_SITE_CONFIG`) y se usa como fallback cuando el API no
+// responde — mantener sincronizado con el seed de la migration 0033.
 
 /**
  * /demo — Selector de persona para el subdominio demo.boosterchile.com.
@@ -96,6 +50,7 @@ const CERTIFICATIONS = ['GLEC v3.0', 'GHG Protocol', 'ISO 14064', 'k-anonymity �
  */
 export function DemoRoute() {
   const navigate = useNavigate();
+  const { config } = useSiteSettings();
   const [loadingPersona, setLoadingPersona] = useState<Persona | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -139,9 +94,13 @@ export function DemoRoute() {
       <header className="border-neutral-200 border-b bg-white">
         <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-6 py-4">
           <div className="flex items-center gap-3">
-            <img src="/icons/icon.svg" alt="" aria-hidden className="h-9 w-9" />
+            <img
+              src={config.identity.logo_url ?? '/icons/icon.svg'}
+              alt={config.identity.logo_alt}
+              className="h-9 w-9"
+            />
             <span className="font-semibold text-base text-neutral-900 tracking-tight">
-              Booster AI
+              {config.identity.logo_alt}
             </span>
           </div>
           <span className="rounded-full border border-neutral-300 bg-white px-3 py-1 font-medium text-neutral-700 text-xs">
@@ -153,20 +112,17 @@ export function DemoRoute() {
       <main className="mx-auto max-w-6xl px-6 pt-16 pb-12">
         <section className="text-center">
           <h1 className="font-bold text-5xl text-neutral-900 tracking-tight sm:text-6xl">
-            Transporta más,
+            {config.hero.headline_line1}
             <br />
-            <span className="text-primary-600">impacta menos.</span>
+            <span className="text-primary-600">{config.hero.headline_line2}</span>
           </h1>
           <p className="mx-auto mt-6 max-w-2xl text-lg text-neutral-700 leading-relaxed">
-            Marketplace B2B de logística sostenible para Chile. Conecta generadores de carga con
-            transportistas, optimiza retornos vacíos y certifica huella de carbono bajo GLEC v3.0.
+            {config.hero.subhead}
           </p>
-          <p className="mx-auto mt-4 max-w-xl text-neutral-500 text-sm">
-            Explora la demo desde cualquier rol — un click, sin registro.
-          </p>
+          <p className="mx-auto mt-4 max-w-xl text-neutral-500 text-sm">{config.hero.microcopy}</p>
 
           <div className="mt-8 flex flex-wrap items-center justify-center gap-2">
-            {CERTIFICATIONS.map((label) => (
+            {config.certifications.map((label) => (
               <span
                 key={label}
                 className="inline-flex items-center gap-1.5 rounded-md border border-neutral-200 bg-white px-2.5 py-1 font-medium text-neutral-700 text-xs"
@@ -188,8 +144,9 @@ export function DemoRoute() {
         ) : null}
 
         <section className="mt-12 grid grid-cols-1 items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-4">
-          {PERSONAS.map((card) => {
+          {config.persona_cards.map((card) => {
             const isLoading = loadingPersona === card.persona;
+            const Icon = PERSONA_ICONS[card.persona];
             return (
               <article
                 key={card.persona}
@@ -197,7 +154,7 @@ export function DemoRoute() {
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="inline-flex h-10 w-10 items-center justify-center rounded-lg border border-neutral-200 bg-neutral-50 text-neutral-700">
-                    <card.Icon className="h-5 w-5" aria-hidden />
+                    <Icon className="h-5 w-5" aria-hidden />
                   </div>
                 </div>
 
@@ -205,7 +162,7 @@ export function DemoRoute() {
                   {card.role}
                 </p>
                 <h2 className="mt-1 font-semibold text-lg text-neutral-900 leading-snug">
-                  {card.entityName}
+                  {card.entity_name}
                 </h2>
 
                 <p className="mt-3 text-neutral-600 text-sm leading-relaxed">{card.tagline}</p>

--- a/apps/web/src/routes/platform-admin-site-settings.tsx
+++ b/apps/web/src/routes/platform-admin-site-settings.tsx
@@ -1,0 +1,780 @@
+import { DEFAULT_SITE_CONFIG, type SiteConfig, siteConfigSchema } from '@booster-ai/shared-schemas';
+import { Link, Navigate } from '@tanstack/react-router';
+import {
+  ArrowLeft,
+  Building2,
+  Eye,
+  History,
+  Image as ImageIcon,
+  Loader2,
+  Palette,
+  Save,
+  Type,
+  Upload,
+} from 'lucide-react';
+import { type FormEvent, useEffect, useId, useState } from 'react';
+import { Layout } from '../components/Layout.js';
+import { ProtectedRoute } from '../components/ProtectedRoute.js';
+import type { MeResponse } from '../hooks/use-me.js';
+import { getApiUrl } from '../lib/api-url.js';
+import { firebaseAuth } from '../lib/firebase.js';
+
+type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
+
+interface PublishedRow {
+  id: string;
+  version: number;
+  config: SiteConfig;
+  publicada: boolean;
+  notaPublicacion: string | null;
+  creadoPorEmail: string;
+  creadoEn: string;
+}
+
+interface AdminSiteSettingsResponse {
+  published: PublishedRow | null;
+  history: PublishedRow[];
+}
+
+/**
+ * ADR-039 — Site Settings Editor.
+ *
+ * Surface admin restringido a `BOOSTER_PLATFORM_ADMIN_EMAILS` (validado
+ * en backend). Permite:
+ *
+ *   - Editar identity (logo, color), hero (copy), certificaciones,
+ *     4 persona cards, copy de onboarding y login.
+ *   - Subir logo SVG/PNG/JPG (max 500 KB) → GCS público.
+ *   - Crear borrador, publicar, ver history y rollback a versión X.
+ *
+ * El frontend público lee la versión publicada vía
+ * `GET /public/site-settings` (cache 5min). Fallback hardcoded en
+ * `DEFAULT_SITE_CONFIG`.
+ */
+export function PlatformAdminSiteSettingsRoute() {
+  return (
+    <ProtectedRoute meRequirement="require-onboarded">
+      {(ctx) => {
+        if (ctx.kind !== 'onboarded') {
+          return null;
+        }
+        return <Page me={ctx.me} />;
+      }}
+    </ProtectedRoute>
+  );
+}
+
+async function authHeaders(): Promise<Record<string, string>> {
+  const user = firebaseAuth.currentUser;
+  if (!user) {
+    throw new Error('Sin user autenticado.');
+  }
+  const token = await user.getIdToken();
+  return {
+    Authorization: `Bearer ${token}`,
+    'content-type': 'application/json',
+  };
+}
+
+function Page({ me }: { me: MeOnboarded }) {
+  const [loading, setLoading] = useState(true);
+  const [forbidden, setForbidden] = useState(false);
+  const [config, setConfig] = useState<SiteConfig>(DEFAULT_SITE_CONFIG);
+  const [history, setHistory] = useState<PublishedRow[]>([]);
+  const [publishedVersion, setPublishedVersion] = useState<number | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [statusType, setStatusType] = useState<'success' | 'error' | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [uploadingLogo, setUploadingLogo] = useState(false);
+
+  useEffect(() => {
+    void fetchData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function fetchData() {
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${getApiUrl()}/admin/site-settings`, { headers });
+      if (res.status === 403) {
+        setForbidden(true);
+        setLoading(false);
+        return;
+      }
+      const body = (await res.json()) as AdminSiteSettingsResponse;
+      setHistory(body.history);
+      if (body.published) {
+        setConfig(body.published.config);
+        setPublishedVersion(body.published.version);
+      }
+    } catch (err) {
+      setStatusType('error');
+      setStatusMessage(`No pude cargar la configuración: ${(err as Error).message}`);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function update<K extends keyof SiteConfig>(section: K, patch: Partial<SiteConfig[K]>) {
+    setConfig((prev) => ({
+      ...prev,
+      [section]: { ...(prev[section] as object), ...patch },
+    }));
+    setDirty(true);
+  }
+
+  function updatePersonaCard(idx: number, patch: Partial<SiteConfig['persona_cards'][number]>) {
+    setConfig((prev) => {
+      const next = [...prev.persona_cards];
+      next[idx] = { ...next[idx], ...patch } as SiteConfig['persona_cards'][number];
+      return { ...prev, persona_cards: next as SiteConfig['persona_cards'] };
+    });
+    setDirty(true);
+  }
+
+  function updateCertifications(line: string) {
+    const list = line
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    setConfig((prev) => ({ ...prev, certifications: list }));
+    setDirty(true);
+  }
+
+  function updatePersonaHighlights(idx: number, text: string) {
+    const list = text
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    updatePersonaCard(idx, { highlights: list });
+  }
+
+  async function handleLogoUpload(file: File) {
+    setUploadingLogo(true);
+    setStatusMessage(null);
+    try {
+      const user = firebaseAuth.currentUser;
+      if (!user) {
+        throw new Error('Sin user autenticado.');
+      }
+      const token = await user.getIdToken();
+      const form = new FormData();
+      form.append('file', file);
+      const res = await fetch(`${getApiUrl()}/admin/site-settings/assets`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+      });
+      const body = (await res.json()) as { url?: string; error?: string };
+      if (!res.ok || !body.url) {
+        throw new Error(body.error ?? 'upload_failed');
+      }
+      update('identity', { logo_url: body.url });
+      setStatusType('success');
+      setStatusMessage('Logo subido. Recuerda guardar y publicar.');
+    } catch (err) {
+      setStatusType('error');
+      setStatusMessage(`Error subiendo logo: ${(err as Error).message}`);
+    } finally {
+      setUploadingLogo(false);
+    }
+  }
+
+  async function handleSaveDraft(e: FormEvent) {
+    e.preventDefault();
+    setSubmitting(true);
+    setStatusMessage(null);
+
+    const parsed = siteConfigSchema.safeParse(config);
+    if (!parsed.success) {
+      setStatusType('error');
+      setStatusMessage(`Validación falló: ${parsed.error.issues[0]?.message ?? 'config inválida'}`);
+      setSubmitting(false);
+      return;
+    }
+
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${getApiUrl()}/admin/site-settings/draft`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ config: parsed.data }),
+      });
+      const body = (await res.json()) as {
+        ok?: boolean;
+        draft?: PublishedRow;
+        error?: string;
+      };
+      if (!res.ok || !body.draft) {
+        throw new Error(body.error ?? 'draft_failed');
+      }
+      // Publicar inmediatamente.
+      const pubRes = await fetch(`${getApiUrl()}/admin/site-settings/publish`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ id: body.draft.id }),
+      });
+      if (!pubRes.ok) {
+        const pubBody = (await pubRes.json()) as { error?: string };
+        throw new Error(pubBody.error ?? 'publish_failed');
+      }
+      setStatusType('success');
+      setStatusMessage(`Versión ${body.draft.version} publicada.`);
+      setDirty(false);
+      setPublishedVersion(body.draft.version);
+      await fetchData();
+    } catch (err) {
+      setStatusType('error');
+      setStatusMessage(`Error al publicar: ${(err as Error).message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRollback(targetVersion: number) {
+    if (
+      !window.confirm(
+        `¿Revertir el sitio a la versión ${targetVersion}? Esto despublica la versión actual.`,
+      )
+    ) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const headers = await authHeaders();
+      const res = await fetch(`${getApiUrl()}/admin/site-settings/rollback`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ target_version: targetVersion }),
+      });
+      const body = (await res.json()) as { ok?: boolean; error?: string };
+      if (!res.ok || !body.ok) {
+        throw new Error(body.error ?? 'rollback_failed');
+      }
+      setStatusType('success');
+      setStatusMessage(`Rollback a versión ${targetVersion} OK.`);
+      await fetchData();
+      setDirty(false);
+    } catch (err) {
+      setStatusType('error');
+      setStatusMessage(`Error en rollback: ${(err as Error).message}`);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleRestoreDefaults() {
+    if (
+      !window.confirm(
+        'Esto reemplaza el formulario con los valores hardcoded por defecto. NO se publica automáticamente — debes apretar "Guardar y publicar" para que aplique.',
+      )
+    ) {
+      return;
+    }
+    setConfig(DEFAULT_SITE_CONFIG);
+    setDirty(true);
+    setStatusMessage('Defaults cargados en el form. Revisa y publica.');
+    setStatusType('success');
+  }
+
+  if (forbidden) {
+    return <Navigate to="/app" />;
+  }
+
+  if (loading) {
+    return (
+      <Layout me={me} title="Configuración del sitio">
+        <div className="flex min-h-[400px] items-center justify-center text-neutral-500">
+          <Loader2 className="mr-2 h-5 w-5 animate-spin" aria-hidden />
+          Cargando configuración…
+        </div>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout me={me} title="Configuración del sitio">
+      <div className="flex items-center justify-between gap-3">
+        <Link
+          to="/app/platform-admin"
+          className="inline-flex items-center gap-1 text-neutral-500 text-sm hover:text-neutral-700"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Platform admin
+        </Link>
+        <div className="flex items-center gap-2">
+          {publishedVersion !== null && (
+            <span className="rounded-md border border-neutral-200 bg-white px-2.5 py-1 font-medium text-neutral-700 text-xs">
+              Versión publicada: <strong className="text-neutral-900">{publishedVersion}</strong>
+            </span>
+          )}
+          {dirty && (
+            <span className="rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1 font-medium text-amber-900 text-xs">
+              Cambios sin publicar
+            </span>
+          )}
+        </div>
+      </div>
+
+      <header className="mt-4 flex items-start gap-4">
+        <div className="flex h-12 w-12 items-center justify-center rounded-lg bg-primary-50 text-primary-700">
+          <Palette className="h-6 w-6" aria-hidden />
+        </div>
+        <div>
+          <h1 className="font-bold text-3xl text-neutral-900 tracking-tight">
+            Configuración del sitio
+          </h1>
+          <p className="mt-1 max-w-2xl text-neutral-600 text-sm">
+            Edita marca, hero, certificaciones y cards de personas que se muestran en{' '}
+            <strong>demo.boosterchile.com</strong>. Los cambios aplican con cache de 5 minutos.
+            ADR-039.
+          </p>
+        </div>
+      </header>
+
+      {statusMessage && (
+        <output
+          className={`mt-6 block rounded-md border px-4 py-3 text-sm ${
+            statusType === 'success'
+              ? 'border-primary-300 bg-primary-50 text-primary-900'
+              : 'border-rose-300 bg-rose-50 text-rose-900'
+          }`}
+        >
+          {statusMessage}
+        </output>
+      )}
+
+      <form onSubmit={handleSaveDraft} className="mt-8 space-y-10">
+        <IdentitySection
+          config={config}
+          onChange={(patch) => update('identity', patch)}
+          onUploadLogo={handleLogoUpload}
+          uploading={uploadingLogo}
+        />
+
+        <HeroSection config={config} onChange={(patch) => update('hero', patch)} />
+
+        <CertificationsSection values={config.certifications} onChange={updateCertifications} />
+
+        <PersonaCardsSection
+          cards={config.persona_cards}
+          onChange={updatePersonaCard}
+          onChangeHighlights={updatePersonaHighlights}
+        />
+
+        <div className="sticky bottom-4 z-10 flex flex-wrap items-center justify-end gap-3 rounded-lg border border-neutral-200 bg-white p-4 shadow-md">
+          <button
+            type="button"
+            onClick={handleRestoreDefaults}
+            className="rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm hover:bg-neutral-50"
+          >
+            Restaurar defaults
+          </button>
+          <a
+            href="https://demo.boosterchile.com/demo"
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm hover:bg-neutral-50"
+          >
+            <Eye className="h-4 w-4" aria-hidden />
+            Abrir demo en nueva pestaña
+          </a>
+          <button
+            type="submit"
+            disabled={submitting || !dirty}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary-600 px-4 py-2 font-semibold text-sm text-white shadow-sm hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {submitting ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Save className="h-4 w-4" aria-hidden />
+            )}
+            Guardar y publicar
+          </button>
+        </div>
+      </form>
+
+      <HistorySection history={history} onRollback={handleRollback} submitting={submitting} />
+    </Layout>
+  );
+}
+
+// =============================================================================
+// SECTIONS
+// =============================================================================
+
+function SectionHeader({
+  Icon,
+  title,
+  description,
+}: {
+  Icon: typeof Building2;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex items-start gap-3 border-neutral-200 border-b pb-3">
+      <div className="flex h-9 w-9 items-center justify-center rounded-md bg-neutral-100 text-neutral-700">
+        <Icon className="h-4 w-4" aria-hidden />
+      </div>
+      <div>
+        <h2 className="font-semibold text-lg text-neutral-900">{title}</h2>
+        <p className="text-neutral-500 text-sm">{description}</p>
+      </div>
+    </div>
+  );
+}
+
+function InputField({
+  label,
+  value,
+  onChange,
+  maxLength,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  maxLength?: number;
+  placeholder?: string;
+}) {
+  const id = useId();
+  return (
+    <label htmlFor={id} className="block">
+      <span className="block font-medium text-neutral-700 text-sm">{label}</span>
+      <input
+        id={id}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        className="mt-1 block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-neutral-900 text-sm shadow-xs focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+      />
+      {maxLength && (
+        <span className="mt-1 block text-right text-neutral-400 text-xs">
+          {value.length} / {maxLength}
+        </span>
+      )}
+    </label>
+  );
+}
+
+function TextareaField({
+  label,
+  value,
+  onChange,
+  maxLength,
+  rows = 3,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  maxLength?: number;
+  rows?: number;
+  placeholder?: string;
+}) {
+  const id = useId();
+  return (
+    <label htmlFor={id} className="block">
+      <span className="block font-medium text-neutral-700 text-sm">{label}</span>
+      <textarea
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={maxLength}
+        rows={rows}
+        placeholder={placeholder}
+        className="mt-1 block w-full rounded-md border border-neutral-300 bg-white px-3 py-2 text-neutral-900 text-sm shadow-xs focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500"
+      />
+      {maxLength && (
+        <span className="mt-1 block text-right text-neutral-400 text-xs">
+          {value.length} / {maxLength}
+        </span>
+      )}
+    </label>
+  );
+}
+
+function IdentitySection({
+  config,
+  onChange,
+  onUploadLogo,
+  uploading,
+}: {
+  config: SiteConfig;
+  onChange: (patch: Partial<SiteConfig['identity']>) => void;
+  onUploadLogo: (file: File) => void | Promise<void>;
+  uploading: boolean;
+}) {
+  return (
+    <section className="space-y-4">
+      <SectionHeader
+        Icon={ImageIcon}
+        title="Identidad de marca"
+        description="Logo principal, color de acento, favicon."
+      />
+
+      <div className="flex flex-wrap items-start gap-6">
+        <div>
+          <span className="block font-medium text-neutral-700 text-sm">Logo actual</span>
+          <div className="mt-2 flex h-24 w-24 items-center justify-center rounded-lg border border-neutral-200 bg-white p-2">
+            <img
+              src={config.identity.logo_url ?? '/icons/icon.svg'}
+              alt={config.identity.logo_alt}
+              className="max-h-full max-w-full"
+            />
+          </div>
+        </div>
+        <div className="flex-1 space-y-3">
+          <label className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-neutral-300 bg-white px-3 py-2 font-medium text-neutral-700 text-sm hover:bg-neutral-50">
+            {uploading ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden />
+            ) : (
+              <Upload className="h-4 w-4" aria-hidden />
+            )}
+            Subir nuevo logo (SVG / PNG / JPG, máx 500 KB)
+            <input
+              type="file"
+              accept="image/svg+xml,image/png,image/jpeg"
+              className="hidden"
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) {
+                  void onUploadLogo(file);
+                }
+              }}
+              disabled={uploading}
+            />
+          </label>
+          {config.identity.logo_url && (
+            <button
+              type="button"
+              onClick={() => onChange({ logo_url: undefined })}
+              className="ml-2 text-rose-700 text-sm hover:underline"
+            >
+              Restaurar logo default
+            </button>
+          )}
+          <InputField
+            label="Texto alternativo (alt)"
+            value={config.identity.logo_alt}
+            onChange={(v) => onChange({ logo_alt: v })}
+            maxLength={60}
+          />
+          <InputField
+            label="Color primario (hex, ej. #1fa058) — opcional"
+            value={config.identity.primary_color ?? ''}
+            onChange={(v) => onChange({ primary_color: v || undefined })}
+            maxLength={7}
+            placeholder="#1fa058"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function HeroSection({
+  config,
+  onChange,
+}: {
+  config: SiteConfig;
+  onChange: (patch: Partial<SiteConfig['hero']>) => void;
+}) {
+  return (
+    <section className="space-y-4">
+      <SectionHeader
+        Icon={Type}
+        title="Hero — propuesta de valor"
+        description="Headline (2 líneas), subtítulo y microcopy del demo landing."
+      />
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <InputField
+          label="Línea 1 del headline"
+          value={config.hero.headline_line1}
+          onChange={(v) => onChange({ headline_line1: v })}
+          maxLength={80}
+        />
+        <InputField
+          label="Línea 2 del headline (acento color)"
+          value={config.hero.headline_line2}
+          onChange={(v) => onChange({ headline_line2: v })}
+          maxLength={80}
+        />
+      </div>
+      <TextareaField
+        label="Subhead (propuesta de valor extendida)"
+        value={config.hero.subhead}
+        onChange={(v) => onChange({ subhead: v })}
+        maxLength={500}
+        rows={3}
+      />
+      <InputField
+        label="Microcopy (CTA secundaria)"
+        value={config.hero.microcopy}
+        onChange={(v) => onChange({ microcopy: v })}
+        maxLength={200}
+      />
+    </section>
+  );
+}
+
+function CertificationsSection({
+  values,
+  onChange,
+}: {
+  values: string[];
+  onChange: (line: string) => void;
+}) {
+  return (
+    <section className="space-y-4">
+      <SectionHeader
+        Icon={Building2}
+        title="Certificaciones"
+        description="Una por línea. Máximo 8. Se muestran como badges en el hero."
+      />
+      <TextareaField
+        label="Lista de certificaciones (una por línea)"
+        value={values.join('\n')}
+        onChange={onChange}
+        rows={5}
+        placeholder={'GLEC v3.0\nGHG Protocol\nISO 14064\nk-anonymity ≥ 5'}
+      />
+    </section>
+  );
+}
+
+function PersonaCardsSection({
+  cards,
+  onChange,
+  onChangeHighlights,
+}: {
+  cards: SiteConfig['persona_cards'];
+  onChange: (idx: number, patch: Partial<SiteConfig['persona_cards'][number]>) => void;
+  onChangeHighlights: (idx: number, text: string) => void;
+}) {
+  return (
+    <section className="space-y-4">
+      <SectionHeader
+        Icon={Building2}
+        title="Cards de personas"
+        description="4 cards (shipper, carrier, conductor, stakeholder). Editables individualmente."
+      />
+
+      <div className="space-y-6">
+        {cards.map((card, idx) => (
+          <div
+            key={card.persona}
+            className="rounded-lg border border-neutral-200 bg-neutral-50 p-4"
+          >
+            <h3 className="mb-3 font-semibold text-neutral-900 text-sm uppercase tracking-wider">
+              {card.persona}
+            </h3>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <InputField
+                label="Rol (etiqueta)"
+                value={card.role}
+                onChange={(v) => onChange(idx, { role: v })}
+                maxLength={50}
+              />
+              <InputField
+                label="Nombre entidad"
+                value={card.entity_name}
+                onChange={(v) => onChange(idx, { entity_name: v })}
+                maxLength={80}
+              />
+            </div>
+            <div className="mt-3">
+              <InputField
+                label="Tagline"
+                value={card.tagline}
+                onChange={(v) => onChange(idx, { tagline: v })}
+                maxLength={200}
+              />
+            </div>
+            <div className="mt-3">
+              <TextareaField
+                label="Highlights (uno por línea, máx 5)"
+                value={card.highlights.join('\n')}
+                onChange={(v) => onChangeHighlights(idx, v)}
+                rows={4}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function HistorySection({
+  history,
+  onRollback,
+  submitting,
+}: {
+  history: PublishedRow[];
+  onRollback: (version: number) => void;
+  submitting: boolean;
+}) {
+  if (history.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="mt-10 rounded-lg border border-neutral-200 bg-white p-5">
+      <div className="mb-3 flex items-center gap-2">
+        <History className="h-5 w-5 text-neutral-700" aria-hidden />
+        <h2 className="font-semibold text-lg text-neutral-900">Historial</h2>
+      </div>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-neutral-200 border-b text-left text-neutral-500 text-xs uppercase">
+            <th className="py-2">Versión</th>
+            <th className="py-2">Estado</th>
+            <th className="py-2">Creado</th>
+            <th className="py-2">Por</th>
+            <th className="py-2">Nota</th>
+            <th className="py-2 text-right">Acción</th>
+          </tr>
+        </thead>
+        <tbody>
+          {history.map((row) => (
+            <tr key={row.id} className="border-neutral-100 border-b">
+              <td className="py-2 font-semibold">{row.version}</td>
+              <td className="py-2">
+                {row.publicada ? (
+                  <span className="rounded bg-primary-100 px-2 py-0.5 font-medium text-primary-800 text-xs">
+                    Publicada
+                  </span>
+                ) : (
+                  <span className="text-neutral-500">Histórica</span>
+                )}
+              </td>
+              <td className="py-2 text-neutral-600">
+                {new Date(row.creadoEn).toLocaleString('es-CL')}
+              </td>
+              <td className="py-2 text-neutral-700">{row.creadoPorEmail}</td>
+              <td className="py-2 text-neutral-600">{row.notaPublicacion ?? '—'}</td>
+              <td className="py-2 text-right">
+                {!row.publicada && (
+                  <button
+                    type="button"
+                    onClick={() => onRollback(row.version)}
+                    disabled={submitting}
+                    className="text-primary-700 text-sm hover:underline disabled:opacity-50"
+                  >
+                    Rollback
+                  </button>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}

--- a/apps/web/src/routes/platform-admin.tsx
+++ b/apps/web/src/routes/platform-admin.tsx
@@ -162,6 +162,23 @@ function PlatformAdminPage() {
           </Link>
         </div>
 
+        <div className="mt-4 flex items-start justify-between gap-4 rounded-lg border border-neutral-200 bg-white p-4">
+          <div>
+            <h3 className="font-semibold text-neutral-900">Configuración del sitio (ADR-039)</h3>
+            <p className="mt-1 text-neutral-600 text-sm">
+              Editor de marca y copy del demo landing (logo, hero, certificaciones, cards de
+              personas). Cambios aplican en runtime con cache 5 min — sin redeploy.
+            </p>
+          </div>
+          <Link
+            to="/app/platform-admin/site-settings"
+            className="inline-flex shrink-0 items-center gap-2 rounded-md border border-primary-300 bg-primary-50 px-3 py-2 font-medium text-primary-700 text-sm hover:bg-primary-100"
+            data-testid="site-settings-link"
+          >
+            Editar sitio →
+          </Link>
+        </div>
+
         <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2">
           <SeedCard onSeed={handleSeed} state={seedState} />
           <CleanCard onClean={handleClean} state={cleanState} setState={setCleanState} />

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         // del coverage para no bloquear PRs por UI admin (ADR-011).
         'src/routes/platform-admin.tsx',
         'src/routes/platform-admin-matching.tsx',
+        'src/routes/platform-admin-site-settings.tsx',
         'src/routes/admin-cobra-hoy.tsx',
         'src/routes/admin-dispositivos.tsx',
         // Modo demo (subdominio demo.boosterchile.com): selector de

--- a/docs/adr/039-site-settings-runtime-configuration.md
+++ b/docs/adr/039-site-settings-runtime-configuration.md
@@ -1,0 +1,160 @@
+# ADR-039 — Site Settings Runtime Configuration
+
+**Estado**: Aceptado
+**Fecha**: 2026-05-13
+**Decisores**: Felipe Vicencio (PO)
+**Supersede**: —
+
+## Contexto
+
+Hasta este ADR, los elementos de marca y copy comercial del frontend
+público (logo, headline, propuesta de valor, cards de personas demo,
+badges de certificación) vivían **hardcoded** en el bundle de
+`apps/web`. Cada cambio — incluso una corrección de una palabra —
+requería:
+
+1. Editar el código fuente
+2. PR + review + CI verde + merge
+3. Build del bundle nuevo
+4. Deploy de Cloud Run web
+5. Cache CDN invalidation
+
+Tiempo total: ~25 min en happy path, mayor si CI falla o hay race
+con otros deploys.
+
+Para demo Corfo (lunes 2026-05-18) y comunicación comercial general,
+necesitamos que el platform-admin pueda **iterar copy y marca sin
+redeploy**. Cambios típicos:
+
+- Probar variantes de headline ("Transporta más, impacta menos" vs
+  alternativas) en hours
+- Subir un logo refinado tras feedback visual
+- Ajustar el tagline de una persona demo
+- Agregar/quitar una certificación
+
+## Decisión
+
+Crear una tabla **`configuracion_sitio`** (PostgreSQL) que persiste la
+configuración del sitio como JSONB versionado. Schema validado por Zod
+en `packages/shared-schemas/src/site-settings.ts`.
+
+**Singleton sobre `publicada=true`** vía partial unique index:
+```sql
+CREATE UNIQUE INDEX configuracion_sitio_publicada_unique
+    ON configuracion_sitio (publicada) WHERE publicada = true;
+```
+
+Cada `publish` es atómico (transacción): desmarca la versión publicada
+anterior, marca la nueva. Cada cambio genera una fila nueva — el
+historial completo queda preservado para rollback.
+
+**Assets** (logos, favicons) van a un **bucket GCS público read-only**
+(`booster-ai-public-assets-{env}`) con CDN cache. Write restringido al
+SA del Cloud Run api. Sanitización SVG anti-XSS en el endpoint de upload.
+
+**Frontend público** lee `GET /public/site-settings` vía TanStack Query
+con `staleTime: 5min`. Fallback a `DEFAULT_SITE_CONFIG` hardcoded
+(mismo `packages/shared-schemas`) si el endpoint falla, devuelve 404 o
+response inválido. Esto asegura que **el sitio nunca se rompe** por un
+issue del backend de configuración.
+
+**Frontend admin** (`/app/platform-admin/site-settings`) tiene form de
+edición + history + rollback. Gated por `BOOSTER_PLATFORM_ADMIN_EMAILS`
+(allowlist, mismo patrón que otras surfaces admin platform-wide).
+
+## Alternativas consideradas
+
+### A. Mantener hardcoded (status quo)
+Rechazada. Costo de cada iteración (~25 min + bloquea CI/deploy
+pipeline) hace que el copy comercial se itere mucho menos de lo que
+debería. Ya impacta el ciclo: tras la primera versión del demo Corfo
+hubo 3 iteraciones de copy en una tarde, cada una requirió PR/deploy.
+
+### B. Env vars con redeploy
+Rechazada. Permite cambios sin tocar código pero sigue requiriendo
+deploy de Cloud Run (~10-15 min). No resuelve el problema; solo lo
+mueve a otra capa.
+
+### C. CMS externo (Strapi, Sanity, Contentful)
+Rechazada. Adds operational complexity (otro servicio que mantener,
+otro auth a configurar, otro vendor lock-in). Sobredimensionado para
+el alcance actual (~10 campos editables). Buena opción si en el
+futuro necesitamos editorial workflow con múltiples editores y revisión.
+
+### D. Tabla `configuracion_sitio` versionada con publish/rollback (elegida)
+Pros:
+- Datos cerca del producto, mismo stack (Drizzle/Hono/PostgreSQL).
+- Versionado natural — `publicada=true` es estado vigente, demás son
+  history.
+- Rollback con un click.
+- Auditoría implícita (`creado_por_email`, `creado_en`).
+- Fallback robusto: si BD/API falla, frontend sirve defaults
+  hardcoded.
+
+Cons:
+- Singleton vía partial unique index no es portable a otros engines
+  (PostgreSQL-specific). Aceptable — stack canónico es Postgres
+  (ADR-001).
+- 5min de cache puede mostrar versión vieja a usuarios cuyo browser
+  ya tenía la query en memoria. Aceptable para copy/marca.
+
+## Schema del config (Zod canónico)
+
+`packages/shared-schemas/src/site-settings.ts` exporta:
+
+```typescript
+SiteConfig = {
+  identity: { logo_url?, logo_alt, favicon_url?, primary_color? },
+  hero: { headline_line1, headline_line2, subhead, microcopy },
+  certifications: string[],
+  persona_cards: PersonaCard[4],  // exactamente 4
+  onboarding?: OnboardingCopy,
+  login?: LoginCopy,
+}
+```
+
+Single source of truth — backend, frontend público y frontend admin
+referencian este schema. Mantiene type safety end-to-end.
+
+## Consecuencias
+
+### Positivas
+- Iteración de marca + copy en **minutos**, no en releases.
+- Audit log natural (history table).
+- Rollback inmediato si una publicación rompe algo visual.
+- Defaults hardcoded en `DEFAULT_SITE_CONFIG` aseguran no-downtime
+  ante fallos del backend de configuración.
+
+### Negativas
+- Una nueva tabla, un nuevo endpoint público, un nuevo bucket GCS, un
+  nuevo bundle de admin UI a mantener.
+- Cache de 5 min puede dar la sensación de "no se aplica" al admin
+  recién publicado — mitigado por el botón "Abrir demo en nueva
+  pestaña" que evita cache (hard reload).
+- Sanitización SVG actual es defensiva (regex anti-XSS); no usa
+  DOMPurify. Riesgo bajo porque el upload requiere admin auth, pero
+  conviene endurecer en v2 con DOMPurify server-side.
+
+### Acciones derivadas
+- v1 (este ADR): identity + hero + certifications + persona_cards
+  editables. Onboarding/login copy quedan opcionales en el schema —
+  el form admin todavía no los incluye (placeholder para v2).
+- v2: agregar onboarding/login copy al form admin, preview iframe
+  pre-publish, DOMPurify para sanitización SVG robusta, audit log
+  visible en la UI.
+- v3 (eventual): si el alcance crece, evaluar migración a CMS externo.
+
+## Costo
+
+- BD: ~1 KB por versión × ~10 versiones/año = ~10 KB/año. Negligible.
+- GCS bucket: <100 MB esperados (logos + favicons). Tier free.
+- Engineering: ~16 hrs implementación inicial (este PR).
+- Operacional: cero — el platform-admin opera el editor solo.
+
+## Referencias
+
+- ADR-001 — Stack selection (Postgres/Drizzle/Hono).
+- ADR-011 — Admin console exclusion del coverage.
+- ADR-034 — Stakeholder organizations (mismo patrón de admin
+  platform-wide).
+- ADR-038 — Routes API key migration (mismo bucket GCS pattern).

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -157,6 +157,11 @@ module "service_api" {
     # esta env var + columna es_demo=true en empresas.
     DEMO_MODE_ACTIVATED = tostring(var.demo_mode_activated)
 
+    # ADR-039 — Site Settings Runtime Configuration. Bucket público de
+    # assets editables (logos, favicons) que sube el admin desde
+    # /app/platform-admin/site-settings.
+    PUBLIC_ASSETS_BUCKET = google_storage_bucket.public_assets.name
+
     # Allowlist de operadores Booster que pueden entrar a /admin/* del API
     # y /app/platform-admin/* de la PWA. CSV de emails (lower-cased en
     # comparison). Sin esta env var nadie es admin — el código defaultea

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -399,3 +399,72 @@ resource "google_storage_bucket_iam_member" "chat_attachments_runtime" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
 }
+
+# =============================================================================
+# Public assets bucket — ADR-039 Site Settings Runtime Configuration
+# =============================================================================
+#
+# Bucket público (read CDN-cached) para assets editables desde Site
+# Settings Editor: logos, favicons, imágenes de marca subidas por el
+# platform-admin desde /app/platform-admin/site-settings.
+#
+# Write restringido al SA del Cloud Run api; read público vía
+# storage.googleapis.com (sin signed URLs, máxima cacheabilidad CDN).
+
+resource "google_storage_bucket" "public_assets" {
+  name                        = "booster-ai-public-assets-${var.environment}"
+  project                     = google_project.booster_ai.project_id
+  location                    = "US" # multi-region para edges CDN globales
+  uniform_bucket_level_access = true
+  force_destroy               = false
+
+  cors {
+    origin = [
+      "https://app.${var.domain}",
+      "https://demo.${var.domain}",
+      "https://${var.domain}",
+      "https://www.${var.domain}",
+      "http://localhost:5173",
+    ]
+    method          = ["GET", "HEAD"]
+    response_header = ["Content-Type", "Cache-Control"]
+    max_age_seconds = 3600
+  }
+
+  versioning {
+    enabled = true
+  }
+
+  # Mantener últimas 5 versiones de cada objeto (rollback rápido si un
+  # logo se reemplaza por error).
+  lifecycle_rule {
+    condition {
+      num_newer_versions = 5
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  labels = {
+    env        = var.environment
+    managed_by = "terraform"
+    purpose    = "public-assets-site-settings"
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# Read público — cualquier visitante puede descargar los assets vía CDN.
+resource "google_storage_bucket_iam_member" "public_assets_public_read" {
+  bucket = google_storage_bucket.public_assets.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
+# Write para el Cloud Run runtime SA — usado por POST /admin/site-settings/assets.
+resource "google_storage_bucket_iam_member" "public_assets_runtime_admin" {
+  bucket = google_storage_bucket.public_assets.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
+}

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -55,3 +55,6 @@ export * from './auth.js';
 
 // AVL IDs catálogo (Wave 2 — Track B1 + B2)
 export * from './avl-ids/index.js';
+
+// Site Settings — configuración runtime editable de marca y copy (ADR-039)
+export * from './site-settings.js';

--- a/packages/shared-schemas/src/site-settings.ts
+++ b/packages/shared-schemas/src/site-settings.ts
@@ -1,0 +1,152 @@
+import { z } from 'zod';
+
+/**
+ * Schema canónico de configuración del sitio (Booster AI).
+ *
+ * El admin puede editar estos campos desde
+ * `/app/platform-admin/site-settings` y los cambios aplican en runtime
+ * a `demo.boosterchile.com`, `/login`, `/onboarding` sin redeploy.
+ *
+ * ADR-039 — Site Settings Runtime Configuration.
+ *
+ * El backend persiste como JSONB en la tabla `configuracion_sitio`
+ * (versionada, singleton sobre `publicada=true`). El frontend lo lee
+ * vía `GET /public/site-settings` (cache 5min) y aplica fallback a
+ * defaults hardcoded si falla.
+ */
+
+export const siteIdentitySchema = z.object({
+  /**
+   * URL HTTPS del logo principal. Override del SVG default
+   * `/icons/icon.svg`. Sirve desde el bucket público
+   * `booster-ai-public-assets-{env}`.
+   */
+  logo_url: z.string().url().optional(),
+  /** Texto alternativo del logo para accesibilidad. */
+  logo_alt: z.string().min(1).max(60).default('Booster AI'),
+  /** URL HTTPS del favicon. Override del default. */
+  favicon_url: z.string().url().optional(),
+  /**
+   * Color primario en formato hex `#RRGGBB`. Override del verde
+   * Booster default `#1fa058`. Propaga a CSS variable `--color-primary-500`
+   * (y el bundle resuelve las variantes 600/700 con shift de luminosidad).
+   */
+  primary_color: z
+    .string()
+    .regex(/^#[0-9A-Fa-f]{6}$/i, 'Color hex inválido — usa formato #RRGGBB')
+    .optional(),
+});
+
+export const heroSchema = z.object({
+  /** Primera línea del headline. */
+  headline_line1: z.string().min(1).max(80),
+  /** Segunda línea (renderiza en color acento primary). */
+  headline_line2: z.string().min(1).max(80),
+  /** Texto descriptivo bajo el headline. */
+  subhead: z.string().min(1).max(500),
+  /** Microcopy adicional (opcional, debajo del subhead). */
+  microcopy: z.string().min(1).max(200),
+});
+
+export const certificationSchema = z.string().min(1).max(40);
+
+export const personaCardSchema = z.object({
+  persona: z.enum(['shipper', 'carrier', 'conductor', 'stakeholder']),
+  role: z.string().min(1).max(50),
+  entity_name: z.string().min(1).max(80),
+  tagline: z.string().min(1).max(200),
+  highlights: z.array(z.string().min(1).max(100)).min(1).max(5),
+});
+
+export const onboardingCopySchema = z.object({
+  step1_title: z.string().min(1).max(100),
+  step2_title: z.string().min(1).max(100),
+  step3_title: z.string().min(1).max(100),
+  step4_title: z.string().min(1).max(100),
+});
+
+export const loginCopySchema = z.object({
+  hero_title: z.string().min(1).max(100),
+  hero_subtitle: z.string().min(1).max(300),
+});
+
+export const siteConfigSchema = z.object({
+  identity: siteIdentitySchema,
+  hero: heroSchema,
+  certifications: z.array(certificationSchema).max(8),
+  persona_cards: z.array(personaCardSchema).length(4),
+  onboarding: onboardingCopySchema.optional(),
+  login: loginCopySchema.optional(),
+});
+
+export type SiteIdentity = z.infer<typeof siteIdentitySchema>;
+export type Hero = z.infer<typeof heroSchema>;
+export type PersonaCard = z.infer<typeof personaCardSchema>;
+export type OnboardingCopy = z.infer<typeof onboardingCopySchema>;
+export type LoginCopy = z.infer<typeof loginCopySchema>;
+export type SiteConfig = z.infer<typeof siteConfigSchema>;
+
+/**
+ * Defaults canónicos — usados como fallback en frontend y como seed
+ * inicial de la migration 0033. Single source of truth de los valores
+ * de marca actuales (PR #216).
+ */
+export const DEFAULT_SITE_CONFIG: SiteConfig = {
+  identity: {
+    logo_alt: 'Booster AI',
+  },
+  hero: {
+    headline_line1: 'Transporta más,',
+    headline_line2: 'impacta menos.',
+    subhead:
+      'Marketplace B2B de logística sostenible para Chile. Conecta generadores de carga con transportistas, optimiza retornos vacíos y certifica huella de carbono bajo GLEC v3.0.',
+    microcopy: 'Explora la demo desde cualquier rol — un click, sin registro.',
+  },
+  certifications: ['GLEC v3.0', 'GHG Protocol', 'ISO 14064', 'k-anonymity ≥ 5'],
+  persona_cards: [
+    {
+      persona: 'shipper',
+      role: 'Generador de carga',
+      entity_name: 'Andina Demo S.A.',
+      tagline: 'Publica cargas, ve ofertas y descarga certificados de huella verificada.',
+      highlights: [
+        '2 sucursales activas (Maipú, Quilicura)',
+        'Matching automático con transportistas',
+        'Certificados GLEC v3.0 descargables',
+      ],
+    },
+    {
+      persona: 'carrier',
+      role: 'Transportista',
+      entity_name: 'Transportes Demo Sur',
+      tagline: 'Acepta cargas, asigna conductor y vehículo, factura sin papeles.',
+      highlights: [
+        '2 vehículos · 1 conductor activo',
+        'Seguimiento en tiempo real vía Teltonika',
+        'Cobra Hoy · pronto pago integrado',
+      ],
+    },
+    {
+      persona: 'conductor',
+      role: 'Conductor profesional',
+      entity_name: 'Pedro González',
+      tagline: 'Ve tu próximo viaje, navega con la ruta eco y reporta GPS desde el celular.',
+      highlights: [
+        'Modo Conductor full-screen',
+        'Ruta eco-eficiente sugerida',
+        'GPS móvil cuando no hay Teltonika',
+      ],
+    },
+    {
+      persona: 'stakeholder',
+      role: 'Observatorio sostenibilidad',
+      entity_name: 'Observatorio Logístico',
+      tagline: 'Métricas agregadas por zona logística con k-anonimización ≥ 5.',
+      highlights: [
+        'Zonas: puertos, mercados, polos industriales',
+        'Sin PII, sin empresas individuales',
+        'Metodología pública auditable',
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## Resumen

Permite al platform-admin editar **marca y copy comercial del frontend público sin redeploy**: logo, propuesta de valor del hero, certificaciones, cards de personas demo. Cambios aplican en runtime con cache de 5 min.

ADR-039 documenta la decisión completa.

## Cómo lo uso

1. Login como admin (allowlist `BOOSTER_PLATFORM_ADMIN_EMAILS`).
2. `/app/platform-admin/site-settings` (link visible en `/app/platform-admin`).
3. Editar campos del form (Identidad, Hero, Certificaciones, Cards).
4. Click \"Guardar y publicar\" → la nueva versión va al demo en <5min.
5. Rollback con un click desde el panel History si algo sale mal.

## Cambios (8 commits, ~1,300 líneas)

| Commit | Capa | Líneas |
|---|---|---|
| 1. \`feat(shared,api): schema + migration 0033\` | Shared schemas + Drizzle | 264 |
| 2. \`feat(api): endpoints + asset upload GCS + wire\` | Backend | 399 |
| 3. \`feat(infra): bucket público GCS\` | Terraform | 74 |
| 4. \`feat(web): hook + UI admin + integración demo\` | Frontend | 885 |
| 5. \`test(api,web): tests + ADR-039\` | Tests + docs | ~250 |

## Lo que se puede editar

| Sección | Campos |
|---|---|
| **Identidad** | Logo (upload SVG/PNG/JPG max 500KB), alt text, color primario hex |
| **Hero** | Headline línea 1, línea 2 (acento), subhead, microcopy |
| **Certificaciones** | Lista de strings (una por línea, max 8) |
| **Cards** | 4 cards (shipper/carrier/conductor/stakeholder): rol, entidad, tagline, highlights |

## Endpoints API

Admin (auth + allowlist):
- \`GET /admin/site-settings\` — published + history últimas 20
- \`GET /admin/site-settings/:version\` — versión específica
- \`POST /admin/site-settings/draft\` — crear borrador
- \`POST /admin/site-settings/publish\` — body \`{id}\` → publicar
- \`POST /admin/site-settings/rollback\` — body \`{target_version}\`
- \`POST /admin/site-settings/assets\` — multipart upload → URL GCS

Público (sin auth, cache 5min):
- \`GET /public/site-settings\` — versión publicada o 404

## Seguridad

- Bucket GCS público para read-only (CDN cache). Write restringido al SA del Cloud Run api.
- Upload sanitizado SVG anti-XSS (regex defensiva contra \`<script>\`, \`on*=\`, \`javascript:\`, iframes/objects).
- Endpoints admin con doble guard: Firebase auth + email allowlist.
- Frontend fallback a \`DEFAULT_SITE_CONFIG\` hardcoded — si BD/API falla, demo nunca se rompe.

## Validación

\`\`\`
$ pnpm --filter=@booster-ai/api typecheck   →   0 errors
$ pnpm --filter=@booster-ai/web typecheck   →   0 errors
$ pnpm exec biome check                     →   clean
$ pnpm exec vitest run site-settings        →   7 tests passed
\`\`\`

## Pasos manuales post-merge

1. **terraform apply** del bucket público (`booster-ai-public-assets-prod`) + IAM. Adjunto el comando en el commit de infra.
2. **Migration auto-corre** en next Cloud Run startup (Drizzle migrate on boot).
3. **Verificar** \`GET /public/site-settings\` post-deploy.
4. **Probar editor** en \`/app/platform-admin/site-settings\` y publicar un cambio trivial (e.g. agregar punto al final del headline) para validar end-to-end.

## v2 — Acciones derivadas

- Form admin para onboarding/login copy (schema ya lo soporta; UI queda).
- Preview iframe pre-publish con draft-id en URL.
- DOMPurify server-side para SVG (más robusto que regex).
- Audit log visible en la UI (history table ya guarda actor + timestamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)