### PR TITLE
fix(rut): aplicar ensureRutHasDash en profile + conductores (consistencia UX)

### DIFF
--- a/apps/web/src/components/profile/ProfileForm.tsx
+++ b/apps/web/src/components/profile/ProfileForm.tsx
@@ -1,4 +1,9 @@
-import { type ProfileUpdateInput, chileanPhoneSchema, rutSchema } from '@booster-ai/shared-schemas';
+import {
+  type ProfileUpdateInput,
+  chileanPhoneSchema,
+  ensureRutHasDash,
+  rutSchema,
+} from '@booster-ai/shared-schemas';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Check, Save } from 'lucide-react';
 import { useState } from 'react';
@@ -51,7 +56,9 @@ const profileFormSchema = z.object({
       (v) => v === '' || chileanPhoneSchema.safeParse(v).success,
       'Número de teléfono Chile inválido',
     ),
-  rut: z.string().refine((v) => v === '' || rutSchema.safeParse(v).success, 'RUT inválido'),
+  rut: z
+    .string()
+    .refine((v) => v === '' || rutSchema.safeParse(ensureRutHasDash(v)).success, 'RUT inválido'),
 });
 
 type ProfileFormValues = z.infer<typeof profileFormSchema>;
@@ -108,7 +115,9 @@ export function ProfileForm({ initial }: ProfileFormProps) {
       }
     }
     if (dirtyFields.rut && values.rut !== '' && initial.rut === null) {
-      const parsed = rutSchema.safeParse(values.rut);
+      // ensureRutHasDash: si user tipeó solo dígitos (teclado móvil),
+      // insertar guión antes del DV. Idempotente para input correcto.
+      const parsed = rutSchema.safeParse(ensureRutHasDash(values.rut));
       if (parsed.success) {
         patch.rut = parsed.data;
       }

--- a/apps/web/src/routes/conductores.tsx
+++ b/apps/web/src/routes/conductores.tsx
@@ -1,4 +1,4 @@
-import { rutSchema } from '@booster-ai/shared-schemas';
+import { ensureRutHasDash, rutSchema } from '@booster-ai/shared-schemas';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Link, useNavigate, useParams } from '@tanstack/react-router';
 import {
@@ -482,14 +482,18 @@ function ConductoresNuevoPage({ me }: { me: MeOnboarded }) {
   useScrollToFirstError(errors, submitCount);
 
   function onSubmit(values: NewConductorForm) {
-    const rutResult = rutSchema.safeParse(values.rut);
+    // ensureRutHasDash: si el operador tipea solo dígitos (teclado
+    // móvil bloquea `-`), normalizar antes de validar. Persistir el
+    // canónico en el mutate.
+    const rutWithDash = ensureRutHasDash(values.rut);
+    const rutResult = rutSchema.safeParse(rutWithDash);
     if (!rutResult.success) {
       const message = rutResult.error.issues[0]?.message ?? 'RUT inválido';
       setFieldError('rut', { type: 'manual', message });
       return;
     }
     setError(null);
-    createM.mutate(values);
+    createM.mutate({ ...values, rut: rutResult.data });
   }
 
   if (activationResult) {


### PR DESCRIPTION
Follow-up del PR #221. Auditoría detectó 2 surfaces más donde el RUT NO pasaba por el helper antes de validar:

1. `apps/web/src/components/profile/ProfileForm.tsx` — edición de perfil del user logueado.
2. `apps/web/src/routes/conductores.tsx` — crear conductor nuevo (carrier).

Ambos usaban `inputMode="text"` ya (no bloqueaban tipeo en móvil), pero si el user solo tipeaba dígitos, el `rutSchema.safeParse` rechazaba.

## Fix

Por consistencia UX (todos los RUT inputs aceptan ambos formatos):

- `ProfileForm`: refine + onSubmit aplican `ensureRutHasDash` antes del schema.
- `conductores.tsx`: onSubmit normaliza y persiste el canónico (`rutResult.data`) en el mutate.

Idempotente. Cero cambios al `rutSchema` canónico.

## Validación

```
pnpm --filter=@booster-ai/web typecheck → 0 errors
biome check → clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)