### PR TITLE
fix(demo): persistir claim is_demo para que el banner no desaparezca tras 1h

### DIFF
--- a/apps/api/src/routes/demo-login.ts
+++ b/apps/api/src/routes/demo-login.ts
@@ -94,6 +94,27 @@ export function createDemoLoginRoutes(opts: { db: Db; firebaseAuth: Auth; logger
       return c.json({ error: 'demo_not_seeded', code: 'demo_not_seeded' }, 503);
     }
 
+    // Persistir los claims en el user record. Los claims en
+    // `createCustomToken(uid, claims)` SOLO viven en el custom token —
+    // cuando Firebase refresca el ID token (cada ~1h) los claims se
+    // pierden porque no están en el user record. Para que el banner
+    // "MODO DEMO" persista entre refreshes hacemos también
+    // `setCustomUserClaims` que los persiste en el user record.
+    try {
+      await opts.firebaseAuth.setCustomUserClaims(userRow.firebaseUid, {
+        is_demo: true,
+        persona,
+      });
+    } catch (err) {
+      // Continuamos — el custom token con claims funcionará para esta
+      // sesión, solo el refresh post-1h perderá el claim. Banner
+      // intermitente es preferible a bloquear el login del demo.
+      opts.logger.warn(
+        { err, persona, firebaseUid: userRow.firebaseUid },
+        'demo/login: setCustomUserClaims falló (banner se perderá tras 1h)',
+      );
+    }
+
     // Mint custom token con claim `is_demo` y `persona`. El claim
     // `is_demo:true` es lo que la PWA usa para mostrar banner persistente
     // y prevenir cualquier acción destructiva en producción.


### PR DESCRIPTION
## Bug visto en screenshot

En la sesión activa de Pedro González (demo conductor) el banner \"🎭 MODO DEMO\" no se mostraba — debería estar visible para que NO se confunda con producción.

## Causa raíz

\`createCustomToken(uid, claims)\` adjunta los claims SOLO al custom token JWT. Cuando el frontend hace \`signInWithCustomToken\` el primer ID token los contiene, pero el ID token expira a la hora y Firebase lo refresca leyendo del **user record**, donde los claims NUNCA fueron persistidos. Resultado: tras ~1h el banner desaparece silenciosamente.

## Fix

Agregar \`firebaseAuth.setCustomUserClaims(uid, {is_demo:true, persona})\` antes del \`createCustomToken\`. Esto persiste los claims en el user record y se incluyen en cada ID token refresh.

Si \`setCustomUserClaims\` falla loggeamos warn pero continuamos el flow — el banner intermitente es preferible a bloquear el login del demo.

## Validación

- typecheck ✅
- 10/10 tests demo-login pasando

## Trade-off documentado

Si el mismo UID del conductor demo en algún futuro hace login como user real (improbable porque el conductor demo usa email sintético \`drivers+...@boosterchile.invalid\`), arrastraría \`is_demo:true\`. Aceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)