### PR TITLE
test(logger): cobertura 93/92/100/93 — createLogger + redaction

### DIFF
--- a/packages/logger/src/createLogger.test.ts
+++ b/packages/logger/src/createLogger.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createLogger } from './createLogger.js';
+
+describe('createLogger', () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+  const captured: string[] = [];
+
+  beforeEach(() => {
+    captured.length = 0;
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      captured.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+  });
+
+  function lastLog(): Record<string, unknown> {
+    const line = captured[captured.length - 1];
+    if (!line) {
+      throw new Error('no log captured');
+    }
+    return JSON.parse(line);
+  }
+
+  it('retorna un logger funcional con métodos pino estándar', () => {
+    const logger = createLogger({ service: 'test-svc' });
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.error).toBe('function');
+    expect(typeof logger.debug).toBe('function');
+    expect(typeof logger.fatal).toBe('function');
+    expect(typeof logger.trace).toBe('function');
+  });
+
+  it('inyecta service + version (defaults: 0.0.0-dev) en cada log', () => {
+    const logger = createLogger({ service: 'api-test' });
+    logger.info('hola');
+    const log = lastLog();
+    expect(log.service).toBe('api-test');
+    expect(log.version).toBe('0.0.0-dev');
+    expect(log.message).toBe('hola');
+  });
+
+  it('respeta version explícita', () => {
+    const logger = createLogger({ service: 'api', version: '1.2.3' });
+    logger.info('x');
+    expect(lastLog().version).toBe('1.2.3');
+  });
+
+  it('respeta level explícito (warn descarta info)', () => {
+    const logger = createLogger({ service: 's', level: 'warn' });
+    logger.info('ignored');
+    logger.warn('kept');
+    const lines = captured.map((c) => JSON.parse(c));
+    expect(lines).toHaveLength(1);
+    expect(lines[0].message).toBe('kept');
+  });
+
+  it('emite timestamp ISO 8601 (stdTimeFunctions.isoTime)', () => {
+    const logger = createLogger({ service: 's' });
+    logger.info('x');
+    const log = lastLog();
+    expect(log.time).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('mapea level a severity GCP en cada log (info→INFO, warn→WARNING, ...)', () => {
+    const logger = createLogger({ service: 's', level: 'trace' });
+    const cases: Array<[() => void, string]> = [
+      [() => logger.trace('m'), 'DEBUG'],
+      [() => logger.debug('m'), 'DEBUG'],
+      [() => logger.info('m'), 'INFO'],
+      [() => logger.warn('m'), 'WARNING'],
+      [() => logger.error('m'), 'ERROR'],
+      [() => logger.fatal('m'), 'CRITICAL'],
+    ];
+    for (const [emit, expectedSeverity] of cases) {
+      captured.length = 0;
+      emit();
+      expect(lastLog().severity).toBe(expectedSeverity);
+    }
+  });
+
+  it('redacta paths sensibles default (password, token, rut, email)', () => {
+    const logger = createLogger({ service: 's' });
+    logger.info(
+      {
+        user: {
+          email: 'u@example.com',
+          password: 'secret',
+          rut: '11.111.111-1',
+          token: 'abc',
+        },
+      },
+      'login attempt',
+    );
+    const log = lastLog();
+    const user = log.user as Record<string, string>;
+    expect(user.email).toBe('[REDACTED]');
+    expect(user.password).toBe('[REDACTED]');
+    expect(user.rut).toBe('[REDACTED]');
+    expect(user.token).toBe('[REDACTED]');
+  });
+
+  it('redacta paths adicionales via additionalRedactionPaths', () => {
+    const logger = createLogger({
+      service: 's',
+      additionalRedactionPaths: ['*.internalId'],
+    });
+    logger.info({ user: { internalId: 'sensitive-12345' } }, 'evt');
+    const user = lastLog().user as Record<string, string>;
+    expect(user.internalId).toBe('[REDACTED]');
+  });
+
+  it('NO redacta campos no-sensibles (fullName_public no es PII path)', () => {
+    const logger = createLogger({ service: 's' });
+    logger.info({ user: { displayName: 'Juan' } }, 'evt');
+    const user = lastLog().user as Record<string, string>;
+    expect(user.displayName).toBe('Juan');
+  });
+
+  it('pretty=true retorna un logger funcional (transport pino-pretty)', () => {
+    const logger = createLogger({ service: 's', pretty: true });
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.error).toBe('function');
+  });
+});

