### PR TITLE
feat(observability): dashboard platform-admin con costos GCP + Twilio + Workspace + salud + histórico mensual

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -43,6 +43,7 @@
     "drizzle-orm": "^0.45.2",
     "firebase-admin": "^13.7.0",
     "google-auth-library": "^10.6.2",
+    "googleapis": "^171.4.0",
     "hono": "^4.12.18",
     "ioredis": "^5.4.2",
     "node-forge": "^1.3.1",

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -456,6 +456,59 @@ const apiEnvSchema = commonEnvSchema
     DEMO_MODE_ACTIVATED: booleanFlag(false),
 
     /**
+     * Dashboard de observabilidad (`/app/platform-admin/observability`).
+     *
+     * Cuando true: el router `/admin/observability/*` está activo y la UI
+     * muestra la sección en sidebar. Cuando false: endpoints retornan
+     * 503 `feature_disabled` y la UI oculta el link.
+     *
+     * Default: true (decisión PO 2026-05-13). El flag existe para rollback
+     * rápido si algo sale mal post-deploy.
+     */
+    OBSERVABILITY_DASHBOARD_ACTIVATED: booleanFlag(true),
+
+    /**
+     * BigQuery dataset que contiene el billing export.
+     * Formato `{project}.{dataset}.{table_prefix}`. La tabla específica
+     * (`gcp_billing_export_v1_*`) se infiere del billing account id.
+     *
+     * Habilitado 2026-05-13 vía consola Cloud Billing → Export. Datos
+     * empiezan a propagar ~24-48h post-habilitación.
+     */
+    BILLING_EXPORT_TABLE: z
+      .string()
+      .default('booster-ai-494222.billing_export.gcp_billing_export_v1_019461_C73CDE_DCE377'),
+
+    /**
+     * Dominio Google Workspace gestionado por Booster. Usado por el
+     * Admin SDK (Domain-Wide Delegation) para listar seats + licenses.
+     *
+     * Vacío → tab "Workspace" del dashboard muestra "no configurado".
+     */
+    GOOGLE_WORKSPACE_DOMAIN: z.string().default(''),
+
+    /**
+     * Precios USD/mes/seat de planes Google Workspace. Google NO expone
+     * estos precios via API; el PO los actualiza vía Terraform var cuando
+     * Google los cambia. El dashboard multiplica seats × precio.
+     *
+     * Defaults a 2026-Q2 list price (Business Starter $6, Standard $12,
+     * Plus $18, Enterprise $30). Ajustar si hay descuento contractual.
+     */
+    GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STARTER: z.coerce.number().default(6),
+    GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STANDARD: z.coerce.number().default(12),
+    GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_PLUS: z.coerce.number().default(18),
+    GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_ENTERPRISE: z.coerce.number().default(30),
+
+    /**
+     * Budget USD/mes contra el cual se compara el spend del mes en curso.
+     * Visible como barra de progreso en el tab Forecast del dashboard.
+     * Default $1000/mes — overrideable via Terraform var.monthly_budget_usd
+     * que ya existe en variables.tf desde ADR-034.
+     */
+    MONTHLY_BUDGET_USD: z.coerce.number().default(1000),
+
+    /**
      * ADR-033 §1 — Pesos custom para los componentes del scoring v2.
      * JSON con shape `{ capacidad: number; backhaul: number;
      * reputacion: number; tier: number }`. Suma debe ser ≈ 1.0

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -488,6 +488,23 @@ const apiEnvSchema = commonEnvSchema
     GOOGLE_WORKSPACE_DOMAIN: z.string().default(''),
 
     /**
+     * Email del admin del Workspace que se impersona via Domain-Wide
+     * Delegation para llamar al Admin SDK. Required cuando
+     * GOOGLE_WORKSPACE_DOMAIN está seteado — sin esto la SA no puede
+     * actuar en nombre del dominio. Default vacío → adapter no se carga
+     * y la tab Workspace muestra "available=false".
+     */
+    GOOGLE_WORKSPACE_IMPERSONATE_EMAIL: z.string().default(''),
+
+    /**
+     * Contenido JSON del SA key de `observability-workspace-reader`.
+     * En Cloud Run viene del secret `google-workspace-admin-credentials`
+     * inyectado como env var (mismo patrón que TWILIO_*). En dev local
+     * puede dejarse vacío y el adapter degrada a `available: false`.
+     */
+    GOOGLE_WORKSPACE_CREDENTIALS_JSON: z.string().default(''),
+
+    /**
      * Precios USD/mes/seat de planes Google Workspace. Google NO expone
      * estos precios via API; el PO los actualiza vía Terraform var cuando
      * Google los cambia. El dashboard multiplica seats × precio.

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -497,12 +497,12 @@ const apiEnvSchema = commonEnvSchema
     GOOGLE_WORKSPACE_IMPERSONATE_EMAIL: z.string().default(''),
 
     /**
-     * Contenido JSON del SA key de `observability-workspace-reader`.
-     * En Cloud Run viene del secret `google-workspace-admin-credentials`
-     * inyectado como env var (mismo patrón que TWILIO_*). En dev local
-     * puede dejarse vacío y el adapter degrada a `available: false`.
+     * Email completo del SA dedicado al Workspace reader. El SA del
+     * Cloud Run impersona esta SA via IAM Credentials `signJwt` (zero-
+     * key, cumple `iam.disableServiceAccountKeyCreation` org policy).
+     * Default vacío → adapter no se carga, UI degrada a "available=false".
      */
-    GOOGLE_WORKSPACE_CREDENTIALS_JSON: z.string().default(''),
+    GOOGLE_WORKSPACE_READER_SA_EMAIL: z.string().default(''),
 
     /**
      * Precios USD/mes/seat de planes Google Workspace. Google NO expone

--- a/apps/api/src/middleware/require-platform-admin.ts
+++ b/apps/api/src/middleware/require-platform-admin.ts
@@ -1,0 +1,78 @@
+import type { Context } from 'hono';
+import { config as appConfig } from '../config.js';
+import type { UserContext } from '../services/user-context.js';
+
+/**
+ * Middleware guard para endpoints `/admin/*` reservados a operadores
+ * Booster (no admins de empresa). Allowlist en
+ * `BOOSTER_PLATFORM_ADMIN_EMAILS` (CSV configurado via Terraform var).
+ *
+ * Patrón originalmente inline en `routes/admin-cobra-hoy.ts` +
+ * `routes/admin-matching-backtest.ts` + `routes/admin-stakeholder-orgs.ts`.
+ * Extraído aquí para DRY al sumar `routes/admin-observability.ts` (spec
+ * 2026-05-13).
+ *
+ * **Patrón de uso** (return-tagged-union, no throws):
+ * ```typescript
+ * app.get('/some/admin/endpoint', async (c) => {
+ *   const auth = requirePlatformAdmin(c, { featureFlag: appConfig.FOO_ACTIVATED });
+ *   if (!auth.ok) {
+ *     return auth.response;
+ *   }
+ *   // auth.userContext + auth.adminEmail disponibles
+ * });
+ * ```
+ *
+ * Respuestas:
+ * - 503 `feature_disabled` si `featureFlag` se pasó y es false
+ * - 401 `unauthorized` si no hay user context (Firebase auth missing)
+ * - 403 `forbidden_platform_admin` si email NO está en allowlist
+ */
+
+interface RequirePlatformAdminSuccess {
+  ok: true;
+  userContext: UserContext;
+  adminEmail: string;
+}
+
+interface RequirePlatformAdminFailure {
+  ok: false;
+  response: Response;
+}
+
+type RequirePlatformAdminResult = RequirePlatformAdminSuccess | RequirePlatformAdminFailure;
+
+export interface RequirePlatformAdminOpts {
+  /**
+   * Si está presente y es `false`, el guard responde 503 `feature_disabled`
+   * antes de chequear auth. Útil para features con kill-switch.
+   * Si está ausente, el guard solo valida auth + allowlist.
+   */
+  featureFlag?: boolean;
+}
+
+export function requirePlatformAdmin(
+  // biome-ignore lint/suspicious/noExplicitAny: hono Context genéricos.
+  c: Context<any, any, any>,
+  opts: RequirePlatformAdminOpts = {},
+): RequirePlatformAdminResult {
+  if (opts.featureFlag === false) {
+    return {
+      ok: false,
+      response: c.json({ error: 'feature_disabled' }, 503),
+    };
+  }
+  const userContext = c.get('userContext') as UserContext | undefined;
+  if (!userContext) {
+    return { ok: false, response: c.json({ error: 'unauthorized' }, 401) };
+  }
+  const email = userContext.user.email?.toLowerCase();
+  const allowlist = appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS;
+  if (!email || !allowlist.includes(email)) {
+    return {
+      ok: false,
+      response: c.json({ error: 'forbidden_platform_admin' }, 403),
+    };
+  }
+  return { ok: true, userContext, adminEmail: email };
+}

--- a/apps/api/src/routes/admin-observability.ts
+++ b/apps/api/src/routes/admin-observability.ts
@@ -1,0 +1,282 @@
+import type { Logger } from '@booster-ai/logger';
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { requirePlatformAdmin } from '../middleware/require-platform-admin.js';
+import type { CostsService } from '../services/observability/costs-service.js';
+import type { ForecastService } from '../services/observability/forecast-service.js';
+import type { FxRateService } from '../services/observability/fx-rate-service.js';
+import type { HealthChecksService } from '../services/observability/health-checks-service.js';
+import type { MonitoringService } from '../services/observability/monitoring-service.js';
+import type { TwilioUsageService } from '../services/observability/twilio-usage-service.js';
+import type { WorkspaceService } from '../services/observability/workspace-service.js';
+
+/**
+ * Router /admin/observability/* — dashboard de observabilidad para
+ * platform-admin Booster (spec 2026-05-13).
+ *
+ * Auth: BOOSTER_PLATFORM_ADMIN_EMAILS allowlist (via requirePlatformAdmin).
+ * Feature flag: OBSERVABILITY_DASHBOARD_ACTIVATED. Si false → 503 antes
+ * de tocar BigQuery o cualquier API externa (kill-switch).
+ *
+ * Endpoints (11):
+ *   GET /health                  — composite snapshot (uptime + run + sql)
+ *   GET /costs/overview          — MTD + previous month + delta% (CLP)
+ *   GET /costs/by-service?days=N — breakdown por servicio GCP
+ *   GET /costs/by-project?days=N — breakdown por GCP project
+ *   GET /costs/trend?days=N      — serie diaria
+ *   GET /costs/top-skus?limit=N  — top SKUs del mes
+ *   GET /usage/cloud-run         — latencia + CPU + RAM + RPS
+ *   GET /usage/cloud-sql         — CPU + RAM + disco + ratio conexiones
+ *   GET /usage/twilio            — balance + top categorías
+ *   GET /usage/workspace         — seats + costo mensual (DWD requerido)
+ *   GET /forecast                — extrapolación fin de mes vs budget
+ */
+
+const rangeQuerySchema = z.object({
+  days: z.coerce.number().int().min(1).max(90).default(30),
+});
+const limitQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+export interface AdminObservabilityRoutesOpts {
+  costsService: CostsService;
+  monitoringService: MonitoringService;
+  /** null si las credentials de Twilio no están configuradas. */
+  twilioUsageService: TwilioUsageService | null;
+  workspaceService: WorkspaceService;
+  forecastService: ForecastService;
+  healthChecksService: HealthChecksService;
+  fxRateService: FxRateService;
+  monthlyBudgetUsd: number;
+  /** OBSERVABILITY_DASHBOARD_ACTIVATED. */
+  featureFlag: boolean;
+  logger: Logger;
+}
+
+export function createAdminObservabilityRoutes(opts: AdminObservabilityRoutesOpts) {
+  const app = new Hono();
+  const guard = () => ({ featureFlag: opts.featureFlag });
+
+  app.get('/health', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    try {
+      const snapshot = await opts.healthChecksService.getSnapshot();
+      return c.json(snapshot);
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err), adminEmail: auth.adminEmail },
+        'admin/observability/health failed',
+      );
+      return c.json({ error: 'internal_error' }, 500);
+    }
+  });
+
+  app.get('/costs/overview', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    try {
+      const result = await opts.costsService.getOverview();
+      return c.json(result);
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/costs/overview failed',
+      );
+      return c.json({ error: 'costs_unavailable' }, 502);
+    }
+  });
+
+  app.get('/costs/by-service', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const parsed = rangeQuerySchema.safeParse({ days: c.req.query('days') });
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_query', details: parsed.error.flatten() }, 400);
+    }
+    try {
+      const result = await opts.costsService.getByService(parsed.data.days);
+      return c.json({ days: parsed.data.days, items: result });
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/costs/by-service failed',
+      );
+      return c.json({ error: 'costs_unavailable' }, 502);
+    }
+  });
+
+  app.get('/costs/by-project', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const parsed = rangeQuerySchema.safeParse({ days: c.req.query('days') });
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_query', details: parsed.error.flatten() }, 400);
+    }
+    try {
+      const result = await opts.costsService.getByProject(parsed.data.days);
+      return c.json({ days: parsed.data.days, items: result });
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/costs/by-project failed',
+      );
+      return c.json({ error: 'costs_unavailable' }, 502);
+    }
+  });
+
+  app.get('/costs/trend', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const parsed = rangeQuerySchema.safeParse({ days: c.req.query('days') });
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_query', details: parsed.error.flatten() }, 400);
+    }
+    try {
+      const result = await opts.costsService.getTrend(parsed.data.days);
+      return c.json({ days: parsed.data.days, points: result });
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/costs/trend failed',
+      );
+      return c.json({ error: 'costs_unavailable' }, 502);
+    }
+  });
+
+  app.get('/costs/top-skus', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const parsed = limitQuerySchema.safeParse({ limit: c.req.query('limit') });
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_query', details: parsed.error.flatten() }, 400);
+    }
+    try {
+      const result = await opts.costsService.getTopSkus(parsed.data.limit);
+      return c.json({ limit: parsed.data.limit, items: result });
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/costs/top-skus failed',
+      );
+      return c.json({ error: 'costs_unavailable' }, 502);
+    }
+  });
+
+  app.get('/usage/cloud-run', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    try {
+      const result = await opts.monitoringService.getCloudRunMetrics();
+      return c.json(result);
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/usage/cloud-run failed',
+      );
+      return c.json({ error: 'monitoring_unavailable' }, 502);
+    }
+  });
+
+  app.get('/usage/cloud-sql', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    try {
+      const result = await opts.monitoringService.getCloudSqlMetrics();
+      return c.json(result);
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/usage/cloud-sql failed',
+      );
+      return c.json({ error: 'monitoring_unavailable' }, 502);
+    }
+  });
+
+  app.get('/usage/twilio', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    if (!opts.twilioUsageService) {
+      return c.json({ available: false, reason: 'twilio_credentials_not_configured' });
+    }
+    try {
+      const [balance, usage] = await Promise.all([
+        opts.twilioUsageService.getBalance(),
+        opts.twilioUsageService.getMonthToDateUsage(),
+      ]);
+      return c.json({ available: true, balance, usage });
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/usage/twilio failed',
+      );
+      return c.json({ error: 'twilio_unavailable' }, 502);
+    }
+  });
+
+  app.get('/usage/workspace', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    try {
+      const result = await opts.workspaceService.getUsageSnapshot();
+      return c.json(result);
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/usage/workspace failed',
+      );
+      return c.json({ available: false, reason: 'internal_error' });
+    }
+  });
+
+  app.get('/forecast', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    try {
+      const [overview, fx] = await Promise.all([
+        opts.costsService.getOverview(),
+        opts.fxRateService.getCurrentRate(),
+      ]);
+      const forecast = opts.forecastService.forecast({
+        mtdCostClp: overview.costClpMonthToDate,
+        budgetUsd: opts.monthlyBudgetUsd,
+        clpPerUsd: fx.clpPerUsd,
+      });
+      return c.json({
+        ...forecast,
+        currentRate: fx,
+      });
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/forecast failed',
+      );
+      return c.json({ error: 'forecast_unavailable' }, 502);
+    }
+  });
+
+  return app;
+}

--- a/apps/api/src/routes/admin-observability.ts
+++ b/apps/api/src/routes/admin-observability.ts
@@ -18,18 +18,19 @@ import type { WorkspaceService } from '../services/observability/workspace-servi
  * Feature flag: OBSERVABILITY_DASHBOARD_ACTIVATED. Si false → 503 antes
  * de tocar BigQuery o cualquier API externa (kill-switch).
  *
- * Endpoints (11):
- *   GET /health                  — composite snapshot (uptime + run + sql)
- *   GET /costs/overview          — MTD + previous month + delta% (CLP)
- *   GET /costs/by-service?days=N — breakdown por servicio GCP
- *   GET /costs/by-project?days=N — breakdown por GCP project
- *   GET /costs/trend?days=N      — serie diaria
- *   GET /costs/top-skus?limit=N  — top SKUs del mes
- *   GET /usage/cloud-run         — latencia + CPU + RAM + RPS
- *   GET /usage/cloud-sql         — CPU + RAM + disco + ratio conexiones
- *   GET /usage/twilio            — balance + top categorías
- *   GET /usage/workspace         — seats + costo mensual (DWD requerido)
- *   GET /forecast                — extrapolación fin de mes vs budget
+ * Endpoints (12):
+ *   GET /health                       — composite snapshot (uptime + run + sql)
+ *   GET /costs/overview               — MTD + delta% apples-to-apples
+ *   GET /costs/by-service?days=N      — breakdown por servicio GCP
+ *   GET /costs/by-project?days=N      — breakdown por GCP project
+ *   GET /costs/trend?days=N           — serie diaria
+ *   GET /costs/top-skus?limit=N       — top SKUs del mes
+ *   GET /costs/monthly-history?months=N — histórico mensual hasta 24 meses
+ *   GET /usage/cloud-run              — latencia + CPU + RAM + RPS
+ *   GET /usage/cloud-sql              — CPU + RAM + disco + ratio conexiones
+ *   GET /usage/twilio                 — balance + top categorías
+ *   GET /usage/workspace              — seats + costo mensual (DWD requerido)
+ *   GET /forecast                     — extrapolación fin de mes vs budget
  */
 
 const rangeQuerySchema = z.object({
@@ -37,6 +38,10 @@ const rangeQuerySchema = z.object({
 });
 const limitQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(50).default(10),
+});
+
+const monthsQuerySchema = z.object({
+  months: z.coerce.number().int().min(1).max(24).default(12),
 });
 
 export interface AdminObservabilityRoutesOpts {
@@ -171,6 +176,27 @@ export function createAdminObservabilityRoutes(opts: AdminObservabilityRoutesOpt
       opts.logger.error(
         { err: err instanceof Error ? err.message : String(err) },
         'admin/observability/costs/top-skus failed',
+      );
+      return c.json({ error: 'costs_unavailable' }, 502);
+    }
+  });
+
+  app.get('/costs/monthly-history', async (c) => {
+    const auth = requirePlatformAdmin(c, guard());
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const parsed = monthsQuerySchema.safeParse({ months: c.req.query('months') });
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_query', details: parsed.error.flatten() }, 400);
+    }
+    try {
+      const items = await opts.costsService.getMonthlyHistory(parsed.data.months);
+      return c.json({ months: parsed.data.months, items });
+    } catch (err) {
+      opts.logger.error(
+        { err: err instanceof Error ? err.message : String(err) },
+        'admin/observability/costs/monthly-history failed',
       );
       return c.json({ error: 'costs_unavailable' }, 502);
     }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -14,6 +14,7 @@ import { createAdminDispositivosRoutes } from './routes/admin-dispositivos.js';
 import { createAdminJobsRoutes } from './routes/admin-jobs.js';
 import { createAdminLiquidacionesRoutes } from './routes/admin-liquidaciones.js';
 import { createAdminMatchingBacktestRoutes } from './routes/admin-matching-backtest.js';
+import { createAdminObservabilityRoutes } from './routes/admin-observability.js';
 import { createAdminSeedRoutes } from './routes/admin-seed.js';
 import { createAdminStakeholderOrgsRoutes } from './routes/admin-stakeholder-orgs.js';
 import { createAssignmentsRoutes } from './routes/assignments.js';
@@ -45,6 +46,7 @@ import { createVehiculosRoutes } from './routes/vehiculos.js';
 import { createMePushSubscriptionRoutes, createWebpushPublicRoutes } from './routes/webpush.js';
 import type { NotifyOfferDeps } from './services/notify-offer.js';
 import type { NotifyTrackingLinkDeps } from './services/notify-tracking-link.js';
+import { buildObservabilityServices } from './services/observability/factory.js';
 import { configureWebPush } from './services/web-push.js';
 
 export interface CreateServerOptions {
@@ -409,6 +411,43 @@ export function createServer(opts: CreateServerOptions): Hono {
     app.use('/admin/matching/*', firebaseAuthMiddleware);
     app.use('/admin/matching/*', userContextMiddleware);
     app.route('/admin/matching', createAdminMatchingBacktestRoutes({ db: opts.db, logger }));
+
+    // Spec 2026-05-13 — Admin platform-wide observability dashboard
+    // (costos GCP + Twilio + Workspace + uptime + capacity + forecast).
+    // Auth idem otros admin/*. Feature flag OBSERVABILITY_DASHBOARD_ACTIVATED.
+    const observability = buildObservabilityServices(
+      {
+        redisHost: config.REDIS_HOST,
+        redisPort: config.REDIS_PORT,
+        ...(config.REDIS_PASSWORD ? { redisPassword: config.REDIS_PASSWORD } : {}),
+        redisTls: config.REDIS_TLS,
+        billingExportTable: config.BILLING_EXPORT_TABLE,
+        gcpProjectId: config.GOOGLE_CLOUD_PROJECT ?? 'booster-ai-494222',
+        ...(config.TWILIO_ACCOUNT_SID ? { twilioAccountSid: config.TWILIO_ACCOUNT_SID } : {}),
+        ...(config.TWILIO_AUTH_TOKEN ? { twilioAuthToken: config.TWILIO_AUTH_TOKEN } : {}),
+        workspaceDomain: config.GOOGLE_WORKSPACE_DOMAIN,
+        workspaceImpersonateEmail: config.GOOGLE_WORKSPACE_IMPERSONATE_EMAIL,
+        workspaceCredentialsJson: config.GOOGLE_WORKSPACE_CREDENTIALS_JSON,
+        workspacePriceMap: {
+          starter: config.GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STARTER,
+          standard: config.GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STANDARD,
+          plus: config.GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_PLUS,
+          enterprise: config.GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_ENTERPRISE,
+        },
+        monthlyBudgetUsd: config.MONTHLY_BUDGET_USD,
+        observabilityDashboardActivated: config.OBSERVABILITY_DASHBOARD_ACTIVATED,
+      },
+      logger,
+    );
+    app.use('/admin/observability/*', firebaseAuthMiddleware);
+    app.use('/admin/observability/*', userContextMiddleware);
+    app.route(
+      '/admin/observability',
+      createAdminObservabilityRoutes({
+        ...observability,
+        logger,
+      }),
+    );
 
     // Vehículos de la empresa activa.
     app.use('/vehiculos/*', firebaseAuthMiddleware);

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -427,7 +427,7 @@ export function createServer(opts: CreateServerOptions): Hono {
         ...(config.TWILIO_AUTH_TOKEN ? { twilioAuthToken: config.TWILIO_AUTH_TOKEN } : {}),
         workspaceDomain: config.GOOGLE_WORKSPACE_DOMAIN,
         workspaceImpersonateEmail: config.GOOGLE_WORKSPACE_IMPERSONATE_EMAIL,
-        workspaceCredentialsJson: config.GOOGLE_WORKSPACE_CREDENTIALS_JSON,
+        workspaceReaderSaEmail: config.GOOGLE_WORKSPACE_READER_SA_EMAIL,
         workspacePriceMap: {
           starter: config.GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STARTER,
           standard: config.GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STANDARD,

--- a/apps/api/src/services/observability/cache.ts
+++ b/apps/api/src/services/observability/cache.ts
@@ -1,0 +1,126 @@
+import type { Logger } from '@booster-ai/logger';
+import Redis from 'ioredis';
+
+/**
+ * Wrapper Redis con TTL para cachear queries caras del Observability
+ * Dashboard (BigQuery $/query, Cloud Monitoring quota qpm, Twilio rate
+ * limits, Workspace SDK rate limits).
+ *
+ * Diseño:
+ * - Una sola instancia compartida por proceso. Reutiliza el Redis principal
+ *   (variables REDIS_HOST/PORT/PASSWORD/TLS del config).
+ * - Key prefix `obs:` para no colisionar con otros usos (chat realtime,
+ *   conversation store, rate-limit counters).
+ * - Valores serializados como JSON. TTL en segundos.
+ * - Fallthrough: si Redis cae o el value es corrupto, llama al fetcher
+ *   directo y loggea WARN. NO crashea el endpoint.
+ *
+ * Patrón de uso:
+ * ```typescript
+ * const data = await cache.getOrFetch(
+ *   'costs:overview',
+ *   300,  // 5 min TTL
+ *   () => fetchCostsFromBigQuery(...)
+ * );
+ * ```
+ */
+
+const KEY_PREFIX = 'obs:';
+
+export interface ObservabilityCacheOpts {
+  host: string;
+  port: number;
+  password?: string | undefined;
+  tls?: boolean | undefined;
+  logger: Logger;
+}
+
+export class ObservabilityCache {
+  private readonly redis: Redis;
+  private readonly logger: Logger;
+
+  constructor(opts: ObservabilityCacheOpts) {
+    this.logger = opts.logger;
+    this.redis = new Redis({
+      host: opts.host,
+      port: opts.port,
+      ...(opts.password ? { password: opts.password } : {}),
+      ...(opts.tls ? { tls: {} } : {}),
+      // No reintentos infinitos — si Redis cae, el cache "miss" se vuelve
+      // un fetch directo y seguimos. NO bloquear el endpoint.
+      maxRetriesPerRequest: 2,
+      // Conectar lazily al primer get/set; evita crashear el startup si
+      // Redis está temporariamente unavailable.
+      lazyConnect: true,
+    });
+
+    this.redis.on('error', (err) => {
+      // No spam: 1 log por minuto.
+      this.logger.warn({ err: err.message }, 'observability cache: Redis error');
+    });
+  }
+
+  /**
+   * Get-or-fetch pattern. Si el value está cacheado y no expiró,
+   * retorna. Si no, llama al fetcher y cachea por TTL segundos.
+   *
+   * @param key key sin prefix (se agrega `obs:` internamente).
+   * @param ttlSeconds tiempo de vida en cache.
+   * @param fetcher función async que produce el valor si miss.
+   */
+  async getOrFetch<T>(key: string, ttlSeconds: number, fetcher: () => Promise<T>): Promise<T> {
+    const fullKey = `${KEY_PREFIX}${key}`;
+    try {
+      const cached = await this.redis.get(fullKey);
+      if (cached !== null) {
+        try {
+          return JSON.parse(cached) as T;
+        } catch (err) {
+          this.logger.warn(
+            { key, err: err instanceof Error ? err.message : String(err) },
+            'observability cache: invalid JSON, refetching',
+          );
+        }
+      }
+    } catch (err) {
+      this.logger.warn(
+        { key, err: err instanceof Error ? err.message : String(err) },
+        'observability cache: Redis get failed, fetching direct',
+      );
+    }
+
+    // Miss o error → fetch + intent de cachear (no bloquea el response)
+    const value = await fetcher();
+    // Fire-and-forget set; no esperamos el ACK del Redis.
+    this.redis.set(fullKey, JSON.stringify(value), 'EX', ttlSeconds).catch((err) => {
+      this.logger.warn(
+        { key, err: err instanceof Error ? err.message : String(err) },
+        'observability cache: Redis set failed (value still returned)',
+      );
+    });
+    return value;
+  }
+
+  /**
+   * Invalida una key (forzar fresh fetch en el próximo getOrFetch).
+   * Útil para tests o admin endpoint de "reset cache".
+   */
+  async invalidate(key: string): Promise<void> {
+    const fullKey = `${KEY_PREFIX}${key}`;
+    try {
+      await this.redis.del(fullKey);
+    } catch (err) {
+      this.logger.warn(
+        { key, err: err instanceof Error ? err.message : String(err) },
+        'observability cache: invalidate failed (non-fatal)',
+      );
+    }
+  }
+
+  /**
+   * Cierra la conexión Redis. Solo en shutdown del proceso.
+   */
+  async close(): Promise<void> {
+    await this.redis.quit();
+  }
+}

--- a/apps/api/src/services/observability/costs-service.ts
+++ b/apps/api/src/services/observability/costs-service.ts
@@ -34,9 +34,22 @@ const QUERY_TIMEOUT_MS = 30_000;
 export interface CostsOverview {
   /** Costo acumulado del mes en curso (1-current day), en CLP. */
   costClpMonthToDate: number;
-  /** Costo del mes anterior completo, en CLP. */
+  /** Costo del mes anterior completo, en CLP. Solo contexto. */
   costClpPreviousMonth: number;
-  /** Δ% vs mes anterior (mismo periodo). null si no hay base. */
+  /**
+   * Costo del mes anterior considerando solo los mismos N días que llevamos
+   * en el mes actual (apples-to-apples). Si hoy es día 13 del mes, este es
+   * el costo del 1° al 13 del mes anterior. Usado para el delta% (más
+   * representativo que comparar contra mes-completo).
+   */
+  costClpPreviousMonthSamePeriod: number;
+  /**
+   * Δ% vs mismo periodo del mes anterior (apples-to-apples). Comparar
+   * mes-actual-parcial vs mes-anterior-completo genera la falsa lectura
+   * "siempre estamos gastando ~70% menos" temprano en el mes. Este delta
+   * usa `costClpPreviousMonthSamePeriod` y responde correctamente "voy
+   * gastando más o menos que el ritmo del mes anterior". null si no hay base.
+   */
   deltaPercentVsPreviousMonth: number | null;
   /** Última actualización del billing_export (UTC). */
   lastBillingExportAt: string | null;
@@ -128,39 +141,61 @@ export class CostsService {
 
   async getOverview(): Promise<CostsOverview> {
     return this.cache.getOrFetch('costs:overview', CACHE_TTL_OVERVIEW, async () => {
+      // Tres buckets en una sola query:
+      //   - thisMonthMtd: 1° del mes actual → hoy
+      //   - prevMonthSamePeriod: 1° del mes anterior → "mismo día del mes anterior"
+      //   - prevMonthFull: 1° del mes anterior → último día del mes anterior
+      // El "mismo día del mes anterior" se computa con DATE_SUB(...,
+      // INTERVAL 1 MONTH) que maneja casos límite (31→28/29 feb, 30→ene 30, etc).
       const sql = `
-        WITH base AS (
+        WITH dates AS (
           SELECT
-            DATE_TRUNC(DATE(usage_start_time, 'America/Santiago'), MONTH) AS month,
-            SUM(cost + IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0)) AS net_cost,
-            ANY_VALUE(currency) AS currency,
-            MAX(export_time) AS last_export
+            CURRENT_DATE('America/Santiago') AS today,
+            DATE_TRUNC(CURRENT_DATE('America/Santiago'), MONTH) AS this_month_start,
+            DATE_SUB(DATE_TRUNC(CURRENT_DATE('America/Santiago'), MONTH), INTERVAL 1 MONTH) AS prev_month_start,
+            DATE_SUB(DATE_TRUNC(CURRENT_DATE('America/Santiago'), MONTH), INTERVAL 1 DAY) AS prev_month_end,
+            DATE_SUB(CURRENT_DATE('America/Santiago'), INTERVAL 1 MONTH) AS prev_month_same_day
+        ),
+        rows AS (
+          SELECT
+            cost + IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0) AS net_cost,
+            currency,
+            export_time,
+            DATE(usage_start_time, 'America/Santiago') AS d
           FROM \`${this.billingExportTable}\`
           WHERE DATE(usage_start_time, 'America/Santiago')
-            >= DATE_TRUNC(CURRENT_DATE('America/Santiago'), MONTH) - INTERVAL 1 MONTH
-          GROUP BY month
+            >= (SELECT prev_month_start FROM dates)
+            AND DATE(usage_start_time, 'America/Santiago')
+            <= (SELECT today FROM dates)
         )
         SELECT
-          month,
-          net_cost,
-          currency,
-          last_export
-        FROM base
-        ORDER BY month DESC
+          SUM(IF(d >= (SELECT this_month_start FROM dates) AND d <= (SELECT today FROM dates), net_cost, 0)) AS this_month_mtd,
+          SUM(IF(d >= (SELECT prev_month_start FROM dates) AND d <= (SELECT prev_month_same_day FROM dates), net_cost, 0)) AS prev_month_same_period,
+          SUM(IF(d >= (SELECT prev_month_start FROM dates) AND d <= (SELECT prev_month_end FROM dates), net_cost, 0)) AS prev_month_full,
+          ANY_VALUE(currency) AS currency,
+          MAX(export_time) AS last_export
+        FROM rows
       `;
       const { rows, currency } = await this.runQuery(sql);
-      const thisMonth = Number.parseFloat(rows[0]?.[1] ?? '0');
-      const previousMonth = Number.parseFloat(rows[1]?.[1] ?? '0');
-      const lastExport = rows[0]?.[3] ?? null;
+      const thisMonthMtd = Number.parseFloat(rows[0]?.[0] ?? '0');
+      const prevMonthSamePeriod = Number.parseFloat(rows[0]?.[1] ?? '0');
+      const prevMonthFull = Number.parseFloat(rows[0]?.[2] ?? '0');
+      const lastExport = rows[0]?.[4] ?? null;
 
-      const thisMonthClp = await this.toClp(thisMonth, currency);
-      const previousMonthClp = await this.toClp(previousMonth, currency);
+      const thisMonthClp = await this.toClp(thisMonthMtd, currency);
+      const prevSamePeriodClp = await this.toClp(prevMonthSamePeriod, currency);
+      const prevFullClp = await this.toClp(prevMonthFull, currency);
+
+      // Delta apples-to-apples: mtd actual vs mismo periodo del mes anterior.
       const delta =
-        previousMonthClp > 0 ? ((thisMonthClp - previousMonthClp) / previousMonthClp) * 100 : null;
+        prevSamePeriodClp > 0
+          ? ((thisMonthClp - prevSamePeriodClp) / prevSamePeriodClp) * 100
+          : null;
 
       return {
         costClpMonthToDate: Math.round(thisMonthClp),
-        costClpPreviousMonth: Math.round(previousMonthClp),
+        costClpPreviousMonth: Math.round(prevFullClp),
+        costClpPreviousMonthSamePeriod: Math.round(prevSamePeriodClp),
         deltaPercentVsPreviousMonth: delta !== null ? Math.round(delta * 10) / 10 : null,
         lastBillingExportAt: lastExport,
       };

--- a/apps/api/src/services/observability/costs-service.ts
+++ b/apps/api/src/services/observability/costs-service.ts
@@ -1,0 +1,354 @@
+import type { Logger } from '@booster-ai/logger';
+import { GoogleAuth } from 'google-auth-library';
+import type { ObservabilityCache } from './cache.js';
+import type { FxRateService } from './fx-rate-service.js';
+
+/**
+ * Cliente BigQuery billing_export para el Observability Dashboard.
+ *
+ * No usa `@google-cloud/bigquery` (10MB+) — invoca el endpoint REST
+ * `bigquery.googleapis.com/bigquery/v2/projects/.../queries` directo
+ * con `fetch` + ADC, igual que `routes-api.ts`.
+ *
+ * Costos se reportan en la moneda nativa del billing account (CLP en
+ * Booster). Si la columna `currency` es USD, convierte vía FxRateService.
+ *
+ * Caching: 5 min TTL — billing_export se actualiza ~cada hora.
+ *
+ * Source schema: gcp_billing_export_v1 (standard schema):
+ *   - service.description (string)
+ *   - sku.description (string)
+ *   - project.id, project.name
+ *   - cost (numeric), currency (string)
+ *   - credits ARRAY<STRUCT<amount FLOAT64>>
+ *   - usage_start_time, usage_end_time (timestamp)
+ */
+
+const BQ_BASE_URL = 'https://bigquery.googleapis.com/bigquery/v2';
+const CACHE_TTL_OVERVIEW = 300; // 5 min
+const CACHE_TTL_BY_SERVICE = 300;
+const CACHE_TTL_TREND = 600; // 10 min — más estable
+const CACHE_TTL_BY_PROJECT = 300;
+const QUERY_TIMEOUT_MS = 30_000;
+
+export interface CostsOverview {
+  /** Costo acumulado del mes en curso (1-current day), en CLP. */
+  costClpMonthToDate: number;
+  /** Costo del mes anterior completo, en CLP. */
+  costClpPreviousMonth: number;
+  /** Δ% vs mes anterior (mismo periodo). null si no hay base. */
+  deltaPercentVsPreviousMonth: number | null;
+  /** Última actualización del billing_export (UTC). */
+  lastBillingExportAt: string | null;
+}
+
+export interface CostsByService {
+  /** Nombre del servicio GCP (e.g., "Cloud Run", "Cloud SQL"). */
+  service: string;
+  /** Costo total del rango, en CLP. */
+  costClp: number;
+  /** % del costo total del rango. */
+  percentOfTotal: number;
+}
+
+export interface CostsTrendPoint {
+  /** ISO date YYYY-MM-DD. */
+  date: string;
+  /** Costo del día en CLP (suma de todos los servicios + proyectos). */
+  costClp: number;
+}
+
+export interface CostsByProject {
+  projectId: string;
+  projectName: string | null;
+  costClp: number;
+  percentOfTotal: number;
+}
+
+export interface TopSku {
+  service: string;
+  sku: string;
+  costClp: number;
+}
+
+export interface CostsServiceOpts {
+  cache: ObservabilityCache;
+  fxRateService: FxRateService;
+  logger: Logger;
+  /** Tabla fully-qualified: `project.dataset.gcp_billing_export_v1_XXXXX`. */
+  billingExportTable: string;
+  /** GCP project que ejecuta los queries (puede ser distinto del billing). */
+  queryProjectId: string;
+  /** Inyectable para tests. Default: global fetch. */
+  fetchImpl?: typeof fetch;
+  /** Inyectable para tests. Default: GoogleAuth ADC. */
+  getAccessToken?: () => Promise<string>;
+}
+
+interface BqQueryResponse {
+  jobComplete?: boolean;
+  rows?: Array<{ f: Array<{ v: string | null }> }>;
+  schema?: { fields: Array<{ name: string }> };
+  errors?: Array<{ message: string }>;
+}
+
+export class CostsService {
+  private readonly cache: ObservabilityCache;
+  private readonly fxRateService: FxRateService;
+  private readonly logger: Logger;
+  private readonly billingExportTable: string;
+  private readonly queryProjectId: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly getAccessToken: () => Promise<string>;
+
+  constructor(opts: CostsServiceOpts) {
+    this.cache = opts.cache;
+    this.fxRateService = opts.fxRateService;
+    this.logger = opts.logger;
+    this.billingExportTable = opts.billingExportTable;
+    this.queryProjectId = opts.queryProjectId;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+
+    if (opts.getAccessToken) {
+      this.getAccessToken = opts.getAccessToken;
+    } else {
+      const auth = new GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/bigquery.readonly'],
+      });
+      this.getAccessToken = async () => {
+        const client = await auth.getClient();
+        const token = await client.getAccessToken();
+        if (!token.token) {
+          throw new Error('BigQuery: failed to obtain access token from ADC');
+        }
+        return token.token;
+      };
+    }
+  }
+
+  async getOverview(): Promise<CostsOverview> {
+    return this.cache.getOrFetch('costs:overview', CACHE_TTL_OVERVIEW, async () => {
+      const sql = `
+        WITH base AS (
+          SELECT
+            DATE_TRUNC(DATE(usage_start_time, 'America/Santiago'), MONTH) AS month,
+            SUM(cost + IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0)) AS net_cost,
+            ANY_VALUE(currency) AS currency,
+            MAX(export_time) AS last_export
+          FROM \`${this.billingExportTable}\`
+          WHERE DATE(usage_start_time, 'America/Santiago')
+            >= DATE_TRUNC(CURRENT_DATE('America/Santiago'), MONTH) - INTERVAL 1 MONTH
+          GROUP BY month
+        )
+        SELECT
+          month,
+          net_cost,
+          currency,
+          last_export
+        FROM base
+        ORDER BY month DESC
+      `;
+      const { rows, currency } = await this.runQuery(sql);
+      const thisMonth = Number.parseFloat(rows[0]?.[1] ?? '0');
+      const previousMonth = Number.parseFloat(rows[1]?.[1] ?? '0');
+      const lastExport = rows[0]?.[3] ?? null;
+
+      const thisMonthClp = await this.toClp(thisMonth, currency);
+      const previousMonthClp = await this.toClp(previousMonth, currency);
+      const delta =
+        previousMonthClp > 0 ? ((thisMonthClp - previousMonthClp) / previousMonthClp) * 100 : null;
+
+      return {
+        costClpMonthToDate: Math.round(thisMonthClp),
+        costClpPreviousMonth: Math.round(previousMonthClp),
+        deltaPercentVsPreviousMonth: delta !== null ? Math.round(delta * 10) / 10 : null,
+        lastBillingExportAt: lastExport,
+      };
+    });
+  }
+
+  async getByService(rangeDays: number): Promise<CostsByService[]> {
+    const clamped = this.clampRangeDays(rangeDays);
+    return this.cache.getOrFetch(`costs:by-service:${clamped}`, CACHE_TTL_BY_SERVICE, async () => {
+      const sql = `
+          SELECT
+            service.description AS service,
+            SUM(cost + IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0)) AS net_cost,
+            ANY_VALUE(currency) AS currency
+          FROM \`${this.billingExportTable}\`
+          WHERE DATE(usage_start_time, 'America/Santiago')
+            >= DATE_SUB(CURRENT_DATE('America/Santiago'), INTERVAL ${clamped} DAY)
+          GROUP BY service
+          HAVING net_cost > 0
+          ORDER BY net_cost DESC
+          LIMIT 20
+        `;
+      const { rows, currency } = await this.runQuery(sql);
+      const items = await Promise.all(
+        rows.map(async (r) => ({
+          service: r[0] ?? 'Unknown',
+          costClp: Math.round(await this.toClp(Number.parseFloat(r[1] ?? '0'), currency)),
+        })),
+      );
+      const total = items.reduce((s, i) => s + i.costClp, 0);
+      return items.map((i) => ({
+        ...i,
+        percentOfTotal: total > 0 ? Math.round((i.costClp / total) * 1000) / 10 : 0,
+      }));
+    });
+  }
+
+  async getTrend(rangeDays: number): Promise<CostsTrendPoint[]> {
+    const clamped = this.clampRangeDays(rangeDays);
+    return this.cache.getOrFetch(`costs:trend:${clamped}`, CACHE_TTL_TREND, async () => {
+      const sql = `
+        SELECT
+          FORMAT_DATE('%Y-%m-%d', DATE(usage_start_time, 'America/Santiago')) AS day,
+          SUM(cost + IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0)) AS net_cost,
+          ANY_VALUE(currency) AS currency
+        FROM \`${this.billingExportTable}\`
+        WHERE DATE(usage_start_time, 'America/Santiago')
+          >= DATE_SUB(CURRENT_DATE('America/Santiago'), INTERVAL ${clamped} DAY)
+        GROUP BY day
+        ORDER BY day ASC
+      `;
+      const { rows, currency } = await this.runQuery(sql);
+      return Promise.all(
+        rows.map(async (r) => ({
+          date: r[0] ?? '',
+          costClp: Math.round(await this.toClp(Number.parseFloat(r[1] ?? '0'), currency)),
+        })),
+      );
+    });
+  }
+
+  async getByProject(rangeDays: number): Promise<CostsByProject[]> {
+    const clamped = this.clampRangeDays(rangeDays);
+    return this.cache.getOrFetch(`costs:by-project:${clamped}`, CACHE_TTL_BY_PROJECT, async () => {
+      const sql = `
+          SELECT
+            project.id AS project_id,
+            ANY_VALUE(project.name) AS project_name,
+            SUM(cost + IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0)) AS net_cost,
+            ANY_VALUE(currency) AS currency
+          FROM \`${this.billingExportTable}\`
+          WHERE DATE(usage_start_time, 'America/Santiago')
+            >= DATE_SUB(CURRENT_DATE('America/Santiago'), INTERVAL ${clamped} DAY)
+            AND project.id IS NOT NULL
+          GROUP BY project_id
+          HAVING net_cost > 0
+          ORDER BY net_cost DESC
+        `;
+      const { rows, currency } = await this.runQuery(sql);
+      const items = await Promise.all(
+        rows.map(async (r) => ({
+          projectId: r[0] ?? 'unknown',
+          projectName: r[1] ?? null,
+          costClp: Math.round(await this.toClp(Number.parseFloat(r[2] ?? '0'), currency)),
+        })),
+      );
+      const total = items.reduce((s, i) => s + i.costClp, 0);
+      return items.map((i) => ({
+        ...i,
+        percentOfTotal: total > 0 ? Math.round((i.costClp / total) * 1000) / 10 : 0,
+      }));
+    });
+  }
+
+  async getTopSkus(limit = 10): Promise<TopSku[]> {
+    const clampedLimit = Math.max(1, Math.min(50, Math.round(limit)));
+    return this.cache.getOrFetch(`costs:top-skus:${clampedLimit}`, CACHE_TTL_OVERVIEW, async () => {
+      const sql = `
+        SELECT
+          service.description AS service,
+          sku.description AS sku,
+          SUM(cost + IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0)) AS net_cost,
+          ANY_VALUE(currency) AS currency
+        FROM \`${this.billingExportTable}\`
+        WHERE DATE(usage_start_time, 'America/Santiago')
+          >= DATE_TRUNC(CURRENT_DATE('America/Santiago'), MONTH)
+        GROUP BY service, sku
+        HAVING net_cost > 0
+        ORDER BY net_cost DESC
+        LIMIT ${clampedLimit}
+      `;
+      const { rows, currency } = await this.runQuery(sql);
+      return Promise.all(
+        rows.map(async (r) => ({
+          service: r[0] ?? 'Unknown',
+          sku: r[1] ?? 'Unknown',
+          costClp: Math.round(await this.toClp(Number.parseFloat(r[2] ?? '0'), currency)),
+        })),
+      );
+    });
+  }
+
+  private clampRangeDays(rangeDays: number): number {
+    return Math.max(1, Math.min(90, Math.round(rangeDays)));
+  }
+
+  private async toClp(amount: number, currency: string | null): Promise<number> {
+    if (!Number.isFinite(amount)) {
+      return 0;
+    }
+    if (!currency || currency === 'CLP') {
+      return amount;
+    }
+    if (currency === 'USD') {
+      return this.fxRateService.usdToClp(amount);
+    }
+    this.logger.warn(
+      { currency, amount },
+      'costs-service: unsupported currency, returning raw value',
+    );
+    return amount;
+  }
+
+  private async runQuery(sql: string): Promise<{
+    rows: Array<Array<string | null>>;
+    currency: string | null;
+  }> {
+    const token = await this.getAccessToken();
+    const url = `${BQ_BASE_URL}/projects/${this.queryProjectId}/queries`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), QUERY_TIMEOUT_MS);
+
+    try {
+      const response = await this.fetchImpl(url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: sql,
+          useLegacySql: false,
+          timeoutMs: QUERY_TIMEOUT_MS,
+        }),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`BigQuery query failed: ${response.status} ${body.slice(0, 200)}`);
+      }
+
+      const json = (await response.json()) as BqQueryResponse;
+      if (json.errors?.length) {
+        throw new Error(`BigQuery error: ${json.errors[0]?.message ?? 'unknown'}`);
+      }
+      if (json.jobComplete === false) {
+        throw new Error('BigQuery query did not complete within timeout');
+      }
+
+      const fields = json.schema?.fields ?? [];
+      const currencyIdx = fields.findIndex((f) => f.name === 'currency');
+      const rows = (json.rows ?? []).map((row) => row.f.map((cell) => cell.v));
+      const currency = currencyIdx >= 0 ? (rows[0]?.[currencyIdx] ?? null) : null;
+
+      return { rows, currency };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/apps/api/src/services/observability/costs-service.ts
+++ b/apps/api/src/services/observability/costs-service.ts
@@ -84,6 +84,17 @@ export interface TopSku {
   costClp: number;
 }
 
+export interface MonthlyHistoryItem {
+  /** "YYYY-MM" (e.g. "2026-04"). */
+  month: string;
+  /** Costo total del mes en CLP (neto de credits). */
+  costClp: number;
+  /** Δ% vs mes anterior en la serie. null para el primer mes. */
+  deltaPercentVsPrior: number | null;
+  /** true si el mes está actualmente en curso (no cerrado todavía). */
+  isCurrent: boolean;
+}
+
 export interface CostsServiceOpts {
   cache: ObservabilityCache;
   fxRateService: FxRateService;
@@ -287,6 +298,55 @@ export class CostsService {
         ...i,
         percentOfTotal: total > 0 ? Math.round((i.costClp / total) * 1000) / 10 : 0,
       }));
+    });
+  }
+
+  /**
+   * Histórico mensual de gasto (últimos N meses, default 12). El mes
+   * actual aparece marcado `isCurrent: true` — su valor es MTD, no mes
+   * cerrado. Permite al admin ver tendencia macro y detectar anomalías.
+   *
+   * Cache 1h — los meses cerrados no cambian, solo el actual se actualiza.
+   */
+  async getMonthlyHistory(months = 12): Promise<MonthlyHistoryItem[]> {
+    const clamped = Math.max(1, Math.min(24, Math.round(months)));
+    return this.cache.getOrFetch(`costs:monthly-history:${clamped}`, 3600, async () => {
+      const sql = `
+          SELECT
+            FORMAT_DATE('%Y-%m', DATE_TRUNC(DATE(usage_start_time, 'America/Santiago'), MONTH)) AS month,
+            SUM(cost + IFNULL((SELECT SUM(amount) FROM UNNEST(credits)), 0)) AS net_cost,
+            ANY_VALUE(currency) AS currency
+          FROM \`${this.billingExportTable}\`
+          WHERE DATE(usage_start_time, 'America/Santiago')
+            >= DATE_TRUNC(CURRENT_DATE('America/Santiago'), MONTH) - INTERVAL ${clamped - 1} MONTH
+          GROUP BY month
+          ORDER BY month ASC
+        `;
+      const { rows, currency } = await this.runQuery(sql);
+      const currentMonth = new Date().toISOString().slice(0, 7);
+
+      const items: MonthlyHistoryItem[] = await Promise.all(
+        rows.map(async (r) => ({
+          month: r[0] ?? '',
+          costClp: Math.round(await this.toClp(Number.parseFloat(r[1] ?? '0'), currency)),
+          deltaPercentVsPrior: null as number | null,
+          isCurrent: r[0] === currentMonth,
+        })),
+      );
+
+      // Segundo pass: calcular delta% encadenado entre meses CERRADOS.
+      // El mes actual queda con `deltaPercentVsPrior = null` porque su MTD
+      // no es comparable con el mes anterior completo (no es apples-to-apples).
+      // El UI lo renderiza como "—" + badge "EN CURSO" para claridad.
+      for (let i = 1; i < items.length; i++) {
+        const current = items[i];
+        const prior = items[i - 1];
+        if (current && !current.isCurrent && prior && prior.costClp > 0) {
+          const delta = ((current.costClp - prior.costClp) / prior.costClp) * 100;
+          current.deltaPercentVsPrior = Math.round(delta * 10) / 10;
+        }
+      }
+      return items;
     });
   }
 

--- a/apps/api/src/services/observability/factory.ts
+++ b/apps/api/src/services/observability/factory.ts
@@ -1,0 +1,172 @@
+import type { Logger } from '@booster-ai/logger';
+import { ObservabilityCache } from './cache.js';
+import { CostsService } from './costs-service.js';
+import { ForecastService } from './forecast-service.js';
+import { FxRateService } from './fx-rate-service.js';
+import { HealthChecksService } from './health-checks-service.js';
+import { MonitoringService } from './monitoring-service.js';
+import { TwilioUsageService } from './twilio-usage-service.js';
+import { createWorkspaceAdminClientGoogleapis } from './workspace-admin-client-googleapis.js';
+import { WorkspaceService } from './workspace-service.js';
+
+/**
+ * Factory que construye TODOS los servicios del Observability Dashboard
+ * a partir de la config + logger. Centraliza el cableado para que
+ * `server.ts` solo importe esta factory.
+ *
+ * Construcción es lazy donde sea posible:
+ * - Redis: `lazyConnect: true` — no conecta hasta primer get/set.
+ * - GoogleAuth: descubre credentials en primer getAccessToken().
+ * - Twilio: omite el service si credentials faltan (return null).
+ * - Workspace adapter: omite si DWD setup pendiente; el servicio
+ *   reporta `available: false` graceful.
+ */
+
+export interface ObservabilityFactoryConfig {
+  redisHost: string;
+  redisPort: number;
+  redisPassword?: string;
+  redisTls: boolean;
+  billingExportTable: string;
+  gcpProjectId: string;
+  twilioAccountSid?: string;
+  twilioAuthToken?: string;
+  workspaceDomain: string;
+  workspaceImpersonateEmail: string;
+  /** Contenido JSON crudo del SA key. Vacío = adapter no se carga. */
+  workspaceCredentialsJson: string;
+  workspacePriceMap: {
+    starter: number;
+    standard: number;
+    plus: number;
+    enterprise: number;
+  };
+  monthlyBudgetUsd: number;
+  observabilityDashboardActivated: boolean;
+}
+
+export interface ObservabilityServices {
+  cache: ObservabilityCache;
+  fxRateService: FxRateService;
+  costsService: CostsService;
+  monitoringService: MonitoringService;
+  twilioUsageService: TwilioUsageService | null;
+  workspaceService: WorkspaceService;
+  forecastService: ForecastService;
+  healthChecksService: HealthChecksService;
+  monthlyBudgetUsd: number;
+  featureFlag: boolean;
+}
+
+export function buildObservabilityServices(
+  config: ObservabilityFactoryConfig,
+  logger: Logger,
+): ObservabilityServices {
+  const cache = new ObservabilityCache({
+    host: config.redisHost,
+    port: config.redisPort,
+    password: config.redisPassword,
+    tls: config.redisTls,
+    logger,
+  });
+
+  const fxRateService = new FxRateService({ cache, logger });
+
+  const costsService = new CostsService({
+    cache,
+    fxRateService,
+    logger,
+    billingExportTable: config.billingExportTable,
+    queryProjectId: config.gcpProjectId,
+  });
+
+  const monitoringService = new MonitoringService({
+    cache,
+    logger,
+    projectId: config.gcpProjectId,
+  });
+
+  const twilioUsageService =
+    config.twilioAccountSid && config.twilioAuthToken
+      ? new TwilioUsageService({
+          cache,
+          fxRateService,
+          logger,
+          accountSid: config.twilioAccountSid,
+          authToken: config.twilioAuthToken,
+        })
+      : null;
+
+  const workspaceAdminClient = tryLoadWorkspaceAdmin(config, logger);
+  const workspaceService = new WorkspaceService({
+    cache,
+    fxRateService,
+    logger,
+    domain: config.workspaceDomain,
+    priceMap: config.workspacePriceMap,
+    ...(workspaceAdminClient ? { adminClient: workspaceAdminClient } : {}),
+  });
+
+  const forecastService = new ForecastService();
+
+  const healthChecksService = new HealthChecksService({
+    cache,
+    monitoringService,
+    logger,
+  });
+
+  return {
+    cache,
+    fxRateService,
+    costsService,
+    monitoringService,
+    twilioUsageService,
+    workspaceService,
+    forecastService,
+    healthChecksService,
+    monthlyBudgetUsd: config.monthlyBudgetUsd,
+    featureFlag: config.observabilityDashboardActivated,
+  };
+}
+
+function tryLoadWorkspaceAdmin(
+  config: ObservabilityFactoryConfig,
+  logger: Logger,
+): ReturnType<typeof createWorkspaceAdminClientGoogleapis> | null {
+  const trimmedJson = config.workspaceCredentialsJson.trim();
+  if (
+    !config.workspaceDomain ||
+    !config.workspaceImpersonateEmail ||
+    !trimmedJson ||
+    trimmedJson.startsWith('ROTATE_ME_')
+  ) {
+    logger.info(
+      {
+        hasDomain: !!config.workspaceDomain,
+        hasImpersonate: !!config.workspaceImpersonateEmail,
+        hasCredsJson: !!trimmedJson && !trimmedJson.startsWith('ROTATE_ME_'),
+      },
+      'observability: workspace admin SDK config incompleta — graceful degradation',
+    );
+    return null;
+  }
+
+  try {
+    const key = JSON.parse(trimmedJson) as { client_email: string; private_key: string };
+    if (!key.client_email || !key.private_key) {
+      logger.warn('observability: workspace credentials missing client_email/private_key');
+      return null;
+    }
+    return createWorkspaceAdminClientGoogleapis({
+      serviceAccountKey: key,
+      impersonateEmail: config.workspaceImpersonateEmail,
+      logger,
+    });
+  } catch (err) {
+    logger.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'observability: failed to parse workspace credentials JSON — graceful degradation',
+    );
+    return null;
+  }
+}

--- a/apps/api/src/services/observability/factory.ts
+++ b/apps/api/src/services/observability/factory.ts
@@ -33,8 +33,8 @@ export interface ObservabilityFactoryConfig {
   twilioAuthToken?: string;
   workspaceDomain: string;
   workspaceImpersonateEmail: string;
-  /** Contenido JSON crudo del SA key. Vacío = adapter no se carga. */
-  workspaceCredentialsJson: string;
+  /** Email del SA dedicado (DWD). Vacío = adapter no se carga. */
+  workspaceReaderSaEmail: string;
   workspacePriceMap: {
     starter: number;
     standard: number;
@@ -133,40 +133,25 @@ function tryLoadWorkspaceAdmin(
   config: ObservabilityFactoryConfig,
   logger: Logger,
 ): ReturnType<typeof createWorkspaceAdminClientGoogleapis> | null {
-  const trimmedJson = config.workspaceCredentialsJson.trim();
   if (
     !config.workspaceDomain ||
     !config.workspaceImpersonateEmail ||
-    !trimmedJson ||
-    trimmedJson.startsWith('ROTATE_ME_')
+    !config.workspaceReaderSaEmail
   ) {
     logger.info(
       {
         hasDomain: !!config.workspaceDomain,
         hasImpersonate: !!config.workspaceImpersonateEmail,
-        hasCredsJson: !!trimmedJson && !trimmedJson.startsWith('ROTATE_ME_'),
+        hasReaderSa: !!config.workspaceReaderSaEmail,
       },
       'observability: workspace admin SDK config incompleta — graceful degradation',
     );
     return null;
   }
 
-  try {
-    const key = JSON.parse(trimmedJson) as { client_email: string; private_key: string };
-    if (!key.client_email || !key.private_key) {
-      logger.warn('observability: workspace credentials missing client_email/private_key');
-      return null;
-    }
-    return createWorkspaceAdminClientGoogleapis({
-      serviceAccountKey: key,
-      impersonateEmail: config.workspaceImpersonateEmail,
-      logger,
-    });
-  } catch (err) {
-    logger.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      'observability: failed to parse workspace credentials JSON — graceful degradation',
-    );
-    return null;
-  }
+  return createWorkspaceAdminClientGoogleapis({
+    readerSaEmail: config.workspaceReaderSaEmail,
+    impersonateEmail: config.workspaceImpersonateEmail,
+    logger,
+  });
 }

--- a/apps/api/src/services/observability/forecast-service.ts
+++ b/apps/api/src/services/observability/forecast-service.ts
@@ -1,0 +1,95 @@
+/**
+ * Forecast lineal del gasto mensual.
+ *
+ * Algoritmo:
+ *   forecastEndOfMonth = mtdCost / dayOfMonth × daysInMonth
+ *
+ * Edge cases manejados:
+ * - dayOfMonth=1 → escalar a 30 días (cero información, valor "optimista")
+ * - mtdCost ≤ 0 → forecast 0
+ * - timezone: usa America/Santiago para evitar saltos a las 21:00 UTC
+ *
+ * Para el dashboard reporta:
+ * - Forecast end-of-month (CLP)
+ * - vs. budget (env var MONTHLY_BUDGET_USD × FX actual)
+ * - Δ% (positivo = sobre budget, negativo = bajo budget)
+ *
+ * No tiene cache propio — la entrada `mtdCost` ya viene cacheada de
+ * CostsService.getOverview().
+ */
+
+export interface ForecastResult {
+  forecastClpEndOfMonth: number;
+  budgetClp: number;
+  variancePercent: number;
+  /** Día del mes usado en el cálculo. */
+  dayOfMonth: number;
+  /** Días totales del mes en curso. */
+  daysInMonth: number;
+  /** Días que restan del mes. */
+  daysRemaining: number;
+}
+
+export interface ForecastInputs {
+  /** Costo acumulado mes a la fecha, en CLP. */
+  mtdCostClp: number;
+  /** Budget mensual en USD (env var MONTHLY_BUDGET_USD). */
+  budgetUsd: number;
+  /** Tipo de cambio actual CLP por USD. */
+  clpPerUsd: number;
+  /** Inyectable para tests (default = new Date()). */
+  now?: Date;
+}
+
+export class ForecastService {
+  forecast(inputs: ForecastInputs): ForecastResult {
+    const now = inputs.now ?? new Date();
+    const { dayOfMonth, daysInMonth, daysRemaining } = this.santiagoMonth(now);
+
+    const safeMtd = Math.max(0, inputs.mtdCostClp);
+    const safeDay = Math.max(1, dayOfMonth);
+    const forecastClp = Math.round((safeMtd / safeDay) * daysInMonth);
+
+    const budgetClp = Math.round(inputs.budgetUsd * inputs.clpPerUsd);
+    const variancePercent =
+      budgetClp > 0 ? Math.round(((forecastClp - budgetClp) / budgetClp) * 1000) / 10 : 0;
+
+    return {
+      forecastClpEndOfMonth: forecastClp,
+      budgetClp,
+      variancePercent,
+      dayOfMonth,
+      daysInMonth,
+      daysRemaining,
+    };
+  }
+
+  /**
+   * Componentes del mes en America/Santiago. Importante: hacer el split
+   * en zona horaria local del negocio para que `dayOfMonth` no salte
+   * por timezone offset.
+   */
+  private santiagoMonth(now: Date): {
+    dayOfMonth: number;
+    daysInMonth: number;
+    daysRemaining: number;
+  } {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: 'America/Santiago',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    const parts = fmt.formatToParts(now);
+    const year = Number.parseInt(parts.find((p) => p.type === 'year')?.value ?? '0', 10);
+    const month = Number.parseInt(parts.find((p) => p.type === 'month')?.value ?? '0', 10);
+    const day = Number.parseInt(parts.find((p) => p.type === 'day')?.value ?? '0', 10);
+    // Día 0 del mes siguiente = último día del mes actual.
+    const daysInMonth = new Date(year, month, 0).getDate();
+    return {
+      dayOfMonth: day,
+      daysInMonth,
+      daysRemaining: Math.max(0, daysInMonth - day),
+    };
+  }
+}

--- a/apps/api/src/services/observability/fx-rate-service.ts
+++ b/apps/api/src/services/observability/fx-rate-service.ts
@@ -1,0 +1,152 @@
+import type { Logger } from '@booster-ai/logger';
+import type { ObservabilityCache } from './cache.js';
+
+/**
+ * Cliente para tipo de cambio CLP/USD via mindicador.cl — API pública
+ * chilena del Banco Central. Devuelve el "dólar observado" oficial
+ * del día.
+ *
+ * Endpoint: https://mindicador.cl/api/dolar
+ *
+ * Respuesta esperada:
+ * ```json
+ * {
+ *   "version": "...",
+ *   "autor": "...",
+ *   "codigo": "dolar",
+ *   "nombre": "Dólar observado",
+ *   "unidad_medida": "Pesos",
+ *   "fecha": "...",
+ *   "serie": [
+ *     { "fecha": "2026-05-13T00:00:00.000Z", "valor": 925.34 },
+ *     ...
+ *   ]
+ * }
+ * ```
+ *
+ * Estrategia:
+ * - Cache 1h (Banco Central actualiza 1 vez/día).
+ * - Cache 24h del "último valor exitoso" como fallback si mindicador.cl
+ *   está caído.
+ * - Fallback hardcoded a 940 si nunca pudimos obtener un valor.
+ */
+
+const MINDICADOR_URL = 'https://mindicador.cl/api/dolar';
+const CACHE_KEY = 'fx:clp-usd';
+const FALLBACK_CACHE_KEY = 'fx:clp-usd:fallback';
+const CACHE_TTL_SECONDS = 3600; // 1h fresh
+const FALLBACK_TTL_SECONDS = 86400; // 24h stale-ok
+const HARDCODED_FALLBACK_CLP_PER_USD = 940;
+const FETCH_TIMEOUT_MS = 5000;
+
+export interface FxRate {
+  /** CLP por 1 USD. */
+  clpPerUsd: number;
+  /** ISO timestamp del fix oficial. */
+  observedAt: string;
+  /** Fuente: 'mindicador' | 'cache-fallback' | 'hardcoded' */
+  source: 'mindicador' | 'cache-fallback' | 'hardcoded';
+}
+
+export interface FxRateServiceOpts {
+  cache: ObservabilityCache;
+  logger: Logger;
+  /** Inyectable para tests. Default: global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export class FxRateService {
+  private readonly cache: ObservabilityCache;
+  private readonly logger: Logger;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: FxRateServiceOpts) {
+    this.cache = opts.cache;
+    this.logger = opts.logger;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  /**
+   * Obtiene el tipo de cambio CLP/USD vigente. Cache 1h en fresh,
+   * 24h en fallback, 940 hardcoded como último recurso.
+   */
+  async getCurrentRate(): Promise<FxRate> {
+    // Fast path: cache fresh
+    return this.cache.getOrFetch<FxRate>(CACHE_KEY, CACHE_TTL_SECONDS, async () => {
+      try {
+        const rate = await this.fetchFromMindicador();
+        // Persistir también en el fallback cache (24h) para que si
+        // mindicador.cl cae mañana, podamos servir el valor de hoy.
+        await this.cache.invalidate(FALLBACK_CACHE_KEY);
+        await this.cache.getOrFetch(FALLBACK_CACHE_KEY, FALLBACK_TTL_SECONDS, async () => rate);
+        return rate;
+      } catch (err) {
+        this.logger.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          'fx-rate: mindicador.cl unavailable, trying fallback cache',
+        );
+
+        // Intentar el fallback cache (último valor exitoso, hasta 24h)
+        try {
+          const fallback = await this.cache.getOrFetch<FxRate | null>(
+            FALLBACK_CACHE_KEY,
+            FALLBACK_TTL_SECONDS,
+            async () => null,
+          );
+          if (fallback) {
+            return { ...fallback, source: 'cache-fallback' as const };
+          }
+        } catch (innerErr) {
+          this.logger.warn(
+            { err: innerErr instanceof Error ? innerErr.message : String(innerErr) },
+            'fx-rate: fallback cache also failed',
+          );
+        }
+
+        // Último recurso: hardcoded
+        return {
+          clpPerUsd: HARDCODED_FALLBACK_CLP_PER_USD,
+          observedAt: new Date().toISOString(),
+          source: 'hardcoded',
+        };
+      }
+    });
+  }
+
+  /**
+   * Convierte un monto USD a CLP usando el tipo actual.
+   * Conveniencia para el resto del código.
+   */
+  async usdToClp(amountUsd: number): Promise<number> {
+    const rate = await this.getCurrentRate();
+    return Math.round(amountUsd * rate.clpPerUsd);
+  }
+
+  private async fetchFromMindicador(): Promise<FxRate> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await this.fetchImpl(MINDICADOR_URL, {
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`mindicador.cl returned ${response.status}`);
+      }
+      const json = (await response.json()) as {
+        serie?: Array<{ fecha?: string; valor?: number }>;
+      };
+      const latest = json.serie?.[0];
+      if (!latest || typeof latest.valor !== 'number' || latest.valor <= 0) {
+        throw new Error('mindicador.cl: malformed response (no serie[0].valor)');
+      }
+      return {
+        clpPerUsd: latest.valor,
+        observedAt: latest.fecha ?? new Date().toISOString(),
+        source: 'mindicador',
+      };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/apps/api/src/services/observability/health-checks-service.ts
+++ b/apps/api/src/services/observability/health-checks-service.ts
@@ -1,0 +1,149 @@
+import type { Logger } from '@booster-ai/logger';
+import type { ObservabilityCache } from './cache.js';
+import type { MonitoringService } from './monitoring-service.js';
+
+/**
+ * Compositor de salud técnica — combina uptime + métricas Cloud Run +
+ * Cloud SQL en un semáforo único (🟢/🟡/🔴) por componente.
+ *
+ * Reglas:
+ * - 🟢 healthy: uptime >= 99.5 AND CPU < 0.7 AND RAM < 0.8
+ * - 🟡 degraded: uptime [98, 99.5) OR CPU [0.7, 0.85) OR RAM [0.8, 0.92)
+ * - 🔴 critical: uptime < 98 OR CPU >= 0.85 OR RAM >= 0.92
+ *
+ * Si un componente no tiene data (Cloud Monitoring no devolvió series),
+ * lo reporta como 'unknown' — la UI lo pinta gris.
+ */
+
+const CACHE_TTL_SECONDS = 60;
+
+export type HealthLevel = 'healthy' | 'degraded' | 'critical' | 'unknown';
+
+export interface ComponentHealth {
+  name: string;
+  level: HealthLevel;
+  message: string;
+}
+
+export interface HealthSnapshot {
+  /** Nivel agregado: peor componente. */
+  overall: HealthLevel;
+  components: ComponentHealth[];
+  lastEvaluatedAt: string;
+}
+
+export interface HealthChecksServiceOpts {
+  cache: ObservabilityCache;
+  monitoringService: MonitoringService;
+  logger: Logger;
+}
+
+export class HealthChecksService {
+  private readonly cache: ObservabilityCache;
+  private readonly monitoringService: MonitoringService;
+
+  constructor(opts: HealthChecksServiceOpts) {
+    this.cache = opts.cache;
+    this.monitoringService = opts.monitoringService;
+  }
+
+  async getSnapshot(): Promise<HealthSnapshot> {
+    return this.cache.getOrFetch('health:snapshot', CACHE_TTL_SECONDS, async () => {
+      const [uptime, cloudRun, cloudSql] = await Promise.all([
+        this.monitoringService.getUptimeSnapshot().catch(() => null),
+        this.monitoringService.getCloudRunMetrics().catch(() => null),
+        this.monitoringService.getCloudSqlMetrics().catch(() => null),
+      ]);
+
+      const components: ComponentHealth[] = [];
+
+      if (uptime && uptime.totalChecks > 0) {
+        components.push({
+          name: 'uptime',
+          level: this.uptimeLevel(uptime.uptimePercent),
+          message: `${uptime.uptimePercent.toFixed(1)}% en últimos 60 min · ${uptime.totalChecks} checks`,
+        });
+      } else {
+        components.push({
+          name: 'uptime',
+          level: 'unknown',
+          message: 'No uptime checks configurados',
+        });
+      }
+
+      if (cloudRun) {
+        components.push({
+          name: 'cloud-run',
+          level: this.resourceLevel(cloudRun.cpuUtilization, cloudRun.ramUtilization),
+          message: this.formatResource(cloudRun.cpuUtilization, cloudRun.ramUtilization),
+        });
+      } else {
+        components.push({
+          name: 'cloud-run',
+          level: 'unknown',
+          message: 'Sin datos de Cloud Monitoring',
+        });
+      }
+
+      if (cloudSql) {
+        components.push({
+          name: 'cloud-sql',
+          level: this.resourceLevel(cloudSql.cpuUtilization, cloudSql.ramUtilization),
+          message: this.formatResource(cloudSql.cpuUtilization, cloudSql.ramUtilization),
+        });
+      } else {
+        components.push({
+          name: 'cloud-sql',
+          level: 'unknown',
+          message: 'Sin datos de Cloud Monitoring',
+        });
+      }
+
+      return {
+        overall: this.worst(components.map((c) => c.level)),
+        components,
+        lastEvaluatedAt: new Date().toISOString(),
+      };
+    });
+  }
+
+  private uptimeLevel(percent: number): HealthLevel {
+    if (percent >= 99.5) {
+      return 'healthy';
+    }
+    if (percent >= 98) {
+      return 'degraded';
+    }
+    return 'critical';
+  }
+
+  private resourceLevel(cpu: number | null, ram: number | null): HealthLevel {
+    if (cpu === null && ram === null) {
+      return 'unknown';
+    }
+    const cpuLevel =
+      cpu === null ? 'healthy' : cpu >= 0.85 ? 'critical' : cpu >= 0.7 ? 'degraded' : 'healthy';
+    const ramLevel =
+      ram === null ? 'healthy' : ram >= 0.92 ? 'critical' : ram >= 0.8 ? 'degraded' : 'healthy';
+    return this.worst([cpuLevel, ramLevel]);
+  }
+
+  private formatResource(cpu: number | null, ram: number | null): string {
+    const cpuStr = cpu === null ? 'n/a' : `${Math.round(cpu * 100)}%`;
+    const ramStr = ram === null ? 'n/a' : `${Math.round(ram * 100)}%`;
+    return `CPU ${cpuStr} · RAM ${ramStr}`;
+  }
+
+  private worst(levels: HealthLevel[]): HealthLevel {
+    if (levels.includes('critical')) {
+      return 'critical';
+    }
+    if (levels.includes('degraded')) {
+      return 'degraded';
+    }
+    if (levels.every((l) => l === 'unknown')) {
+      return 'unknown';
+    }
+    return 'healthy';
+  }
+}

--- a/apps/api/src/services/observability/monitoring-service.ts
+++ b/apps/api/src/services/observability/monitoring-service.ts
@@ -1,0 +1,322 @@
+import type { Logger } from '@booster-ai/logger';
+import { GoogleAuth } from 'google-auth-library';
+import type { ObservabilityCache } from './cache.js';
+
+/**
+ * Cliente Cloud Monitoring API v3 para métricas operativas (uptime,
+ * latencia, CPU, RAM, RPS) del Observability Dashboard.
+ *
+ * No usa `@google-cloud/monitoring` (peso) — invoca el endpoint REST
+ * `monitoring.googleapis.com/v3/projects/.../timeSeries` con fetch + ADC.
+ *
+ * Cache 60s TTL — métricas tienen resolución por minuto en Cloud
+ * Monitoring; pedir más seguido no aporta.
+ */
+
+const MONITORING_BASE_URL = 'https://monitoring.googleapis.com/v3';
+const CACHE_TTL_SECONDS = 60;
+const FETCH_TIMEOUT_MS = 15_000;
+
+export interface MonitoringServiceOpts {
+  cache: ObservabilityCache;
+  logger: Logger;
+  /** Project que tiene los recursos monitoreados (Cloud Run, Cloud SQL). */
+  projectId: string;
+  /** Inyectable para tests. */
+  fetchImpl?: typeof fetch;
+  /** Inyectable para tests. */
+  getAccessToken?: () => Promise<string>;
+}
+
+export interface TimeSeriesPoint {
+  /** ISO timestamp UTC (inicio del intervalo de muestreo). */
+  timestamp: string;
+  /** Valor numérico. */
+  value: number;
+}
+
+export interface UptimeSnapshot {
+  /** % de checks exitosos en la ventana (0-100). */
+  uptimePercent: number;
+  /** Cantidad de uptime checks configurados. */
+  totalChecks: number;
+  /** Última muestra (UTC). */
+  lastSampleAt: string | null;
+}
+
+export interface CloudRunMetrics {
+  /** Latencia p95 (ms). */
+  latencyP95Ms: number | null;
+  /** CPU utilization promedio (0-1). */
+  cpuUtilization: number | null;
+  /** RAM utilization promedio (0-1). */
+  ramUtilization: number | null;
+  /** Requests por segundo (promedio en ventana). */
+  rps: number | null;
+}
+
+export interface CloudSqlMetrics {
+  cpuUtilization: number | null;
+  ramUtilization: number | null;
+  diskUtilization: number | null;
+  connectionsUsedRatio: number | null;
+}
+
+interface TimeSeriesResponse {
+  timeSeries?: Array<{
+    metric?: { type?: string; labels?: Record<string, string> };
+    resource?: { labels?: Record<string, string> };
+    points?: Array<{
+      interval?: { startTime?: string; endTime?: string };
+      value?: {
+        doubleValue?: number;
+        int64Value?: string;
+        boolValue?: boolean;
+        distributionValue?: {
+          mean?: number;
+          count?: string;
+          bucketCounts?: string[];
+          bucketOptions?: unknown;
+        };
+      };
+    }>;
+  }>;
+  error?: { message?: string };
+}
+
+export class MonitoringService {
+  private readonly cache: ObservabilityCache;
+  private readonly logger: Logger;
+  private readonly projectId: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly getAccessToken: () => Promise<string>;
+
+  constructor(opts: MonitoringServiceOpts) {
+    this.cache = opts.cache;
+    this.logger = opts.logger;
+    this.projectId = opts.projectId;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+
+    if (opts.getAccessToken) {
+      this.getAccessToken = opts.getAccessToken;
+    } else {
+      const auth = new GoogleAuth({
+        scopes: ['https://www.googleapis.com/auth/monitoring.read'],
+      });
+      this.getAccessToken = async () => {
+        const client = await auth.getClient();
+        const token = await client.getAccessToken();
+        if (!token.token) {
+          throw new Error('Monitoring: failed to obtain access token from ADC');
+        }
+        return token.token;
+      };
+    }
+  }
+
+  /** Uptime checks: % éxito en últimos 60 minutos. */
+  async getUptimeSnapshot(): Promise<UptimeSnapshot> {
+    return this.cache.getOrFetch('monitoring:uptime', CACHE_TTL_SECONDS, async () => {
+      const { startTime, endTime } = this.lastWindow(60 * 60);
+      const series = await this.fetchTimeSeries({
+        filter: 'metric.type = "monitoring.googleapis.com/uptime_check/check_passed"',
+        startTime,
+        endTime,
+        aggregationAlignmentPeriod: '60s',
+        aggregationPerSeriesAligner: 'ALIGN_FRACTION_TRUE',
+      });
+
+      if (series.length === 0) {
+        return { uptimePercent: 100, totalChecks: 0, lastSampleAt: null };
+      }
+
+      const allPoints = series.flatMap((s) => s.points ?? []);
+      const values = allPoints
+        .map((p) => p.value?.doubleValue ?? p.value?.boolValue)
+        .filter((v): v is number | boolean => v !== undefined)
+        .map((v) => (typeof v === 'boolean' ? (v ? 1 : 0) : v));
+      const avg = values.length > 0 ? values.reduce((a, b) => a + b, 0) / values.length : 1;
+      const lastSampleAt =
+        allPoints[0]?.interval?.endTime ?? allPoints[0]?.interval?.startTime ?? null;
+
+      return {
+        uptimePercent: Math.round(avg * 1000) / 10,
+        totalChecks: series.length,
+        lastSampleAt,
+      };
+    });
+  }
+
+  /** Métricas Cloud Run agregadas a través de todos los servicios del proyecto. */
+  async getCloudRunMetrics(): Promise<CloudRunMetrics> {
+    return this.cache.getOrFetch('monitoring:cloud-run', CACHE_TTL_SECONDS, async () => {
+      const { startTime, endTime } = this.lastWindow(15 * 60);
+
+      const [latencySeries, cpuSeries, ramSeries, requestSeries] = await Promise.all([
+        this.fetchTimeSeries({
+          filter: 'metric.type = "run.googleapis.com/request_latencies"',
+          startTime,
+          endTime,
+          aggregationAlignmentPeriod: '60s',
+          aggregationPerSeriesAligner: 'ALIGN_PERCENTILE_95',
+          aggregationCrossSeriesReducer: 'REDUCE_MEAN',
+        }),
+        this.fetchTimeSeries({
+          filter: 'metric.type = "run.googleapis.com/container/cpu/utilizations"',
+          startTime,
+          endTime,
+          aggregationAlignmentPeriod: '60s',
+          aggregationPerSeriesAligner: 'ALIGN_MEAN',
+          aggregationCrossSeriesReducer: 'REDUCE_MEAN',
+        }),
+        this.fetchTimeSeries({
+          filter: 'metric.type = "run.googleapis.com/container/memory/utilizations"',
+          startTime,
+          endTime,
+          aggregationAlignmentPeriod: '60s',
+          aggregationPerSeriesAligner: 'ALIGN_MEAN',
+          aggregationCrossSeriesReducer: 'REDUCE_MEAN',
+        }),
+        this.fetchTimeSeries({
+          filter: 'metric.type = "run.googleapis.com/request_count"',
+          startTime,
+          endTime,
+          aggregationAlignmentPeriod: '60s',
+          aggregationPerSeriesAligner: 'ALIGN_RATE',
+          aggregationCrossSeriesReducer: 'REDUCE_SUM',
+        }),
+      ]);
+
+      return {
+        latencyP95Ms: this.averageDistMean(latencySeries),
+        cpuUtilization: this.averageDouble(cpuSeries),
+        ramUtilization: this.averageDouble(ramSeries),
+        rps: this.averageDouble(requestSeries),
+      };
+    });
+  }
+
+  /** Métricas Cloud SQL (instance-wide). */
+  async getCloudSqlMetrics(): Promise<CloudSqlMetrics> {
+    return this.cache.getOrFetch('monitoring:cloud-sql', CACHE_TTL_SECONDS, async () => {
+      const { startTime, endTime } = this.lastWindow(15 * 60);
+      const [cpu, mem, disk, conns] = await Promise.all([
+        this.fetchTimeSeries({
+          filter: 'metric.type = "cloudsql.googleapis.com/database/cpu/utilization"',
+          startTime,
+          endTime,
+          aggregationAlignmentPeriod: '60s',
+          aggregationPerSeriesAligner: 'ALIGN_MEAN',
+          aggregationCrossSeriesReducer: 'REDUCE_MEAN',
+        }),
+        this.fetchTimeSeries({
+          filter: 'metric.type = "cloudsql.googleapis.com/database/memory/utilization"',
+          startTime,
+          endTime,
+          aggregationAlignmentPeriod: '60s',
+          aggregationPerSeriesAligner: 'ALIGN_MEAN',
+          aggregationCrossSeriesReducer: 'REDUCE_MEAN',
+        }),
+        this.fetchTimeSeries({
+          filter: 'metric.type = "cloudsql.googleapis.com/database/disk/utilization"',
+          startTime,
+          endTime,
+          aggregationAlignmentPeriod: '60s',
+          aggregationPerSeriesAligner: 'ALIGN_MEAN',
+          aggregationCrossSeriesReducer: 'REDUCE_MEAN',
+        }),
+        this.fetchTimeSeries({
+          filter: 'metric.type = "cloudsql.googleapis.com/database/postgresql/num_backends"',
+          startTime,
+          endTime,
+          aggregationAlignmentPeriod: '60s',
+          aggregationPerSeriesAligner: 'ALIGN_MEAN',
+          aggregationCrossSeriesReducer: 'REDUCE_MEAN',
+        }),
+      ]);
+
+      const connsUsed = this.averageDouble(conns);
+      return {
+        cpuUtilization: this.averageDouble(cpu),
+        ramUtilization: this.averageDouble(mem),
+        diskUtilization: this.averageDouble(disk),
+        // Aproximación: cuenta de backends / 100 como signal. UI lo trata
+        // como ratio 0-1 sin saturarse.
+        connectionsUsedRatio: connsUsed !== null ? Math.min(1, connsUsed / 100) : null,
+      };
+    });
+  }
+
+  private async fetchTimeSeries(params: {
+    filter: string;
+    startTime: string;
+    endTime: string;
+    aggregationAlignmentPeriod: string;
+    aggregationPerSeriesAligner: string;
+    aggregationCrossSeriesReducer?: string;
+  }): Promise<NonNullable<TimeSeriesResponse['timeSeries']>> {
+    const token = await this.getAccessToken();
+    const qs = new URLSearchParams({
+      filter: params.filter,
+      'interval.startTime': params.startTime,
+      'interval.endTime': params.endTime,
+      'aggregation.alignmentPeriod': params.aggregationAlignmentPeriod,
+      'aggregation.perSeriesAligner': params.aggregationPerSeriesAligner,
+      view: 'FULL',
+    });
+    if (params.aggregationCrossSeriesReducer) {
+      qs.set('aggregation.crossSeriesReducer', params.aggregationCrossSeriesReducer);
+    }
+
+    const url = `${MONITORING_BASE_URL}/projects/${this.projectId}/timeSeries?${qs.toString()}`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+    try {
+      const response = await this.fetchImpl(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        this.logger.warn(
+          { status: response.status, body: body.slice(0, 200) },
+          'monitoring: timeSeries fetch failed',
+        );
+        return [];
+      }
+      const json = (await response.json()) as TimeSeriesResponse;
+      return json.timeSeries ?? [];
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private lastWindow(seconds: number): { startTime: string; endTime: string } {
+    const end = new Date();
+    const start = new Date(end.getTime() - seconds * 1000);
+    return { startTime: start.toISOString(), endTime: end.toISOString() };
+  }
+
+  private averageDouble(series: NonNullable<TimeSeriesResponse['timeSeries']>): number | null {
+    const values = series.flatMap((s) =>
+      (s.points ?? []).map((p) => p.value?.doubleValue).filter((v): v is number => v !== undefined),
+    );
+    if (values.length === 0) {
+      return null;
+    }
+    return values.reduce((a, b) => a + b, 0) / values.length;
+  }
+
+  private averageDistMean(series: NonNullable<TimeSeriesResponse['timeSeries']>): number | null {
+    const values = series.flatMap((s) =>
+      (s.points ?? [])
+        .map((p) => p.value?.distributionValue?.mean ?? p.value?.doubleValue)
+        .filter((v): v is number => v !== undefined && Number.isFinite(v)),
+    );
+    if (values.length === 0) {
+      return null;
+    }
+    return values.reduce((a, b) => a + b, 0) / values.length;
+  }
+}

--- a/apps/api/src/services/observability/twilio-usage-service.ts
+++ b/apps/api/src/services/observability/twilio-usage-service.ts
@@ -1,0 +1,141 @@
+import type { Logger } from '@booster-ai/logger';
+import type { ObservabilityCache } from './cache.js';
+import type { FxRateService } from './fx-rate-service.js';
+
+/**
+ * Cliente Twilio Usage Records + Account Balance para el dashboard.
+ *
+ * Twilio expone usage usage por categoría (sms, wa_msg_in, wa_msg_out)
+ * y un endpoint de balance. Auth = HTTP Basic con account SID + auth token.
+ *
+ * Cache 5min — el balance no cambia más rápido y los usage records
+ * agregan por día.
+ */
+
+const TWILIO_BASE_URL = 'https://api.twilio.com';
+const CACHE_TTL_SECONDS = 300;
+const FETCH_TIMEOUT_MS = 10_000;
+
+export interface TwilioUsageServiceOpts {
+  cache: ObservabilityCache;
+  fxRateService: FxRateService;
+  logger: Logger;
+  accountSid: string;
+  authToken: string;
+  /** Inyectable para tests. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface TwilioBalance {
+  balanceUsd: number;
+  balanceClp: number;
+  currency: string;
+}
+
+export interface TwilioUsageItem {
+  category: string;
+  description: string;
+  usage: number;
+  usageUnit: string;
+  priceUsd: number;
+  priceClp: number;
+}
+
+interface BalanceResponse {
+  balance?: string;
+  currency?: string;
+}
+
+interface UsageRecordsResponse {
+  usage_records?: Array<{
+    category?: string;
+    description?: string;
+    usage?: string;
+    usage_unit?: string;
+    price?: string;
+    price_unit?: string;
+  }>;
+}
+
+export class TwilioUsageService {
+  private readonly cache: ObservabilityCache;
+  private readonly fxRateService: FxRateService;
+  private readonly logger: Logger;
+  private readonly accountSid: string;
+  private readonly authHeader: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: TwilioUsageServiceOpts) {
+    this.cache = opts.cache;
+    this.fxRateService = opts.fxRateService;
+    this.logger = opts.logger;
+    this.accountSid = opts.accountSid;
+    this.authHeader = `Basic ${Buffer.from(`${opts.accountSid}:${opts.authToken}`).toString('base64')}`;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async getBalance(): Promise<TwilioBalance> {
+    return this.cache.getOrFetch('twilio:balance', CACHE_TTL_SECONDS, async () => {
+      const url = `${TWILIO_BASE_URL}/2010-04-01/Accounts/${this.accountSid}/Balance.json`;
+      const json = (await this.fetchJson(url)) as BalanceResponse;
+      const balanceUsd = Number.parseFloat(json.balance ?? '0');
+      const balanceClp = await this.fxRateService.usdToClp(balanceUsd);
+      return {
+        balanceUsd,
+        balanceClp,
+        currency: json.currency ?? 'USD',
+      };
+    });
+  }
+
+  /**
+   * Usage records del mes actual, top 10 categorías por costo.
+   */
+  async getMonthToDateUsage(): Promise<TwilioUsageItem[]> {
+    return this.cache.getOrFetch('twilio:usage:mtd', CACHE_TTL_SECONDS, async () => {
+      const url = `${TWILIO_BASE_URL}/2010-04-01/Accounts/${this.accountSid}/Usage/Records/ThisMonth.json?PageSize=100`;
+      const json = (await this.fetchJson(url)) as UsageRecordsResponse;
+      const records = json.usage_records ?? [];
+
+      const items: TwilioUsageItem[] = [];
+      for (const r of records) {
+        const priceUsd = Number.parseFloat(r.price ?? '0');
+        if (priceUsd <= 0) {
+          continue;
+        }
+        items.push({
+          category: r.category ?? 'unknown',
+          description: r.description ?? '',
+          usage: Number.parseFloat(r.usage ?? '0'),
+          usageUnit: r.usage_unit ?? '',
+          priceUsd,
+          priceClp: Math.round(await this.fxRateService.usdToClp(priceUsd)),
+        });
+      }
+      items.sort((a, b) => b.priceUsd - a.priceUsd);
+      return items.slice(0, 10);
+    });
+  }
+
+  private async fetchJson(url: string): Promise<unknown> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const response = await this.fetchImpl(url, {
+        headers: { Authorization: this.authHeader },
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const body = await response.text();
+        this.logger.warn(
+          { status: response.status, body: body.slice(0, 200) },
+          'twilio: API call failed',
+        );
+        throw new Error(`Twilio API returned ${response.status}`);
+      }
+      return await response.json();
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/apps/api/src/services/observability/workspace-admin-client-googleapis.ts
+++ b/apps/api/src/services/observability/workspace-admin-client-googleapis.ts
@@ -1,0 +1,122 @@
+import type { Logger } from '@booster-ai/logger';
+import { google } from 'googleapis';
+import type { WorkspaceAdminClient } from './workspace-service.js';
+
+/**
+ * Adapter "real" del `WorkspaceAdminClient` que usa `googleapis` para
+ * llamar al Admin SDK Directory v1 + Enterprise License Manager v1
+ * via Domain-Wide Delegation (DWD).
+ *
+ * Pre-condición (manual, PO):
+ *   1. SA `observability-workspace-reader@booster-ai-494222...` creada.
+ *   2. DWD habilitado en admin.google.com con scopes:
+ *      - https://www.googleapis.com/auth/admin.directory.user.readonly
+ *      - https://www.googleapis.com/auth/apps.licensing
+ *   3. JSON key subido a Secret Manager: `google-workspace-admin-credentials`.
+ *   4. Email del admin a impersonar configurado en env var
+ *      `GOOGLE_WORKSPACE_IMPERSONATE_EMAIL` (e.g. dev@boosterchile.com).
+ *
+ * Si cualquiera de los pasos falla, este módulo loggea WARN y el caller
+ * pasa `undefined` al `WorkspaceService` — la UI muestra "Workspace
+ * unavailable" sin crashear el API.
+ *
+ * Runbook: docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
+ */
+
+const SCOPES = [
+  'https://www.googleapis.com/auth/admin.directory.user.readonly',
+  'https://www.googleapis.com/auth/apps.licensing',
+];
+
+const PRODUCT_ID = 'Google-Apps';
+
+export interface WorkspaceAdminClientOpts {
+  /** JSON parseado de la SA key (formato GoogleServiceAccountKey). */
+  serviceAccountKey: {
+    client_email: string;
+    private_key: string;
+  };
+  /** Email del admin a impersonar (DWD requires un usuario real). */
+  impersonateEmail: string;
+  logger: Logger;
+}
+
+export function createWorkspaceAdminClientGoogleapis(
+  opts: WorkspaceAdminClientOpts,
+): WorkspaceAdminClient {
+  const jwt = new google.auth.JWT({
+    email: opts.serviceAccountKey.client_email,
+    key: opts.serviceAccountKey.private_key,
+    scopes: SCOPES,
+    subject: opts.impersonateEmail,
+  });
+
+  const directory = google.admin({ version: 'directory_v1', auth: jwt });
+  const licensing = google.licensing({ version: 'v1', auth: jwt });
+
+  return {
+    async listUsers(domain: string): Promise<{ activeUsers: number; suspendedUsers: number }> {
+      let activeUsers = 0;
+      let suspendedUsers = 0;
+      let pageToken: string | undefined;
+      // Cuotas Admin SDK: 2400 qpm; rangos de 500 users por page son OK.
+      do {
+        const params: {
+          domain: string;
+          maxResults: number;
+          projection: string;
+          pageToken?: string;
+        } = {
+          domain,
+          maxResults: 500,
+          projection: 'basic',
+        };
+        if (pageToken) {
+          params.pageToken = pageToken;
+        }
+        const response = await directory.users.list(params);
+        const users = response.data.users ?? [];
+        for (const u of users) {
+          if (u.suspended) {
+            suspendedUsers += 1;
+          } else {
+            activeUsers += 1;
+          }
+        }
+        pageToken = response.data.nextPageToken ?? undefined;
+      } while (pageToken);
+
+      return { activeUsers, suspendedUsers };
+    },
+
+    async listLicenseAssignments(domain: string): Promise<Array<{ skuId: string }>> {
+      const assignments: Array<{ skuId: string }> = [];
+      let pageToken: string | undefined;
+      do {
+        const params: {
+          productId: string;
+          customerId: string;
+          maxResults: number;
+          pageToken?: string;
+        } = {
+          productId: PRODUCT_ID,
+          customerId: domain,
+          maxResults: 1000,
+        };
+        if (pageToken) {
+          params.pageToken = pageToken;
+        }
+        const response = await licensing.licenseAssignments.listForProduct(params);
+        const items = response.data.items ?? [];
+        for (const item of items) {
+          if (item.skuId) {
+            assignments.push({ skuId: item.skuId });
+          }
+        }
+        pageToken = response.data.nextPageToken ?? undefined;
+      } while (pageToken);
+
+      return assignments;
+    },
+  };
+}

--- a/apps/api/src/services/observability/workspace-admin-client-googleapis.ts
+++ b/apps/api/src/services/observability/workspace-admin-client-googleapis.ts
@@ -1,24 +1,40 @@
 import type { Logger } from '@booster-ai/logger';
+import { GoogleAuth, type OAuth2Client } from 'google-auth-library';
 import { google } from 'googleapis';
 import type { WorkspaceAdminClient } from './workspace-service.js';
 
 /**
- * Adapter "real" del `WorkspaceAdminClient` que usa `googleapis` para
- * llamar al Admin SDK Directory v1 + Enterprise License Manager v1
- * via Domain-Wide Delegation (DWD).
+ * Adapter "real" del `WorkspaceAdminClient` que usa googleapis para
+ * llamar Admin SDK Directory v1 + Enterprise License Manager v1 via
+ * Domain-Wide Delegation (DWD).
+ *
+ * Diseño cero-key (cumple `iam.disableServiceAccountKeyCreation` org
+ * policy de Booster):
+ *
+ * 1. El SA del Cloud Run (`booster-cloudrun-sa`) tiene
+ *    `roles/iam.serviceAccountTokenCreator` sobre la SA dedicada
+ *    `observability-workspace-reader`.
+ * 2. En runtime, este adapter:
+ *    a. Construye un JWT con `iss=observability-workspace-reader`,
+ *       `sub=<admin-impersonate-email>` (DWD subject), scopes Admin
+ *       SDK + Licensing.
+ *    b. Llama a IAM Credentials API `signJwt` (firma con la identidad
+ *       de la SA del reader, sin descargar key — la key vive only
+ *       dentro de GCP).
+ *    c. Intercambia el JWT firmado por un access token via OAuth 2
+ *       (grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer).
+ *    d. Usa ese access token para las llamadas Admin SDK + Licensing.
  *
  * Pre-condición (manual, PO):
  *   1. SA `observability-workspace-reader@booster-ai-494222...` creada.
- *   2. DWD habilitado en admin.google.com con scopes:
+ *   2. DWD habilitada en admin.google.com con scopes:
  *      - https://www.googleapis.com/auth/admin.directory.user.readonly
  *      - https://www.googleapis.com/auth/apps.licensing
- *   3. JSON key subido a Secret Manager: `google-workspace-admin-credentials`.
- *   4. Email del admin a impersonar configurado en env var
- *      `GOOGLE_WORKSPACE_IMPERSONATE_EMAIL` (e.g. dev@boosterchile.com).
+ *   3. Email del admin Workspace a impersonar configurado en env var
+ *      `GOOGLE_WORKSPACE_IMPERSONATE_EMAIL`.
  *
- * Si cualquiera de los pasos falla, este módulo loggea WARN y el caller
- * pasa `undefined` al `WorkspaceService` — la UI muestra "Workspace
- * unavailable" sin crashear el API.
+ * Si DWD no se autoriza, este módulo loggea WARN al primer call y el
+ * caller pasa null al `WorkspaceService` — UI muestra unavailable.
  *
  * Runbook: docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
  */
@@ -29,37 +45,125 @@ const SCOPES = [
 ];
 
 const PRODUCT_ID = 'Google-Apps';
+const OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const TOKEN_LIFETIME_SECONDS = 3600;
+/** Re-firmar el JWT cuando queden < 5 min del token (cache margen). */
+const TOKEN_REFRESH_MARGIN_SECONDS = 300;
 
 export interface WorkspaceAdminClientOpts {
-  /** JSON parseado de la SA key (formato GoogleServiceAccountKey). */
-  serviceAccountKey: {
-    client_email: string;
-    private_key: string;
-  };
-  /** Email del admin a impersonar (DWD requires un usuario real). */
+  /** Email completo de la SA dedicada al reader (no del runtime SA). */
+  readerSaEmail: string;
+  /** Email del admin Workspace a impersonar (DWD subject). */
   impersonateEmail: string;
   logger: Logger;
+  /** Inyectable para tests. Si se pasa, omite ADC + IAM Credentials. */
+  fetchImpl?: typeof fetch;
+}
+
+interface CachedToken {
+  accessToken: string;
+  expiresAtMs: number;
 }
 
 export function createWorkspaceAdminClientGoogleapis(
   opts: WorkspaceAdminClientOpts,
 ): WorkspaceAdminClient {
-  const jwt = new google.auth.JWT({
-    email: opts.serviceAccountKey.client_email,
-    key: opts.serviceAccountKey.private_key,
-    scopes: SCOPES,
-    subject: opts.impersonateEmail,
+  const logger = opts.logger;
+  const fetchImpl = opts.fetchImpl ?? fetch;
+
+  // Token cache compartido entre llamadas del mismo proceso.
+  let cached: CachedToken | null = null;
+
+  // ADC client del Cloud Run runtime SA. Tiene tokenCreator sobre el reader SA.
+  const auth = new GoogleAuth({
+    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
   });
 
-  const directory = google.admin({ version: 'directory_v1', auth: jwt });
-  const licensing = google.licensing({ version: 'v1', auth: jwt });
+  async function getDwdAccessToken(): Promise<string> {
+    const nowMs = Date.now();
+    if (cached && cached.expiresAtMs - TOKEN_REFRESH_MARGIN_SECONDS * 1000 > nowMs) {
+      return cached.accessToken;
+    }
+
+    // Step 1: Sign JWT via IAM Credentials API
+    const nowSec = Math.floor(nowMs / 1000);
+    const jwtPayload = {
+      iss: opts.readerSaEmail,
+      sub: opts.impersonateEmail,
+      scope: SCOPES.join(' '),
+      aud: OAUTH_TOKEN_URL,
+      iat: nowSec,
+      exp: nowSec + TOKEN_LIFETIME_SECONDS,
+    };
+
+    const client = (await auth.getClient()) as OAuth2Client;
+    const accessTokenForSign = await client.getAccessToken();
+    if (!accessTokenForSign.token) {
+      throw new Error('workspace adapter: ADC token unavailable');
+    }
+
+    const signResponse = await fetchImpl(
+      `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${opts.readerSaEmail}:signJwt`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessTokenForSign.token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ payload: JSON.stringify(jwtPayload) }),
+      },
+    );
+    if (!signResponse.ok) {
+      const body = await signResponse.text();
+      throw new Error(
+        `workspace adapter: signJwt failed (${signResponse.status}): ${body.slice(0, 200)}`,
+      );
+    }
+    const { signedJwt } = (await signResponse.json()) as { signedJwt: string };
+
+    // Step 2: Exchange signed JWT for access token at OAuth 2 endpoint
+    const tokenResponse = await fetchImpl(OAUTH_TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        assertion: signedJwt,
+      }).toString(),
+    });
+    if (!tokenResponse.ok) {
+      const body = await tokenResponse.text();
+      throw new Error(
+        `workspace adapter: token exchange failed (${tokenResponse.status}): ${body.slice(0, 200)}`,
+      );
+    }
+    const tokenJson = (await tokenResponse.json()) as {
+      access_token: string;
+      expires_in: number;
+    };
+
+    cached = {
+      accessToken: tokenJson.access_token,
+      expiresAtMs: nowMs + tokenJson.expires_in * 1000,
+    };
+    logger.debug('workspace adapter: refreshed DWD access token');
+    return cached.accessToken;
+  }
+
+  // Construimos los clientes googleapis con un auth dummy "OAuth2 with
+  // dynamic token" — usamos un OAuth2Client cuya getAccessToken se
+  // delega a nuestro getDwdAccessToken.
+  function buildAuthForGoogleapis(): OAuth2Client {
+    const oauth = new google.auth.OAuth2();
+    oauth.getAccessToken = async () => ({ token: await getDwdAccessToken() });
+    return oauth;
+  }
 
   return {
     async listUsers(domain: string): Promise<{ activeUsers: number; suspendedUsers: number }> {
+      const directory = google.admin({ version: 'directory_v1', auth: buildAuthForGoogleapis() });
       let activeUsers = 0;
       let suspendedUsers = 0;
       let pageToken: string | undefined;
-      // Cuotas Admin SDK: 2400 qpm; rangos de 500 users por page son OK.
       do {
         const params: {
           domain: string;
@@ -90,6 +194,7 @@ export function createWorkspaceAdminClientGoogleapis(
     },
 
     async listLicenseAssignments(domain: string): Promise<Array<{ skuId: string }>> {
+      const licensing = google.licensing({ version: 'v1', auth: buildAuthForGoogleapis() });
       const assignments: Array<{ skuId: string }> = [];
       let pageToken: string | undefined;
       do {

--- a/apps/api/src/services/observability/workspace-service.ts
+++ b/apps/api/src/services/observability/workspace-service.ts
@@ -1,0 +1,156 @@
+import type { Logger } from '@booster-ai/logger';
+import type { ObservabilityCache } from './cache.js';
+import type { FxRateService } from './fx-rate-service.js';
+
+/**
+ * Cliente Google Workspace Admin SDK + Enterprise License Manager para
+ * el Observability Dashboard.
+ *
+ * Pre-condición operacional: la SA `observability-workspace-reader` está
+ * registrada con Domain-Wide Delegation en admin.google.com con los
+ * scopes apropiados. Si la SA no está configurada, este servicio retorna
+ * `available=false` y la UI muestra el estado graceful (NO crashea).
+ *
+ * Pricing NO viene del API — Workspace API no expone precios. Se
+ * configuran por env var (GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_*) por
+ * SKU. Si la mezcla cambia, el PO actualiza la env var via terraform.
+ *
+ * Cache 1h TTL — number of seats cambia raras veces y la cuota del
+ * Admin SDK es 2400 qpm por user, generosa pero no infinita.
+ */
+
+const CACHE_TTL_SECONDS = 3600;
+
+export interface WorkspacePriceMap {
+  starter: number;
+  standard: number;
+  plus: number;
+  enterprise: number;
+}
+
+export interface WorkspaceServiceOpts {
+  cache: ObservabilityCache;
+  fxRateService: FxRateService;
+  logger: Logger;
+  /** Dominio del Workspace, e.g. boosterchile.com. Vacío = service unavailable. */
+  domain: string;
+  priceMap: WorkspacePriceMap;
+  /**
+   * Inyectable para tests. Tipo "min surface" del Admin SDK + Licensing
+   * que solo expone los métodos que usamos.
+   */
+  adminClient?: WorkspaceAdminClient;
+}
+
+export interface WorkspaceAdminClient {
+  listUsers(domain: string): Promise<{ activeUsers: number; suspendedUsers: number }>;
+  listLicenseAssignments(domain: string): Promise<Array<{ skuId: string }>>;
+}
+
+export interface WorkspaceUsageSnapshot {
+  available: boolean;
+  reason?: string;
+  totalSeats: number;
+  activeSeats: number;
+  suspendedSeats: number;
+  seatsBySku: Record<string, number>;
+  monthlyCostUsd: number;
+  monthlyCostClp: number;
+}
+
+const SKU_TO_PRICE_KEY: Record<string, keyof WorkspacePriceMap> = {
+  '1010020027': 'starter', // Business Starter
+  '1010020028': 'standard', // Business Standard
+  '1010020025': 'plus', // Business Plus
+  '1010060001': 'enterprise', // Enterprise Standard
+  '1010060003': 'enterprise', // Enterprise Plus
+};
+
+export class WorkspaceService {
+  private readonly cache: ObservabilityCache;
+  private readonly fxRateService: FxRateService;
+  private readonly logger: Logger;
+  private readonly domain: string;
+  private readonly priceMap: WorkspacePriceMap;
+  private readonly adminClient: WorkspaceAdminClient | null;
+
+  constructor(opts: WorkspaceServiceOpts) {
+    this.cache = opts.cache;
+    this.fxRateService = opts.fxRateService;
+    this.logger = opts.logger;
+    this.domain = opts.domain;
+    this.priceMap = opts.priceMap;
+    this.adminClient = opts.adminClient ?? null;
+  }
+
+  async getUsageSnapshot(): Promise<WorkspaceUsageSnapshot> {
+    return this.cache.getOrFetch('workspace:snapshot', CACHE_TTL_SECONDS, async () => {
+      if (!this.domain) {
+        return this.unavailable('GOOGLE_WORKSPACE_DOMAIN not configured');
+      }
+      if (!this.adminClient) {
+        return this.unavailable('workspace admin client not initialized (DWD pending)');
+      }
+
+      try {
+        const [users, licenses] = await Promise.all([
+          this.adminClient.listUsers(this.domain),
+          this.adminClient.listLicenseAssignments(this.domain).catch((err) => {
+            this.logger.warn(
+              { err: err instanceof Error ? err.message : String(err) },
+              'workspace: licensing API failed, fallback to user count',
+            );
+            return [] as Array<{ skuId: string }>;
+          }),
+        ]);
+
+        const seatsBySku: Record<string, number> = {};
+        let totalMonthlyCostUsd = 0;
+
+        for (const lic of licenses) {
+          seatsBySku[lic.skuId] = (seatsBySku[lic.skuId] ?? 0) + 1;
+          const priceKey = SKU_TO_PRICE_KEY[lic.skuId];
+          totalMonthlyCostUsd += priceKey ? this.priceMap[priceKey] : this.priceMap.standard;
+        }
+
+        // Si licensing falló, usamos user count × standard price como fallback
+        if (licenses.length === 0 && users.activeUsers > 0) {
+          totalMonthlyCostUsd = users.activeUsers * this.priceMap.standard;
+        }
+
+        const monthlyCostClp = Math.round(await this.fxRateService.usdToClp(totalMonthlyCostUsd));
+
+        return {
+          available: true,
+          totalSeats: users.activeUsers + users.suspendedUsers,
+          activeSeats: users.activeUsers,
+          suspendedSeats: users.suspendedUsers,
+          seatsBySku,
+          monthlyCostUsd: Math.round(totalMonthlyCostUsd * 100) / 100,
+          monthlyCostClp,
+        };
+      } catch (err) {
+        this.logger.warn(
+          { err: err instanceof Error ? err.message : String(err) },
+          'workspace: admin SDK call failed',
+        );
+        return this.unavailable(
+          err instanceof Error ? err.message : 'unknown error calling admin SDK',
+        );
+      }
+    });
+  }
+
+  private unavailable(reason: string): WorkspaceUsageSnapshot {
+    return {
+      available: false,
+      reason,
+      totalSeats: 0,
+      activeSeats: 0,
+      suspendedSeats: 0,
+      seatsBySku: {},
+      monthlyCostUsd: 0,
+      monthlyCostClp: 0,
+    };
+  }
+}

--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -40,3 +40,4 @@ process.env.FIREBASE_PROJECT_ID ??= 'booster-ai-test';
 process.env.JWT_ISSUER ??= 'booster-ai';
 process.env.API_AUDIENCE ??= 'https://api.test.boosterchile.com';
 process.env.ALLOWED_CALLER_SA ??= 'test-caller@booster-ai-test.iam.gserviceaccount.com';
+process.env.BOOSTER_PLATFORM_ADMIN_EMAILS ??= 'dev@boosterchile.com';

--- a/apps/api/test/unit/admin-observability-route.test.ts
+++ b/apps/api/test/unit/admin-observability-route.test.ts
@@ -356,4 +356,176 @@ describe('admin/observability — error paths', () => {
     const res = await app.request('/admin/observability/costs/by-service?days=99999');
     expect(res.status).toBe(400);
   });
+
+  it('GET /health con healthChecksService falla → 500 internal_error', async () => {
+    const opts = buildOpts({
+      healthChecksService: {
+        getSnapshot: vi.fn(async () => {
+          throw new Error('health-fail');
+        }),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/health');
+    expect(res.status).toBe(500);
+  });
+
+  it('GET /costs/by-project con BQ caído → 502', async () => {
+    const opts = buildOpts({
+      costsService: {
+        getOverview: vi.fn(),
+        getByService: vi.fn(),
+        getByProject: vi.fn(async () => {
+          throw new Error('BQ unavailable');
+        }),
+        getTrend: vi.fn(),
+        getTopSkus: vi.fn(),
+        getMonthlyHistory: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/by-project?days=30');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /costs/trend con BQ caído → 502', async () => {
+    const opts = buildOpts({
+      costsService: {
+        getOverview: vi.fn(),
+        getByService: vi.fn(),
+        getByProject: vi.fn(),
+        getTrend: vi.fn(async () => {
+          throw new Error('BQ unavailable');
+        }),
+        getTopSkus: vi.fn(),
+        getMonthlyHistory: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/trend');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /costs/top-skus con BQ caído → 502', async () => {
+    const opts = buildOpts({
+      costsService: {
+        getOverview: vi.fn(),
+        getByService: vi.fn(),
+        getByProject: vi.fn(),
+        getTrend: vi.fn(),
+        getTopSkus: vi.fn(async () => {
+          throw new Error('BQ unavailable');
+        }),
+        getMonthlyHistory: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/top-skus');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /costs/monthly-history con BQ caído → 502', async () => {
+    const opts = buildOpts({
+      costsService: {
+        getOverview: vi.fn(),
+        getByService: vi.fn(),
+        getByProject: vi.fn(),
+        getTrend: vi.fn(),
+        getTopSkus: vi.fn(),
+        getMonthlyHistory: vi.fn(async () => {
+          throw new Error('BQ unavailable');
+        }),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/monthly-history');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /usage/cloud-run con Monitoring caído → 502', async () => {
+    const opts = buildOpts({
+      monitoringService: {
+        getCloudRunMetrics: vi.fn(async () => {
+          throw new Error('monitoring-fail');
+        }),
+        getCloudSqlMetrics: vi.fn(),
+        getUptimeSnapshot: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/usage/cloud-run');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /usage/cloud-sql con Monitoring caído → 502', async () => {
+    const opts = buildOpts({
+      monitoringService: {
+        getCloudRunMetrics: vi.fn(),
+        getCloudSqlMetrics: vi.fn(async () => {
+          throw new Error('monitoring-fail');
+        }),
+        getUptimeSnapshot: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/usage/cloud-sql');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /usage/twilio con Twilio caído → 502', async () => {
+    const opts = buildOpts({
+      twilioUsageService: {
+        getBalance: vi.fn(async () => {
+          throw new Error('twilio-fail');
+        }),
+        getMonthToDateUsage: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/usage/twilio');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /usage/workspace con error inesperado → available=false', async () => {
+    const opts = buildOpts({
+      workspaceService: {
+        getUsageSnapshot: vi.fn(async () => {
+          throw new Error('workspace-fail');
+        }),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/usage/workspace');
+    expect(res.status).toBe(200); // graceful: no crashea
+    const body = (await res.json()) as { available: boolean };
+    expect(body.available).toBe(false);
+  });
+
+  it('GET /forecast con BQ caído → 502', async () => {
+    const opts = buildOpts({
+      costsService: {
+        getOverview: vi.fn(async () => {
+          throw new Error('forecast-base-fail');
+        }),
+        getByService: vi.fn(),
+        getByProject: vi.fn(),
+        getTrend: vi.fn(),
+        getTopSkus: vi.fn(),
+        getMonthlyHistory: vi.fn(),
+        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/forecast');
+    expect(res.status).toBe(502);
+  });
 });

--- a/apps/api/test/unit/admin-observability-route.test.ts
+++ b/apps/api/test/unit/admin-observability-route.test.ts
@@ -68,6 +68,10 @@ function buildOpts(
       ]),
       getTrend: vi.fn(async () => [{ date: '2026-05-13', costClp: 5000 }]),
       getTopSkus: vi.fn(async () => [{ service: 'Cloud Run', sku: 'CPU', costClp: 30000 }]),
+      getMonthlyHistory: vi.fn(async () => [
+        { month: '2026-04', costClp: 250_000, deltaPercentVsPrior: null, isCurrent: false },
+        { month: '2026-05', costClp: 248_350, deltaPercentVsPrior: -0.7, isCurrent: true },
+      ]),
     } as any,
     monitoringService: {
       getCloudRunMetrics: vi.fn(async () => ({
@@ -247,6 +251,25 @@ describe('admin/observability — happy paths', () => {
     expect(opts.costsService.getTopSkus).toHaveBeenCalledWith(5);
   });
 
+  it('GET /costs/monthly-history?months=12 → 200 + items array', async () => {
+    const opts = buildOpts();
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/monthly-history?months=12');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { months: number; items: Array<{ isCurrent: boolean }> };
+    expect(body.months).toBe(12);
+    expect(body.items).toHaveLength(2);
+    expect(opts.costsService.getMonthlyHistory).toHaveBeenCalledWith(12);
+  });
+
+  it('GET /costs/monthly-history sin query → default 12 meses', async () => {
+    const opts = buildOpts();
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/monthly-history');
+    expect(res.status).toBe(200);
+    expect(opts.costsService.getMonthlyHistory).toHaveBeenCalledWith(12);
+  });
+
   it('GET /usage/cloud-run → 200 + metrics', async () => {
     const app = makeApp(buildOpts(), { withContext: true });
     const res = await app.request('/admin/observability/usage/cloud-run');
@@ -312,6 +335,7 @@ describe('admin/observability — error paths', () => {
         getByProject: vi.fn(),
         getTrend: vi.fn(),
         getTopSkus: vi.fn(),
+        getMonthlyHistory: vi.fn(),
       } as any,
     });
     const app = makeApp(opts, { withContext: true });

--- a/apps/api/test/unit/admin-observability-route.test.ts
+++ b/apps/api/test/unit/admin-observability-route.test.ts
@@ -50,7 +50,8 @@ function buildOpts(
     costsService: {
       getOverview: vi.fn(async () => ({
         costClpMonthToDate: 100000,
-        costClpPreviousMonth: 90000,
+        costClpPreviousMonth: 200000,
+        costClpPreviousMonthSamePeriod: 90000,
         deltaPercentVsPreviousMonth: 11.1,
         lastBillingExportAt: '2026-05-13T13:00:00Z',
       })),

--- a/apps/api/test/unit/admin-observability-route.test.ts
+++ b/apps/api/test/unit/admin-observability-route.test.ts
@@ -1,0 +1,334 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { config as appConfig } from '../../src/config.js';
+import {
+  type AdminObservabilityRoutesOpts,
+  createAdminObservabilityRoutes,
+} from '../../src/routes/admin-observability.js';
+import type { UserContext } from '../../src/services/user-context.js';
+
+/**
+ * Integration tests del router /admin/observability/* — coverage:
+ *  - 503 si feature flag OFF
+ *  - 401 si no hay userContext
+ *  - 403 si email no es platform admin
+ *  - 200 + payload si admin + flag ON
+ *  - 502 si provider falla
+ *  - 400 si query inválido
+ *  - graceful degradation Twilio/Workspace
+ *
+ * Mocks: cada servicio del package observability se reemplaza por un
+ * stub con `vi.fn()`. No tocamos red ni Redis.
+ */
+
+const ADMIN_EMAIL = 'dev@boosterchile.com';
+const NON_ADMIN_EMAIL = 'random@example.com';
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as never;
+
+function makeUserCtx(email: string): UserContext {
+  return {
+    user: { id: 'u1', firebaseUid: 'fb1', fullName: 'Felipe', email },
+    activeMembership: null,
+    memberships: [],
+  } as unknown as UserContext;
+}
+
+function buildOpts(
+  overrides?: Partial<AdminObservabilityRoutesOpts>,
+): AdminObservabilityRoutesOpts {
+  const defaults: AdminObservabilityRoutesOpts = {
+    costsService: {
+      getOverview: vi.fn(async () => ({
+        costClpMonthToDate: 100000,
+        costClpPreviousMonth: 90000,
+        deltaPercentVsPreviousMonth: 11.1,
+        lastBillingExportAt: '2026-05-13T13:00:00Z',
+      })),
+      getByService: vi.fn(async () => [
+        { service: 'Cloud Run', costClp: 60000, percentOfTotal: 60 },
+      ]),
+      getByProject: vi.fn(async () => [
+        {
+          projectId: 'booster-ai-494222',
+          projectName: 'booster-ai',
+          costClp: 75000,
+          percentOfTotal: 75,
+        },
+      ]),
+      getTrend: vi.fn(async () => [{ date: '2026-05-13', costClp: 5000 }]),
+      getTopSkus: vi.fn(async () => [{ service: 'Cloud Run', sku: 'CPU', costClp: 30000 }]),
+    } as any,
+    monitoringService: {
+      getCloudRunMetrics: vi.fn(async () => ({
+        latencyP95Ms: 150,
+        cpuUtilization: 0.4,
+        ramUtilization: 0.5,
+        rps: 8,
+      })),
+      getCloudSqlMetrics: vi.fn(async () => ({
+        cpuUtilization: 0.3,
+        ramUtilization: 0.4,
+        diskUtilization: 0.5,
+        connectionsUsedRatio: 0.2,
+      })),
+      getUptimeSnapshot: vi.fn(async () => ({
+        uptimePercent: 99.9,
+        totalChecks: 3,
+        lastSampleAt: '2026-05-13T20:00:00Z',
+      })),
+    } as any,
+    twilioUsageService: {
+      getBalance: vi.fn(async () => ({ balanceUsd: 42.5, balanceClp: 39313, currency: 'USD' })),
+      getMonthToDateUsage: vi.fn(async () => [
+        {
+          category: 'sms',
+          description: 'SMS',
+          usage: 100,
+          usageUnit: 'messages',
+          priceUsd: 5,
+          priceClp: 4625,
+        },
+      ]),
+    } as any,
+    workspaceService: {
+      getUsageSnapshot: vi.fn(async () => ({
+        available: true,
+        totalSeats: 10,
+        activeSeats: 9,
+        suspendedSeats: 1,
+        seatsBySku: { '1010020028': 9 },
+        monthlyCostUsd: 108,
+        monthlyCostClp: 99900,
+      })),
+    } as any,
+    forecastService: {
+      forecast: vi.fn(() => ({
+        forecastClpEndOfMonth: 1000000,
+        budgetClp: 925000,
+        variancePercent: 8.1,
+        dayOfMonth: 15,
+        daysInMonth: 30,
+        daysRemaining: 15,
+      })),
+    } as any,
+    healthChecksService: {
+      getSnapshot: vi.fn(async () => ({
+        overall: 'healthy' as const,
+        components: [{ name: 'uptime', level: 'healthy' as const, message: '99.9%' }],
+        lastEvaluatedAt: '2026-05-13T20:00:00Z',
+      })),
+    } as any,
+    fxRateService: {
+      getCurrentRate: vi.fn(async () => ({
+        clpPerUsd: 925,
+        observedAt: '2026-05-13T00:00:00Z',
+        source: 'mindicador' as const,
+      })),
+    } as any,
+    monthlyBudgetUsd: 1000,
+    featureFlag: true,
+    logger: noopLogger,
+  };
+  return { ...defaults, ...overrides };
+}
+
+function makeApp(
+  opts: AdminObservabilityRoutesOpts,
+  ctx: { email?: string; withContext: boolean },
+) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (ctx.withContext) {
+      c.set('userContext', makeUserCtx(ctx.email ?? ADMIN_EMAIL));
+    }
+    await next();
+  });
+  app.route('/admin/observability', createAdminObservabilityRoutes(opts));
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  appConfig.BOOSTER_PLATFORM_ADMIN_EMAILS = [ADMIN_EMAIL];
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('admin/observability — auth + feature flag', () => {
+  it('503 si feature flag OFF', async () => {
+    const app = makeApp(buildOpts({ featureFlag: false }), {
+      withContext: true,
+      email: ADMIN_EMAIL,
+    });
+    const res = await app.request('/admin/observability/health');
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: 'feature_disabled' });
+  });
+
+  it('401 si sin userContext (Firebase auth missing)', async () => {
+    const app = makeApp(buildOpts(), { withContext: false });
+    const res = await app.request('/admin/observability/health');
+    expect(res.status).toBe(401);
+  });
+
+  it('403 si email no es platform admin', async () => {
+    const app = makeApp(buildOpts(), {
+      withContext: true,
+      email: NON_ADMIN_EMAIL,
+    });
+    const res = await app.request('/admin/observability/health');
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('forbidden_platform_admin');
+  });
+});
+
+describe('admin/observability — happy paths', () => {
+  it('GET /health → 200 + snapshot', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/health');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { overall: string };
+    expect(body.overall).toBe('healthy');
+  });
+
+  it('GET /costs/overview → 200 + delta%', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/costs/overview');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { costClpMonthToDate: number };
+    expect(body.costClpMonthToDate).toBe(100000);
+  });
+
+  it('GET /costs/by-service?days=30 → 200 + items array', async () => {
+    const opts = buildOpts();
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/by-service?days=30');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { days: number; items: Array<unknown> };
+    expect(body.days).toBe(30);
+    expect(body.items).toHaveLength(1);
+    expect(opts.costsService.getByService).toHaveBeenCalledWith(30);
+  });
+
+  it('GET /costs/by-project sin query → days default 30', async () => {
+    const opts = buildOpts();
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/by-project');
+    expect(res.status).toBe(200);
+    expect(opts.costsService.getByProject).toHaveBeenCalledWith(30);
+  });
+
+  it('GET /costs/trend?days=7 → 200 + points', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/costs/trend?days=7');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { points: Array<{ date: string }> };
+    expect(body.points[0]?.date).toBe('2026-05-13');
+  });
+
+  it('GET /costs/top-skus?limit=5 → 200', async () => {
+    const opts = buildOpts();
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/top-skus?limit=5');
+    expect(res.status).toBe(200);
+    expect(opts.costsService.getTopSkus).toHaveBeenCalledWith(5);
+  });
+
+  it('GET /usage/cloud-run → 200 + metrics', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/usage/cloud-run');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { cpuUtilization: number };
+    expect(body.cpuUtilization).toBe(0.4);
+  });
+
+  it('GET /usage/cloud-sql → 200 + metrics', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/usage/cloud-sql');
+    expect(res.status).toBe(200);
+  });
+
+  it('GET /usage/twilio → 200 + balance + usage', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/usage/twilio');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { available: boolean; balance: { balanceUsd: number } };
+    expect(body.available).toBe(true);
+    expect(body.balance.balanceUsd).toBe(42.5);
+  });
+
+  it('GET /usage/twilio sin service configurado → available=false', async () => {
+    const app = makeApp(buildOpts({ twilioUsageService: null }), { withContext: true });
+    const res = await app.request('/admin/observability/usage/twilio');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { available: boolean; reason: string };
+    expect(body.available).toBe(false);
+    expect(body.reason).toBe('twilio_credentials_not_configured');
+  });
+
+  it('GET /usage/workspace → 200 + snapshot', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/usage/workspace');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { available: boolean; totalSeats: number };
+    expect(body.available).toBe(true);
+    expect(body.totalSeats).toBe(10);
+  });
+
+  it('GET /forecast → 200 + forecast + currentRate', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/forecast');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      forecastClpEndOfMonth: number;
+      currentRate: { clpPerUsd: number };
+    };
+    expect(body.forecastClpEndOfMonth).toBe(1000000);
+    expect(body.currentRate.clpPerUsd).toBe(925);
+  });
+});
+
+describe('admin/observability — error paths', () => {
+  it('GET /costs/overview con BQ caído → 502', async () => {
+    const opts = buildOpts({
+      costsService: {
+        getOverview: vi.fn(async () => {
+          throw new Error('BQ unavailable');
+        }),
+        getByService: vi.fn(),
+        getByProject: vi.fn(),
+        getTrend: vi.fn(),
+        getTopSkus: vi.fn(),
+      } as any,
+    });
+    const app = makeApp(opts, { withContext: true });
+    const res = await app.request('/admin/observability/costs/overview');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /costs/by-service?days=abc → 400 invalid_query', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/costs/by-service?days=abc');
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('invalid_query');
+  });
+
+  it('GET /costs/by-service?days=99999 → 400 (out of range)', async () => {
+    const app = makeApp(buildOpts(), { withContext: true });
+    const res = await app.request('/admin/observability/costs/by-service?days=99999');
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/api/test/unit/observability/cache.test.ts
+++ b/apps/api/test/unit/observability/cache.test.ts
@@ -1,0 +1,132 @@
+import type { Logger } from '@booster-ai/logger';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests del ObservabilityCache. Mock de ioredis con un Map en memoria.
+ *
+ * Rationale: ioredis es complejo (pipelines, pubsub). Mock minimal de
+ * los métodos que usamos (get/set/del/quit/on) sobre un Map es
+ * suficiente y mucho más rápido que setup de Redis real.
+ */
+
+const fakeStore = new Map<string, { value: string; expiresAt: number }>();
+
+vi.mock('ioredis', () => {
+  class MockRedis {
+    async get(key: string): Promise<string | null> {
+      const entry = fakeStore.get(key);
+      if (!entry) {
+        return null;
+      }
+      if (Date.now() > entry.expiresAt) {
+        fakeStore.delete(key);
+        return null;
+      }
+      return entry.value;
+    }
+    async set(key: string, value: string, _ex: 'EX', ttlSec: number): Promise<'OK'> {
+      fakeStore.set(key, { value, expiresAt: Date.now() + ttlSec * 1000 });
+      return 'OK';
+    }
+    async del(key: string): Promise<number> {
+      return fakeStore.delete(key) ? 1 : 0;
+    }
+    async quit(): Promise<'OK'> {
+      return 'OK';
+    }
+    on(_event: string, _cb: () => void): void {
+      // noop
+    }
+  }
+  return { default: MockRedis };
+});
+
+// Import después del mock para que vite-node lo aplique.
+const { ObservabilityCache } = await import('../../../src/services/observability/cache.js');
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+describe('ObservabilityCache', () => {
+  let cache: InstanceType<typeof ObservabilityCache>;
+
+  beforeEach(() => {
+    fakeStore.clear();
+    vi.clearAllMocks();
+    cache = new ObservabilityCache({
+      host: 'localhost',
+      port: 6379,
+      logger: fakeLogger,
+    });
+  });
+
+  afterEach(async () => {
+    await cache.close();
+  });
+
+  it('miss → ejecuta fetcher y cachea por TTL', async () => {
+    const fetcher = vi.fn().mockResolvedValue({ data: 'hola' });
+    const result = await cache.getOrFetch('key1', 60, fetcher);
+    expect(result).toEqual({ data: 'hola' });
+    expect(fetcher).toHaveBeenCalledOnce();
+    // ioredis set es fire-and-forget; doy un tick para que se asiente.
+    await new Promise((r) => setTimeout(r, 5));
+    expect(fakeStore.has('obs:key1')).toBe(true);
+  });
+
+  it('hit → NO ejecuta fetcher, retorna del cache', async () => {
+    const fetcher1 = vi.fn().mockResolvedValue({ v: 1 });
+    await cache.getOrFetch('key2', 60, fetcher1);
+    await new Promise((r) => setTimeout(r, 5)); // espera set
+
+    const fetcher2 = vi.fn().mockResolvedValue({ v: 999 });
+    const result = await cache.getOrFetch('key2', 60, fetcher2);
+    expect(result).toEqual({ v: 1 }); // del cache, no del fetcher2
+    expect(fetcher2).not.toHaveBeenCalled();
+  });
+
+  it('TTL expira → re-fetch', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce({ v: 'first' }).mockResolvedValueOnce({
+      v: 'second',
+    });
+    await cache.getOrFetch('key3', 0, fetcher);
+    await new Promise((r) => setTimeout(r, 5));
+    // expira inmediatamente con TTL=0 + tick.
+    // Hacemos sleep > 1s para forzar expiración (Redis tiene resolución de segundos).
+    // Pero en este mock Date.now() resolution es ms, así que TTL=0 ya expiró.
+    const result = await cache.getOrFetch('key3', 0, fetcher);
+    expect(result).toEqual({ v: 'second' });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('JSON corrupto en cache → re-fetch y loggea warn', async () => {
+    // Manualmente corromper el storage
+    fakeStore.set('obs:key4', {
+      value: '{ malformed',
+      expiresAt: Date.now() + 60_000,
+    });
+    const fetcher = vi.fn().mockResolvedValue({ ok: true });
+    const result = await cache.getOrFetch('key4', 60, fetcher);
+    expect(result).toEqual({ ok: true });
+    expect(fetcher).toHaveBeenCalledOnce();
+    expect(fakeLogger.warn).toHaveBeenCalled();
+  });
+
+  it('invalidate elimina la key del cache', async () => {
+    const fetcher = vi.fn().mockResolvedValueOnce({ v: 'first' }).mockResolvedValueOnce({
+      v: 'second',
+    });
+    await cache.getOrFetch('key5', 60, fetcher);
+    await new Promise((r) => setTimeout(r, 5));
+    await cache.invalidate('key5');
+    const result = await cache.getOrFetch('key5', 60, fetcher);
+    expect(result).toEqual({ v: 'second' });
+  });
+});

--- a/apps/api/test/unit/observability/cache.test.ts
+++ b/apps/api/test/unit/observability/cache.test.ts
@@ -129,4 +129,35 @@ describe('ObservabilityCache', () => {
     const result = await cache.getOrFetch('key5', 60, fetcher);
     expect(result).toEqual({ v: 'second' });
   });
+
+  it('Redis password + TLS pasados al constructor (smoke test branches)', async () => {
+    // Solo verifica que la construcción con TLS + password no crashea
+    // (cubre las branches del spread en el constructor de ObservabilityCache).
+    const cacheWithTls = new ObservabilityCache({
+      host: 'localhost',
+      port: 6379,
+      password: 'secret-pass',
+      tls: true,
+      logger: fakeLogger,
+    });
+    expect(cacheWithTls).toBeDefined();
+    await cacheWithTls.close();
+  });
+
+  it('Redis get falla → fallthrough al fetcher sin crashear', async () => {
+    // Forzamos error en get monkey-patcheando el fakeStore.get para
+    // tirar excepción. El cache debería loggear warn + llamar fetcher.
+    const original = fakeStore.get.bind(fakeStore);
+    fakeStore.get = () => {
+      throw new Error('connection refused');
+    };
+    try {
+      const fetcher = vi.fn().mockResolvedValue({ v: 'fallback' });
+      const result = await cache.getOrFetch('key-err', 60, fetcher);
+      expect(result).toEqual({ v: 'fallback' });
+      expect(fetcher).toHaveBeenCalledOnce();
+    } finally {
+      fakeStore.get = original;
+    }
+  });
 });

--- a/apps/api/test/unit/observability/costs-service.test.ts
+++ b/apps/api/test/unit/observability/costs-service.test.ts
@@ -74,45 +74,59 @@ describe('CostsService', () => {
     vi.clearAllMocks();
   });
 
-  it('getOverview: calcula MTD + previous month + delta% (CLP nativo)', async () => {
+  it('getOverview: delta apples-to-apples vs mismo periodo mes anterior', async () => {
+    // Fila única: [thisMonthMtd, prevMonthSamePeriod, prevMonthFull, currency, last_export]
+    // Día 13 del mes — MTD 100k vs mismos 13 días del mes anterior 90k → +11.1%.
+    // Mes anterior completo 200k (contexto, no usado en delta).
     const fetchImpl = makeBqFetch(
-      [
-        ['2026-05-01', '100000', 'CLP', '2026-05-13T13:00:00Z'], // mes actual
-        ['2026-04-01', '90000', 'CLP', '2026-05-13T13:00:00Z'], // mes anterior
-      ],
-      ['month', 'net_cost', 'currency', 'last_export'],
+      [['100000', '90000', '200000', 'CLP', '2026-05-13T13:00:00Z']],
+      ['this_month_mtd', 'prev_month_same_period', 'prev_month_full', 'currency', 'last_export'],
     );
     const svc = buildService(fetchImpl);
     const result = await svc.getOverview();
     expect(result.costClpMonthToDate).toBe(100_000);
-    expect(result.costClpPreviousMonth).toBe(90_000);
+    expect(result.costClpPreviousMonthSamePeriod).toBe(90_000);
+    expect(result.costClpPreviousMonth).toBe(200_000);
     expect(result.deltaPercentVsPreviousMonth).toBeCloseTo(11.1, 1);
     expect(result.lastBillingExportAt).toBe('2026-05-13T13:00:00Z');
   });
 
+  it('getOverview: delta NO compara contra mes completo (evita falso "−83%")', async () => {
+    // Día 5 del mes, MTD muy bajo. Si comparáramos contra mes-completo
+    // anterior (500k) daría "−96%" — falsa lectura. Con apples-to-apples
+    // comparamos contra primeros 5 días del mes anterior (15k): MTD 17k →
+    // delta = +13.3% (representativo del ritmo).
+    const fetchImpl = makeBqFetch(
+      [['17000', '15000', '500000', 'CLP', '2026-05-05T13:00:00Z']],
+      ['this_month_mtd', 'prev_month_same_period', 'prev_month_full', 'currency', 'last_export'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getOverview();
+    expect(result.deltaPercentVsPreviousMonth).toBeCloseTo(13.3, 1);
+    expect(result.deltaPercentVsPreviousMonth).not.toBeCloseTo(-96.6, 1);
+  });
+
   it('getOverview: convierte USD a CLP cuando currency=USD', async () => {
     const fetchImpl = makeBqFetch(
-      [
-        ['2026-05-01', '100', 'USD', '2026-05-13T13:00:00Z'],
-        ['2026-04-01', '90', 'USD', '2026-05-13T13:00:00Z'],
-      ],
-      ['month', 'net_cost', 'currency', 'last_export'],
+      [['100', '90', '200', 'USD', '2026-05-13T13:00:00Z']],
+      ['this_month_mtd', 'prev_month_same_period', 'prev_month_full', 'currency', 'last_export'],
     );
     const svc = buildService(fetchImpl);
     const result = await svc.getOverview();
     expect(result.costClpMonthToDate).toBe(100_000); // 100 USD × 1000
-    expect(result.costClpPreviousMonth).toBe(90_000);
+    expect(result.costClpPreviousMonthSamePeriod).toBe(90_000);
+    expect(result.costClpPreviousMonth).toBe(200_000);
   });
 
-  it('getOverview: previousMonth=0 → deltaPercent=null', async () => {
+  it('getOverview: prevSamePeriod=0 → deltaPercent=null (no division)', async () => {
     const fetchImpl = makeBqFetch(
-      [['2026-05-01', '50000', 'CLP', '2026-05-13T13:00:00Z']],
-      ['month', 'net_cost', 'currency', 'last_export'],
+      [['50000', '0', '40000', 'CLP', '2026-05-01T13:00:00Z']],
+      ['this_month_mtd', 'prev_month_same_period', 'prev_month_full', 'currency', 'last_export'],
     );
     const svc = buildService(fetchImpl);
     const result = await svc.getOverview();
     expect(result.costClpMonthToDate).toBe(50_000);
-    expect(result.costClpPreviousMonth).toBe(0);
+    expect(result.costClpPreviousMonthSamePeriod).toBe(0);
     expect(result.deltaPercentVsPreviousMonth).toBeNull();
   });
 
@@ -238,11 +252,8 @@ describe('CostsService', () => {
 
   it('toClp: currency desconocida → loggea warn pero no crashea', async () => {
     const fetchImpl = makeBqFetch(
-      [
-        ['2026-05-01', '100', 'EUR'],
-        ['2026-04-01', '90', 'EUR'],
-      ],
-      ['month', 'net_cost', 'currency'],
+      [['100', '90', '200', 'EUR', '2026-05-13T13:00:00Z']],
+      ['this_month_mtd', 'prev_month_same_period', 'prev_month_full', 'currency', 'last_export'],
     );
     const svc = buildService(fetchImpl);
     const result = await svc.getOverview();

--- a/apps/api/test/unit/observability/costs-service.test.ts
+++ b/apps/api/test/unit/observability/costs-service.test.ts
@@ -1,0 +1,252 @@
+import type { Logger } from '@booster-ai/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ObservabilityCache } from '../../../src/services/observability/cache.js';
+import { CostsService } from '../../../src/services/observability/costs-service.js';
+import type { FxRateService } from '../../../src/services/observability/fx-rate-service.js';
+
+/**
+ * Tests del CostsService. Mocks:
+ * - cache: in-memory passthrough (igual al patrón de fx-rate-service.test).
+ * - fxRateService: stub que retorna usdToClp determinístico.
+ * - fetch: stub que retorna respuestas BQ con schema simulado.
+ * - getAccessToken: retorna un token fake (evita ADC en CI).
+ */
+
+class InMemoryCacheStub {
+  private readonly store = new Map<string, unknown>();
+  async getOrFetch<T>(key: string, _ttl: number, fetcher: () => Promise<T>): Promise<T> {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+    const value = await fetcher();
+    this.store.set(key, value);
+    return value;
+  }
+  async invalidate(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+  _clear(): void {
+    this.store.clear();
+  }
+}
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+const fakeFx = {
+  usdToClp: vi.fn(async (usd: number) => usd * 1000),
+} as unknown as FxRateService;
+
+function makeBqFetch(rows: Array<Array<string | null>>, fields: string[]): typeof fetch {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    text: async () => '',
+    json: async () => ({
+      jobComplete: true,
+      schema: { fields: fields.map((name) => ({ name })) },
+      rows: rows.map((r) => ({ f: r.map((v) => ({ v })) })),
+    }),
+  })) as unknown as typeof fetch;
+}
+
+function buildService(fetchImpl: typeof fetch): CostsService {
+  return new CostsService({
+    cache: new InMemoryCacheStub() as unknown as ObservabilityCache,
+    fxRateService: fakeFx,
+    logger: fakeLogger,
+    billingExportTable: 'p.d.t',
+    queryProjectId: 'p',
+    fetchImpl,
+    getAccessToken: async () => 'fake-token',
+  });
+}
+
+describe('CostsService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getOverview: calcula MTD + previous month + delta% (CLP nativo)', async () => {
+    const fetchImpl = makeBqFetch(
+      [
+        ['2026-05-01', '100000', 'CLP', '2026-05-13T13:00:00Z'], // mes actual
+        ['2026-04-01', '90000', 'CLP', '2026-05-13T13:00:00Z'], // mes anterior
+      ],
+      ['month', 'net_cost', 'currency', 'last_export'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getOverview();
+    expect(result.costClpMonthToDate).toBe(100_000);
+    expect(result.costClpPreviousMonth).toBe(90_000);
+    expect(result.deltaPercentVsPreviousMonth).toBeCloseTo(11.1, 1);
+    expect(result.lastBillingExportAt).toBe('2026-05-13T13:00:00Z');
+  });
+
+  it('getOverview: convierte USD a CLP cuando currency=USD', async () => {
+    const fetchImpl = makeBqFetch(
+      [
+        ['2026-05-01', '100', 'USD', '2026-05-13T13:00:00Z'],
+        ['2026-04-01', '90', 'USD', '2026-05-13T13:00:00Z'],
+      ],
+      ['month', 'net_cost', 'currency', 'last_export'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getOverview();
+    expect(result.costClpMonthToDate).toBe(100_000); // 100 USD × 1000
+    expect(result.costClpPreviousMonth).toBe(90_000);
+  });
+
+  it('getOverview: previousMonth=0 → deltaPercent=null', async () => {
+    const fetchImpl = makeBqFetch(
+      [['2026-05-01', '50000', 'CLP', '2026-05-13T13:00:00Z']],
+      ['month', 'net_cost', 'currency', 'last_export'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getOverview();
+    expect(result.costClpMonthToDate).toBe(50_000);
+    expect(result.costClpPreviousMonth).toBe(0);
+    expect(result.deltaPercentVsPreviousMonth).toBeNull();
+  });
+
+  it('getByService: incluye percentOfTotal y ordena desc', async () => {
+    const fetchImpl = makeBqFetch(
+      [
+        ['Cloud Run', '60000', 'CLP'],
+        ['Cloud SQL', '30000', 'CLP'],
+        ['Pub/Sub', '10000', 'CLP'],
+      ],
+      ['service', 'net_cost', 'currency'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getByService(30);
+    expect(result).toHaveLength(3);
+    expect(result[0]?.service).toBe('Cloud Run');
+    expect(result[0]?.percentOfTotal).toBe(60);
+    expect(result[2]?.service).toBe('Pub/Sub');
+    expect(result[2]?.percentOfTotal).toBe(10);
+  });
+
+  it('getByService: range > 90 días se clampa a 90', async () => {
+    let capturedBody = '';
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => ({
+          jobComplete: true,
+          schema: { fields: [{ name: 'service' }] },
+          rows: [],
+        }),
+      };
+    }) as unknown as typeof fetch;
+    const svc = buildService(fetchImpl);
+    await svc.getByService(999);
+    expect(capturedBody).toContain('INTERVAL 90 DAY');
+  });
+
+  it('getTrend: retorna serie diaria ordenada por fecha', async () => {
+    const fetchImpl = makeBqFetch(
+      [
+        ['2026-05-10', '8000', 'CLP'],
+        ['2026-05-11', '9000', 'CLP'],
+        ['2026-05-12', '7500', 'CLP'],
+      ],
+      ['day', 'net_cost', 'currency'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getTrend(7);
+    expect(result).toHaveLength(3);
+    expect(result[0]?.date).toBe('2026-05-10');
+    expect(result[0]?.costClp).toBe(8000);
+  });
+
+  it('getByProject: filtra null + calcula percentOfTotal', async () => {
+    const fetchImpl = makeBqFetch(
+      [
+        ['booster-ai-494222', 'booster-ai', '75000', 'CLP'],
+        ['booster-legacy', 'Booster Legacy', '25000', 'CLP'],
+      ],
+      ['project_id', 'project_name', 'net_cost', 'currency'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getByProject(30);
+    expect(result).toHaveLength(2);
+    expect(result[0]?.projectId).toBe('booster-ai-494222');
+    expect(result[0]?.percentOfTotal).toBe(75);
+  });
+
+  it('getTopSkus: pasa LIMIT al SQL y mapea resultados', async () => {
+    let capturedBody = '';
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      capturedBody = init?.body as string;
+      // BQ aplicaría el LIMIT — el mock retorna sólo 5 filas (las top).
+      const rows = Array.from({ length: 5 }, (_, i) => [
+        `Service ${i}`,
+        `SKU ${i}`,
+        String(1000 * (5 - i)),
+        'CLP',
+      ]);
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => ({
+          jobComplete: true,
+          schema: { fields: [{ name: 'service' }, { name: 'sku' }, { name: 'net_cost' }] },
+          rows: rows.map((r) => ({ f: r.map((v) => ({ v })) })),
+        }),
+      };
+    }) as unknown as typeof fetch;
+    const svc = buildService(fetchImpl);
+    const result = await svc.getTopSkus(5);
+    expect(capturedBody).toContain('LIMIT 5');
+    expect(result).toHaveLength(5);
+    expect(result[0]?.costClp).toBe(5000);
+  });
+
+  it('runQuery: BQ error response → throw', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      text: async () => 'internal error',
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    const svc = buildService(fetchImpl);
+    await expect(svc.getOverview()).rejects.toThrow(/BigQuery query failed/);
+  });
+
+  it('runQuery: BQ retorna jobComplete=false → throw', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => ({ jobComplete: false }),
+    })) as unknown as typeof fetch;
+    const svc = buildService(fetchImpl);
+    await expect(svc.getOverview()).rejects.toThrow(/did not complete/);
+  });
+
+  it('toClp: currency desconocida → loggea warn pero no crashea', async () => {
+    const fetchImpl = makeBqFetch(
+      [
+        ['2026-05-01', '100', 'EUR'],
+        ['2026-04-01', '90', 'EUR'],
+      ],
+      ['month', 'net_cost', 'currency'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getOverview();
+    expect(result.costClpMonthToDate).toBe(100); // raw passthrough
+    expect(fakeLogger.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/unit/observability/costs-service.test.ts
+++ b/apps/api/test/unit/observability/costs-service.test.ts
@@ -228,6 +228,65 @@ describe('CostsService', () => {
     expect(result[0]?.costClp).toBe(5000);
   });
 
+  it('getMonthlyHistory: serie ordenada con delta encadenado entre meses cerrados', async () => {
+    // Usamos 3 meses 2024 (cerrados) para que ninguno coincida con el
+    // currentMonth y todos lleven delta calculado.
+    const fetchImpl = makeBqFetch(
+      [
+        ['2024-03', '300000', 'CLP'],
+        ['2024-04', '450000', 'CLP'], // +50% vs mar
+        ['2024-05', '405000', 'CLP'], // -10% vs abr
+      ],
+      ['month', 'net_cost', 'currency'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getMonthlyHistory(3);
+    expect(result).toHaveLength(3);
+    expect(result[0]?.month).toBe('2024-03');
+    expect(result[0]?.deltaPercentVsPrior).toBeNull(); // primer mes sin delta
+    expect(result[1]?.deltaPercentVsPrior).toBeCloseTo(50.0, 1);
+    expect(result[2]?.deltaPercentVsPrior).toBeCloseTo(-10.0, 1);
+  });
+
+  it('getMonthlyHistory: mes en curso → isCurrent=true + delta=null (no apples-to-apples)', async () => {
+    const currentMonth = new Date().toISOString().slice(0, 7);
+    const fetchImpl = makeBqFetch(
+      [
+        ['2024-01', '100000', 'CLP'],
+        [currentMonth, '50000', 'CLP'],
+      ],
+      ['month', 'net_cost', 'currency'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getMonthlyHistory(12);
+    expect(result[0]?.isCurrent).toBe(false);
+    expect(result[1]?.isCurrent).toBe(true);
+    // El mes actual NO calcula delta (MTD vs mes-completo sería engañoso).
+    expect(result[1]?.deltaPercentVsPrior).toBeNull();
+  });
+
+  it('getMonthlyHistory: clampea months a [1, 24]', async () => {
+    let capturedSql = '';
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      const body = JSON.parse(init?.body as string) as { query: string };
+      capturedSql = body.query;
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => ({
+          jobComplete: true,
+          schema: { fields: [{ name: 'month' }] },
+          rows: [],
+        }),
+      };
+    }) as unknown as typeof fetch;
+    const svc = buildService(fetchImpl);
+    await svc.getMonthlyHistory(999);
+    // 24 meses - 1 = 23 (offset desde el mes actual)
+    expect(capturedSql).toContain('INTERVAL 23 MONTH');
+  });
+
   it('runQuery: BQ error response → throw', async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: false,

--- a/apps/api/test/unit/observability/costs-service.test.ts
+++ b/apps/api/test/unit/observability/costs-service.test.ts
@@ -309,6 +309,37 @@ describe('CostsService', () => {
     await expect(svc.getOverview()).rejects.toThrow(/did not complete/);
   });
 
+  it('constructor sin getAccessToken inyectado → usa GoogleAuth ADC (smoke)', async () => {
+    // En setup.ts se mockea google-auth-library globalmente → token='test-access-token'.
+    // Aquí verificamos que el path "construct + lazy auth" no crashea.
+    const fetchImpl = makeBqFetch(
+      [['1000', '900', '2000', 'CLP', '2026-05-13T13:00:00Z']],
+      ['this_month_mtd', 'prev_month_same_period', 'prev_month_full', 'currency', 'last_export'],
+    );
+    const svc = new CostsService({
+      cache: new InMemoryCacheStub() as unknown as ObservabilityCache,
+      fxRateService: fakeFx,
+      logger: fakeLogger,
+      billingExportTable: 'p.d.t',
+      queryProjectId: 'p',
+      fetchImpl,
+      // sin getAccessToken — fuerza el path ADC del constructor
+    });
+    const result = await svc.getOverview();
+    expect(result.costClpMonthToDate).toBe(1000);
+  });
+
+  it('toClp: amount NaN → retorna 0 (defensa contra parseFloat fail)', async () => {
+    const fetchImpl = makeBqFetch(
+      [['not-a-number', '0', '0', 'CLP', '2026-05-13T13:00:00Z']],
+      ['this_month_mtd', 'prev_month_same_period', 'prev_month_full', 'currency', 'last_export'],
+    );
+    const svc = buildService(fetchImpl);
+    const result = await svc.getOverview();
+    // parseFloat('not-a-number') = NaN → toClp retorna 0
+    expect(result.costClpMonthToDate).toBe(0);
+  });
+
   it('toClp: currency desconocida → loggea warn pero no crashea', async () => {
     const fetchImpl = makeBqFetch(
       [['100', '90', '200', 'EUR', '2026-05-13T13:00:00Z']],

--- a/apps/api/test/unit/observability/factory.test.ts
+++ b/apps/api/test/unit/observability/factory.test.ts
@@ -1,0 +1,149 @@
+import type { Logger } from '@booster-ai/logger';
+import { describe, expect, it, vi } from 'vitest';
+import { buildObservabilityServices } from '../../../src/services/observability/factory.js';
+
+/**
+ * Tests del `buildObservabilityServices` factory. Verifica que:
+ * - Servicios siempre construidos: cache + fx + costs + monitoring +
+ *   forecast + health + workspace.
+ * - `twilioUsageService` es null si faltan creds (graceful degradation).
+ * - `workspace adapter` no se monta si falta domain/impersonate/reader-sa
+ *   (graceful degradation log info, no crash).
+ *
+ * No mockeamos los servicios concretos — confiamos que cada uno tiene
+ * sus tests aislados. Este factory test sólo verifica el cableado.
+ */
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+const baseConfig = {
+  redisHost: 'localhost',
+  redisPort: 6379,
+  redisTls: false,
+  billingExportTable: 'p.d.t',
+  gcpProjectId: 'p',
+  workspaceDomain: '',
+  workspaceImpersonateEmail: '',
+  workspaceReaderSaEmail: '',
+  workspacePriceMap: { starter: 6, standard: 12, plus: 18, enterprise: 30 },
+  monthlyBudgetUsd: 1000,
+  observabilityDashboardActivated: true,
+};
+
+describe('buildObservabilityServices', () => {
+  it('construye todos los servicios core + monthlyBudgetUsd + featureFlag', () => {
+    const services = buildObservabilityServices(baseConfig, fakeLogger);
+    expect(services.cache).toBeDefined();
+    expect(services.fxRateService).toBeDefined();
+    expect(services.costsService).toBeDefined();
+    expect(services.monitoringService).toBeDefined();
+    expect(services.workspaceService).toBeDefined();
+    expect(services.forecastService).toBeDefined();
+    expect(services.healthChecksService).toBeDefined();
+    expect(services.monthlyBudgetUsd).toBe(1000);
+    expect(services.featureFlag).toBe(true);
+    // Cleanup: cerrar Redis connection lazy
+    services.cache.close().catch(() => {
+      /* noop */
+    });
+  });
+
+  it('twilioUsageService=null cuando faltan credentials', () => {
+    const services = buildObservabilityServices(baseConfig, fakeLogger);
+    expect(services.twilioUsageService).toBeNull();
+    services.cache.close().catch(() => {
+      /* noop */
+    });
+  });
+
+  it('twilioUsageService=instancia cuando las 2 creds están seteadas', () => {
+    const services = buildObservabilityServices(
+      { ...baseConfig, twilioAccountSid: 'ACtest', twilioAuthToken: 'auth-token-secret' },
+      fakeLogger,
+    );
+    expect(services.twilioUsageService).not.toBeNull();
+    services.cache.close().catch(() => {
+      /* noop */
+    });
+  });
+
+  it('twilioUsageService=null si solo 1 de las 2 creds está seteada', () => {
+    const services = buildObservabilityServices(
+      { ...baseConfig, twilioAccountSid: 'ACtest' }, // auth-token missing
+      fakeLogger,
+    );
+    expect(services.twilioUsageService).toBeNull();
+    services.cache.close().catch(() => {
+      /* noop */
+    });
+  });
+
+  it('workspace adapter null cuando domain vacío → loggea info graceful', () => {
+    const services = buildObservabilityServices(baseConfig, fakeLogger);
+    // El servicio se construye, pero el adapter interno no — verificable
+    // indirectamente porque el log info se emite con el reason.
+    expect(services.workspaceService).toBeDefined();
+    expect(fakeLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ hasDomain: false }),
+      expect.stringContaining('workspace admin SDK config incompleta'),
+    );
+    services.cache.close().catch(() => {
+      /* noop */
+    });
+  });
+
+  it('workspace adapter null si reader SA email está vacío (aunque domain + impersonate sí)', () => {
+    const services = buildObservabilityServices(
+      {
+        ...baseConfig,
+        workspaceDomain: 'boosterchile.com',
+        workspaceImpersonateEmail: 'admin@boosterchile.com',
+        workspaceReaderSaEmail: '', // missing
+      },
+      fakeLogger,
+    );
+    expect(services.workspaceService).toBeDefined();
+    expect(fakeLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ hasReaderSa: false }),
+      expect.stringContaining('workspace admin SDK config incompleta'),
+    );
+    services.cache.close().catch(() => {
+      /* noop */
+    });
+  });
+
+  it('workspace adapter construido cuando los 3 fields están presentes', () => {
+    const services = buildObservabilityServices(
+      {
+        ...baseConfig,
+        workspaceDomain: 'boosterchile.com',
+        workspaceImpersonateEmail: 'admin@boosterchile.com',
+        workspaceReaderSaEmail: 'reader@booster-ai.iam.gserviceaccount.com',
+      },
+      fakeLogger,
+    );
+    expect(services.workspaceService).toBeDefined();
+    services.cache.close().catch(() => {
+      /* noop */
+    });
+  });
+
+  it('featureFlag=false se propaga desde config', () => {
+    const services = buildObservabilityServices(
+      { ...baseConfig, observabilityDashboardActivated: false },
+      fakeLogger,
+    );
+    expect(services.featureFlag).toBe(false);
+    services.cache.close().catch(() => {
+      /* noop */
+    });
+  });
+});

--- a/apps/api/test/unit/observability/forecast-service.test.ts
+++ b/apps/api/test/unit/observability/forecast-service.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { ForecastService } from '../../../src/services/observability/forecast-service.js';
+
+describe('ForecastService', () => {
+  const svc = new ForecastService();
+
+  it('día 15 de 30 → forecast = 2× MTD', () => {
+    const now = new Date('2026-06-15T15:00:00Z'); // junio tiene 30 días
+    const result = svc.forecast({
+      mtdCostClp: 500_000,
+      budgetUsd: 1000,
+      clpPerUsd: 925,
+      now,
+    });
+    expect(result.dayOfMonth).toBe(15);
+    expect(result.daysInMonth).toBe(30);
+    expect(result.forecastClpEndOfMonth).toBe(1_000_000);
+    expect(result.budgetClp).toBe(925_000);
+    expect(result.variancePercent).toBeCloseTo(8.1, 1); // (1M - 925k)/925k
+  });
+
+  it('día 1 → forecast escala a daysInMonth completos', () => {
+    const now = new Date('2026-05-01T15:00:00Z'); // mayo: 31 días
+    const result = svc.forecast({
+      mtdCostClp: 30_000,
+      budgetUsd: 1000,
+      clpPerUsd: 925,
+      now,
+    });
+    expect(result.dayOfMonth).toBe(1);
+    expect(result.daysInMonth).toBe(31);
+    expect(result.forecastClpEndOfMonth).toBe(930_000); // 30k × 31
+  });
+
+  it('día último del mes → forecast = MTD (no extrapola)', () => {
+    const now = new Date('2026-05-31T15:00:00Z');
+    const result = svc.forecast({
+      mtdCostClp: 800_000,
+      budgetUsd: 1000,
+      clpPerUsd: 925,
+      now,
+    });
+    expect(result.dayOfMonth).toBe(31);
+    expect(result.daysInMonth).toBe(31);
+    expect(result.forecastClpEndOfMonth).toBe(800_000);
+    expect(result.daysRemaining).toBe(0);
+  });
+
+  it('MTD = 0 → forecast = 0 y variance es -100%', () => {
+    const now = new Date('2026-05-15T15:00:00Z');
+    const result = svc.forecast({
+      mtdCostClp: 0,
+      budgetUsd: 1000,
+      clpPerUsd: 925,
+      now,
+    });
+    expect(result.forecastClpEndOfMonth).toBe(0);
+    expect(result.variancePercent).toBe(-100);
+  });
+
+  it('budget = 0 → variance = 0 (no division by zero)', () => {
+    const now = new Date('2026-05-15T15:00:00Z');
+    const result = svc.forecast({
+      mtdCostClp: 500_000,
+      budgetUsd: 0,
+      clpPerUsd: 925,
+      now,
+    });
+    expect(result.budgetClp).toBe(0);
+    expect(result.variancePercent).toBe(0);
+  });
+
+  it('mtdCost negativo (créditos) → trata como 0', () => {
+    const now = new Date('2026-05-15T15:00:00Z');
+    const result = svc.forecast({
+      mtdCostClp: -1000,
+      budgetUsd: 1000,
+      clpPerUsd: 925,
+      now,
+    });
+    expect(result.forecastClpEndOfMonth).toBe(0);
+  });
+
+  it('febrero de año no bisiesto = 28 días', () => {
+    const now = new Date('2026-02-14T15:00:00Z'); // 2026 no bisiesto
+    const result = svc.forecast({
+      mtdCostClp: 100_000,
+      budgetUsd: 1000,
+      clpPerUsd: 925,
+      now,
+    });
+    expect(result.daysInMonth).toBe(28);
+    expect(result.dayOfMonth).toBe(14);
+    expect(result.forecastClpEndOfMonth).toBe(200_000); // 100k × 28 / 14
+  });
+});

--- a/apps/api/test/unit/observability/fx-rate-service.test.ts
+++ b/apps/api/test/unit/observability/fx-rate-service.test.ts
@@ -1,0 +1,165 @@
+import type { Logger } from '@booster-ai/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ObservabilityCache } from '../../../src/services/observability/cache.js';
+import { FxRateService } from '../../../src/services/observability/fx-rate-service.js';
+
+/**
+ * Tests del FxRateService (mindicador.cl).
+ *
+ * Mock del cache con una implementación inline que respeta el contrato
+ * `getOrFetch(key, ttl, fetcher)` y `invalidate(key)` — más rápido que
+ * mockear ioredis + cache wrapper.
+ */
+
+class InMemoryCacheStub {
+  private readonly store = new Map<string, unknown>();
+
+  async getOrFetch<T>(key: string, _ttlSec: number, fetcher: () => Promise<T>): Promise<T> {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+    const value = await fetcher();
+    this.store.set(key, value);
+    return value;
+  }
+
+  async invalidate(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+
+  // Helper para tests: forzar valor en cache
+  _set(key: string, value: unknown): void {
+    this.store.set(key, value);
+  }
+
+  _clear(): void {
+    this.store.clear();
+  }
+}
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+function makeFetchOk(serie: Array<{ fecha: string; valor: number }>): typeof fetch {
+  return vi.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ serie }),
+  })) as unknown as typeof fetch;
+}
+
+function makeFetchFail(): typeof fetch {
+  return vi.fn(async () => {
+    throw new Error('ECONNREFUSED');
+  }) as unknown as typeof fetch;
+}
+
+describe('FxRateService', () => {
+  let cache: InMemoryCacheStub;
+
+  beforeEach(() => {
+    cache = new InMemoryCacheStub();
+    vi.clearAllMocks();
+  });
+
+  it('mindicador OK → retorna source=mindicador y guarda en fallback', async () => {
+    const fetchImpl = makeFetchOk([{ fecha: '2026-05-13T00:00:00.000Z', valor: 925.34 }]);
+    const svc = new FxRateService({
+      cache: cache as unknown as ObservabilityCache,
+      logger: fakeLogger,
+      fetchImpl,
+    });
+
+    const rate = await svc.getCurrentRate();
+    expect(rate.clpPerUsd).toBe(925.34);
+    expect(rate.source).toBe('mindicador');
+    expect(rate.observedAt).toBe('2026-05-13T00:00:00.000Z');
+  });
+
+  it('mindicador caído + fallback cache hit → source=cache-fallback', async () => {
+    const fetchImpl = makeFetchFail();
+    // Pre-poblar el fallback cache con un valor "de ayer"
+    cache._set('fx:clp-usd:fallback', {
+      clpPerUsd: 920,
+      observedAt: '2026-05-12T00:00:00.000Z',
+      source: 'mindicador',
+    });
+    const svc = new FxRateService({
+      cache: cache as unknown as ObservabilityCache,
+      logger: fakeLogger,
+      fetchImpl,
+    });
+
+    const rate = await svc.getCurrentRate();
+    expect(rate.clpPerUsd).toBe(920);
+    expect(rate.source).toBe('cache-fallback');
+    expect(fakeLogger.warn).toHaveBeenCalled();
+  });
+
+  it('mindicador caído + sin fallback → hardcoded 940', async () => {
+    const fetchImpl = makeFetchFail();
+    const svc = new FxRateService({
+      cache: cache as unknown as ObservabilityCache,
+      logger: fakeLogger,
+      fetchImpl,
+    });
+
+    const rate = await svc.getCurrentRate();
+    expect(rate.clpPerUsd).toBe(940);
+    expect(rate.source).toBe('hardcoded');
+  });
+
+  it('usdToClp redondea correctamente al entero más cercano', async () => {
+    const fetchImpl = makeFetchOk([{ fecha: '2026-05-13T00:00:00Z', valor: 925.5 }]);
+    const svc = new FxRateService({
+      cache: cache as unknown as ObservabilityCache,
+      logger: fakeLogger,
+      fetchImpl,
+    });
+
+    const clp = await svc.usdToClp(100);
+    expect(clp).toBe(92550); // 100 × 925.50
+  });
+
+  it('mindicador retorna body malformado (sin serie) → cae al fallback', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({}), // sin serie
+    })) as unknown as typeof fetch;
+    cache._set('fx:clp-usd:fallback', {
+      clpPerUsd: 900,
+      observedAt: '2026-05-10T00:00:00Z',
+      source: 'mindicador',
+    });
+    const svc = new FxRateService({
+      cache: cache as unknown as ObservabilityCache,
+      logger: fakeLogger,
+      fetchImpl,
+    });
+
+    const rate = await svc.getCurrentRate();
+    expect(rate.clpPerUsd).toBe(900);
+    expect(rate.source).toBe('cache-fallback');
+  });
+
+  it('mindicador retorna valor inválido (<=0) → fallback', async () => {
+    const fetchImpl = makeFetchOk([{ fecha: '2026-05-13T00:00:00Z', valor: 0 }]);
+    const svc = new FxRateService({
+      cache: cache as unknown as ObservabilityCache,
+      logger: fakeLogger,
+      fetchImpl,
+    });
+
+    const rate = await svc.getCurrentRate();
+    expect(rate.clpPerUsd).toBe(940);
+    expect(rate.source).toBe('hardcoded');
+  });
+});

--- a/apps/api/test/unit/observability/health-checks-service.test.ts
+++ b/apps/api/test/unit/observability/health-checks-service.test.ts
@@ -1,0 +1,156 @@
+import type { Logger } from '@booster-ai/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ObservabilityCache } from '../../../src/services/observability/cache.js';
+import { HealthChecksService } from '../../../src/services/observability/health-checks-service.js';
+import type { MonitoringService } from '../../../src/services/observability/monitoring-service.js';
+
+class InMemoryCacheStub {
+  private readonly store = new Map<string, unknown>();
+  async getOrFetch<T>(key: string, _ttl: number, fetcher: () => Promise<T>): Promise<T> {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+    const value = await fetcher();
+    this.store.set(key, value);
+    return value;
+  }
+  async invalidate(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+function buildMonitoring(opts: {
+  uptime?: { uptimePercent: number; totalChecks: number; lastSampleAt: string | null };
+  cloudRun?: {
+    cpuUtilization: number | null;
+    ramUtilization: number | null;
+    latencyP95Ms: number | null;
+    rps: number | null;
+  } | null;
+  cloudSql?: {
+    cpuUtilization: number | null;
+    ramUtilization: number | null;
+    diskUtilization: number | null;
+    connectionsUsedRatio: number | null;
+  } | null;
+}): MonitoringService {
+  return {
+    getUptimeSnapshot: vi.fn(
+      async () => opts.uptime ?? { uptimePercent: 100, totalChecks: 0, lastSampleAt: null },
+    ),
+    getCloudRunMetrics: vi.fn(async () => {
+      if (opts.cloudRun === null) {
+        throw new Error('mock-fail');
+      }
+      return (
+        opts.cloudRun ?? { cpuUtilization: 0.4, ramUtilization: 0.5, latencyP95Ms: 100, rps: 5 }
+      );
+    }),
+    getCloudSqlMetrics: vi.fn(async () => {
+      if (opts.cloudSql === null) {
+        throw new Error('mock-fail');
+      }
+      return (
+        opts.cloudSql ?? {
+          cpuUtilization: 0.3,
+          ramUtilization: 0.4,
+          diskUtilization: 0.5,
+          connectionsUsedRatio: 0.2,
+        }
+      );
+    }),
+  } as unknown as MonitoringService;
+}
+
+function build(monitoring: MonitoringService): HealthChecksService {
+  return new HealthChecksService({
+    cache: new InMemoryCacheStub() as unknown as ObservabilityCache,
+    monitoringService: monitoring,
+    logger: fakeLogger,
+  });
+}
+
+describe('HealthChecksService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('healthy: uptime >99.5 + CPU<0.7 + RAM<0.8 → overall healthy', async () => {
+    const svc = build(
+      buildMonitoring({
+        uptime: { uptimePercent: 99.9, totalChecks: 3, lastSampleAt: 'now' },
+        cloudRun: { cpuUtilization: 0.3, ramUtilization: 0.4, latencyP95Ms: 120, rps: 8 },
+        cloudSql: {
+          cpuUtilization: 0.2,
+          ramUtilization: 0.3,
+          diskUtilization: 0.4,
+          connectionsUsedRatio: 0.1,
+        },
+      }),
+    );
+    const result = await svc.getSnapshot();
+    expect(result.overall).toBe('healthy');
+    expect(result.components).toHaveLength(3);
+  });
+
+  it('degraded: CPU=0.75 (>=0.7) → degraded', async () => {
+    const svc = build(
+      buildMonitoring({
+        uptime: { uptimePercent: 99.9, totalChecks: 1, lastSampleAt: 'now' },
+        cloudRun: { cpuUtilization: 0.75, ramUtilization: 0.5, latencyP95Ms: 200, rps: 8 },
+      }),
+    );
+    const result = await svc.getSnapshot();
+    expect(result.overall).toBe('degraded');
+    const cloudRunComp = result.components.find((c) => c.name === 'cloud-run');
+    expect(cloudRunComp?.level).toBe('degraded');
+  });
+
+  it('critical: uptime=95% → critical', async () => {
+    const svc = build(
+      buildMonitoring({
+        uptime: { uptimePercent: 95, totalChecks: 2, lastSampleAt: 'now' },
+        cloudRun: { cpuUtilization: 0.3, ramUtilization: 0.3, latencyP95Ms: 100, rps: 5 },
+      }),
+    );
+    const result = await svc.getSnapshot();
+    expect(result.overall).toBe('critical');
+  });
+
+  it('monitoringService falla → componente queda como unknown', async () => {
+    const svc = build(
+      buildMonitoring({
+        uptime: { uptimePercent: 100, totalChecks: 2, lastSampleAt: 'now' },
+        cloudRun: null,
+        cloudSql: null,
+      }),
+    );
+    const result = await svc.getSnapshot();
+    const cloudRunComp = result.components.find((c) => c.name === 'cloud-run');
+    expect(cloudRunComp?.level).toBe('unknown');
+    // uptime healthy + run/sql unknown → no 'critical' ni 'degraded', no 'all unknown' → 'healthy'
+    expect(result.overall).toBe('healthy');
+  });
+
+  it('todos los componentes unknown → overall=unknown', async () => {
+    const svc = build(
+      buildMonitoring({
+        uptime: { uptimePercent: 100, totalChecks: 0, lastSampleAt: null },
+        cloudRun: null,
+        cloudSql: null,
+      }),
+    );
+    const result = await svc.getSnapshot();
+    expect(result.overall).toBe('unknown');
+  });
+});

--- a/apps/api/test/unit/observability/monitoring-service.test.ts
+++ b/apps/api/test/unit/observability/monitoring-service.test.ts
@@ -1,0 +1,194 @@
+import type { Logger } from '@booster-ai/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ObservabilityCache } from '../../../src/services/observability/cache.js';
+import { MonitoringService } from '../../../src/services/observability/monitoring-service.js';
+
+/**
+ * Tests del MonitoringService — mock de Cloud Monitoring API v3 con
+ * respuestas simuladas. No requiere ADC.
+ */
+
+class InMemoryCacheStub {
+  private readonly store = new Map<string, unknown>();
+  async getOrFetch<T>(key: string, _ttl: number, fetcher: () => Promise<T>): Promise<T> {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+    const value = await fetcher();
+    this.store.set(key, value);
+    return value;
+  }
+  async invalidate(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+function makeFetch(responseByFilter: Record<string, unknown>): typeof fetch {
+  return vi.fn(async (url: string) => {
+    const u = new URL(url);
+    const filter = u.searchParams.get('filter') ?? '';
+    const key = Object.keys(responseByFilter).find((k) => filter.includes(k)) ?? '__default__';
+    const payload = responseByFilter[key] ?? { timeSeries: [] };
+    return {
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => payload,
+    };
+  }) as unknown as typeof fetch;
+}
+
+function buildService(fetchImpl: typeof fetch): MonitoringService {
+  return new MonitoringService({
+    cache: new InMemoryCacheStub() as unknown as ObservabilityCache,
+    logger: fakeLogger,
+    projectId: 'booster-ai-494222',
+    fetchImpl,
+    getAccessToken: async () => 'fake-token',
+  });
+}
+
+describe('MonitoringService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getUptimeSnapshot: agrega series y reporta uptime%', async () => {
+    const fetchImpl = makeFetch({
+      uptime_check: {
+        timeSeries: [
+          {
+            points: [
+              { interval: { endTime: '2026-05-13T20:00:00Z' }, value: { doubleValue: 1.0 } },
+              { interval: { endTime: '2026-05-13T19:59:00Z' }, value: { doubleValue: 1.0 } },
+              { interval: { endTime: '2026-05-13T19:58:00Z' }, value: { doubleValue: 0.0 } },
+            ],
+          },
+          {
+            points: [
+              { interval: { endTime: '2026-05-13T20:00:00Z' }, value: { doubleValue: 1.0 } },
+            ],
+          },
+        ],
+      },
+    });
+    const svc = buildService(fetchImpl);
+    const result = await svc.getUptimeSnapshot();
+    // 3 successes / 4 samples = 75%
+    expect(result.uptimePercent).toBe(75);
+    expect(result.totalChecks).toBe(2);
+    expect(result.lastSampleAt).toBe('2026-05-13T20:00:00Z');
+  });
+
+  it('getUptimeSnapshot: sin series → 100% / 0 checks', async () => {
+    const fetchImpl = makeFetch({ uptime_check: { timeSeries: [] } });
+    const svc = buildService(fetchImpl);
+    const result = await svc.getUptimeSnapshot();
+    expect(result.uptimePercent).toBe(100);
+    expect(result.totalChecks).toBe(0);
+    expect(result.lastSampleAt).toBeNull();
+  });
+
+  it('getCloudRunMetrics: agrega 4 métricas en paralelo', async () => {
+    const fetchImpl = makeFetch({
+      request_latencies: {
+        timeSeries: [
+          { points: [{ value: { distributionValue: { mean: 120 } } }] },
+          { points: [{ value: { distributionValue: { mean: 180 } } }] },
+        ],
+      },
+      'container/cpu/utilizations': {
+        timeSeries: [{ points: [{ value: { doubleValue: 0.45 } }] }],
+      },
+      'container/memory/utilizations': {
+        timeSeries: [{ points: [{ value: { doubleValue: 0.6 } }] }],
+      },
+      request_count: {
+        timeSeries: [{ points: [{ value: { doubleValue: 12.5 } }] }],
+      },
+    });
+    const svc = buildService(fetchImpl);
+    const result = await svc.getCloudRunMetrics();
+    expect(result.latencyP95Ms).toBe(150); // avg(120, 180)
+    expect(result.cpuUtilization).toBe(0.45);
+    expect(result.ramUtilization).toBe(0.6);
+    expect(result.rps).toBe(12.5);
+  });
+
+  it('getCloudRunMetrics: métricas vacías → null', async () => {
+    const fetchImpl = makeFetch({});
+    const svc = buildService(fetchImpl);
+    const result = await svc.getCloudRunMetrics();
+    expect(result.latencyP95Ms).toBeNull();
+    expect(result.cpuUtilization).toBeNull();
+    expect(result.ramUtilization).toBeNull();
+    expect(result.rps).toBeNull();
+  });
+
+  it('getCloudSqlMetrics: conexiones se mapea a ratio /100', async () => {
+    const fetchImpl = makeFetch({
+      'cpu/utilization': { timeSeries: [{ points: [{ value: { doubleValue: 0.3 } }] }] },
+      'memory/utilization': { timeSeries: [{ points: [{ value: { doubleValue: 0.5 } }] }] },
+      'disk/utilization': { timeSeries: [{ points: [{ value: { doubleValue: 0.25 } }] }] },
+      num_backends: { timeSeries: [{ points: [{ value: { doubleValue: 30 } }] }] },
+    });
+    const svc = buildService(fetchImpl);
+    const result = await svc.getCloudSqlMetrics();
+    expect(result.cpuUtilization).toBe(0.3);
+    expect(result.ramUtilization).toBe(0.5);
+    expect(result.diskUtilization).toBe(0.25);
+    expect(result.connectionsUsedRatio).toBeCloseTo(0.3); // 30/100
+  });
+
+  it('getCloudSqlMetrics: 200 conexiones se clampa a ratio=1', async () => {
+    const fetchImpl = makeFetch({
+      num_backends: { timeSeries: [{ points: [{ value: { doubleValue: 200 } }] }] },
+    });
+    const svc = buildService(fetchImpl);
+    const result = await svc.getCloudSqlMetrics();
+    expect(result.connectionsUsedRatio).toBe(1);
+  });
+
+  it('fetchTimeSeries: error HTTP → loggea warn y retorna []', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 403,
+      text: async () => 'forbidden',
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    const svc = buildService(fetchImpl);
+    const result = await svc.getCloudRunMetrics();
+    expect(result.cpuUtilization).toBeNull();
+    expect(fakeLogger.warn).toHaveBeenCalled();
+  });
+
+  it('getUptimeSnapshot: maneja bool values además de double', async () => {
+    const fetchImpl = makeFetch({
+      uptime_check: {
+        timeSeries: [
+          {
+            points: [
+              { value: { boolValue: true } },
+              { value: { boolValue: true } },
+              { value: { boolValue: false } },
+              { value: { boolValue: true } },
+            ],
+          },
+        ],
+      },
+    });
+    const svc = buildService(fetchImpl);
+    const result = await svc.getUptimeSnapshot();
+    expect(result.uptimePercent).toBe(75); // 3/4
+  });
+});

--- a/apps/api/test/unit/observability/require-platform-admin.test.ts
+++ b/apps/api/test/unit/observability/require-platform-admin.test.ts
@@ -1,0 +1,124 @@
+import type { Context } from 'hono';
+import { describe, expect, it } from 'vitest';
+import { requirePlatformAdmin } from '../../../src/middleware/require-platform-admin.js';
+
+/**
+ * Tests del middleware admin reusable (extract de admin-cobra-hoy).
+ * Mock del Hono Context inline para evitar setup de toda la app.
+ *
+ * BOOSTER_PLATFORM_ADMIN_EMAILS default en test env = `['dev@boosterchile.com']`
+ * (proviene de la config zod default cuando la env var no está).
+ */
+
+function makeMockContext(opts: {
+  userEmail?: string | null;
+  hasUserContext?: boolean;
+}): Context<any, any, any> {
+  const userContext = opts.hasUserContext
+    ? {
+        user: { email: opts.userEmail ?? null },
+      }
+    : undefined;
+
+  let lastResponse: { body: unknown; status: number } | null = null;
+
+  return {
+    get: (key: string) => (key === 'userContext' ? userContext : undefined),
+    json: (body: unknown, status: number) => {
+      lastResponse = { body, status };
+      // mock simple — el guard sólo necesita un valor truthy con .status
+      return { __mockBody: body, status, __getLast: () => lastResponse } as unknown as Response;
+    },
+  } as any;
+}
+
+describe('requirePlatformAdmin', () => {
+  it('returns ok=true cuando el email está en allowlist y hay userContext', () => {
+    const c = makeMockContext({
+      userEmail: 'dev@boosterchile.com',
+      hasUserContext: true,
+    });
+    const result = requirePlatformAdmin(c);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.adminEmail).toBe('dev@boosterchile.com');
+      expect(result.userContext.user.email).toBe('dev@boosterchile.com');
+    }
+  });
+
+  it('returns 401 cuando NO hay userContext (Firebase auth missing)', () => {
+    const c = makeMockContext({ hasUserContext: false });
+    const result = requirePlatformAdmin(c);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const body = (result.response as unknown as { __mockBody: { error: string }; status: number })
+        .__mockBody;
+      const status = (result.response as unknown as { status: number }).status;
+      expect(status).toBe(401);
+      expect(body.error).toBe('unauthorized');
+    }
+  });
+
+  it('returns 403 cuando el email NO está en allowlist', () => {
+    const c = makeMockContext({
+      userEmail: 'random-user@gmail.com',
+      hasUserContext: true,
+    });
+    const result = requirePlatformAdmin(c);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const body = (result.response as unknown as { __mockBody: { error: string } }).__mockBody;
+      const status = (result.response as unknown as { status: number }).status;
+      expect(status).toBe(403);
+      expect(body.error).toBe('forbidden_platform_admin');
+    }
+  });
+
+  it('returns 503 cuando featureFlag=false (kill-switch)', () => {
+    const c = makeMockContext({
+      userEmail: 'dev@boosterchile.com',
+      hasUserContext: true,
+    });
+    const result = requirePlatformAdmin(c, { featureFlag: false });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const body = (result.response as unknown as { __mockBody: { error: string } }).__mockBody;
+      const status = (result.response as unknown as { status: number }).status;
+      expect(status).toBe(503);
+      expect(body.error).toBe('feature_disabled');
+    }
+  });
+
+  it('email comparison is case-insensitive (allowlist lowercased)', () => {
+    const c = makeMockContext({
+      userEmail: 'DEV@BoosterChile.COM',
+      hasUserContext: true,
+    });
+    const result = requirePlatformAdmin(c);
+    expect(result.ok).toBe(true);
+  });
+
+  it('userContext con email=null/undefined falla con 403', () => {
+    const c = makeMockContext({
+      userEmail: null,
+      hasUserContext: true,
+    });
+    const result = requirePlatformAdmin(c);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const status = (result.response as unknown as { status: number }).status;
+      expect(status).toBe(403);
+    }
+  });
+
+  it('featureFlag=true permite continuar al check de auth', () => {
+    const c = makeMockContext({ hasUserContext: false });
+    const result = requirePlatformAdmin(c, { featureFlag: true });
+    // featureFlag pasa pero auth falla → 401, no 503
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const status = (result.response as unknown as { status: number }).status;
+      expect(status).toBe(401);
+    }
+  });
+});

--- a/apps/api/test/unit/observability/twilio-usage-service.test.ts
+++ b/apps/api/test/unit/observability/twilio-usage-service.test.ts
@@ -1,0 +1,145 @@
+import type { Logger } from '@booster-ai/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ObservabilityCache } from '../../../src/services/observability/cache.js';
+import type { FxRateService } from '../../../src/services/observability/fx-rate-service.js';
+import { TwilioUsageService } from '../../../src/services/observability/twilio-usage-service.js';
+
+class InMemoryCacheStub {
+  private readonly store = new Map<string, unknown>();
+  async getOrFetch<T>(key: string, _ttl: number, fetcher: () => Promise<T>): Promise<T> {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+    const value = await fetcher();
+    this.store.set(key, value);
+    return value;
+  }
+  async invalidate(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+const fakeFx = {
+  usdToClp: vi.fn(async (usd: number) => Math.round(usd * 925)),
+} as unknown as FxRateService;
+
+function build(fetchImpl: typeof fetch): TwilioUsageService {
+  return new TwilioUsageService({
+    cache: new InMemoryCacheStub() as unknown as ObservabilityCache,
+    fxRateService: fakeFx,
+    logger: fakeLogger,
+    accountSid: 'ACtest123',
+    authToken: 'auth-token-secret',
+    fetchImpl,
+  });
+}
+
+describe('TwilioUsageService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getBalance: USD balance + conversion CLP', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => ({ balance: '42.50', currency: 'USD' }),
+    })) as unknown as typeof fetch;
+    const svc = build(fetchImpl);
+    const result = await svc.getBalance();
+    expect(result.balanceUsd).toBe(42.5);
+    expect(result.balanceClp).toBe(39_313); // 42.50 × 925 = 39312.5 → round
+    expect(result.currency).toBe('USD');
+  });
+
+  it('getBalance: Basic auth header correcto', async () => {
+    let capturedAuth = '';
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      capturedAuth = (init?.headers as Record<string, string>)?.Authorization ?? '';
+      return {
+        ok: true,
+        status: 200,
+        text: async () => '',
+        json: async () => ({ balance: '0', currency: 'USD' }),
+      };
+    }) as unknown as typeof fetch;
+    const svc = build(fetchImpl);
+    await svc.getBalance();
+    const expected = `Basic ${Buffer.from('ACtest123:auth-token-secret').toString('base64')}`;
+    expect(capturedAuth).toBe(expected);
+  });
+
+  it('getMonthToDateUsage: filtra price=0, ordena por priceUsd desc, top 10', async () => {
+    const records = [
+      { category: 'sms', description: 'SMS', usage: '500', usage_unit: 'messages', price: '10' },
+      {
+        category: 'wa_msg_in',
+        description: 'WA in',
+        usage: '1000',
+        usage_unit: 'messages',
+        price: '0',
+      }, // filtrado
+      {
+        category: 'wa_msg_out',
+        description: 'WA out',
+        usage: '200',
+        usage_unit: 'messages',
+        price: '25.50',
+      },
+      {
+        category: 'voice',
+        description: 'Voice',
+        usage: '60',
+        usage_unit: 'minutes',
+        price: '5.25',
+      },
+    ];
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => ({ usage_records: records }),
+    })) as unknown as typeof fetch;
+    const svc = build(fetchImpl);
+    const result = await svc.getMonthToDateUsage();
+    expect(result).toHaveLength(3); // wa_msg_in filtered out
+    expect(result[0]?.category).toBe('wa_msg_out');
+    expect(result[0]?.priceUsd).toBe(25.5);
+    expect(result[2]?.category).toBe('voice');
+  });
+
+  it('getMonthToDateUsage: lista vacía si Twilio no devuelve registros', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => '',
+      json: async () => ({ usage_records: [] }),
+    })) as unknown as typeof fetch;
+    const svc = build(fetchImpl);
+    const result = await svc.getMonthToDateUsage();
+    expect(result).toEqual([]);
+  });
+
+  it('getBalance: API error → throw', async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      text: async () => 'unauthorized',
+      json: async () => ({}),
+    })) as unknown as typeof fetch;
+    const svc = build(fetchImpl);
+    await expect(svc.getBalance()).rejects.toThrow(/401/);
+    expect(fakeLogger.warn).toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/unit/observability/workspace-admin-client-googleapis.test.ts
+++ b/apps/api/test/unit/observability/workspace-admin-client-googleapis.test.ts
@@ -1,0 +1,227 @@
+import type { Logger } from '@booster-ai/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests del adapter zero-key.
+ *
+ * Mockeamos `googleapis` para que las llamadas `directory.users.list` y
+ * `licensing.licenseAssignments.listForProduct` retornen data fake y NO
+ * intenten autenticarse por sí mismas. El flow signJwt + token exchange
+ * lo testamos por separado interceptando `fetch`.
+ */
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+const mockListUsers = vi.fn();
+const mockListLicenseAssignments = vi.fn();
+
+vi.mock('googleapis', () => ({
+  google: {
+    admin: () => ({
+      users: { list: mockListUsers },
+    }),
+    licensing: () => ({
+      licenseAssignments: { listForProduct: mockListLicenseAssignments },
+    }),
+    auth: {
+      OAuth2: class {
+        getAccessToken = async () => ({ token: 'mocked' });
+      },
+    },
+  },
+}));
+
+const { createWorkspaceAdminClientGoogleapis } = await import(
+  '../../../src/services/observability/workspace-admin-client-googleapis.js'
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function makeFetchImpl(handler: (url: string) => Response | Promise<Response>): typeof fetch {
+  return vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input.toString();
+    return handler(url);
+  }) as unknown as typeof fetch;
+}
+
+describe('workspace-admin-client-googleapis', () => {
+  it('listUsers: cuenta active + suspended correctamente', async () => {
+    mockListUsers.mockResolvedValue({
+      data: {
+        users: [
+          { primaryEmail: 'a@x.com', suspended: false },
+          { primaryEmail: 'b@x.com', suspended: true },
+          { primaryEmail: 'c@x.com', suspended: false },
+        ],
+        nextPageToken: undefined,
+      },
+    });
+    const fetchImpl = makeFetchImpl(
+      async (url) =>
+        ({
+          ok: true,
+          status: 200,
+          text: async () => '',
+          json: async () =>
+            url.includes(':signJwt')
+              ? { signedJwt: 'fake.jwt' }
+              : { access_token: 'fake-token', expires_in: 3600 },
+        }) as Response,
+    );
+
+    const client = createWorkspaceAdminClientGoogleapis({
+      readerSaEmail: 'reader@booster-ai.iam.gserviceaccount.com',
+      impersonateEmail: 'admin@boosterchile.com',
+      logger: fakeLogger,
+      fetchImpl,
+    });
+
+    const result = await client.listUsers('boosterchile.com');
+    expect(result).toEqual({ activeUsers: 2, suspendedUsers: 1 });
+    expect(mockListUsers).toHaveBeenCalledWith(
+      expect.objectContaining({ domain: 'boosterchile.com', maxResults: 500, projection: 'basic' }),
+    );
+  });
+
+  it('listUsers: paginación con nextPageToken', async () => {
+    mockListUsers
+      .mockResolvedValueOnce({
+        data: { users: [{ suspended: false }, { suspended: false }], nextPageToken: 'page2' },
+      })
+      .mockResolvedValueOnce({
+        data: { users: [{ suspended: true }] },
+      });
+    const fetchImpl = makeFetchImpl(
+      async (url) =>
+        ({
+          ok: true,
+          status: 200,
+          text: async () => '',
+          json: async () =>
+            url.includes(':signJwt')
+              ? { signedJwt: 'fake.jwt' }
+              : { access_token: 'fake-token', expires_in: 3600 },
+        }) as Response,
+    );
+
+    const client = createWorkspaceAdminClientGoogleapis({
+      readerSaEmail: 'reader@booster-ai.iam.gserviceaccount.com',
+      impersonateEmail: 'admin@boosterchile.com',
+      logger: fakeLogger,
+      fetchImpl,
+    });
+    const result = await client.listUsers('boosterchile.com');
+    expect(result.activeUsers).toBe(2);
+    expect(result.suspendedUsers).toBe(1);
+    expect(mockListUsers).toHaveBeenCalledTimes(2);
+    expect(mockListUsers).toHaveBeenLastCalledWith(expect.objectContaining({ pageToken: 'page2' }));
+  });
+
+  it('listLicenseAssignments: agrupa skuIds', async () => {
+    mockListLicenseAssignments.mockResolvedValue({
+      data: {
+        items: [{ skuId: '1010020028' }, { skuId: '1010020028' }, { skuId: '1010020025' }],
+      },
+    });
+    const fetchImpl = makeFetchImpl(
+      async (url) =>
+        ({
+          ok: true,
+          status: 200,
+          text: async () => '',
+          json: async () =>
+            url.includes(':signJwt')
+              ? { signedJwt: 'fake.jwt' }
+              : { access_token: 'fake-token', expires_in: 3600 },
+        }) as Response,
+    );
+
+    const client = createWorkspaceAdminClientGoogleapis({
+      readerSaEmail: 'reader@booster-ai.iam.gserviceaccount.com',
+      impersonateEmail: 'admin@boosterchile.com',
+      logger: fakeLogger,
+      fetchImpl,
+    });
+    const result = await client.listLicenseAssignments('boosterchile.com');
+    expect(result).toHaveLength(3);
+    expect(result).toContainEqual({ skuId: '1010020028' });
+    expect(result).toContainEqual({ skuId: '1010020025' });
+  });
+
+  it('listLicenseAssignments: maneja respuesta sin items', async () => {
+    mockListLicenseAssignments.mockResolvedValue({ data: {} });
+    const fetchImpl = makeFetchImpl(
+      async (url) =>
+        ({
+          ok: true,
+          status: 200,
+          text: async () => '',
+          json: async () =>
+            url.includes(':signJwt')
+              ? { signedJwt: 'fake.jwt' }
+              : { access_token: 'fake-token', expires_in: 3600 },
+        }) as Response,
+    );
+
+    const client = createWorkspaceAdminClientGoogleapis({
+      readerSaEmail: 'reader@booster-ai.iam.gserviceaccount.com',
+      impersonateEmail: 'admin@boosterchile.com',
+      logger: fakeLogger,
+      fetchImpl,
+    });
+    const result = await client.listLicenseAssignments('boosterchile.com');
+    expect(result).toEqual([]);
+  });
+
+  it('listLicenseAssignments: paginación + filtra items sin skuId', async () => {
+    mockListLicenseAssignments
+      .mockResolvedValueOnce({
+        data: {
+          items: [{ skuId: '1010020028' }, { skuId: null }, { skuId: '1010020025' }],
+          nextPageToken: 'p2',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: { items: [{ skuId: '1010020027' }] },
+      });
+    const fetchImpl = makeFetchImpl(
+      async (url) =>
+        ({
+          ok: true,
+          status: 200,
+          text: async () => '',
+          json: async () =>
+            url.includes(':signJwt')
+              ? { signedJwt: 'fake.jwt' }
+              : { access_token: 'fake-token', expires_in: 3600 },
+        }) as Response,
+    );
+
+    const client = createWorkspaceAdminClientGoogleapis({
+      readerSaEmail: 'reader@booster-ai.iam.gserviceaccount.com',
+      impersonateEmail: 'admin@boosterchile.com',
+      logger: fakeLogger,
+      fetchImpl,
+    });
+    const result = await client.listLicenseAssignments('boosterchile.com');
+    // 3 con skuId real (el null se filtra) + 1 de página 2
+    expect(result).toHaveLength(3);
+    expect(mockListLicenseAssignments).toHaveBeenCalledTimes(2);
+  });
+
+  // NOTA: error paths del flow signJwt + token exchange se validan E2E
+  // via gcloud impersonate-service-account (sesión 2026-05-13). Mockear
+  // googleapis al nivel de poder simular fallos del Bearer token requeriría
+  // exponer `getDwdAccessToken` como helper público — el costo de testing
+  // surface vs valor no compensa para este path.
+});

--- a/apps/api/test/unit/observability/workspace-service.test.ts
+++ b/apps/api/test/unit/observability/workspace-service.test.ts
@@ -1,0 +1,129 @@
+import type { Logger } from '@booster-ai/logger';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ObservabilityCache } from '../../../src/services/observability/cache.js';
+import type { FxRateService } from '../../../src/services/observability/fx-rate-service.js';
+import {
+  type WorkspaceAdminClient,
+  WorkspaceService,
+} from '../../../src/services/observability/workspace-service.js';
+
+class InMemoryCacheStub {
+  private readonly store = new Map<string, unknown>();
+  async getOrFetch<T>(key: string, _ttl: number, fetcher: () => Promise<T>): Promise<T> {
+    if (this.store.has(key)) {
+      return this.store.get(key) as T;
+    }
+    const value = await fetcher();
+    this.store.set(key, value);
+    return value;
+  }
+  async invalidate(key: string): Promise<void> {
+    this.store.delete(key);
+  }
+}
+
+const fakeLogger: Logger = {
+  trace: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: vi.fn(),
+  child: () => fakeLogger,
+} as unknown as Logger;
+
+const fakeFx = {
+  usdToClp: vi.fn(async (usd: number) => Math.round(usd * 925)),
+} as unknown as FxRateService;
+
+const priceMap = { starter: 6, standard: 12, plus: 18, enterprise: 30 };
+
+function build(adminClient: WorkspaceAdminClient | null, domain = 'boosterchile.com') {
+  return new WorkspaceService({
+    cache: new InMemoryCacheStub() as unknown as ObservabilityCache,
+    fxRateService: fakeFx,
+    logger: fakeLogger,
+    domain,
+    priceMap,
+    ...(adminClient ? { adminClient } : {}),
+  });
+}
+
+describe('WorkspaceService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('domain vacío → available=false con reason', async () => {
+    const svc = build(null, '');
+    const result = await svc.getUsageSnapshot();
+    expect(result.available).toBe(false);
+    expect(result.reason).toContain('GOOGLE_WORKSPACE_DOMAIN');
+  });
+
+  it('adminClient ausente → available=false con reason DWD', async () => {
+    const svc = build(null);
+    const result = await svc.getUsageSnapshot();
+    expect(result.available).toBe(false);
+    expect(result.reason).toContain('DWD');
+  });
+
+  it('licensing API ok → calcula costo por SKU usando priceMap', async () => {
+    const adminClient: WorkspaceAdminClient = {
+      listUsers: vi.fn(async () => ({ activeUsers: 5, suspendedUsers: 1 })),
+      listLicenseAssignments: vi.fn(async () => [
+        { skuId: '1010020027' }, // starter × 6
+        { skuId: '1010020028' }, // standard × 12
+        { skuId: '1010020028' }, // standard × 12
+        { skuId: '1010020025' }, // plus × 18
+        { skuId: '1010060003' }, // enterprise × 30
+      ]),
+    };
+    const svc = build(adminClient);
+    const result = await svc.getUsageSnapshot();
+    expect(result.available).toBe(true);
+    expect(result.totalSeats).toBe(6);
+    expect(result.activeSeats).toBe(5);
+    expect(result.suspendedSeats).toBe(1);
+    expect(result.monthlyCostUsd).toBe(78); // 6+12+12+18+30
+    expect(result.monthlyCostClp).toBe(72_150); // 78 × 925
+    expect(result.seatsBySku['1010020028']).toBe(2);
+  });
+
+  it('licensing API falla → fallback usa user count × standard price', async () => {
+    const adminClient: WorkspaceAdminClient = {
+      listUsers: vi.fn(async () => ({ activeUsers: 10, suspendedUsers: 0 })),
+      listLicenseAssignments: vi.fn(async () => {
+        throw new Error('licensing scope not granted');
+      }),
+    };
+    const svc = build(adminClient);
+    const result = await svc.getUsageSnapshot();
+    expect(result.available).toBe(true);
+    expect(result.monthlyCostUsd).toBe(120); // 10 × 12 (standard)
+    expect(fakeLogger.warn).toHaveBeenCalled();
+  });
+
+  it('SKU desconocida → fallback a standard price', async () => {
+    const adminClient: WorkspaceAdminClient = {
+      listUsers: vi.fn(async () => ({ activeUsers: 1, suspendedUsers: 0 })),
+      listLicenseAssignments: vi.fn(async () => [{ skuId: 'unknown-sku' }]),
+    };
+    const svc = build(adminClient);
+    const result = await svc.getUsageSnapshot();
+    expect(result.monthlyCostUsd).toBe(12); // standard
+  });
+
+  it('listUsers falla → reporta unavailable con reason del error', async () => {
+    const adminClient: WorkspaceAdminClient = {
+      listUsers: vi.fn(async () => {
+        throw new Error('admin scope missing');
+      }),
+      listLicenseAssignments: vi.fn(async () => []),
+    };
+    const svc = build(adminClient);
+    const result = await svc.getUsageSnapshot();
+    expect(result.available).toBe(false);
+    expect(result.reason).toContain('admin scope missing');
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "@hookform/resolvers": "^3.10.0",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-router": "^1.169.2",
+    "@tremor/react": "^3.18.7",
     "@vis.gl/react-google-maps": "^1.5.0",
     "clsx": "^2.1.1",
     "firebase": "^12.10.0",

--- a/apps/web/src/components/observability/CapacityTab.test.tsx
+++ b/apps/web/src/components/observability/CapacityTab.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../../lib/api-client.js';
+import { CapacityTab } from './CapacityTab.js';
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe('CapacityTab', () => {
+  it('renderiza utilizations Cloud Run + Cloud SQL', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path === '/admin/observability/usage/cloud-run') {
+        return {
+          latencyP95Ms: 150,
+          cpuUtilization: 0.45,
+          ramUtilization: 0.6,
+          rps: 12.5,
+        };
+      }
+      if (path === '/admin/observability/usage/cloud-sql') {
+        return {
+          cpuUtilization: 0.3,
+          ramUtilization: 0.5,
+          diskUtilization: 0.4,
+          connectionsUsedRatio: 0.2,
+        };
+      }
+      return {};
+    });
+
+    render(<CapacityTab />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByText('45%')).toBeInTheDocument()); // CPU Cloud Run
+    expect(screen.getByText('60%')).toBeInTheDocument(); // RAM Cloud Run
+    expect(screen.getByText('150 ms')).toBeInTheDocument();
+    expect(screen.getByText('12.5 rps')).toBeInTheDocument();
+  });
+
+  it('valores null → Sin datos', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      latencyP95Ms: null,
+      cpuUtilization: null,
+      ramUtilization: null,
+      rps: null,
+      diskUtilization: null,
+      connectionsUsedRatio: null,
+    });
+    render(<CapacityTab />, { wrapper: wrapper() });
+    await waitFor(() => {
+      expect(screen.getAllByText('Sin datos').length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/web/src/components/observability/CapacityTab.tsx
+++ b/apps/web/src/components/observability/CapacityTab.tsx
@@ -1,0 +1,197 @@
+import { ProgressBar } from '@tremor/react';
+import {
+  useObservabilityCloudRun,
+  useObservabilityCloudSql,
+} from '../../hooks/use-observability.js';
+import { KpiCard } from './KpiCard.js';
+
+/**
+ * Tab Capacity — headroom CPU/RAM/disco/conexiones de Cloud Run + Cloud SQL.
+ * Usa @tremor/react ProgressBar para mostrar % de uso con color semáforo.
+ */
+export function CapacityTab() {
+  const cloudRun = useObservabilityCloudRun();
+  const cloudSql = useObservabilityCloudSql();
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="font-semibold text-lg text-neutral-900">Cloud Run</h2>
+        <p className="mt-1 mb-3 text-neutral-500 text-xs">
+          Media de utilización en últimos 15 min. Cache 60s.
+        </p>
+        {cloudRun.isLoading ? (
+          <SkeletonGrid count={4} />
+        ) : cloudRun.data ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <KpiCard
+              label="CPU"
+              value={
+                <UtilizationBar
+                  value={cloudRun.data.cpuUtilization}
+                  thresholds={{ warning: 0.7, critical: 0.85 }}
+                />
+              }
+              status={resourceLevel(cloudRun.data.cpuUtilization, 0.7, 0.85)}
+            />
+            <KpiCard
+              label="RAM"
+              value={
+                <UtilizationBar
+                  value={cloudRun.data.ramUtilization}
+                  thresholds={{ warning: 0.8, critical: 0.92 }}
+                />
+              }
+              status={resourceLevel(cloudRun.data.ramUtilization, 0.8, 0.92)}
+            />
+            <KpiCard
+              label="Latencia p95"
+              value={
+                <span className="font-bold text-3xl">
+                  {cloudRun.data.latencyP95Ms !== null
+                    ? `${Math.round(cloudRun.data.latencyP95Ms)} ms`
+                    : '—'}
+                </span>
+              }
+              description="Cloud Run request_latencies (avg)"
+              status="neutral"
+            />
+            <KpiCard
+              label="Throughput"
+              value={
+                <span className="font-bold text-3xl">
+                  {cloudRun.data.rps !== null ? `${cloudRun.data.rps.toFixed(1)} rps` : '—'}
+                </span>
+              }
+              description="request_count rate"
+              status="neutral"
+            />
+          </div>
+        ) : (
+          <ErrorBox error={cloudRun.error} retry={cloudRun.refetch} />
+        )}
+      </section>
+
+      <section>
+        <h2 className="font-semibold text-lg text-neutral-900">Cloud SQL Postgres</h2>
+        <p className="mt-1 mb-3 text-neutral-500 text-xs">
+          Headroom de recursos de la instancia. Si CPU/RAM/disk se acercan al límite, es momento de
+          right-size.
+        </p>
+        {cloudSql.isLoading ? (
+          <SkeletonGrid count={4} />
+        ) : cloudSql.data ? (
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <KpiCard
+              label="CPU"
+              value={
+                <UtilizationBar
+                  value={cloudSql.data.cpuUtilization}
+                  thresholds={{ warning: 0.7, critical: 0.85 }}
+                />
+              }
+              status={resourceLevel(cloudSql.data.cpuUtilization, 0.7, 0.85)}
+            />
+            <KpiCard
+              label="RAM"
+              value={
+                <UtilizationBar
+                  value={cloudSql.data.ramUtilization}
+                  thresholds={{ warning: 0.8, critical: 0.92 }}
+                />
+              }
+              status={resourceLevel(cloudSql.data.ramUtilization, 0.8, 0.92)}
+            />
+            <KpiCard
+              label="Disco"
+              value={
+                <UtilizationBar
+                  value={cloudSql.data.diskUtilization}
+                  thresholds={{ warning: 0.75, critical: 0.9 }}
+                />
+              }
+              status={resourceLevel(cloudSql.data.diskUtilization, 0.75, 0.9)}
+            />
+            <KpiCard
+              label="Conexiones"
+              value={
+                <UtilizationBar
+                  value={cloudSql.data.connectionsUsedRatio}
+                  thresholds={{ warning: 0.7, critical: 0.9 }}
+                />
+              }
+              status={resourceLevel(cloudSql.data.connectionsUsedRatio, 0.7, 0.9)}
+            />
+          </div>
+        ) : (
+          <ErrorBox error={cloudSql.error} retry={cloudSql.refetch} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function UtilizationBar({
+  value,
+  thresholds,
+}: {
+  value: number | null;
+  thresholds: { warning: number; critical: number };
+}) {
+  if (value === null) {
+    return <span className="text-neutral-400 text-sm">Sin datos</span>;
+  }
+  const percent = Math.round(value * 100);
+  const color =
+    value >= thresholds.critical ? 'red' : value >= thresholds.warning ? 'amber' : 'emerald';
+  return (
+    <div className="space-y-2">
+      <div className="font-bold text-3xl text-neutral-900 tabular-nums">{percent}%</div>
+      <ProgressBar value={percent} color={color} />
+    </div>
+  );
+}
+
+function resourceLevel(
+  value: number | null,
+  warning: number,
+  critical: number,
+): 'healthy' | 'degraded' | 'critical' | 'unknown' {
+  if (value === null) {
+    return 'unknown';
+  }
+  if (value >= critical) {
+    return 'critical';
+  }
+  if (value >= warning) {
+    return 'degraded';
+  }
+  return 'healthy';
+}
+
+function SkeletonGrid({ count }: { count: number }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      {Array.from({ length: count }, (_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholder
+        <div key={i} className="h-24 animate-pulse rounded-md bg-neutral-100" />
+      ))}
+    </div>
+  );
+}
+
+function ErrorBox({ error, retry }: { error: Error | null; retry: () => void }) {
+  return (
+    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm">
+      <div className="font-medium">No se pudo cargar la utilización</div>
+      {error && <div className="mt-1 font-mono text-xs">{error.message}</div>}
+      <button
+        type="button"
+        onClick={() => retry()}
+        className="mt-2 inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-1 font-medium text-xs hover:bg-amber-100"
+      >
+        Reintentar
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/observability/CostosTab.test.tsx
+++ b/apps/web/src/components/observability/CostosTab.test.tsx
@@ -42,6 +42,15 @@ describe('CostosTab', () => {
       if (path.startsWith('/admin/observability/costs/top-skus')) {
         return { limit: 10, items: [{ service: 'Cloud Run', sku: 'CPU', costClp: 30_000 }] };
       }
+      if (path.startsWith('/admin/observability/costs/monthly-history')) {
+        return {
+          months: 12,
+          items: [
+            { month: '2026-04', costClp: 250_000, deltaPercentVsPrior: null, isCurrent: false },
+            { month: '2026-05', costClp: 248_350, deltaPercentVsPrior: -0.7, isCurrent: true },
+          ],
+        };
+      }
       return {};
     });
 

--- a/apps/web/src/components/observability/CostosTab.test.tsx
+++ b/apps/web/src/components/observability/CostosTab.test.tsx
@@ -1,0 +1,68 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../../lib/api-client.js';
+import { CostosTab } from './CostosTab.js';
+
+function wrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('CostosTab', () => {
+  it('renderiza overview + breakdowns cuando endpoints OK', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path === '/admin/observability/costs/overview') {
+        return {
+          costClpMonthToDate: 100_000,
+          costClpPreviousMonth: 90_000,
+          deltaPercentVsPreviousMonth: 11.1,
+          lastBillingExportAt: '2026-05-13T13:00:00Z',
+        };
+      }
+      if (path.startsWith('/admin/observability/costs/by-service')) {
+        return { days: 30, items: [{ service: 'Cloud Run', costClp: 60_000, percentOfTotal: 60 }] };
+      }
+      if (path.startsWith('/admin/observability/costs/by-project')) {
+        return { days: 30, items: [] };
+      }
+      if (path.startsWith('/admin/observability/costs/trend')) {
+        return { days: 30, points: [{ date: '2026-05-13', costClp: 5000 }] };
+      }
+      if (path.startsWith('/admin/observability/costs/top-skus')) {
+        return { limit: 10, items: [{ service: 'Cloud Run', sku: 'CPU', costClp: 30_000 }] };
+      }
+      return {};
+    });
+
+    render(<CostosTab />, {
+      wrapper: wrapper(new QueryClient({ defaultOptions: { queries: { retry: false } } })),
+    });
+
+    // El KPI MTD se renderiza
+    await waitFor(() => {
+      expect(screen.getByText(/\$100\.000 CLP/)).toBeInTheDocument();
+    });
+    // Top SKUs table
+    expect(screen.getByText('Top 10 SKUs del mes')).toBeInTheDocument();
+  });
+
+  it('muestra placeholder de error si el provider falla', async () => {
+    vi.spyOn(api, 'get').mockRejectedValue(new Error('502 BQ unavailable'));
+    render(<CostosTab />, {
+      wrapper: wrapper(new QueryClient({ defaultOptions: { queries: { retry: false } } })),
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText(/No se pudo cargar|Sin datos/).length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/web/src/components/observability/CostosTab.test.tsx
+++ b/apps/web/src/components/observability/CostosTab.test.tsx
@@ -24,7 +24,8 @@ describe('CostosTab', () => {
       if (path === '/admin/observability/costs/overview') {
         return {
           costClpMonthToDate: 100_000,
-          costClpPreviousMonth: 90_000,
+          costClpPreviousMonth: 200_000,
+          costClpPreviousMonthSamePeriod: 90_000,
           deltaPercentVsPreviousMonth: 11.1,
           lastBillingExportAt: '2026-05-13T13:00:00Z',
         };

--- a/apps/web/src/components/observability/CostosTab.tsx
+++ b/apps/web/src/components/observability/CostosTab.tsx
@@ -17,8 +17,16 @@ import { TrendChart } from './TrendChart.js';
  *   - Trend chart 30d
  *   - DonutChart by-service
  *   - BarChart by-project
+ *   - Histórico mensual + link a facturas oficiales
  *   - Tabla top SKUs
  */
+
+// Billing account ID público de Booster (no es secreto). Si cambia,
+// actualizar aquí + en compute.tf si llega a env var. Validado en
+// gcloud billing projects describe booster-ai-494222.
+const BOOSTER_BILLING_ACCOUNT_ID = '019461-C73CDE-DCE377';
+const INVOICES_URL = `https://console.cloud.google.com/billing/${BOOSTER_BILLING_ACCOUNT_ID}/invoices`;
+
 export function CostosTab() {
   const overview = useObservabilityCostsOverview();
   const byService = useObservabilityCostsByService(30);
@@ -160,14 +168,17 @@ export function CostosTab() {
           <div>
             <h3 className="font-medium text-neutral-900 text-sm">Histórico mensual</h3>
             <p className="mt-0.5 text-neutral-500 text-xs">
-              Últimos 12 meses (mes actual = MTD, no cerrado). Fuente: BigQuery billing_export.
+              Últimos 12 meses (mes actual = MTD, no cerrado). Fuente: BigQuery billing_export (uso
+              GCP, granular por servicio). Para PDFs oficiales y montos finales con créditos/ajustes
+              aplicados, ver el link →
             </p>
           </div>
           <a
-            href="https://console.cloud.google.com/billing"
+            href={INVOICES_URL}
             target="_blank"
             rel="noopener noreferrer"
             className="text-primary-700 text-xs hover:underline"
+            title="Facturas oficiales emitidas por Google. Esta tabla muestra gasto del billing_export (puede diferir levemente por créditos/ajustes que solo aparecen en la factura)."
           >
             Ver facturas oficiales en Cloud Console →
           </a>

--- a/apps/web/src/components/observability/CostosTab.tsx
+++ b/apps/web/src/components/observability/CostosTab.tsx
@@ -54,9 +54,20 @@ export function CostosTab() {
             )
           }
           description={
-            overview.data
-              ? `Mes anterior: $${overview.data.costClpPreviousMonth.toLocaleString('es-CL')} CLP`
-              : null
+            overview.data ? (
+              <>
+                <div>
+                  vs mismo periodo mes anterior:{' '}
+                  <strong>
+                    ${overview.data.costClpPreviousMonthSamePeriod.toLocaleString('es-CL')} CLP
+                  </strong>
+                </div>
+                <div className="mt-0.5 text-neutral-400">
+                  Mes anterior completo: $
+                  {overview.data.costClpPreviousMonth.toLocaleString('es-CL')} CLP
+                </div>
+              </>
+            ) : null
           }
           status="neutral"
         />

--- a/apps/web/src/components/observability/CostosTab.tsx
+++ b/apps/web/src/components/observability/CostosTab.tsx
@@ -4,6 +4,7 @@ import {
   useObservabilityCostsByService,
   useObservabilityCostsOverview,
   useObservabilityCostsTrend,
+  useObservabilityMonthlyHistory,
   useObservabilityTopSkus,
 } from '../../hooks/use-observability.js';
 import { CurrencyValue } from './CurrencyValue.js';
@@ -24,6 +25,7 @@ export function CostosTab() {
   const byProject = useObservabilityCostsByProject(30);
   const trend = useObservabilityCostsTrend(30);
   const topSkus = useObservabilityTopSkus(10);
+  const monthlyHistory = useObservabilityMonthlyHistory(12);
 
   return (
     <div className="space-y-6">
@@ -154,6 +156,34 @@ export function CostosTab() {
       </div>
 
       <section className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+        <div className="flex items-baseline justify-between gap-3">
+          <div>
+            <h3 className="font-medium text-neutral-900 text-sm">Histórico mensual</h3>
+            <p className="mt-0.5 text-neutral-500 text-xs">
+              Últimos 12 meses (mes actual = MTD, no cerrado). Fuente: BigQuery billing_export.
+            </p>
+          </div>
+          <a
+            href="https://console.cloud.google.com/billing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary-700 text-xs hover:underline"
+          >
+            Ver facturas oficiales en Cloud Console →
+          </a>
+        </div>
+        <div className="mt-3">
+          {monthlyHistory.isLoading ? (
+            <SkeletonRect height={280} />
+          ) : monthlyHistory.data && monthlyHistory.data.items.length > 0 ? (
+            <MonthlyHistoryView items={monthlyHistory.data.items} />
+          ) : (
+            <ErrorBox error={monthlyHistory.error} retry={monthlyHistory.refetch} empty />
+          )}
+        </div>
+      </section>
+
+      <section className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
         <h3 className="font-medium text-neutral-900 text-sm">Top 10 SKUs del mes</h3>
         {topSkus.isLoading ? (
           <SkeletonRect height={200} />
@@ -187,6 +217,94 @@ export function CostosTab() {
       </section>
     </div>
   );
+}
+
+function MonthlyHistoryView({
+  items,
+}: {
+  items: Array<{
+    month: string;
+    costClp: number;
+    deltaPercentVsPrior: number | null;
+    isCurrent: boolean;
+  }>;
+}) {
+  return (
+    <>
+      <div style={{ height: 220, width: '100%' }}>
+        <BarChart
+          className="h-full w-full"
+          data={items.map((i) => ({
+            month: formatMonthShort(i.month),
+            Costo: i.costClp,
+          }))}
+          index="month"
+          categories={['Costo']}
+          colors={['emerald']}
+          valueFormatter={(v) => `$${Math.round(v).toLocaleString('es-CL')}`}
+          yAxisWidth={75}
+          showLegend={false}
+        />
+      </div>
+      <table className="mt-4 w-full text-sm">
+        <thead>
+          <tr className="border-neutral-100 border-b text-left text-neutral-500 text-xs">
+            <th className="py-2 font-medium">Mes</th>
+            <th className="py-2 text-right font-medium">Gasto CLP</th>
+            <th className="py-2 text-right font-medium">Δ% vs mes anterior</th>
+          </tr>
+        </thead>
+        <tbody>
+          {[...items].reverse().map((m) => (
+            <tr key={m.month} className="border-neutral-50 border-b last:border-0">
+              <td className="py-2 text-neutral-700">
+                {formatMonthLong(m.month)}
+                {m.isCurrent && (
+                  <span className="ml-2 inline-flex rounded bg-amber-50 px-1.5 py-0.5 font-medium text-[10px] text-amber-700 uppercase tracking-wide">
+                    En curso
+                  </span>
+                )}
+              </td>
+              <td className="py-2 text-right font-medium tabular-nums">
+                ${m.costClp.toLocaleString('es-CL')}
+              </td>
+              <td
+                className={`py-2 text-right tabular-nums ${
+                  m.deltaPercentVsPrior === null
+                    ? 'text-neutral-400'
+                    : m.deltaPercentVsPrior > 0
+                      ? 'text-danger-700'
+                      : m.deltaPercentVsPrior < 0
+                        ? 'text-success-700'
+                        : 'text-neutral-500'
+                }`}
+              >
+                {m.deltaPercentVsPrior === null
+                  ? '—'
+                  : `${m.deltaPercentVsPrior > 0 ? '↑' : m.deltaPercentVsPrior < 0 ? '↓' : '·'} ${Math.abs(m.deltaPercentVsPrior).toFixed(1)}%`}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </>
+  );
+}
+
+function formatMonthShort(yyyymm: string): string {
+  const [y, m] = yyyymm.split('-').map(Number);
+  if (!y || !m) {
+    return yyyymm;
+  }
+  return new Date(y, m - 1, 1).toLocaleDateString('es-CL', { month: 'short', year: '2-digit' });
+}
+
+function formatMonthLong(yyyymm: string): string {
+  const [y, m] = yyyymm.split('-').map(Number);
+  if (!y || !m) {
+    return yyyymm;
+  }
+  return new Date(y, m - 1, 1).toLocaleDateString('es-CL', { month: 'long', year: 'numeric' });
 }
 
 function SkeletonRect({ height }: { height: number }) {

--- a/apps/web/src/components/observability/CostosTab.tsx
+++ b/apps/web/src/components/observability/CostosTab.tsx
@@ -1,0 +1,213 @@
+import { BarChart, DonutChart } from '@tremor/react';
+import {
+  useObservabilityCostsByProject,
+  useObservabilityCostsByService,
+  useObservabilityCostsOverview,
+  useObservabilityCostsTrend,
+  useObservabilityTopSkus,
+} from '../../hooks/use-observability.js';
+import { CurrencyValue } from './CurrencyValue.js';
+import { KpiCard } from './KpiCard.js';
+import { TrendChart } from './TrendChart.js';
+
+/**
+ * Tab Costos — composite de:
+ *   - KPI MTD + previous + delta%
+ *   - Trend chart 30d
+ *   - DonutChart by-service
+ *   - BarChart by-project
+ *   - Tabla top SKUs
+ */
+export function CostosTab() {
+  const overview = useObservabilityCostsOverview();
+  const byService = useObservabilityCostsByService(30);
+  const byProject = useObservabilityCostsByProject(30);
+  const trend = useObservabilityCostsTrend(30);
+  const topSkus = useObservabilityTopSkus(10);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="font-semibold text-lg text-neutral-900">Costos del mes en curso</h2>
+        <p className="mt-1 text-neutral-500 text-xs">
+          Fuente: BigQuery billing_export (cache 5 min). Última actualización:{' '}
+          {overview.data?.lastBillingExportAt
+            ? new Date(overview.data.lastBillingExportAt).toLocaleString('es-CL')
+            : '—'}
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <KpiCard
+          label="Mes a la fecha"
+          value={
+            overview.isLoading ? (
+              <span className="text-neutral-400 text-sm">Cargando…</span>
+            ) : overview.data ? (
+              <CurrencyValue
+                amountClp={overview.data.costClpMonthToDate}
+                deltaPercent={overview.data.deltaPercentVsPreviousMonth}
+                size="xl"
+              />
+            ) : (
+              <span className="text-neutral-400 text-sm">—</span>
+            )
+          }
+          description={
+            overview.data
+              ? `Mes anterior: $${overview.data.costClpPreviousMonth.toLocaleString('es-CL')} CLP`
+              : null
+          }
+          status="neutral"
+        />
+        <KpiCard
+          label="Tendencia 30d"
+          value={
+            <span className="text-2xl text-neutral-900">
+              {trend.data ? `${trend.data.points.length} días` : '—'}
+            </span>
+          }
+          description="Serie diaria del gasto consolidado (CLP)."
+          status="neutral"
+        />
+        <KpiCard
+          label="Top servicios"
+          value={
+            <span className="text-2xl text-neutral-900">
+              {byService.data ? `${byService.data.items.length}` : '—'}
+            </span>
+          }
+          description="Servicios GCP con gasto >0 en últimos 30d."
+          status="neutral"
+        />
+      </div>
+
+      <section className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+        <h3 className="font-medium text-neutral-900 text-sm">Gasto diario (últimos 30 días)</h3>
+        <div className="mt-3">
+          {trend.isLoading ? (
+            <SkeletonRect height={280} />
+          ) : trend.data ? (
+            <TrendChart points={trend.data.points} height={280} />
+          ) : (
+            <ErrorBox error={trend.error} retry={trend.refetch} />
+          )}
+        </div>
+      </section>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <section className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+          <h3 className="font-medium text-neutral-900 text-sm">Por servicio GCP</h3>
+          <div className="mt-3">
+            {byService.isLoading ? (
+              <SkeletonRect height={260} />
+            ) : byService.data && byService.data.items.length > 0 ? (
+              <DonutChart
+                className="h-60"
+                data={byService.data.items.map((i) => ({ name: i.service, value: i.costClp }))}
+                category="value"
+                index="name"
+                valueFormatter={(v) => `$${Math.round(v).toLocaleString('es-CL')}`}
+                colors={['emerald', 'cyan', 'amber', 'indigo', 'rose', 'fuchsia']}
+              />
+            ) : (
+              <ErrorBox error={byService.error} retry={byService.refetch} empty />
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+          <h3 className="font-medium text-neutral-900 text-sm">Por proyecto GCP</h3>
+          <div className="mt-3">
+            {byProject.isLoading ? (
+              <SkeletonRect height={260} />
+            ) : byProject.data && byProject.data.items.length > 0 ? (
+              <BarChart
+                className="h-60"
+                data={byProject.data.items.map((i) => ({
+                  project: i.projectName ?? i.projectId,
+                  Costo: i.costClp,
+                }))}
+                index="project"
+                categories={['Costo']}
+                colors={['emerald']}
+                valueFormatter={(v) => `$${Math.round(v).toLocaleString('es-CL')}`}
+                yAxisWidth={75}
+                showLegend={false}
+              />
+            ) : (
+              <ErrorBox error={byProject.error} retry={byProject.refetch} empty />
+            )}
+          </div>
+        </section>
+      </div>
+
+      <section className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+        <h3 className="font-medium text-neutral-900 text-sm">Top 10 SKUs del mes</h3>
+        {topSkus.isLoading ? (
+          <SkeletonRect height={200} />
+        ) : topSkus.data && topSkus.data.items.length > 0 ? (
+          <table className="mt-3 w-full text-sm">
+            <thead>
+              <tr className="border-neutral-100 border-b text-left text-neutral-500 text-xs">
+                <th className="py-2 font-medium">Servicio</th>
+                <th className="py-2 font-medium">SKU</th>
+                <th className="py-2 text-right font-medium">Costo CLP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {topSkus.data.items.map((s) => (
+                <tr
+                  key={`${s.service}-${s.sku}`}
+                  className="border-neutral-50 border-b last:border-0"
+                >
+                  <td className="py-2 text-neutral-700">{s.service}</td>
+                  <td className="py-2 text-neutral-600 text-xs">{s.sku}</td>
+                  <td className="py-2 text-right font-medium tabular-nums">
+                    ${s.costClp.toLocaleString('es-CL')}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <ErrorBox error={topSkus.error} retry={topSkus.refetch} empty />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function SkeletonRect({ height }: { height: number }) {
+  return (
+    <div
+      className="animate-pulse rounded-md bg-neutral-100"
+      style={{ height }}
+      aria-label="Cargando"
+    />
+  );
+}
+
+function ErrorBox({
+  error,
+  retry,
+  empty,
+}: {
+  error: Error | null;
+  retry: () => void;
+  empty?: boolean;
+}) {
+  return (
+    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm">
+      <div className="font-medium">{empty ? 'Sin datos disponibles' : 'No se pudo cargar'}</div>
+      {error && <div className="mt-1 font-mono text-xs">{error.message}</div>}
+      <button
+        type="button"
+        onClick={() => retry()}
+        className="mt-2 inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-1 font-medium text-xs hover:bg-amber-100"
+      >
+        Reintentar
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/observability/CurrencyValue.test.tsx
+++ b/apps/web/src/components/observability/CurrencyValue.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CurrencyValue } from './CurrencyValue.js';
+
+describe('CurrencyValue', () => {
+  it('formatea CLP con separadores es-CL', () => {
+    render(<CurrencyValue amountClp={1234567} />);
+    expect(screen.getByText(/1\.234\.567/)).toBeInTheDocument();
+  });
+
+  it('redondea decimales antes de formatear', () => {
+    render(<CurrencyValue amountClp={1234.7} />);
+    expect(screen.getByText(/\$1\.235 CLP/)).toBeInTheDocument();
+  });
+
+  it('muestra delta% en rojo cuando aumenta (gasto malo)', () => {
+    render(<CurrencyValue amountClp={1000} deltaPercent={15.5} />);
+    expect(screen.getByText(/15\.5%/)).toBeInTheDocument();
+    expect(screen.getByText('↑')).toBeInTheDocument();
+  });
+
+  it('muestra delta% en verde cuando baja (gasto bueno)', () => {
+    render(<CurrencyValue amountClp={1000} deltaPercent={-5.2} />);
+    expect(screen.getByText(/5\.2%/)).toBeInTheDocument();
+    expect(screen.getByText('↓')).toBeInTheDocument();
+  });
+
+  it('no renderiza delta cuando es null', () => {
+    render(<CurrencyValue amountClp={1000} deltaPercent={null} />);
+    expect(screen.queryByText('%')).not.toBeInTheDocument();
+  });
+
+  it('no renderiza delta cuando es undefined', () => {
+    render(<CurrencyValue amountClp={1000} />);
+    expect(screen.queryByText('%')).not.toBeInTheDocument();
+  });
+
+  it('acepta prefix y suffix custom', () => {
+    render(<CurrencyValue amountClp={42} prefix="USD " suffix="" />);
+    expect(screen.getByText(/USD 42/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/observability/CurrencyValue.tsx
+++ b/apps/web/src/components/observability/CurrencyValue.tsx
@@ -1,0 +1,49 @@
+/**
+ * Renderiza un monto CLP con separadores de miles (es-CL) y delta% opcional
+ * coloreado (verde si baja, rojo si sube — porque en gasto la dirección
+ * óptima es bajar).
+ */
+export function CurrencyValue({
+  amountClp,
+  deltaPercent,
+  prefix = '$',
+  suffix = ' CLP',
+  size = 'lg',
+}: {
+  amountClp: number;
+  deltaPercent?: number | null;
+  prefix?: string;
+  suffix?: string;
+  size?: 'sm' | 'md' | 'lg' | 'xl';
+}) {
+  const sizeClass = {
+    sm: 'text-sm',
+    md: 'text-base',
+    lg: 'text-2xl font-semibold',
+    xl: 'text-4xl font-bold',
+  }[size];
+
+  const formatted = `${prefix}${Math.round(amountClp).toLocaleString('es-CL')}${suffix}`;
+
+  return (
+    <div className="inline-flex items-baseline gap-2">
+      <span className={`${sizeClass} text-neutral-900 tabular-nums`}>{formatted}</span>
+      {deltaPercent !== null && deltaPercent !== undefined && <DeltaBadge percent={deltaPercent} />}
+    </div>
+  );
+}
+
+function DeltaBadge({ percent }: { percent: number }) {
+  // En gasto: subir es malo (rojo), bajar es bueno (verde).
+  const isIncrease = percent > 0;
+  const color = isIncrease ? 'bg-danger-50 text-danger-700' : 'bg-success-50 text-success-700';
+  const arrow = isIncrease ? '↑' : percent < 0 ? '↓' : '·';
+  const value = `${Math.abs(percent).toFixed(1)}%`;
+
+  return (
+    <span className={`inline-flex items-center gap-0.5 rounded px-1.5 py-0.5 text-xs ${color}`}>
+      <span aria-hidden>{arrow}</span>
+      {value}
+    </span>
+  );
+}

--- a/apps/web/src/components/observability/ForecastTab.test.tsx
+++ b/apps/web/src/components/observability/ForecastTab.test.tsx
@@ -1,0 +1,74 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../../lib/api-client.js';
+import { ForecastTab } from './ForecastTab.js';
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe('ForecastTab', () => {
+  it('renderiza forecast + budget + variance bajo budget', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      forecastClpEndOfMonth: 800_000,
+      budgetClp: 925_000,
+      variancePercent: -13.5,
+      dayOfMonth: 15,
+      daysInMonth: 30,
+      daysRemaining: 15,
+      currentRate: {
+        clpPerUsd: 925,
+        observedAt: '2026-05-13T00:00:00Z',
+        source: 'mindicador',
+      },
+    });
+    render(<ForecastTab />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByText(/\$800\.000 CLP/)).toBeInTheDocument());
+    expect(screen.getByText(/13\.5% bajo budget/)).toBeInTheDocument();
+    expect(screen.getByText('mindicador')).toBeInTheDocument();
+  });
+
+  it('sobre budget muestra ↑ y porcentaje', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      forecastClpEndOfMonth: 1_200_000,
+      budgetClp: 925_000,
+      variancePercent: 29.7,
+      dayOfMonth: 15,
+      daysInMonth: 30,
+      daysRemaining: 15,
+      currentRate: {
+        clpPerUsd: 925,
+        observedAt: '2026-05-13T00:00:00Z',
+        source: 'mindicador',
+      },
+    });
+    render(<ForecastTab />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByText(/29\.7% sobre budget/)).toBeInTheDocument());
+  });
+
+  it('FX source ≠ mindicador → muestra advertencia stale', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      forecastClpEndOfMonth: 500_000,
+      budgetClp: 925_000,
+      variancePercent: -45.9,
+      dayOfMonth: 10,
+      daysInMonth: 30,
+      daysRemaining: 20,
+      currentRate: {
+        clpPerUsd: 940,
+        observedAt: '2026-05-13T00:00:00Z',
+        source: 'hardcoded',
+      },
+    });
+    render(<ForecastTab />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByText(/FX no es del día actual/)).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/components/observability/ForecastTab.tsx
+++ b/apps/web/src/components/observability/ForecastTab.tsx
@@ -1,0 +1,119 @@
+import { ProgressBar } from '@tremor/react';
+import { useObservabilityForecast } from '../../hooks/use-observability.js';
+import { CurrencyValue } from './CurrencyValue.js';
+import { KpiCard } from './KpiCard.js';
+
+/**
+ * Tab Forecast — extrapolación lineal del gasto del mes en curso vs
+ * budget mensual configurable. FX dinámico desde mindicador.cl.
+ */
+export function ForecastTab() {
+  const forecast = useObservabilityForecast();
+
+  if (forecast.isLoading) {
+    return <SkeletonRect height={400} />;
+  }
+
+  if (!forecast.data) {
+    return (
+      <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm">
+        <div className="font-medium">No se pudo cargar el forecast</div>
+        {forecast.error && <div className="mt-1 font-mono text-xs">{forecast.error.message}</div>}
+        <button
+          type="button"
+          onClick={() => forecast.refetch()}
+          className="mt-2 inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-1 font-medium text-xs hover:bg-amber-100"
+        >
+          Reintentar
+        </button>
+      </div>
+    );
+  }
+
+  const d = forecast.data;
+  const pctOfBudget =
+    d.budgetClp > 0 ? Math.round((d.forecastClpEndOfMonth / d.budgetClp) * 100) : 0;
+  const progressColor = pctOfBudget >= 100 ? 'red' : pctOfBudget >= 85 ? 'amber' : 'emerald';
+  const isOver = d.variancePercent > 0;
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="font-semibold text-lg text-neutral-900">Proyección fin de mes</h2>
+        <p className="mt-1 text-neutral-500 text-xs">
+          Día {d.dayOfMonth} de {d.daysInMonth} ({d.daysRemaining} restantes). Extrapolación lineal
+          de lo gastado a la fecha. FX: {d.currentRate.clpPerUsd} CLP/USD ({d.currentRate.source}).
+        </p>
+      </header>
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <KpiCard
+          label="Forecast fin de mes"
+          value={<CurrencyValue amountClp={d.forecastClpEndOfMonth} size="xl" />}
+          description={`${pctOfBudget}% del budget mensual`}
+          status={isOver ? (pctOfBudget >= 110 ? 'critical' : 'degraded') : 'healthy'}
+        />
+        <KpiCard
+          label="Budget mensual"
+          value={<CurrencyValue amountClp={d.budgetClp} size="xl" />}
+          description="MONTHLY_BUDGET_USD × FX actual"
+          status="neutral"
+        />
+      </div>
+
+      <section className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm">
+        <div className="mb-2 flex items-center justify-between gap-3">
+          <h3 className="font-medium text-neutral-900 text-sm">Avance vs budget</h3>
+          <span
+            className={`font-medium text-xs ${isOver ? 'text-danger-700' : 'text-success-700'}`}
+          >
+            {isOver ? '↑' : '↓'} {Math.abs(d.variancePercent).toFixed(1)}%{' '}
+            {isOver ? 'sobre' : 'bajo'} budget
+          </span>
+        </div>
+        <ProgressBar value={Math.min(100, pctOfBudget)} color={progressColor} />
+        <div className="mt-2 flex justify-between text-neutral-500 text-xs">
+          <span>$0 CLP</span>
+          <span>{pctOfBudget}%</span>
+          <span>${d.budgetClp.toLocaleString('es-CL')} CLP</span>
+        </div>
+      </section>
+
+      <section className="rounded-md border border-neutral-200 bg-neutral-50 p-4 text-sm">
+        <h3 className="font-medium text-neutral-900">Información de tipo de cambio</h3>
+        <dl className="mt-2 grid grid-cols-1 gap-2 text-xs sm:grid-cols-3">
+          <div>
+            <dt className="text-neutral-500">Fuente</dt>
+            <dd className="font-medium text-neutral-900">{d.currentRate.source}</dd>
+          </div>
+          <div>
+            <dt className="text-neutral-500">CLP por USD</dt>
+            <dd className="font-medium tabular-nums">${d.currentRate.clpPerUsd.toFixed(2)}</dd>
+          </div>
+          <div>
+            <dt className="text-neutral-500">Observado</dt>
+            <dd className="font-medium">
+              {new Date(d.currentRate.observedAt).toLocaleDateString('es-CL')}
+            </dd>
+          </div>
+        </dl>
+        {d.currentRate.source !== 'mindicador' && (
+          <div className="mt-2 text-amber-800 text-xs">
+            ⚠️ FX no es del día actual. Si mindicador.cl está caído, el valor puede ser de hasta 24h
+            o el fallback hardcoded 940. El forecast se ajustará cuando se restablezca.
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function SkeletonRect({ height }: { height: number }) {
+  return (
+    <div
+      className="animate-pulse rounded-md bg-neutral-100"
+      style={{ height }}
+      aria-label="Cargando forecast"
+    />
+  );
+}

--- a/apps/web/src/components/observability/HealthIndicator.test.tsx
+++ b/apps/web/src/components/observability/HealthIndicator.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { HealthIndicator } from './HealthIndicator.js';
+
+describe('HealthIndicator', () => {
+  it('renderiza label + message para healthy', () => {
+    render(<HealthIndicator level="healthy" label="Uptime" message="99.9%" />);
+    expect(screen.getByText('Uptime')).toBeInTheDocument();
+    expect(screen.getByText('99.9%')).toBeInTheDocument();
+  });
+
+  it('aria-label incluye level y message', () => {
+    render(<HealthIndicator level="degraded" label="CPU" message="78%" />);
+    const el = screen.getByLabelText(/CPU: degraded — 78%/);
+    expect(el).toBeInTheDocument();
+  });
+
+  it('omite message si no se pasa', () => {
+    render(<HealthIndicator level="critical" label="Disk" />);
+    expect(screen.getByText('Disk')).toBeInTheDocument();
+    expect(screen.getByLabelText('Disk: critical')).toBeInTheDocument();
+  });
+
+  it('renderiza para todos los levels sin crashear', () => {
+    const levels = ['healthy', 'degraded', 'critical', 'unknown'] as const;
+    for (const level of levels) {
+      const { unmount } = render(<HealthIndicator level={level} label={`Test-${level}`} />);
+      expect(screen.getByText(`Test-${level}`)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/apps/web/src/components/observability/HealthIndicator.tsx
+++ b/apps/web/src/components/observability/HealthIndicator.tsx
@@ -1,0 +1,46 @@
+/**
+ * Indicador visual healthy/degraded/critical/unknown — dot coloreado +
+ * label.
+ *
+ * Uso típico:
+ *   <HealthIndicator level="healthy" label="Uptime" message="99.9% en últimos 60 min" />
+ */
+export function HealthIndicator({
+  level,
+  label,
+  message,
+}: {
+  level: 'healthy' | 'degraded' | 'critical' | 'unknown';
+  label: string;
+  message?: string;
+}) {
+  const dotColor = {
+    healthy: 'bg-success-500',
+    degraded: 'bg-amber-500',
+    critical: 'bg-danger-500',
+    unknown: 'bg-neutral-300',
+  }[level];
+
+  const labelColor = {
+    healthy: 'text-success-700',
+    degraded: 'text-amber-700',
+    critical: 'text-danger-700',
+    unknown: 'text-neutral-600',
+  }[level];
+
+  const ariaLabel = `${label}: ${level}${message ? ` — ${message}` : ''}`;
+
+  return (
+    <output
+      className="flex items-center gap-3 rounded-md bg-neutral-50 p-3"
+      aria-label={ariaLabel}
+      data-testid={`health-${label.toLowerCase().replace(/\s+/g, '-')}`}
+    >
+      <span className={`inline-block h-3 w-3 shrink-0 rounded-full ${dotColor}`} aria-hidden />
+      <div className="min-w-0 flex-1">
+        <div className={`font-medium text-sm ${labelColor}`}>{label}</div>
+        {message && <div className="mt-0.5 text-neutral-600 text-xs">{message}</div>}
+      </div>
+    </output>
+  );
+}

--- a/apps/web/src/components/observability/KpiCard.test.tsx
+++ b/apps/web/src/components/observability/KpiCard.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { KpiCard } from './KpiCard.js';
+
+describe('KpiCard', () => {
+  it('renderiza label uppercase + value + description', () => {
+    render(
+      <KpiCard
+        label="Cost MTD"
+        value={<span>$100.000 CLP</span>}
+        description="vs $90.000 mes anterior"
+      />,
+    );
+    expect(screen.getByText('Cost MTD')).toBeInTheDocument();
+    expect(screen.getByText('$100.000 CLP')).toBeInTheDocument();
+    expect(screen.getByText('vs $90.000 mes anterior')).toBeInTheDocument();
+  });
+
+  it('aplica color de borde según status', () => {
+    const { container } = render(<KpiCard label="Test" value="42" status="critical" />);
+    const section = container.querySelector('section');
+    expect(section?.className).toContain('border-l-danger-500');
+  });
+
+  it('data-testid generado en kebab-case desde label', () => {
+    render(<KpiCard label="Cloud Run CPU" value="40%" />);
+    expect(screen.getByTestId('kpi-cloud-run-cpu')).toBeInTheDocument();
+  });
+
+  it('omite description si no se pasa', () => {
+    render(<KpiCard label="Test" value="42" />);
+    expect(screen.queryByText(/description/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/observability/KpiCard.tsx
+++ b/apps/web/src/components/observability/KpiCard.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Tarjeta KPI compacta para el Observability Dashboard.
+ *
+ * Layout simple sin tremor (para evitar conflictos CSS con el design
+ * system de Booster). Tremor lo reservamos para charts (LineChart,
+ * BarChart) donde sí aporta valor real.
+ */
+export function KpiCard({
+  label,
+  value,
+  description,
+  status,
+  icon,
+}: {
+  label: string;
+  value: ReactNode;
+  description?: ReactNode;
+  /** Color del borde left + dot — semáforo de salud. */
+  status?: 'healthy' | 'degraded' | 'critical' | 'unknown' | 'neutral';
+  icon?: ReactNode;
+}) {
+  const borderClass = {
+    healthy: 'border-l-success-500',
+    degraded: 'border-l-amber-500',
+    critical: 'border-l-danger-500',
+    unknown: 'border-l-neutral-300',
+    neutral: 'border-l-primary-500',
+  }[status ?? 'neutral'];
+
+  return (
+    <section
+      className={`rounded-lg border border-neutral-200 border-l-4 bg-white p-4 shadow-sm ${borderClass}`}
+      data-testid={`kpi-${label.toLowerCase().replace(/\s+/g, '-')}`}
+    >
+      <header className="flex items-center justify-between gap-2">
+        <span className="font-medium text-neutral-600 text-xs uppercase tracking-wide">
+          {label}
+        </span>
+        {icon && <span className="text-neutral-400">{icon}</span>}
+      </header>
+      <div className="mt-2">{value}</div>
+      {description && <div className="mt-2 text-neutral-500 text-xs">{description}</div>}
+    </section>
+  );
+}

--- a/apps/web/src/components/observability/SaludTab.test.tsx
+++ b/apps/web/src/components/observability/SaludTab.test.tsx
@@ -1,0 +1,43 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../../lib/api-client.js';
+import { SaludTab } from './SaludTab.js';
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe('SaludTab', () => {
+  it('renderiza overall + componentes cuando snapshot OK', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      overall: 'healthy',
+      components: [
+        { name: 'uptime', level: 'healthy', message: '99.9%' },
+        { name: 'cloud-run', level: 'degraded', message: 'CPU 78%' },
+      ],
+      lastEvaluatedAt: '2026-05-13T20:00:00Z',
+    });
+    render(<SaludTab />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByText('🟢 Healthy')).toBeInTheDocument());
+    expect(screen.getByText('uptime')).toBeInTheDocument();
+    expect(screen.getByText('cloud-run')).toBeInTheDocument();
+  });
+
+  it('muestra estado crítico cuando overall=critical', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      overall: 'critical',
+      components: [{ name: 'uptime', level: 'critical', message: '95%' }],
+      lastEvaluatedAt: '2026-05-13T20:00:00Z',
+    });
+    render(<SaludTab />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByText(/🔴 Critical/)).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/components/observability/SaludTab.tsx
+++ b/apps/web/src/components/observability/SaludTab.tsx
@@ -1,0 +1,93 @@
+import { useObservabilityHealth } from '../../hooks/use-observability.js';
+import { HealthIndicator } from './HealthIndicator.js';
+import { KpiCard } from './KpiCard.js';
+
+/**
+ * Tab Salud — composite health snapshot del backend.
+ * Renderiza el overall + un HealthIndicator por componente.
+ */
+export function SaludTab() {
+  const health = useObservabilityHealth();
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h2 className="font-semibold text-lg text-neutral-900">Salud técnica</h2>
+        <p className="mt-1 text-neutral-500 text-xs">
+          Uptime checks + Cloud Run + Cloud SQL. Cache 60s.
+        </p>
+      </header>
+
+      <KpiCard
+        label="Estado general"
+        value={
+          health.isLoading ? (
+            <span className="text-neutral-400 text-sm">Cargando…</span>
+          ) : health.data ? (
+            <OverallBadge level={health.data.overall} />
+          ) : (
+            <span className="text-neutral-400 text-sm">—</span>
+          )
+        }
+        description={
+          health.data
+            ? `Última evaluación: ${new Date(health.data.lastEvaluatedAt).toLocaleString('es-CL')}`
+            : null
+        }
+        status={health.data?.overall ?? 'neutral'}
+      />
+
+      <section>
+        <h3 className="mb-2 font-medium text-neutral-900 text-sm">Componentes</h3>
+        {health.isLoading ? (
+          <SkeletonStack count={3} />
+        ) : health.data ? (
+          <div className="space-y-2">
+            {health.data.components.map((c) => (
+              <HealthIndicator key={c.name} level={c.level} label={c.name} message={c.message} />
+            ))}
+          </div>
+        ) : (
+          <ErrorBox error={health.error} retry={health.refetch} />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function OverallBadge({ level }: { level: 'healthy' | 'degraded' | 'critical' | 'unknown' }) {
+  const text = {
+    healthy: '🟢 Healthy',
+    degraded: '🟡 Degraded',
+    critical: '🔴 Critical',
+    unknown: '⚪ Unknown',
+  }[level];
+  return <span className="font-semibold text-2xl">{text}</span>;
+}
+
+function SkeletonStack({ count }: { count: number }) {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: count }, (_, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholder
+        <div key={i} className="h-12 animate-pulse rounded-md bg-neutral-100" />
+      ))}
+    </div>
+  );
+}
+
+function ErrorBox({ error, retry }: { error: Error | null; retry: () => void }) {
+  return (
+    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-amber-900 text-sm">
+      <div className="font-medium">No se pudo cargar el health snapshot</div>
+      {error && <div className="mt-1 font-mono text-xs">{error.message}</div>}
+      <button
+        type="button"
+        onClick={() => retry()}
+        className="mt-2 inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-1 font-medium text-xs hover:bg-amber-100"
+      >
+        Reintentar
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/observability/TrendChart.tsx
+++ b/apps/web/src/components/observability/TrendChart.tsx
@@ -33,10 +33,15 @@ export function TrendChart({
     );
   }
 
+  // NOTA: Tremor LineChart consume `className` para su wrapper interno; si
+  // pasamos `h-[280px]` como template string, Tailwind 4 no detecta la clase
+  // arbitrary y el wrapper queda con height: 0 (chart invisible). Usamos
+  // `h-full` (clase estándar siempre emitida) y forzamos la altura del
+  // parent vía style inline.
   return (
-    <div style={{ height }}>
+    <div style={{ height, width: '100%' }}>
       <LineChart
-        className={`h-[${height}px]`}
+        className="h-full w-full"
         data={data}
         index="date"
         categories={[categoryLabel]}

--- a/apps/web/src/components/observability/TrendChart.tsx
+++ b/apps/web/src/components/observability/TrendChart.tsx
@@ -1,0 +1,60 @@
+import { LineChart } from '@tremor/react';
+
+/**
+ * Line chart de serie temporal usando @tremor/react. Wrapper que normaliza
+ * la API a la shape que devuelve `/admin/observability/costs/trend`:
+ *   [{ date: '2026-05-13', costClp: 5000 }, ...]
+ *
+ * Formato eje Y: CLP con separadores de miles. Eje X: fecha en es-CL
+ * (corto: "13 may", "14 may").
+ */
+export function TrendChart({
+  points,
+  categoryLabel = 'Costo CLP',
+  height = 280,
+}: {
+  points: Array<{ date: string; costClp: number }>;
+  categoryLabel?: string;
+  height?: number;
+}) {
+  const data = points.map((p) => ({
+    date: formatShortDate(p.date),
+    [categoryLabel]: p.costClp,
+  }));
+
+  if (points.length === 0) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-md border border-neutral-200 bg-neutral-50 text-neutral-500 text-sm"
+        style={{ height }}
+      >
+        Sin datos en el rango seleccionado.
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ height }}>
+      <LineChart
+        className={`h-[${height}px]`}
+        data={data}
+        index="date"
+        categories={[categoryLabel]}
+        colors={['emerald']}
+        valueFormatter={(v) => `$${Math.round(v).toLocaleString('es-CL')}`}
+        showLegend={false}
+        yAxisWidth={75}
+      />
+    </div>
+  );
+}
+
+function formatShortDate(iso: string): string {
+  // iso = "2026-05-13"; parse local sin timezone shift
+  const [y, m, d] = iso.split('-').map(Number);
+  if (!y || !m || !d) {
+    return iso;
+  }
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString('es-CL', { day: 'numeric', month: 'short' });
+}

--- a/apps/web/src/components/observability/UsoTab.test.tsx
+++ b/apps/web/src/components/observability/UsoTab.test.tsx
@@ -1,0 +1,70 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../../lib/api-client.js';
+import { UsoTab } from './UsoTab.js';
+
+function wrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.restoreAllMocks());
+
+describe('UsoTab', () => {
+  it('renderiza Twilio + Workspace cuando ambos available', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path === '/admin/observability/usage/twilio') {
+        return {
+          available: true,
+          balance: { balanceUsd: 42.5, balanceClp: 39_313, currency: 'USD' },
+          usage: [
+            {
+              category: 'sms',
+              description: 'SMS',
+              usage: 500,
+              usageUnit: 'messages',
+              priceUsd: 10,
+              priceClp: 9250,
+            },
+          ],
+        };
+      }
+      if (path === '/admin/observability/usage/workspace') {
+        return {
+          available: true,
+          totalSeats: 10,
+          activeSeats: 9,
+          suspendedSeats: 1,
+          seatsBySku: { '1010020028': 9 },
+          monthlyCostUsd: 108,
+          monthlyCostClp: 99_900,
+        };
+      }
+      return {};
+    });
+
+    render(<UsoTab />, { wrapper: wrapper() });
+    await waitFor(() => expect(screen.getByText(/\$42\.50 USD/)).toBeInTheDocument());
+    expect(screen.getByText('sms')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument(); // totalSeats
+  });
+
+  it('Twilio not configured → muestra estado unavailable', async () => {
+    vi.spyOn(api, 'get').mockImplementation(async (path: string) => {
+      if (path === '/admin/observability/usage/twilio') {
+        return { available: false, reason: 'twilio_credentials_not_configured' };
+      }
+      return { available: false, reason: 'DWD pending' };
+    });
+    render(<UsoTab />, { wrapper: wrapper() });
+    await waitFor(() => {
+      expect(screen.getByText('Twilio no configurado')).toBeInTheDocument();
+      expect(screen.getByText('Workspace no configurado')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/observability/UsoTab.tsx
+++ b/apps/web/src/components/observability/UsoTab.tsx
@@ -1,0 +1,165 @@
+import {
+  useObservabilityTwilio,
+  useObservabilityWorkspace,
+} from '../../hooks/use-observability.js';
+import { CurrencyValue } from './CurrencyValue.js';
+import { KpiCard } from './KpiCard.js';
+
+/**
+ * Tab Uso — Twilio (balance + categorías MTD) + Google Workspace
+ * (seats + costo mensual). Ambos servicios soportan graceful
+ * degradation: si no están configurados, se muestra estado
+ * "no disponible" sin crashear el dashboard.
+ */
+export function UsoTab() {
+  const twilio = useObservabilityTwilio();
+  const workspace = useObservabilityWorkspace();
+
+  return (
+    <div className="space-y-6">
+      <section>
+        <h2 className="font-semibold text-lg text-neutral-900">Twilio (WhatsApp + SMS)</h2>
+        <p className="mt-1 mb-3 text-neutral-500 text-xs">
+          Balance + top categorías del mes en curso.
+        </p>
+        {twilio.isLoading ? (
+          <SkeletonRect height={140} />
+        ) : twilio.data?.available ? (
+          <div className="space-y-3">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              <KpiCard
+                label="Balance Twilio"
+                value={
+                  <div className="space-y-1">
+                    <div className="font-bold text-2xl">
+                      ${twilio.data.balance.balanceUsd.toFixed(2)} USD
+                    </div>
+                    <div className="text-neutral-500 text-sm">
+                      ≈ <CurrencyValue amountClp={twilio.data.balance.balanceClp} size="sm" />
+                    </div>
+                  </div>
+                }
+                description="Saldo prepago disponible."
+                status={twilio.data.balance.balanceUsd < 10 ? 'critical' : 'healthy'}
+              />
+              <KpiCard
+                label="Categorías facturadas (mes)"
+                value={<span className="font-bold text-2xl">{twilio.data.usage.length}</span>}
+                description="Top 10 ordenadas por costo USD."
+                status="neutral"
+              />
+            </div>
+            {twilio.data.usage.length > 0 ? (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-neutral-100 border-b text-left text-neutral-500 text-xs">
+                    <th className="py-2 font-medium">Categoría</th>
+                    <th className="py-2 font-medium">Descripción</th>
+                    <th className="py-2 text-right font-medium">Uso</th>
+                    <th className="py-2 text-right font-medium">USD</th>
+                    <th className="py-2 text-right font-medium">CLP</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {twilio.data.usage.map((u) => (
+                    <tr key={u.category} className="border-neutral-50 border-b last:border-0">
+                      <td className="py-2 text-neutral-700">{u.category}</td>
+                      <td className="py-2 text-neutral-500 text-xs">{u.description}</td>
+                      <td className="py-2 text-right text-neutral-700 tabular-nums">
+                        {u.usage.toLocaleString('es-CL')} {u.usageUnit}
+                      </td>
+                      <td className="py-2 text-right tabular-nums">${u.priceUsd.toFixed(2)}</td>
+                      <td className="py-2 text-right font-medium tabular-nums">
+                        ${u.priceClp.toLocaleString('es-CL')}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            ) : (
+              <div className="rounded-md bg-neutral-50 p-3 text-neutral-500 text-sm">
+                Sin uso facturado este mes.
+              </div>
+            )}
+          </div>
+        ) : (
+          <UnavailableBox
+            title="Twilio no configurado"
+            reason={twilio.data && !twilio.data.available ? twilio.data.reason : undefined}
+          />
+        )}
+      </section>
+
+      <section>
+        <h2 className="font-semibold text-lg text-neutral-900">Google Workspace</h2>
+        <p className="mt-1 mb-3 text-neutral-500 text-xs">
+          Seats activos + suspendidos. Precios USD/seat configurables vía env var.
+        </p>
+        {workspace.isLoading ? (
+          <SkeletonRect height={140} />
+        ) : workspace.data?.available ? (
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <KpiCard
+              label="Seats totales"
+              value={<span className="font-bold text-3xl">{workspace.data.totalSeats}</span>}
+              description={`${workspace.data.activeSeats} activos · ${workspace.data.suspendedSeats} suspendidos`}
+              status="neutral"
+            />
+            <KpiCard
+              label="Costo mensual"
+              value={<CurrencyValue amountClp={workspace.data.monthlyCostClp} size="xl" />}
+              description={`≈ $${workspace.data.monthlyCostUsd.toFixed(2)} USD`}
+              status="neutral"
+            />
+            <KpiCard
+              label="Breakdown por SKU"
+              value={
+                <span className="text-2xl">{Object.keys(workspace.data.seatsBySku).length}</span>
+              }
+              description={
+                Object.entries(workspace.data.seatsBySku)
+                  .map(([sku, n]) => `${sku}: ${n}`)
+                  .join(' · ') || 'Sin licencias detectadas'
+              }
+              status="neutral"
+            />
+          </div>
+        ) : (
+          <UnavailableBox
+            title="Workspace no configurado"
+            reason={workspace.data?.reason}
+            hint="Sigue el runbook docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md para habilitar Domain-Wide Delegation."
+          />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function SkeletonRect({ height }: { height: number }) {
+  return (
+    <div
+      className="animate-pulse rounded-md bg-neutral-100"
+      style={{ height }}
+      aria-label="Cargando"
+    />
+  );
+}
+
+function UnavailableBox({
+  title,
+  reason,
+  hint,
+}: {
+  title: string;
+  reason?: string | undefined;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-md border border-neutral-200 bg-neutral-50 p-4 text-sm">
+      <div className="font-medium text-neutral-900">{title}</div>
+      {reason && <div className="mt-1 text-neutral-600 text-xs">{reason}</div>}
+      {hint && <div className="mt-2 text-neutral-500 text-xs">{hint}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-observability.test.tsx
+++ b/apps/web/src/hooks/use-observability.test.tsx
@@ -1,0 +1,126 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../lib/api-client.js';
+import {
+  useObservabilityCloudRun,
+  useObservabilityCostsByService,
+  useObservabilityCostsOverview,
+  useObservabilityHealth,
+  useObservabilityTwilio,
+} from './use-observability.js';
+
+/**
+ * Tests de los hooks TanStack Query del Observability Dashboard.
+ *
+ * Mockean `api.get` para evitar fetch real. Cada test valida:
+ * - El hook llama al endpoint correcto.
+ * - Pasa los query params (days, limit) correctamente.
+ * - Retorna data al success state.
+ */
+
+function makeWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useObservabilityHealth', () => {
+  it('GET /admin/observability/health', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      overall: 'healthy',
+      components: [],
+      lastEvaluatedAt: '2026-05-13T20:00:00Z',
+    });
+    const { result } = renderHook(() => useObservabilityHealth(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('/admin/observability/health');
+    expect(result.current.data?.overall).toBe('healthy');
+  });
+});
+
+describe('useObservabilityCostsOverview', () => {
+  it('GET /admin/observability/costs/overview', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      costClpMonthToDate: 100000,
+      costClpPreviousMonth: 90000,
+      deltaPercentVsPreviousMonth: 11.1,
+      lastBillingExportAt: '2026-05-13T13:00:00Z',
+    });
+    const { result } = renderHook(() => useObservabilityCostsOverview(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('/admin/observability/costs/overview');
+    expect(result.current.data?.costClpMonthToDate).toBe(100000);
+  });
+});
+
+describe('useObservabilityCostsByService', () => {
+  it('default days=30', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({ days: 30, items: [] });
+    const { result } = renderHook(() => useObservabilityCostsByService(), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('/admin/observability/costs/by-service?days=30');
+  });
+
+  it('custom days=7', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({ days: 7, items: [] });
+    const { result } = renderHook(() => useObservabilityCostsByService(7), {
+      wrapper: makeWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('/admin/observability/costs/by-service?days=7');
+  });
+});
+
+describe('useObservabilityCloudRun', () => {
+  it('GET /admin/observability/usage/cloud-run', async () => {
+    const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
+      latencyP95Ms: 150,
+      cpuUtilization: 0.4,
+      ramUtilization: 0.5,
+      rps: 8,
+    });
+    const { result } = renderHook(() => useObservabilityCloudRun(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(spy).toHaveBeenCalledWith('/admin/observability/usage/cloud-run');
+    expect(result.current.data?.cpuUtilization).toBe(0.4);
+  });
+});
+
+describe('useObservabilityTwilio', () => {
+  it('available=true con balance y usage', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      available: true,
+      balance: { balanceUsd: 42.5, balanceClp: 39313, currency: 'USD' },
+      usage: [],
+    });
+    const { result } = renderHook(() => useObservabilityTwilio(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.available).toBe(true);
+  });
+
+  it('available=false si Twilio no configurado', async () => {
+    vi.spyOn(api, 'get').mockResolvedValueOnce({
+      available: false,
+      reason: 'twilio_credentials_not_configured',
+    });
+    const { result } = renderHook(() => useObservabilityTwilio(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.available).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-observability.test.tsx
+++ b/apps/web/src/hooks/use-observability.test.tsx
@@ -54,7 +54,8 @@ describe('useObservabilityCostsOverview', () => {
   it('GET /admin/observability/costs/overview', async () => {
     const spy = vi.spyOn(api, 'get').mockResolvedValueOnce({
       costClpMonthToDate: 100000,
-      costClpPreviousMonth: 90000,
+      costClpPreviousMonth: 200000,
+      costClpPreviousMonthSamePeriod: 90000,
       deltaPercentVsPreviousMonth: 11.1,
       lastBillingExportAt: '2026-05-13T13:00:00Z',
     });

--- a/apps/web/src/hooks/use-observability.ts
+++ b/apps/web/src/hooks/use-observability.ts
@@ -62,6 +62,13 @@ export interface TopSku {
   costClp: number;
 }
 
+export interface MonthlyHistoryItem {
+  month: string;
+  costClp: number;
+  deltaPercentVsPrior: number | null;
+  isCurrent: boolean;
+}
+
 export interface CloudRunMetrics {
   latencyP95Ms: number | null;
   cpuUtilization: number | null;
@@ -166,6 +173,17 @@ export function useObservabilityCostsTrend(days = 30) {
     queryFn: () =>
       api.get<{ days: number; points: CostsTrendPoint[] }>(
         `/admin/observability/costs/trend?days=${days}`,
+      ),
+    staleTime: STALE_COSTS,
+  });
+}
+
+export function useObservabilityMonthlyHistory(months = 12) {
+  return useQuery({
+    queryKey: ['observability', 'costs', 'monthly-history', months],
+    queryFn: () =>
+      api.get<{ months: number; items: MonthlyHistoryItem[] }>(
+        `/admin/observability/costs/monthly-history?months=${months}`,
       ),
     staleTime: STALE_COSTS,
   });

--- a/apps/web/src/hooks/use-observability.ts
+++ b/apps/web/src/hooks/use-observability.ts
@@ -1,0 +1,219 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../lib/api-client.js';
+
+/**
+ * Hooks TanStack Query para el Observability Dashboard
+ * (/app/platform-admin/observability).
+ *
+ * Convenciones:
+ * - staleTime 60s para queries de UI ligero (health, usage).
+ * - staleTime 5min para costos (BigQuery ya cachea 5min server-side).
+ * - refetchOnWindowFocus: false (heredado del provider global), para
+ *   no martillar BigQuery cada vez que el admin cambia de pestaña.
+ * - Cada hook tiene un namespace queryKey `['observability', ...]` para
+ *   que el QueryClient pueda invalidar el dashboard entero con un
+ *   `queryClient.invalidateQueries({ queryKey: ['observability'] })`.
+ */
+
+// ---------------- Tipos espejo de los responses de apps/api ----------------
+
+export interface HealthSnapshot {
+  overall: 'healthy' | 'degraded' | 'critical' | 'unknown';
+  components: Array<{
+    name: string;
+    level: 'healthy' | 'degraded' | 'critical' | 'unknown';
+    message: string;
+  }>;
+  lastEvaluatedAt: string;
+}
+
+export interface CostsOverview {
+  costClpMonthToDate: number;
+  costClpPreviousMonth: number;
+  deltaPercentVsPreviousMonth: number | null;
+  lastBillingExportAt: string | null;
+}
+
+export interface CostsByServiceItem {
+  service: string;
+  costClp: number;
+  percentOfTotal: number;
+}
+
+export interface CostsByProjectItem {
+  projectId: string;
+  projectName: string | null;
+  costClp: number;
+  percentOfTotal: number;
+}
+
+export interface CostsTrendPoint {
+  date: string;
+  costClp: number;
+}
+
+export interface TopSku {
+  service: string;
+  sku: string;
+  costClp: number;
+}
+
+export interface CloudRunMetrics {
+  latencyP95Ms: number | null;
+  cpuUtilization: number | null;
+  ramUtilization: number | null;
+  rps: number | null;
+}
+
+export interface CloudSqlMetrics {
+  cpuUtilization: number | null;
+  ramUtilization: number | null;
+  diskUtilization: number | null;
+  connectionsUsedRatio: number | null;
+}
+
+export type TwilioUsageResponse =
+  | {
+      available: true;
+      balance: { balanceUsd: number; balanceClp: number; currency: string };
+      usage: Array<{
+        category: string;
+        description: string;
+        usage: number;
+        usageUnit: string;
+        priceUsd: number;
+        priceClp: number;
+      }>;
+    }
+  | { available: false; reason: string };
+
+export interface WorkspaceUsageSnapshot {
+  available: boolean;
+  reason?: string;
+  totalSeats: number;
+  activeSeats: number;
+  suspendedSeats: number;
+  seatsBySku: Record<string, number>;
+  monthlyCostUsd: number;
+  monthlyCostClp: number;
+}
+
+export interface ForecastResponse {
+  forecastClpEndOfMonth: number;
+  budgetClp: number;
+  variancePercent: number;
+  dayOfMonth: number;
+  daysInMonth: number;
+  daysRemaining: number;
+  currentRate: {
+    clpPerUsd: number;
+    observedAt: string;
+    source: 'mindicador' | 'cache-fallback' | 'hardcoded';
+  };
+}
+
+// ---------------- Hooks ----------------
+
+const STALE_HEALTH = 60_000;
+const STALE_COSTS = 5 * 60_000;
+const STALE_USAGE = 60_000;
+
+export function useObservabilityHealth() {
+  return useQuery({
+    queryKey: ['observability', 'health'],
+    queryFn: () => api.get<HealthSnapshot>('/admin/observability/health'),
+    staleTime: STALE_HEALTH,
+  });
+}
+
+export function useObservabilityCostsOverview() {
+  return useQuery({
+    queryKey: ['observability', 'costs', 'overview'],
+    queryFn: () => api.get<CostsOverview>('/admin/observability/costs/overview'),
+    staleTime: STALE_COSTS,
+  });
+}
+
+export function useObservabilityCostsByService(days = 30) {
+  return useQuery({
+    queryKey: ['observability', 'costs', 'by-service', days],
+    queryFn: () =>
+      api.get<{ days: number; items: CostsByServiceItem[] }>(
+        `/admin/observability/costs/by-service?days=${days}`,
+      ),
+    staleTime: STALE_COSTS,
+  });
+}
+
+export function useObservabilityCostsByProject(days = 30) {
+  return useQuery({
+    queryKey: ['observability', 'costs', 'by-project', days],
+    queryFn: () =>
+      api.get<{ days: number; items: CostsByProjectItem[] }>(
+        `/admin/observability/costs/by-project?days=${days}`,
+      ),
+    staleTime: STALE_COSTS,
+  });
+}
+
+export function useObservabilityCostsTrend(days = 30) {
+  return useQuery({
+    queryKey: ['observability', 'costs', 'trend', days],
+    queryFn: () =>
+      api.get<{ days: number; points: CostsTrendPoint[] }>(
+        `/admin/observability/costs/trend?days=${days}`,
+      ),
+    staleTime: STALE_COSTS,
+  });
+}
+
+export function useObservabilityTopSkus(limit = 10) {
+  return useQuery({
+    queryKey: ['observability', 'costs', 'top-skus', limit],
+    queryFn: () =>
+      api.get<{ limit: number; items: TopSku[] }>(
+        `/admin/observability/costs/top-skus?limit=${limit}`,
+      ),
+    staleTime: STALE_COSTS,
+  });
+}
+
+export function useObservabilityCloudRun() {
+  return useQuery({
+    queryKey: ['observability', 'usage', 'cloud-run'],
+    queryFn: () => api.get<CloudRunMetrics>('/admin/observability/usage/cloud-run'),
+    staleTime: STALE_USAGE,
+  });
+}
+
+export function useObservabilityCloudSql() {
+  return useQuery({
+    queryKey: ['observability', 'usage', 'cloud-sql'],
+    queryFn: () => api.get<CloudSqlMetrics>('/admin/observability/usage/cloud-sql'),
+    staleTime: STALE_USAGE,
+  });
+}
+
+export function useObservabilityTwilio() {
+  return useQuery({
+    queryKey: ['observability', 'usage', 'twilio'],
+    queryFn: () => api.get<TwilioUsageResponse>('/admin/observability/usage/twilio'),
+    staleTime: STALE_USAGE,
+  });
+}
+
+export function useObservabilityWorkspace() {
+  return useQuery({
+    queryKey: ['observability', 'usage', 'workspace'],
+    queryFn: () => api.get<WorkspaceUsageSnapshot>('/admin/observability/usage/workspace'),
+    staleTime: STALE_USAGE,
+  });
+}
+
+export function useObservabilityForecast() {
+  return useQuery({
+    queryKey: ['observability', 'forecast'],
+    queryFn: () => api.get<ForecastResponse>('/admin/observability/forecast'),
+    staleTime: STALE_COSTS,
+  });
+}

--- a/apps/web/src/hooks/use-observability.ts
+++ b/apps/web/src/hooks/use-observability.ts
@@ -29,7 +29,11 @@ export interface HealthSnapshot {
 
 export interface CostsOverview {
   costClpMonthToDate: number;
+  /** Costo del mes anterior completo (contexto). */
   costClpPreviousMonth: number;
+  /** Costo del mismo periodo del mes anterior (apples-to-apples). */
+  costClpPreviousMonthSamePeriod: number;
+  /** Δ% vs mismo periodo mes anterior — la métrica de "voy más o menos que el ritmo del mes pasado". */
   deltaPercentVsPreviousMonth: number | null;
   lastBillingExportAt: string | null;
 }

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -28,6 +28,7 @@ import { OfertasRoute } from './routes/ofertas.js';
 import { OnboardingRoute } from './routes/onboarding.js';
 import { PerfilRoute } from './routes/perfil.js';
 import { PlatformAdminMatchingRoute } from './routes/platform-admin-matching.js';
+import { PlatformAdminObservabilityRoute } from './routes/platform-admin-observability.js';
 import { PlatformAdminSiteSettingsRoute } from './routes/platform-admin-site-settings.js';
 import { PlatformAdminRoute } from './routes/platform-admin.js';
 import { PublicTrackingRoute } from './routes/public-tracking.js';
@@ -237,6 +238,14 @@ const platformAdminSiteSettingsRoute = createRoute({
   component: PlatformAdminSiteSettingsRoute,
 });
 
+// Spec 2026-05-13 — Observability dashboard (costos GCP + Twilio +
+// Workspace + salud + capacity + forecast). Misma gate platform-admin.
+const platformAdminObservabilityRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/app/platform-admin/observability',
+  component: PlatformAdminObservabilityRoute,
+});
+
 const vehiculosNuevoRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/app/vehiculos/nuevo',
@@ -360,6 +369,7 @@ const routeTree = rootRoute.addChildren([
   platformAdminRoute,
   platformAdminMatchingRoute,
   platformAdminSiteSettingsRoute,
+  platformAdminObservabilityRoute,
   cargasListRoute,
   cargasNuevaRoute,
   cargasDetalleRoute,

--- a/apps/web/src/routes/platform-admin-observability.test.tsx
+++ b/apps/web/src/routes/platform-admin-observability.test.tsx
@@ -1,13 +1,17 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../lib/api-client.js';
 
 /**
- * Tests del skeleton route /app/platform-admin/observability.
+ * Tests del route /app/platform-admin/observability con los 5 tabs reales.
  *
  * Patrón de mocks (consistente con platform-admin-matching.test.tsx):
  *   - `ProtectedRoute` bypass.
  *   - `Link` de tanstack-router → `<a>`.
+ *   - `api.get` mockeado para que los hooks TanStack Query no fallen al
+ *     hidratar (los tabs montan al cambiar activeTab).
  */
 
 vi.mock('../components/ProtectedRoute.js', () => ({
@@ -24,8 +28,19 @@ vi.mock('@tanstack/react-router', () => ({
 
 const { PlatformAdminObservabilityRoute } = await import('./platform-admin-observability.js');
 
+function renderWithProviders(): void {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <PlatformAdminObservabilityRoute />
+    </QueryClientProvider>,
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // Stub api.get para que los hooks no exploten cuando se monten los tabs.
+  vi.spyOn(api, 'get').mockResolvedValue({});
 });
 afterEach(() => {
   vi.restoreAllMocks();
@@ -33,7 +48,7 @@ afterEach(() => {
 
 describe('PlatformAdminObservabilityRoute', () => {
   it('renderiza los 5 tabs', () => {
-    render(<PlatformAdminObservabilityRoute />);
+    renderWithProviders();
     expect(screen.getByTestId('observability-tab-costos')).toBeInTheDocument();
     expect(screen.getByTestId('observability-tab-salud')).toBeInTheDocument();
     expect(screen.getByTestId('observability-tab-uso')).toBeInTheDocument();
@@ -42,13 +57,13 @@ describe('PlatformAdminObservabilityRoute', () => {
   });
 
   it('costos es el tab inicial activo', () => {
-    render(<PlatformAdminObservabilityRoute />);
+    renderWithProviders();
     expect(screen.getByTestId('observability-panel-costos')).toBeInTheDocument();
     expect(screen.getByTestId('observability-tab-costos')).toHaveAttribute('aria-selected', 'true');
   });
 
   it('click cambia el tab activo y renderiza el panel correspondiente', () => {
-    render(<PlatformAdminObservabilityRoute />);
+    renderWithProviders();
     fireEvent.click(screen.getByTestId('observability-tab-forecast'));
     expect(screen.getByTestId('observability-panel-forecast')).toBeInTheDocument();
     expect(screen.getByTestId('observability-tab-forecast')).toHaveAttribute(
@@ -62,7 +77,7 @@ describe('PlatformAdminObservabilityRoute', () => {
   });
 
   it('header tiene link de regreso a /app/platform-admin', () => {
-    render(<PlatformAdminObservabilityRoute />);
+    renderWithProviders();
     expect(screen.getByText(/Volver a Platform Admin/)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/routes/platform-admin-observability.test.tsx
+++ b/apps/web/src/routes/platform-admin-observability.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Tests del skeleton route /app/platform-admin/observability.
+ *
+ * Patrón de mocks (consistente con platform-admin-matching.test.tsx):
+ *   - `ProtectedRoute` bypass.
+ *   - `Link` de tanstack-router → `<a>`.
+ */
+
+vi.mock('../components/ProtectedRoute.js', () => ({
+  ProtectedRoute: ({ children }: { children: () => ReactNode }) => <>{children()}</>,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, ...rest }: { children: ReactNode; to: string }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+const { PlatformAdminObservabilityRoute } = await import('./platform-admin-observability.js');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PlatformAdminObservabilityRoute', () => {
+  it('renderiza los 5 tabs', () => {
+    render(<PlatformAdminObservabilityRoute />);
+    expect(screen.getByTestId('observability-tab-costos')).toBeInTheDocument();
+    expect(screen.getByTestId('observability-tab-salud')).toBeInTheDocument();
+    expect(screen.getByTestId('observability-tab-uso')).toBeInTheDocument();
+    expect(screen.getByTestId('observability-tab-capacity')).toBeInTheDocument();
+    expect(screen.getByTestId('observability-tab-forecast')).toBeInTheDocument();
+  });
+
+  it('costos es el tab inicial activo', () => {
+    render(<PlatformAdminObservabilityRoute />);
+    expect(screen.getByTestId('observability-panel-costos')).toBeInTheDocument();
+    expect(screen.getByTestId('observability-tab-costos')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('click cambia el tab activo y renderiza el panel correspondiente', () => {
+    render(<PlatformAdminObservabilityRoute />);
+    fireEvent.click(screen.getByTestId('observability-tab-forecast'));
+    expect(screen.getByTestId('observability-panel-forecast')).toBeInTheDocument();
+    expect(screen.getByTestId('observability-tab-forecast')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(screen.getByTestId('observability-tab-costos')).toHaveAttribute(
+      'aria-selected',
+      'false',
+    );
+  });
+
+  it('header tiene link de regreso a /app/platform-admin', () => {
+    render(<PlatformAdminObservabilityRoute />);
+    expect(screen.getByText(/Volver a Platform Admin/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/platform-admin-observability.tsx
+++ b/apps/web/src/routes/platform-admin-observability.tsx
@@ -1,0 +1,166 @@
+import { Link } from '@tanstack/react-router';
+import {
+  ActivityIcon,
+  AlertTriangleIcon,
+  ArrowLeft,
+  BarChart3Icon,
+  GaugeIcon,
+  Loader2,
+  TrendingUpIcon,
+  WalletIcon,
+} from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+import { ProtectedRoute } from '../components/ProtectedRoute.js';
+
+/**
+ * /app/platform-admin/observability — dashboard de costos y operaciones
+ * para platform-admin Booster (spec 2026-05-13).
+ *
+ * Auth: server-side BOOSTER_PLATFORM_ADMIN_EMAILS allowlist (403 si no).
+ * `meRequirement=skip` — admin no requiere membership/empresa propia.
+ *
+ * Esta route es el skeleton del C5. Los 5 tabs se implementan en C6
+ * (apps/web/src/components/observability/{Costos,Salud,Uso,Capacity,Forecast}Tab.tsx).
+ */
+
+type TabId = 'costos' | 'salud' | 'uso' | 'capacity' | 'forecast';
+
+interface TabSpec {
+  id: TabId;
+  label: string;
+  icon: ReactNode;
+  description: string;
+}
+
+const TABS: TabSpec[] = [
+  {
+    id: 'costos',
+    label: 'Costos',
+    icon: <WalletIcon className="h-4 w-4" aria-hidden />,
+    description: 'GCP + Twilio + Workspace en CLP, breakdown por servicio y proyecto',
+  },
+  {
+    id: 'salud',
+    label: 'Salud',
+    icon: <ActivityIcon className="h-4 w-4" aria-hidden />,
+    description: 'Uptime checks + Cloud Run + Cloud SQL — semáforos por componente',
+  },
+  {
+    id: 'uso',
+    label: 'Uso',
+    icon: <BarChart3Icon className="h-4 w-4" aria-hidden />,
+    description: 'Twilio (balance + categorías), Google Workspace (seats + costo)',
+  },
+  {
+    id: 'capacity',
+    label: 'Capacity',
+    icon: <GaugeIcon className="h-4 w-4" aria-hidden />,
+    description: 'Headroom CPU/RAM/disco/conexiones para Cloud Run + Cloud SQL',
+  },
+  {
+    id: 'forecast',
+    label: 'Forecast',
+    icon: <TrendingUpIcon className="h-4 w-4" aria-hidden />,
+    description: 'Proyección fin de mes vs MONTHLY_BUDGET_USD, FX dinámico mindicador.cl',
+  },
+];
+
+export function PlatformAdminObservabilityRoute() {
+  return (
+    <ProtectedRoute meRequirement="skip">{() => <PlatformAdminObservabilityPage />}</ProtectedRoute>
+  );
+}
+
+function PlatformAdminObservabilityPage() {
+  const [activeTab, setActiveTab] = useState<TabId>('costos');
+
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-50">
+      <header className="border-neutral-200 border-b bg-white">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-3">
+          <div className="flex items-center gap-3">
+            <BarChart3Icon className="h-6 w-6 text-primary-600" aria-hidden />
+            <div>
+              <div className="font-semibold text-neutral-900">Observabilidad de plataforma</div>
+              <div className="text-neutral-500 text-xs">
+                Costos GCP + Twilio + Google Workspace · Salud técnica · Forecast
+              </div>
+            </div>
+          </div>
+          <Link
+            to="/app/platform-admin"
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-neutral-700 text-sm transition hover:bg-neutral-100"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden />
+            Volver a Platform Admin
+          </Link>
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-7xl flex-1 px-6 py-6">
+        <nav
+          className="-mb-px flex flex-wrap gap-1 border-neutral-200 border-b"
+          aria-label="Tabs"
+          role="tablist"
+        >
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              aria-selected={activeTab === tab.id}
+              data-testid={`observability-tab-${tab.id}`}
+              onClick={() => setActiveTab(tab.id)}
+              className={`inline-flex items-center gap-2 border-b-2 px-4 py-2 font-medium text-sm transition ${
+                activeTab === tab.id
+                  ? 'border-primary-600 text-primary-700'
+                  : 'border-transparent text-neutral-600 hover:border-neutral-300 hover:text-neutral-900'
+              }`}
+            >
+              {tab.icon}
+              {tab.label}
+            </button>
+          ))}
+        </nav>
+
+        <div className="mt-6">
+          <div className="mb-4 text-neutral-600 text-sm">
+            {TABS.find((t) => t.id === activeTab)?.description}
+          </div>
+          <TabContent active={activeTab} />
+        </div>
+      </main>
+    </div>
+  );
+}
+
+/**
+ * Placeholder de cada tab — C6 reemplaza con componentes reales
+ * (CostosTab, SaludTab, UsoTab, CapacityTab, ForecastTab).
+ */
+function TabContent({ active }: { active: TabId }) {
+  return (
+    <section
+      role="tabpanel"
+      data-testid={`observability-panel-${active}`}
+      className="rounded-lg border border-neutral-300 border-dashed bg-white p-8"
+    >
+      <div className="flex items-start gap-3">
+        <Loader2 className="h-5 w-5 animate-spin text-neutral-400" aria-hidden />
+        <div>
+          <h2 className="font-semibold text-neutral-900">Tab {active}</h2>
+          <p className="mt-1 text-neutral-600 text-sm">
+            Skeleton del C5 — la implementación de este tab llega en el commit C6 del PR de
+            observability dashboard. Endpoints del backend ya operativos en
+            <code className="ml-1 rounded bg-neutral-100 px-1 text-xs">/admin/observability/*</code>
+            .
+          </p>
+          <div className="mt-4 inline-flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900 text-xs">
+            <AlertTriangleIcon className="h-3.5 w-3.5" aria-hidden />
+            Pendiente C6 · backend está listo y respondiendo.
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/routes/platform-admin-observability.tsx
+++ b/apps/web/src/routes/platform-admin-observability.tsx
@@ -1,16 +1,19 @@
 import { Link } from '@tanstack/react-router';
 import {
   ActivityIcon,
-  AlertTriangleIcon,
   ArrowLeft,
   BarChart3Icon,
   GaugeIcon,
-  Loader2,
   TrendingUpIcon,
   WalletIcon,
 } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
+import { CapacityTab } from '../components/observability/CapacityTab.js';
+import { CostosTab } from '../components/observability/CostosTab.js';
+import { ForecastTab } from '../components/observability/ForecastTab.js';
+import { SaludTab } from '../components/observability/SaludTab.js';
+import { UsoTab } from '../components/observability/UsoTab.js';
 
 /**
  * /app/platform-admin/observability — dashboard de costos y operaciones
@@ -134,33 +137,14 @@ function PlatformAdminObservabilityPage() {
   );
 }
 
-/**
- * Placeholder de cada tab — C6 reemplaza con componentes reales
- * (CostosTab, SaludTab, UsoTab, CapacityTab, ForecastTab).
- */
 function TabContent({ active }: { active: TabId }) {
   return (
-    <section
-      role="tabpanel"
-      data-testid={`observability-panel-${active}`}
-      className="rounded-lg border border-neutral-300 border-dashed bg-white p-8"
-    >
-      <div className="flex items-start gap-3">
-        <Loader2 className="h-5 w-5 animate-spin text-neutral-400" aria-hidden />
-        <div>
-          <h2 className="font-semibold text-neutral-900">Tab {active}</h2>
-          <p className="mt-1 text-neutral-600 text-sm">
-            Skeleton del C5 — la implementación de este tab llega en el commit C6 del PR de
-            observability dashboard. Endpoints del backend ya operativos en
-            <code className="ml-1 rounded bg-neutral-100 px-1 text-xs">/admin/observability/*</code>
-            .
-          </p>
-          <div className="mt-4 inline-flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-amber-900 text-xs">
-            <AlertTriangleIcon className="h-3.5 w-3.5" aria-hidden />
-            Pendiente C6 · backend está listo y respondiendo.
-          </div>
-        </div>
-      </div>
+    <section role="tabpanel" data-testid={`observability-panel-${active}`}>
+      {active === 'costos' && <CostosTab />}
+      {active === 'salud' && <SaludTab />}
+      {active === 'uso' && <UsoTab />}
+      {active === 'capacity' && <CapacityTab />}
+      {active === 'forecast' && <ForecastTab />}
     </section>
   );
 }

--- a/apps/web/src/routes/platform-admin.tsx
+++ b/apps/web/src/routes/platform-admin.tsx
@@ -153,13 +153,22 @@ function PlatformAdminPage() {
               idempotente — re-ejecutar no duplica entidades.
             </p>
           </div>
-          <Link
-            to="/app/platform-admin/matching"
-            className="inline-flex shrink-0 items-center gap-2 rounded-md border border-primary-300 bg-primary-50 px-3 py-2 font-medium text-primary-700 text-sm hover:bg-primary-100"
-            data-testid="matching-backtest-link"
-          >
-            Comparar algoritmo de asignación →
-          </Link>
+          <div className="flex shrink-0 flex-wrap items-center gap-2">
+            <Link
+              to="/app/platform-admin/matching"
+              className="inline-flex items-center gap-2 rounded-md border border-primary-300 bg-primary-50 px-3 py-2 font-medium text-primary-700 text-sm hover:bg-primary-100"
+              data-testid="matching-backtest-link"
+            >
+              Comparar algoritmo de asignación →
+            </Link>
+            <Link
+              to="/app/platform-admin/observability"
+              className="inline-flex items-center gap-2 rounded-md border border-primary-300 bg-primary-50 px-3 py-2 font-medium text-primary-700 text-sm hover:bg-primary-100"
+              data-testid="observability-dashboard-link"
+            >
+              Observabilidad de plataforma →
+            </Link>
+          </div>
         </div>
 
         <div className="mt-4 flex items-start justify-between gap-4 rounded-lg border border-neutral-200 bg-white p-4">

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,6 +1,20 @@
 @import "tailwindcss";
 
 /**
+ * Observability dashboard (spec 2026-05-13) — @tremor/react construye
+ * clases Tailwind dinámicamente (template strings `fill-${color}-${shade}`,
+ * `bg-${color}-${shade}`, etc.) dentro de su `dist/lib/utils.js`. Tailwind 4
+ * NO puede detectar estas clases vía @source porque no existen como literales
+ * en el código fuente.
+ *
+ * Solución: safelist explícita con brace expansion. Cubre los 6 colores que
+ * usamos en el dashboard observability + neutrals (Tremor también los usa
+ * para axes, gridlines, labels) en las shades estándar. ~1300 clases extra
+ * en el bundle final — aceptable para un admin-only route raramente visitado.
+ */
+@source inline("{hover:,focus:,data-[selected]:,dark:,}{bg,text,border,fill,stroke,ring}-{emerald,red,amber,cyan,indigo,rose,fuchsia,violet,sky,gray,slate,zinc}-{50,100,200,300,400,500,600,700,800,900}");
+
+/**
  * Tema de Booster AI — Tailwind 4 CSS-first config.
  *
  * Espejo de los tokens en @booster-ai/ui-tokens. Si modificas algo aquí,

--- a/apps/web/test/setup.ts
+++ b/apps/web/test/setup.ts
@@ -2,6 +2,24 @@ import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
 import { afterEach, vi } from 'vitest';
 
+// jsdom no implementa ResizeObserver, requerido por @tremor/react /
+// recharts (LineChart, BarChart, DonutChart, ProgressBar). Stub minimal
+// para evitar "ReferenceError: ResizeObserver is not defined" cuando los
+// componentes intentan medirse al montar.
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class ResizeObserverStub {
+    observe(): void {
+      // noop
+    }
+    unobserve(): void {
+      // noop
+    }
+    disconnect(): void {
+      // noop
+    }
+  } as unknown as typeof ResizeObserver;
+}
+
 // Stub VITE_* env vars antes que cualquier test importe `src/lib/env.ts`
 // (env.ts hace parse zod at-import; sin stub, lanza al cargar el módulo).
 // Los tests que necesitan valores específicos pueden sobreescribir vía

--- a/docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
+++ b/docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
@@ -1,0 +1,216 @@
+# Runbook — Configurar Google Workspace Admin SDK con Domain-Wide Delegation
+
+**Fecha**: 2026-05-13
+**Audiencia**: Felipe Vicencio (Super-admin de Workspace `boosterchile.com`)
+**Tiempo estimado**: ~15 minutos
+**Prerequisito**: ser **Super Admin** en `admin.google.com`
+
+Este runbook habilita que el backend de Booster AI (Cloud Run) lea licencias + seats activos de Google Workspace via **Domain-Wide Delegation (DWD)** sin necesidad de credenciales de usuario humano.
+
+---
+
+## Por qué necesitamos esto
+
+El Dashboard Observabilidad (`/app/platform-admin/observability`) muestra:
+- Seats activos de Workspace por plan
+- Costo mensual estimado del Workspace (seats × precio configurado)
+
+Workspace Admin SDK requiere autenticación con OAuth Domain-Wide Delegation — el Service Account de Cloud Run "impersona" al Super Admin del Workspace y lee licencias de solo-lectura.
+
+**Scope solicitado**: `https://www.googleapis.com/auth/admin.directory.subscription.readonly` + `https://www.googleapis.com/auth/admin.directory.user.readonly` (read-only, no puede modificar nada).
+
+---
+
+## Pasos
+
+### Paso 1 — Crear Service Account en GCP
+
+Service Account dedicada (separada del runtime SA del Cloud Run para least-privilege):
+
+```bash
+gcloud iam service-accounts create observability-workspace-reader \
+  --display-name="Observability Workspace Reader" \
+  --description="Lee seats + licencias Workspace via Admin SDK DWD. Solo-lectura. Usado por /admin/observability/usage." \
+  --project=booster-ai-494222
+```
+
+Anota el email que se crea: `observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com`
+
+### Paso 2 — Crear key JSON de la SA
+
+```bash
+gcloud iam service-accounts keys create /tmp/workspace-reader-key.json \
+  --iam-account=observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com \
+  --project=booster-ai-494222
+```
+
+⚠️ Esta key es sensible. NO la committeas al repo. La vas a subir a Secret Manager en el paso 5 y después la borras de tu laptop.
+
+### Paso 3 — Obtener el Client ID de la SA
+
+Workspace identifica la SA por su **Client ID numérico** (≠ email).
+
+```bash
+gcloud iam service-accounts describe observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com \
+  --project=booster-ai-494222 \
+  --format="value(oauth2ClientId)"
+```
+
+Anota el número que devuelve (e.g. `109876543210987654321`).
+
+### Paso 4 — Autorizar la SA en Workspace Admin Console
+
+Esto es el paso manual de la consola web. **Necesitas ser Super Admin de `boosterchile.com`**.
+
+1. Abre [admin.google.com](https://admin.google.com) → login con tu cuenta de super admin
+2. Menú izquierdo → **Security** → **Access and data control** → **API controls**
+3. En la sección "Domain wide delegation", click **Manage Domain Wide Delegation**
+4. Click **Add new**
+5. Completar:
+   - **Client ID**: el número del paso 3 (e.g. `109876543210987654321`)
+   - **OAuth scopes** (CSV, copia-pega exacto):
+     ```
+     https://www.googleapis.com/auth/admin.directory.subscription.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
+     ```
+6. Click **Authorize**
+
+✅ La SA ya puede leer Workspace en modo read-only desde el Cloud Run.
+
+### Paso 5 — Subir la key JSON a Secret Manager
+
+```bash
+# Crear el secret (idempotente)
+gcloud secrets create google-workspace-admin-credentials \
+  --project=booster-ai-494222 \
+  --replication-policy=automatic \
+  2>/dev/null || echo "Secret ya existe — skip create"
+
+# Subir la versión inicial
+gcloud secrets versions add google-workspace-admin-credentials \
+  --data-file=/tmp/workspace-reader-key.json \
+  --project=booster-ai-494222
+
+# Verificar
+gcloud secrets versions access latest \
+  --secret=google-workspace-admin-credentials \
+  --project=booster-ai-494222 \
+  | jq -r '.client_email'
+# Debe imprimir: observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com
+```
+
+### Paso 6 — Limpiar la key local
+
+```bash
+# IMPORTANTE: borrar la key del laptop después de subirla a Secret Manager
+rm /tmp/workspace-reader-key.json
+shred -u /tmp/workspace-reader-key.json 2>/dev/null || true
+```
+
+### Paso 7 — Otorgar accessor al SA del Cloud Run
+
+El runtime SA del Cloud Run (`booster-cloudrun-sa@...`) necesita leer este secret.
+
+```bash
+gcloud secrets add-iam-policy-binding google-workspace-admin-credentials \
+  --member=serviceAccount:booster-cloudrun-sa@booster-ai-494222.iam.gserviceaccount.com \
+  --role=roles/secretmanager.secretAccessor \
+  --project=booster-ai-494222
+```
+
+Esto se va a aplicar también via Terraform en `infrastructure/security.tf` cuando mergees el PR del dashboard — el comando manual es para que funcione antes del merge.
+
+---
+
+## Verificación
+
+Una vez aplicado el PR del dashboard observability:
+
+```bash
+# Endpoint nuevo del API que valida la conectividad Workspace
+curl -s -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
+  https://api.boosterchile.com/admin/observability/usage/workspace \
+  | jq '.seats_active, .plan_distribution'
+
+# Debe retornar algo como:
+# 5
+# { "business_standard": 3, "business_starter": 2 }
+```
+
+Si retorna `{ "error": "workspace_not_configured" }` → revisar paso 4 (scope autorizado) y paso 5 (secret cargado).
+
+---
+
+## Configurar precios por seat (config Terraform)
+
+Workspace API **NO expone precios productivos** (Google los reserva). Los precios van en variables Terraform que el PO actualiza cuando Google los cambia:
+
+```hcl
+# infrastructure/variables.tf (se agregará en C1 del dashboard PR)
+variable "google_workspace_price_per_seat_usd_starter" {
+  description = "USD/mes por seat Google Workspace Business Starter"
+  default     = 6
+}
+
+variable "google_workspace_price_per_seat_usd_standard" {
+  default = 12
+}
+
+variable "google_workspace_price_per_seat_usd_plus" {
+  default = 18
+}
+
+variable "google_workspace_price_per_seat_usd_enterprise" {
+  default = 30  # rough — Enterprise tiene pricing custom
+}
+```
+
+Si pagas un descuento (educacional, ONG, partnership), edita la variable correspondiente en `infrastructure/terraform.tfvars` (local, no committed).
+
+---
+
+## Rotación de la key (recomendado cada 90 días)
+
+```bash
+# Listar keys existentes
+gcloud iam service-accounts keys list \
+  --iam-account=observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com \
+  --project=booster-ai-494222
+
+# Generar nueva key
+gcloud iam service-accounts keys create /tmp/new-key.json \
+  --iam-account=observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com
+
+# Subir como nueva versión del secret
+gcloud secrets versions add google-workspace-admin-credentials \
+  --data-file=/tmp/new-key.json
+
+# Eliminar key vieja (después de validar que la nueva funciona)
+gcloud iam service-accounts keys delete <OLD_KEY_ID> \
+  --iam-account=observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com
+
+# Limpiar
+rm /tmp/new-key.json
+```
+
+---
+
+## Troubleshooting
+
+| Error | Causa | Fix |
+|---|---|---|
+| `403 Not Authorized to access this resource/api` | Scope no autorizado en Workspace Admin Console | Re-hacer Paso 4 con los scopes exactos |
+| `404 Domain not found` | DWD configurada con dominio incorrecto | El subject del OAuth flow debe ser un email de `@boosterchile.com` con rol admin |
+| `401 Invalid credentials` | Key JSON corrupta o secret mal cargado | Re-hacer Paso 5 |
+| `400 Invalid impersonation principal` | La SA no tiene `iam.serviceAccountTokenCreator` sobre sí misma | `gcloud iam service-accounts add-iam-policy-binding observability-workspace-reader@... --member=serviceAccount:observability-workspace-reader@... --role=roles/iam.serviceAccountTokenCreator` |
+
+---
+
+## Estado actual de servicios Booster que pagas (referencia para configurar precios)
+
+Verifica tu billing actual en [admin.google.com → Billing](https://admin.google.com/ac/billing/subscriptions) para confirmar qué plan tienes y cuántos seats.
+
+Para el dashboard, **solo necesitamos que la SA pueda contar seats por plan**. El precio sale de las variables Terraform.
+
+---
+
+🤖 Generado para Claude session 2026-05-13 implementación dashboard observability

--- a/docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
+++ b/docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
@@ -1,11 +1,15 @@
 # Runbook — Configurar Google Workspace Admin SDK con Domain-Wide Delegation
 
-**Fecha**: 2026-05-13
+**Fecha**: 2026-05-13 (revisado 2026-05-13: cambio a zero-key)
 **Audiencia**: Felipe Vicencio (Super-admin de Workspace `boosterchile.com`)
-**Tiempo estimado**: ~15 minutos
+**Tiempo estimado**: ~10 minutos (solo 1 paso manual en admin.google.com)
 **Prerequisito**: ser **Super Admin** en `admin.google.com`
 
-Este runbook habilita que el backend de Booster AI (Cloud Run) lea licencias + seats activos de Google Workspace via **Domain-Wide Delegation (DWD)** sin necesidad de credenciales de usuario humano.
+Este runbook habilita que el backend de Booster AI (Cloud Run) lea
+licencias + seats activos de Google Workspace via **Domain-Wide
+Delegation (DWD)** sin necesidad de credenciales de usuario humano y
+**sin JSON keys** descargadas (cumple `iam.disableServiceAccountKeyCreation`
+org policy de Booster).
 
 ---
 
@@ -15,182 +19,146 @@ El Dashboard Observabilidad (`/app/platform-admin/observability`) muestra:
 - Seats activos de Workspace por plan
 - Costo mensual estimado del Workspace (seats × precio configurado)
 
-Workspace Admin SDK requiere autenticación con OAuth Domain-Wide Delegation — el Service Account de Cloud Run "impersona" al Super Admin del Workspace y lee licencias de solo-lectura.
+Workspace Admin SDK requiere autenticación con OAuth Domain-Wide
+Delegation — pero **NO necesita una JSON key local**. En vez de eso,
+usamos IAM Credentials `signJwt`:
 
-**Scope solicitado**: `https://www.googleapis.com/auth/admin.directory.subscription.readonly` + `https://www.googleapis.com/auth/admin.directory.user.readonly` (read-only, no puede modificar nada).
+1. SA dedicada `observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com`
+2. Runtime SA `booster-cloudrun-sa@...` tiene `iam.serviceAccountTokenCreator` sobre la reader SA
+3. En runtime, el código:
+   - Construye un JWT con `iss=<reader SA>`, `sub=<admin email>`, scopes Admin SDK
+   - Lo firma vía IAM Credentials API (la private key vive solo dentro de GCP)
+   - Lo intercambia por un access token vía OAuth 2 (`grant_type=jwt-bearer`)
+   - Usa ese access token para llamar Admin SDK + Licensing API
+
+**Cero key descargada. Cero secreto en Secret Manager. Cero rotación manual.**
+
+**Scopes solicitados**:
+- `https://www.googleapis.com/auth/admin.directory.user.readonly`
+- `https://www.googleapis.com/auth/apps.licensing`
 
 ---
 
 ## Pasos
 
-### Paso 1 — Crear Service Account en GCP
+### Paso 1 — SA dedicada creada (ya existe)
 
-Service Account dedicada (separada del runtime SA del Cloud Run para least-privilege):
+La SA `observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com`
+se crea automáticamente vía Terraform (`infrastructure/iam.tf` →
+`google_service_account.observability_workspace_reader`).
+
+Si necesitas crearla manualmente (antes de `terraform apply`):
 
 ```bash
 gcloud iam service-accounts create observability-workspace-reader \
   --display-name="Observability Workspace Reader" \
-  --description="Lee seats + licencias Workspace via Admin SDK DWD. Solo-lectura. Usado por /admin/observability/usage." \
+  --description="Lee seats + licencias Workspace via Admin SDK DWD. Zero-key." \
   --project=booster-ai-494222
 ```
 
-Anota el email que se crea: `observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com`
+### Paso 2 — Otorgar tokenCreator al runtime SA (ya en Terraform)
 
-### Paso 2 — Crear key JSON de la SA
+Cubierto por `google_service_account_iam_member.cloudrun_can_impersonate_workspace_reader`.
+
+Manual (si necesitas que funcione antes de `terraform apply`):
 
 ```bash
-gcloud iam service-accounts keys create /tmp/workspace-reader-key.json \
-  --iam-account=observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com \
+gcloud iam service-accounts add-iam-policy-binding \
+  observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com \
+  --member=serviceAccount:booster-cloudrun-sa@booster-ai-494222.iam.gserviceaccount.com \
+  --role=roles/iam.serviceAccountTokenCreator \
   --project=booster-ai-494222
 ```
-
-⚠️ Esta key es sensible. NO la committeas al repo. La vas a subir a Secret Manager en el paso 5 y después la borras de tu laptop.
 
 ### Paso 3 — Obtener el Client ID de la SA
 
 Workspace identifica la SA por su **Client ID numérico** (≠ email).
 
 ```bash
-gcloud iam service-accounts describe observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com \
+gcloud iam service-accounts describe \
+  observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com \
   --project=booster-ai-494222 \
   --format="value(oauth2ClientId)"
 ```
 
-Anota el número que devuelve (e.g. `109876543210987654321`).
+**Valor actual (2026-05-13)**: `111745462454884197415`
 
-### Paso 4 — Autorizar la SA en Workspace Admin Console
+### Paso 4 — Autorizar la SA en Workspace Admin Console ⚠️ MANUAL
 
-Esto es el paso manual de la consola web. **Necesitas ser Super Admin de `boosterchile.com`**.
+Este es el único paso manual. **Necesitas ser Super Admin de `boosterchile.com`**.
 
-1. Abre [admin.google.com](https://admin.google.com) → login con tu cuenta de super admin
+1. Abre [admin.google.com](https://admin.google.com) → login con cuenta super admin
 2. Menú izquierdo → **Security** → **Access and data control** → **API controls**
-3. En la sección "Domain wide delegation", click **Manage Domain Wide Delegation**
+3. En "Domain wide delegation", click **Manage Domain Wide Delegation**
 4. Click **Add new**
 5. Completar:
-   - **Client ID**: el número del paso 3 (e.g. `109876543210987654321`)
+   - **Client ID**: `111745462454884197415`
    - **OAuth scopes** (CSV, copia-pega exacto):
      ```
-     https://www.googleapis.com/auth/admin.directory.subscription.readonly,https://www.googleapis.com/auth/admin.directory.user.readonly
+     https://www.googleapis.com/auth/admin.directory.user.readonly,https://www.googleapis.com/auth/apps.licensing
      ```
 6. Click **Authorize**
 
-✅ La SA ya puede leer Workspace en modo read-only desde el Cloud Run.
+✅ Listo. La SA ya puede leer Workspace en read-only desde Cloud Run.
 
-### Paso 5 — Subir la key JSON a Secret Manager
+### Paso 5 — Verificación
 
-```bash
-# Crear el secret (idempotente)
-gcloud secrets create google-workspace-admin-credentials \
-  --project=booster-ai-494222 \
-  --replication-policy=automatic \
-  2>/dev/null || echo "Secret ya existe — skip create"
-
-# Subir la versión inicial
-gcloud secrets versions add google-workspace-admin-credentials \
-  --data-file=/tmp/workspace-reader-key.json \
-  --project=booster-ai-494222
-
-# Verificar
-gcloud secrets versions access latest \
-  --secret=google-workspace-admin-credentials \
-  --project=booster-ai-494222 \
-  | jq -r '.client_email'
-# Debe imprimir: observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com
-```
-
-### Paso 6 — Limpiar la key local
+Una vez deployado el PR del dashboard observability:
 
 ```bash
-# IMPORTANTE: borrar la key del laptop después de subirla a Secret Manager
-rm /tmp/workspace-reader-key.json
-shred -u /tmp/workspace-reader-key.json 2>/dev/null || true
-```
-
-### Paso 7 — Otorgar accessor al SA del Cloud Run
-
-El runtime SA del Cloud Run (`booster-cloudrun-sa@...`) necesita leer este secret.
-
-```bash
-gcloud secrets add-iam-policy-binding google-workspace-admin-credentials \
-  --member=serviceAccount:booster-cloudrun-sa@booster-ai-494222.iam.gserviceaccount.com \
-  --role=roles/secretmanager.secretAccessor \
-  --project=booster-ai-494222
-```
-
-Esto se va a aplicar también via Terraform en `infrastructure/security.tf` cuando mergees el PR del dashboard — el comando manual es para que funcione antes del merge.
-
----
-
-## Verificación
-
-Una vez aplicado el PR del dashboard observability:
-
-```bash
-# Endpoint nuevo del API que valida la conectividad Workspace
 curl -s -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
   https://api.boosterchile.com/admin/observability/usage/workspace \
-  | jq '.seats_active, .plan_distribution'
-
-# Debe retornar algo como:
-# 5
-# { "business_standard": 3, "business_starter": 2 }
+  | jq '.available, .activeSeats, .seatsBySku'
 ```
 
-Si retorna `{ "error": "workspace_not_configured" }` → revisar paso 4 (scope autorizado) y paso 5 (secret cargado).
+Debe retornar:
+- `available: true`
+- `activeSeats: <N>`
+- `seatsBySku: { "1010020028": N, ... }` (o vacío si Workspace gratuito)
+
+Si retorna `available: false` con `reason: "..."`:
+- "workspace admin client not initialized" → falta env var `GOOGLE_WORKSPACE_READER_SA_EMAIL` (cubierto por Terraform)
+- "403 Not Authorized" → re-hacer Paso 4 con scopes exactos
+- "401 Invalid credentials" → verificar `iam.serviceAccountTokenCreator` binding (Paso 2)
+- "Bad Request: Invalid sub" → email `GOOGLE_WORKSPACE_IMPERSONATE_EMAIL` no es admin del dominio
 
 ---
 
 ## Configurar precios por seat (config Terraform)
 
-Workspace API **NO expone precios productivos** (Google los reserva). Los precios van en variables Terraform que el PO actualiza cuando Google los cambia:
+Workspace API **NO expone precios productivos** (Google los reserva). Los
+precios van en variables Terraform que el PO actualiza cuando Google los
+cambia (revisar trimestralmente en [workspace.google.com/pricing](https://workspace.google.com/pricing)):
 
 ```hcl
-# infrastructure/variables.tf (se agregará en C1 del dashboard PR)
-variable "google_workspace_price_per_seat_usd_starter" {
-  description = "USD/mes por seat Google Workspace Business Starter"
-  default     = 6
-}
-
-variable "google_workspace_price_per_seat_usd_standard" {
-  default = 12
-}
-
-variable "google_workspace_price_per_seat_usd_plus" {
-  default = 18
-}
-
-variable "google_workspace_price_per_seat_usd_enterprise" {
-  default = 30  # rough — Enterprise tiene pricing custom
-}
+# infrastructure/variables.tf
+variable "google_workspace_price_per_seat_usd_starter"     { default = 6 }
+variable "google_workspace_price_per_seat_usd_standard"    { default = 12 }
+variable "google_workspace_price_per_seat_usd_plus"        { default = 18 }
+variable "google_workspace_price_per_seat_usd_enterprise"  { default = 30 }
 ```
 
-Si pagas un descuento (educacional, ONG, partnership), edita la variable correspondiente en `infrastructure/terraform.tfvars` (local, no committed).
+Si hay descuento (educacional, ONG, partnership), edita la variable
+correspondiente en `infrastructure/terraform.tfvars` (local, no commited).
 
 ---
 
-## Rotación de la key (recomendado cada 90 días)
+## Cambios desde versión anterior del runbook
 
-```bash
-# Listar keys existentes
-gcloud iam service-accounts keys list \
-  --iam-account=observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com \
-  --project=booster-ai-494222
+La versión inicial (commit C1) usaba un Service Account JSON key
+cargado en Secret Manager (`google-workspace-admin-credentials`). Eso
+no funciona en Booster porque la org policy
+`iam.disableServiceAccountKeyCreation` bloquea creación de keys.
 
-# Generar nueva key
-gcloud iam service-accounts keys create /tmp/new-key.json \
-  --iam-account=observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com
+**Refactor 2026-05-13** (commit C7):
+- Eliminado secret `google-workspace-admin-credentials`
+- Eliminado env var `GOOGLE_WORKSPACE_CREDENTIALS_JSON`
+- Agregado env var `GOOGLE_WORKSPACE_READER_SA_EMAIL`
+- Agregado IAM binding `cloudrun_can_impersonate_workspace_reader`
+- Adapter usa IAM Credentials `signJwt` + OAuth 2 token exchange
 
-# Subir como nueva versión del secret
-gcloud secrets versions add google-workspace-admin-credentials \
-  --data-file=/tmp/new-key.json
-
-# Eliminar key vieja (después de validar que la nueva funciona)
-gcloud iam service-accounts keys delete <OLD_KEY_ID> \
-  --iam-account=observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com
-
-# Limpiar
-rm /tmp/new-key.json
-```
+Ventajas: cero rotación de keys, cero secreto sensible en Secret
+Manager, cumple cero-trust principle.
 
 ---
 
@@ -198,18 +166,11 @@ rm /tmp/new-key.json
 
 | Error | Causa | Fix |
 |---|---|---|
-| `403 Not Authorized to access this resource/api` | Scope no autorizado en Workspace Admin Console | Re-hacer Paso 4 con los scopes exactos |
-| `404 Domain not found` | DWD configurada con dominio incorrecto | El subject del OAuth flow debe ser un email de `@boosterchile.com` con rol admin |
-| `401 Invalid credentials` | Key JSON corrupta o secret mal cargado | Re-hacer Paso 5 |
-| `400 Invalid impersonation principal` | La SA no tiene `iam.serviceAccountTokenCreator` sobre sí misma | `gcloud iam service-accounts add-iam-policy-binding observability-workspace-reader@... --member=serviceAccount:observability-workspace-reader@... --role=roles/iam.serviceAccountTokenCreator` |
-
----
-
-## Estado actual de servicios Booster que pagas (referencia para configurar precios)
-
-Verifica tu billing actual en [admin.google.com → Billing](https://admin.google.com/ac/billing/subscriptions) para confirmar qué plan tienes y cuántos seats.
-
-Para el dashboard, **solo necesitamos que la SA pueda contar seats por plan**. El precio sale de las variables Terraform.
+| `403 Not Authorized to access this resource/api` | Scope no autorizado en Workspace Admin Console | Re-hacer Paso 4 con scopes exactos |
+| `400 Bad Request: Invalid sub` | `GOOGLE_WORKSPACE_IMPERSONATE_EMAIL` no es admin del dominio | Usar un email super-admin de Workspace |
+| `permission denied: signJwt` | Falta `iam.serviceAccountTokenCreator` binding | Re-correr Paso 2 |
+| `404 Domain not found` | DWD configurada con dominio incorrecto | El subject del OAuth flow debe ser email de `@boosterchile.com` con rol admin |
+| `available: false, reason: workspace admin SDK config incompleta` | Faltan env vars en Cloud Run | Verificar `GOOGLE_WORKSPACE_DOMAIN`, `GOOGLE_WORKSPACE_IMPERSONATE_EMAIL`, `GOOGLE_WORKSPACE_READER_SA_EMAIL` en Cloud Run revision |
 
 ---
 

--- a/docs/specs/2026-05-13-observability-dashboard-plan.md
+++ b/docs/specs/2026-05-13-observability-dashboard-plan.md
@@ -1,0 +1,276 @@
+# Plan técnico — Dashboard observabilidad
+
+**Fecha**: 2026-05-13
+**Spec**: [`docs/specs/2026-05-13-observability-dashboard.md`](2026-05-13-observability-dashboard.md)
+**Esfuerzo**: ~9.5 días, 1 PR grande con 6 commits atómicos
+
+---
+
+## Arquitectura
+
+```
+┌──────────────────────────────────────────────────────┐
+│  apps/web  /app/platform-admin/observability         │
+│  ├─ Tabs: Costos | Salud | Uso | Capacity | Forecast │
+│  ├─ Componentes reusables: KpiCard, TrendChart, HealthIndicator │
+│  └─ @tremor/react (UI library admin-grade)           │
+└──────────────────────────────────────────────────────┘
+                           │
+                  HTTPS + Firebase Auth
+                           ↓
+┌──────────────────────────────────────────────────────┐
+│  apps/api  /admin/observability/*  (9 endpoints)     │
+│  ├─ requirePlatformAdmin middleware                  │
+│  ├─ Redis cache wrapper (TTL configurable)           │
+│  └─ services/observability/* (6 clientes)            │
+└──────────────────────────────────────────────────────┘
+                           ↓
+┌──────────────────────────────────────────────────────┐
+│  Clientes externos                                   │
+│  ├─ BigQuery billing_export    (ADC, fetch directo)  │
+│  ├─ Cloud Monitoring API       (ADC, fetch directo)  │
+│  ├─ Twilio Usage API           (Account credentials) │
+│  ├─ Google Workspace Admin SDK (googleapis + DWD)    │
+│  └─ mindicador.cl              (no auth, FX CLP)     │
+└──────────────────────────────────────────────────────┘
+```
+
+## Archivos a crear/modificar
+
+### Backend (`apps/api`)
+
+| Archivo | Cambio | LOC est. |
+|---|---|---|
+| `src/middleware/require-platform-admin.ts` | **NEW**: middleware extraído (DRY desde admin-cobra-hoy.ts) | ~30 |
+| `src/services/observability/cache.ts` | **NEW**: Redis cache wrapper TTL configurable | ~60 |
+| `src/services/observability/fx-rate-service.ts` | **NEW**: mindicador.cl client + cache 1h + fallback 940 | ~70 |
+| `src/services/observability/costs-service.ts` | **NEW**: BigQuery client + parsers (top SKUs, by-service, trend, by-project) | ~250 |
+| `src/services/observability/monitoring-service.ts` | **NEW**: Cloud Monitoring API client (uptime, latency, CPU, RAM, RPS) | ~200 |
+| `src/services/observability/twilio-usage-service.ts` | **NEW**: Twilio Usage Records + Account Balance | ~120 |
+| `src/services/observability/workspace-service.ts` | **NEW**: Admin SDK subscriptions + license assignments | ~150 |
+| `src/services/observability/forecast-service.ts` | **NEW**: extrapolación lineal + edge cases | ~80 |
+| `src/services/observability/health-checks-service.ts` | **NEW**: composite que orquesta uptime checks → semáforo | ~100 |
+| `src/routes/admin-observability.ts` | **NEW**: 9 endpoints | ~300 |
+| `src/server.ts` | **EDIT**: registrar router | +5 |
+| `src/config.ts` | **EDIT**: 5 env vars nuevas | +30 |
+| `package.json` | **EDIT**: agregar `googleapis` | +1 dep |
+
+**Tests** (`apps/api/test/unit/observability/`):
+
+| Archivo | Tests | LOC |
+|---|---|---|
+| `costs-service.test.ts` | 10 (mock fetch BQ + parse) | ~250 |
+| `monitoring-service.test.ts` | 8 (mock fetch + parse time series) | ~200 |
+| `twilio-usage-service.test.ts` | 5 (mock fetch + balance formatter) | ~120 |
+| `workspace-service.test.ts` | 5 (mock googleapis SDK) | ~150 |
+| `forecast-service.test.ts` | 6 (edge cases: día 1, día 31, NaN) | ~120 |
+| `cache.test.ts` | 4 (TTL, miss, hit, error) | ~100 |
+| `fx-rate-service.test.ts` | 4 (success, cache hit, API down → fallback) | ~80 |
+| `require-platform-admin.test.ts` | 3 (admin ok, no admin 403, no auth 401) | ~70 |
+
+`apps/api/test/integration/admin-observability.test.ts`: 9 endpoints × 3 escenarios (auth, no-auth, admin allowlist) = ~27 tests.
+
+### Frontend (`apps/web`)
+
+| Archivo | Cambio | LOC est. |
+|---|---|---|
+| `src/routes/platform-admin-observability.tsx` | **NEW**: main route + tabs orchestration | ~250 |
+| `src/components/observability/CostsTab.tsx` | **NEW** | ~250 |
+| `src/components/observability/HealthTab.tsx` | **NEW** | ~200 |
+| `src/components/observability/UsageTab.tsx` | **NEW** | ~250 |
+| `src/components/observability/CapacityTab.tsx` | **NEW** | ~200 |
+| `src/components/observability/ForecastTab.tsx` | **NEW** | ~150 |
+| `src/components/observability/KpiCard.tsx` | **NEW**: reusable card con value + delta | ~80 |
+| `src/components/observability/TrendChart.tsx` | **NEW**: wrapper recharts/tremor LineChart | ~100 |
+| `src/components/observability/HealthIndicator.tsx` | **NEW**: dot 🟢🟡🔴 + tooltip | ~50 |
+| `src/components/observability/CurrencyValue.tsx` | **NEW**: format CLP con thousands + delta% color | ~50 |
+| `src/hooks/use-observability-costs.ts` | **NEW**: TanStack Query hooks (5) | ~150 |
+| `src/hooks/use-observability-monitoring.ts` | **NEW** | ~120 |
+| `src/routes/platform-admin.tsx` | **EDIT**: agregar card "Observabilidad" en grid de admin | +20 |
+| `src/router.tsx` o `src/main.tsx` | **EDIT**: registrar route | +5 |
+| `package.json` | **EDIT**: agregar `@tremor/react` + `recharts` (dep transitiva) | +2 deps |
+
+**Tests**:
+
+| Archivo | Tests | LOC |
+|---|---|---|
+| `src/routes/platform-admin-observability.test.tsx` | 6 (renders, tabs switching, error states, auth required) | ~250 |
+| `src/components/observability/*.test.tsx` (4 archivos) | 4×3 tests cada uno (renders, deltas, empty state) | ~120 ea |
+
+### Infra (`infrastructure/`)
+
+| Archivo | Cambio |
+|---|---|
+| `variables.tf` | Add `observability_dashboard_activated` (default true), `google_workspace_domain`, `google_workspace_price_per_seat_usd_standard/plus/enterprise` |
+| `compute.tf` (module `service_api`) | Inject env vars + secret `google-workspace-admin-credentials` |
+| `iam.tf` | Grant `roles/bigquery.dataViewer` al SA `cloud_run_runtime` sobre dataset `billing_export` (scoped, no project-wide) |
+| `security.tf` | Add secret `google-workspace-admin-credentials` para domain-wide delegation JSON |
+
+### Documentation
+
+| Archivo | Cambio |
+|---|---|
+| `docs/specs/2026-05-13-observability-dashboard.md` | (existe) |
+| `docs/specs/2026-05-13-observability-dashboard-plan.md` | (este) |
+| `apps/api/src/services/observability/README.md` | **NEW**: arquitectura + caching + adding nuevo provider |
+| `docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md` | **NEW**: paso a paso config Google Workspace Domain-Wide Delegation (acción manual del PO) |
+
+---
+
+## Orden de commits
+
+Cada commit compila + tests pass. 1 PR con 6 commits secuenciales.
+
+### C1: deps + env vars (~30 min, foundation)
+
+- `apps/web/package.json`: `@tremor/react`
+- `apps/api/package.json`: `googleapis`
+- `apps/api/src/config.ts`: 5 env vars nuevas (zod schema)
+- `infrastructure/variables.tf`: variables nuevas con defaults seguros
+- `infrastructure/compute.tf`: inject env vars al service_api
+- `pnpm install`, `pnpm typecheck` — debe pasar
+- Commit: `chore(observability): scaffold deps + env vars`
+
+### C2: middleware + cache + fx + tests (~1 día)
+
+- `src/middleware/require-platform-admin.ts` + test (extract de admin-cobra-hoy)
+- `src/services/observability/cache.ts` + test (Redis TTL wrapper)
+- `src/services/observability/fx-rate-service.ts` + test
+- Commit: `feat(observability): admin middleware + cache + FX client`
+
+### C3: providers GCP + Twilio + Workspace + tests (~2 días)
+
+- `costs-service.ts` + test (BigQuery)
+- `monitoring-service.ts` + test (Cloud Monitoring)
+- `twilio-usage-service.ts` + test
+- `workspace-service.ts` + test (googleapis Admin SDK)
+- `forecast-service.ts` + test
+- `health-checks-service.ts` + test
+- Commit: `feat(observability): clientes BigQuery + Monitoring + Twilio + Workspace + forecast`
+
+### C4: router + 9 endpoints + integration tests (~1 día)
+
+- `src/routes/admin-observability.ts` (9 endpoints)
+- `src/server.ts`: registrar router
+- `infrastructure/iam.tf`: BigQuery role al SA
+- `test/integration/admin-observability.test.ts`
+- Commit: `feat(observability): router /admin/observability/* con 9 endpoints`
+
+### C5: frontend componentes + hooks (~1 día)
+
+- Componentes reusables (`KpiCard`, `TrendChart`, `HealthIndicator`, `CurrencyValue`)
+- Hooks `use-observability-*` (TanStack Query)
+- Skeleton de route `platform-admin-observability.tsx` con 5 tabs vacíos
+- Tests unitarios de los componentes
+- Commit: `feat(observability): UI components + hooks TanStack Query`
+
+### C6: 5 tabs implementados + E2E + activation (~2 días)
+
+- CostsTab, HealthTab, UsageTab, CapacityTab, ForecastTab
+- Update `platform-admin.tsx` (sidebar/cards link)
+- E2E Playwright: navegar como admin, validar carga
+- Smoke test prod post-deploy
+- Commit: `feat(observability): 5 tabs Costos+Salud+Uso+Capacity+Forecast`
+
+**Total commits**: 6 · **PR único** con título `feat(observability): dashboard platform-admin con costos+uso+salud+forecast`
+
+---
+
+## Riesgos técnicos + mitigaciones
+
+| Riesgo | Probabilidad | Impacto | Mitigación |
+|---|---|---|---|
+| **Google Workspace Admin SDK requiere Domain-Wide Delegation** (config manual en Workspace Admin Console por el PO) | Alta | Bloquea Workspace tab si no se configura | Runbook detallado + fallback a "Workspace data unavailable" graceful en UI |
+| **BigQuery query sin filtro temporal scan completo** | Media | Costo $5+/query | Validación zod obligatoria de `from/to` en endpoints; max range 90d |
+| **mindicador.cl down** | Baja | FX stale o roto | Fallback hardcoded a 940 + cache 24h del último valor exitoso |
+| **Cloud Monitoring quota (6k qpm)** | Baja | 429 errors | Cache 1min + coalesce widgets multi-query en paralelo controlado |
+| **Twilio API auth complica si no usa env vars existentes** | Baja | No carga tab Uso/Twilio | Reusar `TWILIO_ACCOUNT_SID` + `TWILIO_AUTH_TOKEN` ya configurados |
+| **@tremor/react CSS conflicta con design system actual** | Baja | UI fea | Scoping CSS via wrapper component + override de colors Booster (verde) |
+| **TanStack Query refetch al re-focus tab → tormenta de queries** | Media | Hits a BQ caros | `staleTime: 5min` + `refetchOnWindowFocus: false` para queries pesadas |
+| **`googleapis` package pesa ~10MB en deps** | Baja | apps/api Docker image más grande | Aceptable; ya tenemos `@google-cloud/*` similares en deps |
+| **CC Booster en Workspace billing API es 0% automático** | Alta | Precios hardcoded por env var (PO actualiza si cambian) | Configurable via env vars, documentado en runbook |
+
+---
+
+## Dependencias nuevas
+
+### `@tremor/react` (apps/web) — ~150kb minified gzipped
+
+**Justificación**:
+- Componentes admin-grade out-of-box: `Card`, `Metric`, `LineChart`, `BarChart`, `Badge`, `Tab`, `Table`, `ProgressBar`
+- Ahorra ~3 días de dev vs construir cards/charts custom
+- Solo se carga en `/app/platform-admin/observability` (admin-only route, raras visitas)
+- Sin alternativa nativa de Booster — no existe lib charts en el repo
+
+**Alternativa descartada**: `recharts` solo (~80kb) requiere construir KPI cards + tables + badges custom (~3 días extra).
+
+### `googleapis` (apps/api) — ~10MB unpacked
+
+**Justificación**:
+- Admin SDK requiere OAuth Domain-Wide Delegation con JWT signing
+- Reimplementar manualmente requires google-auth-library (ya tenemos) + JWT signing + retries + manejo errores → 2 días dev
+- `googleapis` lo da out-of-box con un import: `google.admin('directory_v1').users.list()`
+- Otros packages del repo usan `@google-cloud/*` específicos (kms, pubsub, storage) — `googleapis` es el "directory" missing.
+
+**Alternativa descartada**: implementación manual del SDK Admin Directory v1 con `google-auth-library` (2 días extra, propensa a bugs).
+
+---
+
+## Migraciones BD
+
+**NINGUNA**. El dashboard solo lee de fuentes externas (BQ, Monitoring API, Twilio, Workspace) + cache Redis volátil. No tiene state propio.
+
+---
+
+## Feature flag rollout
+
+- Variable: `OBSERVABILITY_DASHBOARD_ACTIVATED` en `apps/api/src/config.ts` zod schema + `infrastructure/variables.tf`
+- Default: `true` (decisión PO 2026-05-13)
+- Backend: endpoints retornan 503 con `{ error: 'feature_disabled' }` si flag=false
+- Frontend: hook lee `/feature-flags` endpoint (ya existe) — si false, sidebar oculta el link y route redirige a `/app`
+- Rollback: cambiar `var.observability_dashboard_activated = false` en `terraform.tfvars` + `terraform apply` (~30s)
+
+---
+
+## Smoke test plan post-deploy
+
+```bash
+# 1. health check del nuevo endpoint
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -H "Authorization: Bearer $(gcloud auth print-identity-token)" \
+  https://api.boosterchile.com/admin/observability/health
+# Expected: 200
+
+# 2. costs overview (con admin auth)
+curl -s -H "Authorization: Bearer $TOKEN" \
+  https://api.boosterchile.com/admin/observability/costs/overview \
+  | jq '.cost_clp_month_to_date'
+# Expected: número ≠ null si billing_export tiene datos
+
+# 3. UI carga
+playwright test apps/web/test/e2e/observability-dashboard.spec.ts
+```
+
+---
+
+## Aprobación
+
+- [ ] Felipe Vicencio (PO): aprueba archivos a crear + orden de commits + dependencias nuevas
+- [ ] Tras aprobación: ejecutar `/build` con el primer commit (C1).
+
+---
+
+## Pre-condiciones manual del PO antes de C4
+
+(Estas las realiza el PO ANTES de que el deploy del C4 sea funcional. El código tolera el estado de "no configurado" con graceful degradation.)
+
+1. **Google Workspace Admin Console**:
+   - Crear Service Account dedicada: `observability-workspace-reader@booster-ai-494222.iam.gserviceaccount.com`
+   - Habilitar Domain-Wide Delegation
+   - En `admin.google.com` → Security → API Controls → Domain-wide Delegation → agregar Client ID con scope `https://www.googleapis.com/auth/admin.directory.subscription.readonly` + `https://www.googleapis.com/auth/admin.directory.user.readonly`
+   - Descargar JSON key → subir a Secret Manager con `gcloud secrets versions add google-workspace-admin-credentials --data-file=key.json`
+   - Runbook detallado en `docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md`
+
+2. **Twilio** (ya configurado): los secrets `twilio-account-sid` + `twilio-auth-token` ya existen + el SA `cloud_run_runtime` ya tiene acceso. Sin acción adicional.
+
+3. **BigQuery billing_export** (ya creado en sesión 2026-05-13): dataset `booster-ai-494222.billing_export` con los 3 toggles habilitados desde Cloud Console. Datos empezaron a propagar a partir de 2026-05-13 ~13:00 CLT.

--- a/docs/specs/2026-05-13-observability-dashboard.md
+++ b/docs/specs/2026-05-13-observability-dashboard.md
@@ -1,0 +1,269 @@
+# Spec — Dashboard de observabilidad de costos y operación
+
+**Fecha**: 2026-05-13
+**Autor**: Claude (Opus 4.7) + Felipe Vicencio
+**Tipo**: feature nueva, multi-archivo (~15 archivos), cambia contrato de API (nuevos endpoints `/admin/observability/*`)
+**ADR referenciado**: encaja en el modelo existente de platform-admin (`apps/api/src/routes/admin-*`, `apps/web/src/routes/platform-admin-*`). No requiere ADR nuevo.
+
+---
+
+## Problema
+
+Hoy no existe una vista consolidada del estado operacional + financiero de Booster. Para responder "¿cuánto gastamos en GCP este mes?", "¿qué servicio está bajo más carga?", "¿quedan tokens Gemini para terminar el mes?", "¿Twilio está funcionando OK?", el PO tiene que abrir manualmente:
+
+- Cloud Console → Billing → Reports (con filtros por SKU + project)
+- Cloud Monitoring → Dashboards (latencia, RPS, errores)
+- Twilio Console → Usage (mensajes WhatsApp + SMS enviados + saldo)
+- BigQuery → queries manuales sobre `billing_export`
+- Logs → grep manual de errores
+
+**Evidencia del dolor**:
+- Sesión 2026-05-13 (auditoría profunda): el PO descubrió que Booster 2.0 (`big-cabinet-482101-s3`) seguía generando ~$80-150/mes durante meses sin detectar. Sin dashboard, el costo de duplicación pasó inadvertido.
+- La auditoría profunda manual tomó ~3 horas. Con dashboard, sería 2 clicks.
+- Banner GCP "unrestricted API keys" salió 2 veces sin ningún sistema interno que lo alertara.
+- Tras el deploy DR, el log ingest pasó de 2 GB/mes a 149 GB/mes; nadie lo detectó por una semana (solo se vio cuando Claude revisó manualmente).
+
+El sistema necesita que costo + uso + salud sean **visibles continuamente al PO**, no solo cuando alguien pregunta.
+
+---
+
+## Solución propuesta
+
+Nueva sección `/app/platform-admin/observability` (rol: `BOOSTER_PLATFORM_ADMIN_EMAILS` allowlist, mismo patrón que `/app/platform-admin/cobra-hoy` y `/app/platform-admin/matching`) con **5 tabs**:
+
+1. **Costos**: KPIs del mes en curso + trend 90d + top SKUs + breakdown por servicio GCP + costo Twilio.
+2. **Salud**: uptime checks status, p95 latency `api/web/marketing`, error rate, BD CPU/RAM, Redis memory, Cloud SQL conexiones activas.
+3. **Uso**: Cloud Run RPS por servicio, Pub/Sub messages/lag, Vertex AI Gemini tokens consumidos hoy/mes, Twilio mensajes enviados.
+4. **Capacity**: uso real vs límites configurados (RAM Cloud SQL, instances Cloud Run, quota Routes API, etc.) — semáforo verde/amarillo/rojo.
+5. **Forecast + Alertas**: extrapolación lineal del costo del mes en curso + lista de Cloud Monitoring alerts activas.
+
+**Backend** (`apps/api`): nuevo router `/admin/observability/*` con 9 endpoints; nuevo package `@booster-ai/observability-providers` con clientes BigQuery (billing GCP), Cloud Monitoring (métricas), Twilio (usage), Google Workspace Admin SDK (seats + license info), FX (tipo de cambio dinámico CLP via mindicador.cl).
+
+**Frontend** (`apps/web`): nueva ruta `/app/platform-admin/observability` + 5 tabs + componentes reusables (`KpiCard`, `TrendChart`, `HealthIndicator`).
+
+**Cache**: TTL 5min en backend para queries BigQuery (caro) + 1min para Cloud Monitoring (barato). Redis-backed.
+
+---
+
+## Criterios de aceptación
+
+Cada criterio es verificable con evidencia objetiva.
+
+### Tab Costos
+
+1. **Cards superior** mostrando:
+   - Costo total mes en curso (CLP) con delta vs mes anterior (%) — suma GCP + Twilio + Google Workspace
+   - Costo total últimos 30 días (CLP)
+   - Top 3 servicios GCP por costo (mes en curso)
+   - Costo Twilio mes en curso (USD → CLP convertido a tipo de cambio del día)
+   - Costo Google Workspace mes en curso (USD → CLP) — seats activos × plan price/seat
+   - Tipo de cambio CLP/USD visible (con fecha del fix vía mindicador.cl)
+   **Evidencia**: screenshot de la página con valores ≠ "0" cuando billing_export tenga datos (post 24-48h habilitación).
+
+2. **Gráfico de línea** de costo diario últimos 90 días, agrupable por servicio.
+   **Evidencia**: query BQ subyacente retorna data; gráfico renderiza sin errores.
+
+3. **Tabla drilldown** top 20 SKUs ordenado por costo descendente con: SKU, servicio, costo CLP, % del total.
+   **Evidencia**: paginable, ordenable por columna.
+
+4. **Comparativa Booster AI vs Booster 2.0** durante el período de duplicación (post-sunset desaparece).
+   **Evidencia**: filtro `project.id IN (booster-ai-494222, big-cabinet-482101-s3)` con barras separadas hasta 2026-06-12 (project delete).
+
+### Tab Salud
+
+5. **Status grid** con 8 checks de uptime:
+   - api.boosterchile.com/health
+   - app.boosterchile.com
+   - boosterchile.com (apex)
+   - marketing.boosterchile.com (si LB lo sirve)
+   - demo.boosterchile.com
+   - telemetry-tls.boosterchile.com:5061
+   - telemetry-dr.boosterchile.com:5061
+   - Cloud SQL connection probe
+   Cada uno: 🟢 OK / 🟡 degraded (>p95 baseline) / 🔴 down. Última verificación timestamp.
+   **Evidencia**: las URLs reales se chequean via Cloud Monitoring uptime_check resources; status reflejará el último check.
+
+6. **Métricas Cloud SQL** (instancia `booster-ai-pg-07d9e939`):
+   - CPU % última hora (línea)
+   - RAM % última hora (línea)
+   - Conexiones activas
+   - Storage GB usado / total (50 GB)
+   **Evidencia**: queries a Cloud Monitoring API con metric.type `cloudsql.googleapis.com/database/...`.
+
+7. **Métricas Redis**:
+   - Memory usage %
+   - Hits/misses ratio
+   **Evidencia**: queries `redis.googleapis.com/stats/...`.
+
+### Tab Uso
+
+8. **Cloud Run** por servicio:
+   - RPS últimos 60 min
+   - p50/p95 latency
+   - error rate (5xx)
+   - instances actives
+   **Evidencia**: cards por servicio (api/web/marketing/whatsapp-bot/etc).
+
+9. **Pub/Sub** topics activos:
+   - Mensajes publicados últimas 24h por topic
+   - Backlog (mensajes unacked)
+   **Evidencia**: tabla con todos los topics + métricas.
+
+10. **Vertex AI Gemini**:
+    - Tokens input consumidos hoy + mes
+    - Tokens output consumidos hoy + mes
+    - Costo estimado mes (USD → CLP)
+    **Evidencia**: `aiplatform.googleapis.com/publisher/online_serving/token_count` desde Cloud Monitoring.
+
+11. **Twilio**:
+    - Mensajes WhatsApp enviados hoy + mes
+    - Mensajes SMS enviados hoy + mes
+    - Costo estimado mes
+    - Saldo actual de la cuenta
+    **Evidencia**: Twilio REST API `Usage.Records` + `Account.Balance`.
+
+11b. **Google Workspace**:
+    - Seats activos (por plan): Business Starter / Standard / Plus / Enterprise
+    - Cost/seat según plan (configurable env vars `GOOGLE_WORKSPACE_PRICE_PER_SEAT_*`)
+    - Costo mensual total estimado USD + CLP
+    - Last sync timestamp (Admin SDK)
+    **Evidencia**: Google Workspace Admin SDK `subscriptions.list` para licencias activas; pricing por plan en config (Workspace API no expone costo).
+
+### Tab Capacity
+
+12. **Headroom semáforo**:
+    - Cloud SQL CPU p99 7d / threshold 70%
+    - Cloud SQL RAM p99 7d / threshold 75%
+    - Cloud SQL Storage / 80% del disk_size
+    - Cloud Run instances max alcanzado / max_instances configurado
+    - Vertex AI Gemini quota usage / quota límite
+    - Twilio mensajes/día / quota Meta WhatsApp aprobada
+    - Routes API requests/día / quota configurada
+    Cada uno: 🟢 < 60% / 🟡 60-80% / 🔴 > 80%.
+    **Evidencia**: cards con valor + threshold visible + color.
+
+### Tab Forecast + Alertas
+
+13. **Forecast costo mes**: extrapolación lineal del costo running × (días totales / días transcurridos). Mostrar también histórico de los 3 meses previos para sanity check.
+    **Evidencia**: número estimado con disclaimer del método (lineal, no ML).
+
+14. **Cloud Monitoring alerts activas**: lista con: nombre, severity, condition, when fired, current value.
+    **Evidencia**: API `monitoring.googleapis.com/v3/projects/.../alertPolicies` filtrada por `enabled=true` + estado.
+
+15. **Budget status**: progreso del mes vs `var.monthly_budget_usd` (default $500 según `variables.tf`). Barra de progreso + color.
+
+### Cross-cutting
+
+16. **Auth**: el endpoint y la página rechazan acceso de usuarios NO en `BOOSTER_PLATFORM_ADMIN_EMAILS` con 401/403, mismo patrón que `admin-cobra-hoy.ts:90`.
+    **Evidencia**: test unit que verifica el rechazo.
+
+17. **Cache**: queries BigQuery se cachean 5 min en Redis (compartido entre instances Cloud Run); Cloud Monitoring queries se cachean 1 min.
+    **Evidencia**: log de hit/miss rate accesible vía métricas custom.
+
+18. **Performance**: la página inicial carga en < 3s con cache caliente.
+    **Evidencia**: smoke test Playwright timing.
+
+19. **i18n**: todo el texto en español (CLAUDE.md regla de UI). Números formateados con thousands separator `.` (Chile).
+    **Evidencia**: code review + visual.
+
+20. **Mobile responsive**: la página funciona en pantalla 375px ancho (iPhone SE).
+    **Evidencia**: Playwright snapshot a 375px width.
+
+---
+
+## No goals (scope creep prevention)
+
+Lo que esta spec **NO** cubre:
+
+- **Cost attribution per-tenant (empresa)**: requiere labeling de Cloud Run revisions por empresa, no factible sin re-arquitectura. Follow-up.
+- **Forecasting con ML/ARIMA**: solo extrapolación lineal del mes en curso. Más sofisticado puede venir cuando haya 6+ meses de billing data.
+- **Alertas configurables por usuario**: solo se muestran las alerts que ya existen en Cloud Monitoring (configuradas via Terraform `monitoring.tf`). Configurar nuevas alerts desde la UI es follow-up.
+- **Export PDF/Excel del dashboard**: solo vista web, no descargas. Si se necesita exportar, captura screenshot manual.
+- **Histórico previo a 2026-05-13**: BigQuery billing_export se habilitó en esa fecha. Datos previos no están disponibles. La comparativa de Booster 2.0 vs AI solo cubre el período disponible.
+- **Cobertura de servicios fuera de GCP+Twilio+Workspace**: no incluye AWS, GitHub, etc. Booster opera solo en GCP+Twilio+Workspace per inventario actual.
+- **Workspace usage breakdown por usuario individual**: solo seats agregados por plan. Atribución usuario-a-usuario es PII innecesaria para vista financiera.
+- **Workspace billing 100% automatizado**: Workspace API NO expone precios productivos. El cost/seat va por env var configurable. Si Google cambia precios, el PO actualiza el env. Trade-off aceptado.
+- **Notificaciones push/email del dashboard**: las alertas ya tienen `email_alerts` notification channel; el dashboard solo lee, no crea alerts ni notifica.
+
+---
+
+## Riesgos + mitigaciones
+
+| Riesgo | Mitigación |
+|---|---|
+| Queries BigQuery costosas si se llaman sin filtro temporal | Backend obliga `from/to` parameter; default últimos 30d; cache 5min Redis |
+| Twilio API rate limits (100 req/s con account credentials) | Cache 5min de `Usage.Records`; `Account.Balance` cache 15min |
+| Cloud Monitoring API quotas (6k queries/min por project) | Cache 1min agregado; coalesce dashboards multi-widget en N queries paralelas |
+| Datos faltantes los primeros 24-48h (billing_export aún no popula) | UI muestra "datos aún propagando" state; no error |
+| BOOSTER_PLATFORM_ADMIN_EMAILS comprometido = ve toda la financiera | Allowlist en var (no cambia sin TF apply); audit log de cada acceso al dashboard (Cloud Audit Logs) |
+| Forecast lineal sesga al alza si hay spike inicial del mes | Disclaimer visible "extrapolación lineal" + comparar con histórico |
+| Dashboard rompe si Twilio API down | Tab Uso muestra error específico, no crashea toda la página |
+
+---
+
+## Plan de testing
+
+### Unit tests (`apps/api/test/unit/observability/`)
+
+- `costs-service.test.ts`: query builder + parser de BQ response. Mock fetch. ~10 tests.
+- `monitoring-service.test.ts`: Cloud Monitoring API parser. Mock fetch. ~8 tests.
+- `twilio-usage-service.test.ts`: Twilio API parser + balance formatter. Mock fetch. ~5 tests.
+- `forecast-service.test.ts`: extrapolación lineal con edge cases (mes en día 1, mes en día 31, NaN). ~6 tests.
+- `cache.test.ts`: Redis cache wrapper TTL. ~4 tests.
+- `auth-middleware.test.ts`: rechazo a no-admins. ~3 tests.
+
+Total: ~36 unit tests, coverage >85% del módulo.
+
+### Integration tests
+
+- `observability-routes.test.ts` (apps/api/test/integration/): cada endpoint responde 200 con auth válida, 401 sin auth, 403 con auth de no-admin.
+
+### E2E (Playwright)
+
+- `observability-dashboard.spec.ts`:
+  - Login con admin → la sección aparece en sidebar
+  - Tab "Costos" renderiza cards sin errors en consola
+  - Tab "Salud" todos los indicadores se cargan en <5s
+  - Login con NO admin → la sección NO aparece (o aparece deshabilitada)
+
+### Smoke production
+
+- Health check del nuevo endpoint `/admin/observability/health` debe responder 200 al SA admin.
+
+---
+
+## Rollout
+
+1. **Feature flag**: `OBSERVABILITY_DASHBOARD_ACTIVATED` (default `true` en `variables.tf`, decision PO 2026-05-13).
+2. **Sprint W1**: implementación completa + smoke tests + activación inmediata al merge.
+3. **Acceso**: solo `BOOSTER_PLATFORM_ADMIN_EMAILS` (Felipe + futuros admins). El resto de usuarios ni ve el link en sidebar.
+4. **Rollback**: flag a `false` en 1 commit + apply. Page redirige a `/app` con toast "feature deshabilitada".
+5. **Monitoring del propio dashboard**: agregar uptime check para `/admin/observability/health` + alerta si responde 5xx >5min.
+
+---
+
+## Estimación de esfuerzo
+
+| Componente | Días |
+|---|---|
+| Package `@booster-ai/observability-providers` (5 clientes: BQ + Monitoring + Twilio + Workspace + FX + cache) | 2.5 |
+| Backend routes `/admin/observability/*` (9 endpoints) | 2 |
+| Frontend route + 5 tabs + componentes reusables | 3 |
+| Tests unit + integration + E2E | 1.5 |
+| Documentación + smoke tests prod | 0.5 |
+| **Total** | **~9.5 días** |
+
+Cabe dentro de un sprint de 2 semanas (10 días hábiles) con buffer del 5%.
+
+**Decisiones PO 2026-05-13** aprobadas:
+- ✅ Agregar Google Workspace (Admin SDK + cost/seat config)
+- ✅ FX dinámico (mindicador.cl, cache 1h, dólar observado Chile)
+- ✅ Feature flag default `true` (activación día 1)
+- ✅ Budget BQ <1% free tier OK
+
+---
+
+## Aprobación
+
+- [ ] Felipe Vicencio (PO): aprueba scope + criterios de aceptación
+- [ ] Tras aprobación: continuar con `/plan` para producir plan técnico detallado.

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -168,6 +168,20 @@ module "service_api" {
     # comparison). Sin esta env var nadie es admin — el código defaultea
     # a array vacío. Era un bug detectado post-stack ADR-033.
     BOOSTER_PLATFORM_ADMIN_EMAILS = var.booster_platform_admin_emails
+
+    # Observability dashboard — spec 2026-05-13. Lee billing_export
+    # (BigQuery), Cloud Monitoring API, Twilio Usage, Google Workspace
+    # Admin SDK. Feature flag para rollback rápido vía terraform var.
+    OBSERVABILITY_DASHBOARD_ACTIVATED = tostring(var.observability_dashboard_activated)
+    BILLING_EXPORT_TABLE              = var.billing_export_table
+    GOOGLE_WORKSPACE_DOMAIN           = var.google_workspace_domain
+    # Precios USD/seat/mes — Workspace API no los expone, configurados
+    # como vars Terraform. PO actualiza si Google cambia pricing.
+    GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STARTER    = tostring(var.google_workspace_price_per_seat_usd_starter)
+    GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STANDARD   = tostring(var.google_workspace_price_per_seat_usd_standard)
+    GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_PLUS       = tostring(var.google_workspace_price_per_seat_usd_plus)
+    GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_ENTERPRISE = tostring(var.google_workspace_price_per_seat_usd_enterprise)
+    MONTHLY_BUDGET_USD                             = tostring(var.monthly_budget_usd)
   })
   secrets = merge(local.common_secrets, {
     # Mismo secret que el bot — un solo lugar de verdad para rotaciones.

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -176,6 +176,9 @@ module "service_api" {
     BILLING_EXPORT_TABLE               = var.billing_export_table
     GOOGLE_WORKSPACE_DOMAIN            = var.google_workspace_domain
     GOOGLE_WORKSPACE_IMPERSONATE_EMAIL = var.google_workspace_impersonate_email
+    # SA dedicada al reader (cero-key, signJwt via IAM Credentials).
+    # Definida en iam.tf como google_service_account.observability_workspace_reader.
+    GOOGLE_WORKSPACE_READER_SA_EMAIL = google_service_account.observability_workspace_reader.email
     # Precios USD/seat/mes — Workspace API no los expone, configurados
     # como vars Terraform. PO actualiza si Google cambia pricing.
     GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STARTER    = tostring(var.google_workspace_price_per_seat_usd_starter)
@@ -216,13 +219,10 @@ module "service_api" {
     WEBPUSH_VAPID_PUBLIC_KEY  = google_secret_manager_secret.secrets["webpush-vapid-public-key"].secret_id
     WEBPUSH_VAPID_PRIVATE_KEY = google_secret_manager_secret.secrets["webpush-vapid-private-key"].secret_id
 
-    # Observability dashboard (spec 2026-05-13) — JSON key del SA de
-    # `observability-workspace-reader` para Admin SDK Domain-Wide
-    # Delegation. Si el secret está en placeholder ROTATE_ME_*, el
-    # factory.ts detecta el prefijo y skipea sin crashear (la tab
-    # Workspace del dashboard muestra "available=false"). Runbook:
-    # docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
-    GOOGLE_WORKSPACE_CREDENTIALS_JSON = google_secret_manager_secret.secrets["google-workspace-admin-credentials"].secret_id
+    # NOTA observability dashboard: el reader SA usa IAM Credentials
+    # `signJwt` para producir JWTs DWD on-the-fly (cero-key). No hay
+    # secret JSON que montar. El email del reader SA viene de env vars
+    # (no de Secret Manager) porque no es sensible.
 
     # ADR-038: GOOGLE_ROUTES_API_KEY eliminada. apps/api ahora autentica
     # contra Routes API con ADC + header X-Goog-User-Project (el SA del

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -172,9 +172,10 @@ module "service_api" {
     # Observability dashboard — spec 2026-05-13. Lee billing_export
     # (BigQuery), Cloud Monitoring API, Twilio Usage, Google Workspace
     # Admin SDK. Feature flag para rollback rápido vía terraform var.
-    OBSERVABILITY_DASHBOARD_ACTIVATED = tostring(var.observability_dashboard_activated)
-    BILLING_EXPORT_TABLE              = var.billing_export_table
-    GOOGLE_WORKSPACE_DOMAIN           = var.google_workspace_domain
+    OBSERVABILITY_DASHBOARD_ACTIVATED  = tostring(var.observability_dashboard_activated)
+    BILLING_EXPORT_TABLE               = var.billing_export_table
+    GOOGLE_WORKSPACE_DOMAIN            = var.google_workspace_domain
+    GOOGLE_WORKSPACE_IMPERSONATE_EMAIL = var.google_workspace_impersonate_email
     # Precios USD/seat/mes — Workspace API no los expone, configurados
     # como vars Terraform. PO actualiza si Google cambia pricing.
     GOOGLE_WORKSPACE_PRICE_PER_SEAT_USD_STARTER    = tostring(var.google_workspace_price_per_seat_usd_starter)
@@ -214,6 +215,14 @@ module "service_api" {
     # `npx web-push generate-vapid-keys`.
     WEBPUSH_VAPID_PUBLIC_KEY  = google_secret_manager_secret.secrets["webpush-vapid-public-key"].secret_id
     WEBPUSH_VAPID_PRIVATE_KEY = google_secret_manager_secret.secrets["webpush-vapid-private-key"].secret_id
+
+    # Observability dashboard (spec 2026-05-13) — JSON key del SA de
+    # `observability-workspace-reader` para Admin SDK Domain-Wide
+    # Delegation. Si el secret está en placeholder ROTATE_ME_*, el
+    # factory.ts detecta el prefijo y skipea sin crashear (la tab
+    # Workspace del dashboard muestra "available=false"). Runbook:
+    # docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
+    GOOGLE_WORKSPACE_CREDENTIALS_JSON = google_secret_manager_secret.secrets["google-workspace-admin-credentials"].secret_id
 
     # ADR-038: GOOGLE_ROUTES_API_KEY eliminada. apps/api ahora autentica
     # contra Routes API con ADC + header X-Goog-User-Project (el SA del

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -103,6 +103,31 @@ resource "google_service_account_iam_member" "cloudrun_self_signer" {
   member             = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
 }
 
+# Observability dashboard (spec 2026-05-13) — SA dedicada con surface
+# area minimal: solo se usa para impersonar al Workspace admin via DWD
+# y leer seats + licencias. NO se le crea JSON key (cumple org policy
+# `iam.disableServiceAccountKeyCreation`). El runtime SA tiene
+# `serviceAccountTokenCreator` sobre ella, así que puede llamar
+# IAM Credentials `signJwt` para producir el JWT DWD on-the-fly.
+#
+# Pre-condición operativa: autorizar el oauth2ClientId de esta SA en
+# admin.google.com → Security → API Controls → Domain-wide Delegation
+# con los scopes admin.directory.user.readonly + apps.licensing.
+# Runbook: docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
+resource "google_service_account" "observability_workspace_reader" {
+  account_id   = "observability-workspace-reader"
+  display_name = "Observability Workspace Reader"
+  description  = "Lee seats + licencias Workspace via Admin SDK DWD. Solo-lectura. Usado por /admin/observability/usage. Zero-key (signJwt via IAM Credentials)."
+  project      = google_project.booster_ai.project_id
+  depends_on   = [google_project_service.apis]
+}
+
+resource "google_service_account_iam_member" "cloudrun_can_impersonate_workspace_reader" {
+  service_account_id = google_service_account.observability_workspace_reader.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
+}
+
 # Custom role mínimo para que el SA Cloud Run pueda crear/borrar
 # subscriptions efímeras del chat SSE (P3.b). Los roles standard
 # pubsub.publisher/pubsub.subscriber NO incluyen subscriptions.create

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -73,6 +73,10 @@ locals {
     "roles/cloudtrace.agent",
     "roles/monitoring.metricWriter",
     "roles/logging.logWriter",
+    # Observability dashboard (spec 2026-05-13) — read time series via API.
+    # metricWriter solo permite write; viewer es el read mínimo necesario
+    # para /admin/observability/usage/cloud-run|cloud-sql.
+    "roles/monitoring.viewer",
   ]
 }
 
@@ -142,10 +146,10 @@ resource "google_service_account" "github_deployer" {
 
 locals {
   github_deployer_roles = [
-    "roles/run.admin",                # Deploy a Cloud Run
-    "roles/cloudbuild.builds.editor", # Trigger Cloud Build
+    "roles/run.admin",                 # Deploy a Cloud Run
+    "roles/cloudbuild.builds.editor",  # Trigger Cloud Build
     "roles/cloudbuild.workerPoolUser", # Usar el private worker pool (PR #68)
-    "roles/artifactregistry.writer",  # Push Docker images
+    "roles/artifactregistry.writer",   # Push Docker images
     # roles/iam.serviceAccountUser REMOVIDO del project-level (Trivy IaC
     # AVD-GCP-0008 — too broad; permitia impersonar CUALQUIER SA del proyecto).
     # Reemplazado por google_service_account_iam_member.github_can_impersonate_runtime

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -243,12 +243,13 @@ locals {
     "webpush-vapid-public-key",
     "webpush-vapid-private-key",
 
-    # Observability dashboard (spec 2026-05-13) — Service Account JSON key
-    # de `observability-workspace-reader` para llamar Admin SDK con
-    # Domain-Wide Delegation. Cargar con:
-    #   gcloud secrets versions add google-workspace-admin-credentials --data-file=key.json
-    # Runbook: docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
-    "google-workspace-admin-credentials",
+    # NOTA: spec 2026-05-13 observability dashboard usaba originalmente un
+    # secret `google-workspace-admin-credentials` con el JSON key del SA
+    # `observability-workspace-reader`. Refactor: cumple org policy
+    # `iam.disableServiceAccountKeyCreation` reemplazando JSON key por
+    # IAM Credentials `signJwt` con impersonación (zero-key). El SA
+    # `observability-workspace-reader` se crea en iam.tf y el runtime SA
+    # tiene `roles/iam.serviceAccountTokenCreator` sobre ella.
 
     # NOTA: google-routes-api-key eliminada en ADR-038 — el backend ahora
     # autentica contra Routes API con ADC + header X-Goog-User-Project (SA

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -243,6 +243,13 @@ locals {
     "webpush-vapid-public-key",
     "webpush-vapid-private-key",
 
+    # Observability dashboard (spec 2026-05-13) — Service Account JSON key
+    # de `observability-workspace-reader` para llamar Admin SDK con
+    # Domain-Wide Delegation. Cargar con:
+    #   gcloud secrets versions add google-workspace-admin-credentials --data-file=key.json
+    # Runbook: docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md
+    "google-workspace-admin-credentials",
+
     # NOTA: google-routes-api-key eliminada en ADR-038 — el backend ahora
     # autentica contra Routes API con ADC + header X-Goog-User-Project (SA
     # cloud_run_runtime tiene serviceusage.serviceUsageConsumer). Cero

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -409,6 +409,12 @@ variable "google_workspace_domain" {
   default     = "boosterchile.com"
 }
 
+variable "google_workspace_impersonate_email" {
+  description = "Email del admin del Workspace que la SA observability-workspace-reader impersona via Domain-Wide Delegation. Required cuando google_workspace_domain está seteado."
+  type        = string
+  default     = "dev@boosterchile.com"
+}
+
 # Precios USD/mes/seat de planes Google Workspace. Google no expone via API;
 # el PO los actualiza cuando Google publica nuevos precios.
 # Source: https://workspace.google.com/pricing (revisar trimestralmente).

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -387,3 +387,51 @@ variable "booster_platform_admin_emails" {
   type        = string
   default     = "dev@boosterchile.com"
 }
+
+# ---------------------------------------------------------------------------
+# Observability Dashboard (spec 2026-05-13)
+# ---------------------------------------------------------------------------
+variable "observability_dashboard_activated" {
+  description = "Feature flag para el dashboard de observabilidad /app/platform-admin/observability. Default true."
+  type        = bool
+  default     = true
+}
+
+variable "billing_export_table" {
+  description = "BigQuery table fully qualified que contiene el billing export. La tabla específica gcp_billing_export_v1_* se infiere del billing account id."
+  type        = string
+  default     = "booster-ai-494222.billing_export.gcp_billing_export_v1_019461_C73CDE_DCE377"
+}
+
+variable "google_workspace_domain" {
+  description = "Dominio Google Workspace gestionado por Booster (e.g. boosterchile.com). Vacío deshabilita el tab Workspace del dashboard."
+  type        = string
+  default     = "boosterchile.com"
+}
+
+# Precios USD/mes/seat de planes Google Workspace. Google no expone via API;
+# el PO los actualiza cuando Google publica nuevos precios.
+# Source: https://workspace.google.com/pricing (revisar trimestralmente).
+variable "google_workspace_price_per_seat_usd_starter" {
+  description = "USD/mes por seat de Business Starter"
+  type        = number
+  default     = 6
+}
+
+variable "google_workspace_price_per_seat_usd_standard" {
+  description = "USD/mes por seat de Business Standard"
+  type        = number
+  default     = 12
+}
+
+variable "google_workspace_price_per_seat_usd_plus" {
+  description = "USD/mes por seat de Business Plus"
+  type        = number
+  default     = 18
+}
+
+variable "google_workspace_price_per_seat_usd_enterprise" {
+  description = "USD/mes por seat de Enterprise (precio aproximado, custom contracts típico)"
+  type        = number
+  default     = 30
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       google-auth-library:
         specifier: ^10.6.2
         version: 10.6.2
+      googleapis:
+        specifier: ^171.4.0
+        version: 171.4.0
       hono:
         specifier: ^4.12.18
         version: 4.12.18
@@ -447,6 +450,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.169.2
         version: 1.169.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tremor/react':
+        specifier: ^3.18.7
+        version: 3.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vis.gl/react-google-maps':
         specifier: ^1.5.0
         version: 1.8.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2307,6 +2313,39 @@ packages:
   '@firebase/webchannel-wrapper@1.0.6':
     resolution: {integrity: sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@1.3.0':
+    resolution: {integrity: sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.19.2':
+    resolution: {integrity: sha512-JyNk4A0Ezirq8FlXECvRtQOX/iBe5Ize0W/pLkrZjfHW9GUV7Xnq6zm6fyZuQzaHHqEnVizmvlA96e1/CkZv+w==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/react@0.26.28':
+    resolution: {integrity: sha512-yORQuuAtVpiRjpMhdc0wJj06b9JFjrYF4qp96j++v2NBpbi6SEGF7donUJ3TMieerQ6qVkAv1tgr7L4r5roTqw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@google-cloud/bigquery@7.9.4':
     resolution: {integrity: sha512-C7jeI+9lnCDYK3cRDujcBsPgiwshWKn/f0BiaJmClplfyosCLfWE83iGQ0eKH113UZzjR9c9q7aZQg0nU388sw==}
     engines: {node: '>=14.0.0'}
@@ -2368,6 +2407,13 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@headlessui/react@2.2.0':
+    resolution: {integrity: sha512-RzCEg+LXsuI7mHiSomsu/gBJSjpupm6A1qIZ5sWjd7JhARNlMiSA4kKfJpCKwU9tE+zMRterhhrP74PvfJrpXQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^18 || ^19 || ^19.0.0-rc
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -2393,6 +2439,15 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@internationalized/date@3.12.1':
+    resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
+
+  '@internationalized/number@3.6.6':
+    resolution: {integrity: sha512-iFgmQaXHE0vytNfpLZWOC2mEJCBRzcUxt53Xf/yCXG93lRvqas237i3r7X4RKMwO3txiyZD4mQjKAByFv6UGSQ==}
+
+  '@internationalized/string@3.2.8':
+    resolution: {integrity: sha512-NdbMQUSfXLYIQol5VyMtinm9pZDciiMfN7RtmSuSB78io1hqwJ0naYfxyW6vgxWBkzWymQa/3uLDlbfmshtCaA==}
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
@@ -2947,6 +3002,23 @@ packages:
   '@protobufjs/utf8@1.1.1':
     resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
+  '@react-aria/focus@3.22.0':
+    resolution: {integrity: sha512-ZfDOVuVhqDsM9mkNji3QUZ/d40JhlVgXrDkrfXylM1035QCrcTHN7m2DpbE95sU2A8EQb4wikvt5jM6K/73BPg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-aria/interactions@3.28.0':
+    resolution: {integrity: sha512-OXwdU1EWFdMxmr/K1CXNGJzmNlCClByb+PuCaqUyzBymHPCGVhawirLIon/CrIN5psh3AiWpHSh4H0WeJdVpng==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  '@react-types/shared@3.34.0':
+    resolution: {integrity: sha512-gp6xo/s2lX54AlTjOiqwDnxA7UW79BNvI9dB9pr3LZTzRKCd1ZA+ZbgKw/ReIiWuvvVw/8QFJpnqeeFyLocMcQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
@@ -3148,6 +3220,9 @@ packages:
   '@swc/helpers@0.3.17':
     resolution: {integrity: sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==}
 
+  '@swc/helpers@0.5.21':
+    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -3263,6 +3338,12 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-virtual@3.13.24':
+    resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/router-core@1.169.2':
     resolution: {integrity: sha512-5sm0DJF1A7Mz+9gy4Gz/lLovNailK3yot4vYvz9MkBUPw26uLnhQiR8hSCYxucjE0wD6Mdlc5l+Z0/XTlZ7xHw==}
     engines: {node: '>=20.19'}
@@ -3299,6 +3380,9 @@ packages:
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
+  '@tanstack/virtual-core@3.14.0':
+    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
+
   '@tanstack/virtual-file-routes@1.161.7':
     resolution: {integrity: sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ==}
     engines: {node: '>=20.19'}
@@ -3332,6 +3416,12 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tremor/react@3.18.7':
+    resolution: {integrity: sha512-nmqvf/1m0GB4LXc7v2ftdfSLoZhy5WLrhV6HNf0SOriE6/l8WkYeWuhQq8QsBjRi94mUIKLJ/VC3/Y/pj6VubQ==}
+    peerDependencies:
+      react: ^18.0.0
+      react-dom: '>=16.6.0'
 
   '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1':
     resolution: {integrity: sha512-/67zpWDBLV+oYAEL682s1ktXL0HgqX76f6gaVGkGnVZlBbm1zd0v4Bz8MFF2GGhoX9rvfq3KSQHubFHwa6w6/Q==}
@@ -3399,6 +3489,33 @@ packages:
 
   '@types/conventional-commits-parser@5.0.2':
     resolution: {integrity: sha512-BgT2szDXnVypgpNxOK8aL5SGjUdaQbC++WZNjF1Qge3Og2+zhHj+RWhmehLhYyvQwqAmvezruVfOf8+3m74W+g==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -3609,6 +3726,10 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
 
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
@@ -3956,6 +4077,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   dargs@8.1.0:
     resolution: {integrity: sha512-wAV9QHOsNbwnWdNW2FYvE1P56wtgSbM+3SZcdGiWQILwVjACCXDCI3Ai8QlCjMDB8YK5zySiXZYBiwGmNY3lnw==}
     engines: {node: '>=12'}
@@ -3980,6 +4145,9 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -3991,6 +4159,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -4050,6 +4221,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -4299,6 +4473,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -4333,6 +4510,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -4567,6 +4748,14 @@ packages:
     resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
     engines: {node: '>=14'}
 
+  googleapis-common@8.0.1:
+    resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
+    engines: {node: '>=18.0.0'}
+
+  googleapis@171.4.0:
+    resolution: {integrity: sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==}
+    engines: {node: '>=18'}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -4712,6 +4901,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
@@ -5175,6 +5368,9 @@ packages:
 
   lodash.upperfirst@4.3.1:
     resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
@@ -5675,6 +5871,9 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proto3-json-serializer@2.0.2:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
@@ -5690,6 +5889,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.1:
+    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -5703,6 +5906,18 @@ packages:
     resolution: {integrity: sha512-kKr2uQ2AokadPjvTyKJQad9xELbZwYzWlNfI3Uz2j/ib5u6H9lDP7fUUR//rMycd0gv4Z5P1qXMfXR8YpIxrjQ==}
     hasBin: true
 
+  react-aria@3.48.0:
+    resolution: {integrity: sha512-jQjd4rBEIMqecBaAKYJbVGK6EqIHLa5znVQ7jwFyK5vCyljoj6KhgtiahmcIPsG5vG5vEDLw+ba+bEWn6A2P4w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-day-picker@8.10.2:
+    resolution: {integrity: sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==}
+    peerDependencies:
+      date-fns: ^2.28.0 || ^3.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
@@ -5714,12 +5929,41 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
+
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-stately@3.46.0:
+    resolution: {integrity: sha512-OdxhWvHgs2L4OJGIs7hnuTr5WjjMM6enhNEAMRqiekhF8+ITvA2LRwNftOZwcogaoCslGYq5S2VQTQwnm0GbCA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
+  react-transition-state@2.3.3:
+    resolution: {integrity: sha512-wsIyg07ohlWEAYDZHvuXh/DY7mxlcLb0iqVv2aMXJ0gwgPVKNWKhOyNyzuJy/tt/6urSq0WT6BBZ/tdpybaAsQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -5751,6 +5995,16 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -6121,6 +6375,9 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
   tailwind-merge@2.6.1:
     resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
 
@@ -6174,6 +6431,9 @@ packages:
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -6356,6 +6616,9 @@ packages:
     peerDependencies:
       browserslist: '>= 4.21.0'
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
@@ -6367,6 +6630,9 @@ packages:
   uuid@14.0.0:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-plugin-pwa@0.21.2:
     resolution: {integrity: sha512-vFhH6Waw8itNu37hWUJxL50q+CBbNcMVzsKaYHQVrfxTt3ihk3PeLO22SbiP1UNWzcEPaTQv+YVxe4G0KOjAkg==}
@@ -8264,6 +8530,45 @@ snapshots:
 
   '@firebase/webchannel-wrapper@1.0.6': {}
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/react-dom@2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@floating-ui/react@0.19.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+
+  '@floating-ui/react@0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@floating-ui/utils': 0.2.11
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.4.0
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@google-cloud/bigquery@7.9.4':
     dependencies:
       '@google-cloud/common': 5.0.2
@@ -8395,6 +8700,15 @@ snapshots:
       protobufjs: 7.5.7
       yargs: 17.7.2
 
+  '@headlessui/react@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/focus': 3.22.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@react-aria/interactions': 3.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual': 3.13.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@hono/node-server@1.19.14(hono@4.12.18)':
     dependencies:
       hono: 4.12.18
@@ -8414,6 +8728,18 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 22.19.18
+
+  '@internationalized/date@3.12.1':
+    dependencies:
+      '@swc/helpers': 0.5.21
+
+  '@internationalized/number@3.6.6':
+    dependencies:
+      '@swc/helpers': 0.5.21
+
+  '@internationalized/string@3.2.8':
+    dependencies:
+      '@swc/helpers': 0.5.21
 
   '@ioredis/commands@1.5.1': {}
 
@@ -9190,6 +9516,25 @@ snapshots:
 
   '@protobufjs/utf8@1.1.1': {}
 
+  '@react-aria/focus@3.22.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@swc/helpers': 0.5.21
+      react: 18.3.1
+      react-aria: 3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@react-aria/interactions@3.28.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@react-types/shared': 3.34.0(react@18.3.1)
+      '@swc/helpers': 0.5.21
+      react: 18.3.1
+      react-aria: 3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@react-types/shared@3.34.0(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/plugin-babel@6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.3)':
@@ -9335,6 +9680,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -9428,6 +9777,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  '@tanstack/react-virtual@3.13.24(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.14.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@tanstack/router-core@1.169.2':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -9485,6 +9840,8 @@ snapshots:
 
   '@tanstack/store@0.9.3': {}
 
+  '@tanstack/virtual-core@3.14.0': {}
+
   '@tanstack/virtual-file-routes@1.161.7': {}
 
   '@testing-library/dom@10.4.1':
@@ -9520,6 +9877,18 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
+
+  '@tremor/react@3.18.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react': 0.19.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@headlessui/react': 2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      date-fns: 3.6.0
+      react: 18.3.1
+      react-day-picker: 8.10.2(date-fns@3.6.0)(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-state: 2.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      tailwind-merge: 2.6.1
 
   '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1':
     dependencies:
@@ -9589,6 +9958,30 @@ snapshots:
   '@types/conventional-commits-parser@5.0.2':
     dependencies:
       '@types/node': 22.19.18
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/deep-eql@4.0.2': {}
 
@@ -9818,6 +10211,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
 
   aria-query@5.3.0:
     dependencies:
@@ -10158,6 +10555,44 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   dargs@8.1.0: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -10185,11 +10620,15 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-fns@3.6.0: {}
+
   dateformat@4.6.3: {}
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -10251,6 +10690,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
 
   dot-prop@5.3.0:
     dependencies:
@@ -10538,6 +10982,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
@@ -10570,6 +11016,8 @@ snapshots:
   fast-copy@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -10932,6 +11380,23 @@ snapshots:
 
   google-logging-utils@1.1.3: {}
 
+  googleapis-common@8.0.1:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.4
+      google-auth-library: 10.6.2
+      qs: 6.15.1
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  googleapis@171.4.0:
+    dependencies:
+      google-auth-library: 10.6.2
+      googleapis-common: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -11061,6 +11526,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   ioredis@5.10.1:
     dependencies:
@@ -11511,6 +11978,8 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash.upperfirst@4.3.1: {}
+
+  lodash@4.18.1: {}
 
   log-update@6.1.0:
     dependencies:
@@ -11964,6 +12433,12 @@ snapshots:
 
   process@0.11.10: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   proto3-json-serializer@2.0.2:
     dependencies:
       protobufjs: 7.5.7
@@ -11990,6 +12465,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.1:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
@@ -12002,6 +12481,25 @@ snapshots:
       minimist: 1.2.8
       through2: 2.0.5
 
+  react-aria@3.48.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@18.3.1)
+      '@swc/helpers': 0.5.21
+      aria-hidden: 1.2.6
+      clsx: 2.1.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-stately: 3.46.0(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  react-day-picker@8.10.2(date-fns@3.6.0)(react@18.3.1):
+    dependencies:
+      date-fns: 3.6.0
+      react: 18.3.1
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -12012,9 +12510,45 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
 
+  react-is@18.3.1: {}
+
   react-refresh@0.17.0: {}
+
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-stately@3.46.0(react@18.3.1):
+    dependencies:
+      '@internationalized/date': 3.12.1
+      '@internationalized/number': 3.6.6
+      '@internationalized/string': 3.2.8
+      '@react-types/shared': 3.34.0(react@18.3.1)
+      '@swc/helpers': 0.5.21
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  react-transition-state@2.3.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react@18.3.1:
     dependencies:
@@ -12058,6 +12592,23 @@ snapshots:
   readdirp@4.1.2: {}
 
   real-require@0.2.0: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.18.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   redent@3.0.0:
     dependencies:
@@ -12496,6 +13047,8 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  tabbable@6.4.0: {}
+
   tailwind-merge@2.6.1: {}
 
   tailwindcss@4.3.0: {}
@@ -12553,6 +13106,8 @@ snapshots:
   through@2.3.8: {}
 
   tiny-inflate@1.0.3: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 
@@ -12747,6 +13302,8 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  url-template@2.0.8: {}
+
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -12754,6 +13311,23 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@14.0.0: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-plugin-pwa@0.21.2(vite@6.4.2(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.4))(workbox-build@7.4.1(@types/babel__core@7.20.5))(workbox-window@7.4.1):
     dependencies:


### PR DESCRIPTION
## Summary

Dashboard de observabilidad completo en `/app/platform-admin/observability` para platform-admin Booster. Reemplaza el "abrir Cloud Console + DevTools" con una vista unificada de costos, salud técnica, uso de servicios externos, capacity y forecast.

- **5 tabs**: Costos · Salud · Uso · Capacity · Forecast
- **12 endpoints backend** en `/admin/observability/*` con auth `BOOSTER_PLATFORM_ADMIN_EMAILS` allowlist + feature flag `OBSERVABILITY_DASHBOARD_ACTIVATED` (default true)
- **Gasto real con métricas honestas**: delta% apples-to-apples (mes-actual-MTD vs mismo-periodo-mes-anterior), histórico 12 meses, link directo a facturas oficiales en Cloud Console
- **Workspace adapter zero-key**: cumple `iam.disableServiceAccountKeyCreation` org policy via IAM Credentials `signJwt` impersonation (no JSON keys descargadas)
- **DWD ya configurado en producción**: SA `observability-workspace-reader` con `tokenCreator` binding, Client ID `111745462454884197415` autorizado en admin.google.com con scopes `admin.directory.user.readonly` + `apps.licensing`

## Test plan

- [x] **Unit + integration tests**: 2031 pass (1027 api + 1004 web), 0 regressions
- [x] **Typecheck**: api + web clean
- [x] **Biome lint**: clean
- [x] **Production build**: OK (CSS 277kB gzip 34kB con Tremor safelist)
- [x] **Visual UX/UI con backend mock**:
  - Tab Costos: KPI MTD con delta apples-to-apples, TrendChart 30d, DonutChart por servicio, BarChart por proyecto, histórico 12 meses, top SKUs
  - Tab Salud: semáforos 🟢🟡🔴 por componente (uptime + Cloud Run + Cloud SQL)
  - Tab Uso: Twilio balance + categorías + Workspace seats + costo mensual
  - Tab Capacity: 8 KpiCards con ProgressBars semáforo
  - Tab Forecast: extrapolación lineal vs budget + FX info mindicador
- [x] **DWD end-to-end verificado**: `signJwt` → token exchange → Admin SDK call funciona desde Cloud Run SA
- [x] **Bugs detectados en visual review y arreglados antes de merge**:
  - Tremor charts renderizaban sin colores (Tailwind 4 safelist via `@source inline`)
  - TrendChart con height 0 (arbitrary class dinámica)

## Commits (11)

```
41089f9 docs(observability): link directo a facturas oficiales + nota uso vs facturas
34ea7b0 feat(observability): histórico mensual hasta 24 meses + link a facturas oficiales
326225f feat(observability): delta% apples-to-apples vs mismo periodo mes anterior
32bf317 fix(observability): Tremor charts no rendereaban colores ni dimensiones (Tailwind 4)
8dbb37b refactor(observability): workspace adapter zero-key via IAM Credentials signJwt
e798164 feat(observability): 5 tabs Costos+Salud+Uso+Capacity+Forecast (C6)
e2ac263 feat(observability): UI skeleton + componentes reusables + hooks TanStack Query (C5)
fca5692 feat(observability): router /admin/observability/* con 11 endpoints + IAM + factory (C4)
bb194b2 feat(observability): clientes BigQuery + Monitoring + Twilio + Workspace + forecast (C3)
5cc94f8 feat(observability): middleware admin reusable + cache Redis + FX client (C2)
9aa7dae chore(observability): scaffold deps + env vars + Terraform (C1/6)
```

## Spec + Plan

- [docs/specs/2026-05-13-observability-dashboard.md](docs/specs/2026-05-13-observability-dashboard.md)
- [docs/specs/2026-05-13-observability-dashboard-plan.md](docs/specs/2026-05-13-observability-dashboard-plan.md)
- [docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md](docs/runbooks/2026-05-13-workspace-admin-sdk-setup.md) (zero-key version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)