### PR TITLE
fix(rut): aceptar input sin guión + teclado móvil correcto en login y onboarding

### DIFF
--- a/apps/web/src/components/login/LoginUniversal.tsx
+++ b/apps/web/src/components/login/LoginUniversal.tsx
@@ -1,6 +1,7 @@
 import {
   USER_TYPE_HINT_LABEL,
   type UserTypeHint,
+  ensureRutHasDash,
   loginRutSchema,
   rutSchema,
 } from '@booster-ai/shared-schemas';
@@ -151,7 +152,11 @@ export function LoginUniversal() {
     setRutError(null);
     setSubmitError(null);
 
-    const rutParsed = rutSchema.safeParse(rut);
+    // Pre-procesar: si el user tipeó solo dígitos (móvil bloquea el `-`
+    // con inputMode numeric), insertar guión automáticamente antes del
+    // dígito verificador. Idempotente — input con guión queda intacto.
+    const rutWithDash = ensureRutHasDash(rut);
+    const rutParsed = rutSchema.safeParse(rutWithDash);
     if (!rutParsed.success) {
       setRutError(rutParsed.error.issues[0]?.message ?? 'RUT inválido');
       return;
@@ -324,11 +329,15 @@ function FormView(props: FormViewProps) {
             <input
               type="text"
               autoComplete="username"
-              inputMode="numeric"
+              // inputMode="text" (no "numeric") — el RUT tiene guión y opcionalmente
+              // "K" en el dígito verificador. El teclado numérico móvil bloquea
+              // el guión y la letra. Si user tipea solo dígitos, ensureRutHasDash
+              // lo formatea antes de validar.
+              inputMode="text"
               value={props.rut}
               onChange={(e) => props.onChangeRut(e.target.value)}
               className="rounded-md border border-neutral-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-200"
-              placeholder="12.345.678-9"
+              placeholder="12.345.678-9 (también 123456789 funciona)"
               data-testid="login-rut-input"
             />
             {props.rutError && (

--- a/apps/web/src/components/onboarding/OnboardingForm.tsx
+++ b/apps/web/src/components/onboarding/OnboardingForm.tsx
@@ -1,6 +1,7 @@
 import {
   type EmpresaOnboardingInput,
   empresaOnboardingInputSchema,
+  ensureRutHasDash,
 } from '@booster-ai/shared-schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from '@tanstack/react-router';
@@ -133,7 +134,28 @@ export function OnboardingForm({ firebaseEmail, firebaseName }: OnboardingFormPr
     trigger,
     control,
     watch,
+    setValue,
+    getValues,
   } = methods;
+
+  /**
+   * Auto-formato RUT al blur: si el user tipeó solo dígitos (teclado
+   * móvil suele venir sin `-`), insertar guión antes del dígito
+   * verificador. Idempotente para inputs ya bien formateados. Esto
+   * corre ANTES de que el zodResolver valide en `mode: onBlur`.
+   */
+  function normalizeRutFieldOnBlur(field: 'user.rut' | 'empresa.rut') {
+    return () => {
+      const current = getValues(field);
+      if (typeof current !== 'string') {
+        return;
+      }
+      const normalized = ensureRutHasDash(current);
+      if (normalized !== current) {
+        setValue(field, normalized, { shouldValidate: true, shouldDirty: true });
+      }
+    };
+  }
 
   async function nextStep() {
     const fieldsToValidate: ReadonlyArray<Parameters<typeof trigger>[0]> = (() => {
@@ -173,8 +195,19 @@ export function OnboardingForm({ firebaseEmail, firebaseName }: OnboardingFormPr
   }
 
   async function onSubmit(values: EmpresaOnboardingInput) {
+    // Pre-procesar RUTs: si user tipeó solo dígitos (teclado móvil),
+    // insertar guión automáticamente antes del dígito verificador.
+    // Idempotente para inputs ya bien formateados. user.rut es opcional.
+    const normalized: EmpresaOnboardingInput = {
+      ...values,
+      user: {
+        ...values.user,
+        rut: values.user.rut ? ensureRutHasDash(values.user.rut) : values.user.rut,
+      },
+      empresa: { ...values.empresa, rut: ensureRutHasDash(values.empresa.rut) },
+    };
     try {
-      await mutation.mutateAsync(values);
+      await mutation.mutateAsync(normalized);
       void navigate({ to: '/app' });
     } catch {
       // mutation.error ya tiene el ApiError; el render lo muestra abajo.
@@ -246,13 +279,13 @@ export function OnboardingForm({ firebaseEmail, firebaseName }: OnboardingFormPr
             />
             <FormField
               label="RUT (opcional)"
-              hint="Tu RUT personal sin puntos. Ejemplo: 12345678-5. No lo usamos para facturar."
+              hint="Tu RUT personal. Acepta con o sin puntos y con o sin guión (123456785 también funciona)."
               error={errors.user?.rut?.message}
               render={({ id, describedBy }) => (
                 <input
                   id={id}
                   aria-describedby={describedBy}
-                  {...register('user.rut')}
+                  {...register('user.rut', { onBlur: normalizeRutFieldOnBlur('user.rut') })}
                   autoComplete="off"
                   placeholder="12345678-5"
                   inputMode="text"
@@ -285,13 +318,13 @@ export function OnboardingForm({ firebaseEmail, firebaseName }: OnboardingFormPr
             />
             <FormField
               label="RUT empresa"
-              hint="Sin puntos, con guión. Ejemplo: 76123456-0"
+              hint="RUT de tu empresa. Acepta con o sin puntos y con o sin guión (761234560 también funciona)."
               error={errors.empresa?.rut?.message}
               render={({ id, describedBy }) => (
                 <input
                   id={id}
                   aria-describedby={describedBy}
-                  {...register('empresa.rut')}
+                  {...register('empresa.rut', { onBlur: normalizeRutFieldOnBlur('empresa.rut') })}
                   autoComplete="off"
                   placeholder="76123456-0"
                   inputMode="text"

--- a/apps/web/src/routes/login-conductor.tsx
+++ b/apps/web/src/routes/login-conductor.tsx
@@ -1,4 +1,4 @@
-import { rutSchema } from '@booster-ai/shared-schemas';
+import { ensureRutHasDash, rutSchema } from '@booster-ai/shared-schemas';
 import { useNavigate } from '@tanstack/react-router';
 import { Headphones } from 'lucide-react';
 import { type FormEvent, useState } from 'react';
@@ -47,7 +47,11 @@ export function LoginConductorRoute() {
     setRutError(null);
     setSubmitError(null);
 
-    const rutParsed = rutSchema.safeParse(rut);
+    // Pre-procesar: si el user tipeó solo dígitos (móvil con teclado
+    // numérico bloquea `-`), insertar guión automáticamente antes del
+    // dígito verificador. Idempotente.
+    const rutWithDash = ensureRutHasDash(rut);
+    const rutParsed = rutSchema.safeParse(rutWithDash);
     if (!rutParsed.success) {
       setRutError(rutParsed.error.issues[0]?.message ?? 'RUT inválido');
       return;

--- a/packages/shared-schemas/src/primitives/chile.ts
+++ b/packages/shared-schemas/src/primitives/chile.ts
@@ -24,6 +24,42 @@ export function normalizeRut(raw: string): string {
 }
 
 /**
+ * Inserta automáticamente el guión antes del dígito verificador si el
+ * input solo tiene dígitos (caso típico móvil: `inputMode="numeric"` no
+ * permite tipear `-`).
+ *
+ * Reglas:
+ *   - Si ya tiene `-`: devuelve tal cual (uppercase + sin puntos).
+ *   - Si solo tiene dígitos+K (7 a 9 chars): inserta `-` antes del último.
+ *   - En otro caso: devuelve tal cual (sin tocar, deja que rutSchema
+ *     rechace y muestre error legible).
+ *
+ * Idempotente: aplicar dos veces no cambia el resultado.
+ *
+ * Ejemplos:
+ *   ensureRutHasDash('12345678K')   → '12345678-K'
+ *   ensureRutHasDash('12345678-9')  → '12345678-9'
+ *   ensureRutHasDash('12.345.678-9')→ '12345678-9'
+ *   ensureRutHasDash('abc')         → 'abc'   (rutSchema rechaza después)
+ */
+export function ensureRutHasDash(raw: string): string {
+  const trimmed = raw.trim().toUpperCase();
+  if (trimmed === '') {
+    return trimmed;
+  }
+  // Quitar puntos primero para simplificar.
+  const withoutDots = trimmed.replace(/\./g, '');
+  if (withoutDots.includes('-')) {
+    return withoutDots;
+  }
+  // Solo dígitos (+K opcional al final), longitud razonable de RUT (7-9).
+  if (/^\d{7,8}[\dK]$/.test(withoutDots)) {
+    return `${withoutDots.slice(0, -1)}-${withoutDots.slice(-1)}`;
+  }
+  return withoutDots;
+}
+
+/**
  * Formatea un RUT canónico (sin puntos) para display con separadores
  * de miles. Ej: "12345678-5" → "12.345.678-5".
  *

--- a/packages/shared-schemas/test/primitives/chile-rut.test.ts
+++ b/packages/shared-schemas/test/primitives/chile-rut.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { formatRutForDisplay, normalizeRut, rutSchema } from '../../src/primitives/chile.js';
+import {
+  ensureRutHasDash,
+  formatRutForDisplay,
+  normalizeRut,
+  rutSchema,
+} from '../../src/primitives/chile.js';
 
 describe('normalizeRut', () => {
   it('quita puntos manteniendo el guión', () => {
@@ -52,5 +57,49 @@ describe('rutSchema transform', () => {
 
   it('formato inválido → throw', () => {
     expect(() => rutSchema.parse('no-es-rut')).toThrow();
+  });
+});
+
+describe('ensureRutHasDash', () => {
+  it('input sin guión (solo dígitos) → inserta guión antes del último', () => {
+    expect(ensureRutHasDash('111111111')).toBe('11111111-1');
+  });
+
+  it('input sin guión con K → inserta guión, uppercase', () => {
+    expect(ensureRutHasDash('12345670k')).toBe('12345670-K');
+  });
+
+  it('input ya con guión → no toca (sin puntos)', () => {
+    expect(ensureRutHasDash('11111111-1')).toBe('11111111-1');
+  });
+
+  it('input con puntos y guión → quita puntos', () => {
+    expect(ensureRutHasDash('11.111.111-1')).toBe('11111111-1');
+  });
+
+  it('input con puntos pero sin guión (solo dígitos) → quita puntos + inserta guión', () => {
+    expect(ensureRutHasDash('11.111.111.1')).toBe('11111111-1');
+  });
+
+  it('input demasiado corto → devuelve sin tocar (rutSchema rechazará luego)', () => {
+    expect(ensureRutHasDash('123')).toBe('123');
+  });
+
+  it('input vacío → vacío', () => {
+    expect(ensureRutHasDash('')).toBe('');
+  });
+
+  it('input con espacios → trim y formatea', () => {
+    expect(ensureRutHasDash('  111111111  ')).toBe('11111111-1');
+  });
+
+  it('idempotente (aplicar dos veces no cambia)', () => {
+    const once = ensureRutHasDash('111111111');
+    expect(ensureRutHasDash(once)).toBe(once);
+  });
+
+  it('integración con rutSchema: input sin guión + ensureRutHasDash pasa validación', () => {
+    const normalized = ensureRutHasDash('111111111');
+    expect(rutSchema.parse(normalized)).toBe('11111111-1');
   });
 });


### PR DESCRIPTION
## Bug reportado

Felipe: \"ayer crearon un generador de carga y luego intentaron ingresar y no podían ingresar con el rut ya que no permitía el guión\".

## Causa raíz

\`apps/web/src/components/login/LoginUniversal.tsx\` línea 327 usaba \`inputMode=\"numeric\"\` que en móvil (iOS/Android) muestra el **teclado numérico puro** — sin guión \`-\`, sin letras. El RUT chileno canónico requiere \`12345678-9\` (con guión) y opcionalmente \`K\` en el dígito verificador. El user no podía completar el formato y rutSchema rechazaba.

## Fix de 3 capas

### 1. Helper compartido `ensureRutHasDash(raw)` (packages/shared-schemas)

- Input \`12345678K\` → \`12345678-K\` (inserta guión + uppercase)
- Input \`12.345.678-9\` → \`12345678-9\` (normaliza puntos)
- Input \`12345678-9\` → \`12345678-9\` (idempotente)
- Input corto/vacío → devuelve tal cual (rutSchema rechaza después con mensaje claro)
- **10 tests nuevos** cubriendo todos los edge cases

### 2. LoginUniversal.tsx — el bug original

- \`inputMode=\"numeric\"\` → \`inputMode=\"text\"\` (permite teclado completo en móvil)
- Pre-procesa con \`ensureRutHasDash\` antes de \`rutSchema.safeParse\`
- Placeholder educativo: \"12.345.678-9 (también 123456789 funciona)\"

### 3. login-conductor.tsx + OnboardingForm.tsx — robustez

- \`login-conductor.tsx\`: pre-procesa con helper antes del schema
- \`OnboardingForm.tsx\`: agrega \`onBlur\` en \`register('user.rut', 'empresa.rut')\` que auto-formatea antes de que zodResolver valide
- Hints actualizados: \"Acepta con o sin puntos y con o sin guión\"

## Validación

\`\`\`
$ pnpm --filter=@booster-ai/shared-schemas vitest run chile-rut.test.ts → 21/21 ✅
$ pnpm --filter=@booster-ai/web typecheck                              → 0 errors
$ pnpm exec biome check ...                                            → clean
\`\`\`

## Compatibilidad

- **Idempotente**: inputs bien formateados quedan intactos
- **rutSchema sin cambios**: validación canónica final (DV check) sigue siendo la misma
- **Cero breaking**: agrega tolerancia al input, no quita validación

## Smoke post-deploy (TODO)

1. Validar `POST /auth/login-rut` con body `{rut:'111111111',clave:'000000'}` (sin guión) → debe pasar validación frontend y llegar al backend que NO acepta sin guión — entonces el helper debe convertirlo a `11111111-1` antes del POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)