--- a/packages/logger/src/redaction.test.ts
+++ b/packages/logger/src/redaction.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { redactionPaths } from './redaction.js';
+
+describe('redactionPaths', () => {
+  it('incluye credentials core (password, token, api_key, authorization)', () => {
+    expect(redactionPaths).toContain('*.password');
+    expect(redactionPaths).toContain('*.token');
+    expect(redactionPaths).toContain('*.api_key');
+    expect(redactionPaths).toContain('*.authorization');
+    expect(redactionPaths).toContain('req.headers.authorization');
+    expect(redactionPaths).toContain('req.headers.cookie');
+  });
+
+  it('incluye PII Ley 19.628 (email, phone, rut, dni, address, fullName)', () => {
+    expect(redactionPaths).toContain('*.email');
+    expect(redactionPaths).toContain('*.phone');
+    expect(redactionPaths).toContain('*.rut');
+    expect(redactionPaths).toContain('*.dni');
+    expect(redactionPaths).toContain('*.address');
+    expect(redactionPaths).toContain('*.fullName');
+    expect(redactionPaths).toContain('*.full_name');
+  });
+
+  it('cubre ambas convenciones (camelCase y snake_case) para PII', () => {
+    expect(redactionPaths).toContain('*.phoneNumber');
+    expect(redactionPaths).toContain('*.phone_number');
+    expect(redactionPaths).toContain('*.streetAddress');
+    expect(redactionPaths).toContain('*.street_address');
+    expect(redactionPaths).toContain('*.creditCard');
+    expect(redactionPaths).toContain('*.credit_card');
+  });
+
+  it('incluye datos de pago (creditCard, cvv, cvc)', () => {
+    expect(redactionPaths).toContain('*.creditCard');
+    expect(redactionPaths).toContain('*.cvv');
+    expect(redactionPaths).toContain('*.cvc');
+  });
+
+  it('incluye firmas digitales', () => {
+    expect(redactionPaths).toContain('*.signature');
+    expect(redactionPaths).toContain('*.digitalSignature');
+    expect(redactionPaths).toContain('*.digital_signature');
+  });
+
+  it('es un array no vacío y todas las entries son strings', () => {
+    expect(redactionPaths.length).toBeGreaterThan(20);
+    for (const path of redactionPaths) {
+      expect(typeof path).toBe('string');
+      expect(path.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/logger/vitest.config.ts
+++ b/packages/logger/vitest.config.ts
@@ -7,18 +7,14 @@ export default defineConfig({
     include: ['src/**/*.{test,spec}.ts', 'test/**/*.{test,spec}.ts'],
     coverage: {
       provider: 'v8',
-      // json-summary OMITIDO (bash gate skip). Se restaura en
-      // chore/coverage-logger-2026-05-16 cuando alcance 80/80/80/80.
-      reporter: ['text', 'json', 'html', 'lcov'],
+      reporter: ['text', 'json', 'json-summary', 'html', 'lcov'],
       include: ['src/**/*.ts'],
       exclude: ['src/**/*.d.ts', 'src/**/index.ts', 'src/**/*.test.ts', 'src/**/*.spec.ts'],
-      // Baseline 0/0/0/0 (sin tests). Levantar a 80/80/80/80 en
-      // chore/coverage-logger-2026-05-16.
       thresholds: {
-        lines: 0,
-        functions: 0,
-        branches: 0,
-        statements: 0,
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
       },
     },
   },


### PR DESCRIPTION
## Summary

Levanta `@booster-ai/logger` de baseline 0/0/0/0 a **93/92/100/93**.

## Cambios

- `src/createLogger.test.ts` (nuevo, 10 tests): pino setup, severity mapping, redaction, pretty transport.
- `src/redaction.test.ts` (nuevo, 6 tests): cobertura de paths Ley 19.628 + GDPR + pagos + firmas.
- `vitest.config.ts`: threshold 0/0/0/0 → 80/80/80/80, restaura `json-summary`.

## Coverage

| Métrica | Antes | Ahora |
|---|---|---|
| Statements | 0% | 93.33% (14/15) |
| Branches | 0% | 92.3% (12/13) |
| Functions | 0% | 100% (3/3) |
| Lines | 0% | 93.33% (14/15) |

Línea no cubierta: `createLogger.ts:88` (default branch en switch — inalcanzable desde pino).

## Anti-Prove-It checks

- Si `pinoLevelToGcpSeverity` mapea mal (e.g. error→WARNING) → fail.
- Si redaction default deja pasar password/email/rut/token → fail.
- Si `additionalRedactionPaths` no se concatena → fail.
- Si timestamp no es ISO 8601 → fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)