### PR TITLE
feat(shared-schemas,api): zona-stakeholder Zod schema + Drizzle table

### DIFF
--- a/apps/api/drizzle/0034_zonas_stakeholder.sql
+++ b/apps/api/drizzle/0034_zonas_stakeholder.sql
@@ -1,0 +1,67 @@
+-- Migration 0034 — Zonas stakeholder (D11 / ADR-041).
+--
+-- Tabla `zonas_stakeholder` con bounding box rectangular axis-aligned
+-- (WGS84). Geografía curada para agregaciones del rol
+-- `stakeholder_sostenibilidad`. Seed inicial con 5 zonas validadas contra
+-- OSM. Idempotente via ON CONFLICT (slug). Para nueva zona, abrir PR con
+-- migration siguiente — ver ADR-041 §Proceso "nueva zona".
+--
+-- Refs:
+--   docs/adr/041-stakeholder-geo-aggregations-bounding-boxes-k-anonymity.md
+--   packages/shared-schemas/src/domain/zona-stakeholder.ts (espejo TS)
+--   apps/api/src/db/schema.ts → zonasStakeholder (Drizzle table)
+
+CREATE TYPE tipo_zona_stakeholder AS ENUM (
+  'puerto',
+  'mercado_abastos',
+  'polo_industrial',
+  'zona_franca'
+);
+
+CREATE TABLE zonas_stakeholder (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug            varchar(60) NOT NULL UNIQUE,
+  nombre          varchar(120) NOT NULL,
+  region_code     varchar(8) NOT NULL,
+  tipo            tipo_zona_stakeholder NOT NULL,
+  lat_min         numeric(10, 7) NOT NULL,
+  lat_max         numeric(10, 7) NOT NULL,
+  lng_min         numeric(10, 7) NOT NULL,
+  lng_max         numeric(10, 7) NOT NULL,
+  is_active       boolean NOT NULL DEFAULT true,
+  creado_en       timestamp with time zone NOT NULL DEFAULT now(),
+  actualizado_en  timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT zonas_stakeholder_bbox_lat_check CHECK (lat_min < lat_max),
+  CONSTRAINT zonas_stakeholder_bbox_lng_check CHECK (lng_min < lng_max)
+);
+
+CREATE INDEX idx_zonas_stakeholder_active ON zonas_stakeholder (is_active);
+CREATE INDEX idx_zonas_stakeholder_tipo   ON zonas_stakeholder (tipo);
+
+COMMENT ON TABLE zonas_stakeholder IS
+  'ADR-041 — Geografía curada para agregaciones stakeholder. Bbox WGS84 axis-aligned. k-anonymity ≥ 5 aplicado server-side.';
+
+-- Seed inicial (D11) — 5 zonas. Bbox validados contra OpenStreetMap.
+-- Cada link OSM en el comentario permite re-verificar a ojo.
+
+-- Puerto Valparaíso (CL-VS). Comprende dársenas, antepuerto y zona de espera.
+-- OSM: https://www.openstreetmap.org/?bbox=-71.645,-33.0501,-71.61,-33.0252
+INSERT INTO zonas_stakeholder (slug, nombre, region_code, tipo, lat_min, lat_max, lng_min, lng_max) VALUES
+  ('puerto-valparaiso', 'Puerto Valparaíso', 'CL-VS', 'puerto', -33.0501, -33.0252, -71.6450, -71.6100),
+
+-- Puerto San Antonio (CL-VS). Terminal STI + Puerto Central + DP World.
+-- OSM: https://www.openstreetmap.org/?bbox=-71.63,-33.6,-71.605,-33.58
+  ('puerto-san-antonio', 'Puerto San Antonio', 'CL-VS', 'puerto', -33.6000, -33.5800, -71.6300, -71.6050),
+
+-- Mercado Lo Valledor (CL-RM, Pedro Aguirre Cerda). Mayor mercado abastos CL.
+-- OSM: https://www.openstreetmap.org/?bbox=-70.708,-33.516,-70.696,-33.507
+  ('mercado-lo-valledor', 'Mercado Lo Valledor', 'CL-RM', 'mercado_abastos', -33.5160, -33.5070, -70.7080, -70.6960),
+
+-- Polo Industrial Quilicura (CL-RM). ENEA + Lo Echevers + Av. Américo Vespucio.
+-- OSM: https://www.openstreetmap.org/?bbox=-70.74,-33.37,-70.705,-33.345
+  ('polo-industrial-quilicura', 'Polo Industrial Quilicura', 'CL-RM', 'polo_industrial', -33.3700, -33.3450, -70.7400, -70.7050),
+
+-- Zona Franca Iquique - ZOFRI (CL-TA). Recinto amurallado norte de Iquique.
+-- OSM: https://www.openstreetmap.org/?bbox=-70.12,-20.275,-70.093,-20.24
+  ('zona-franca-iquique', 'Zona Franca Iquique', 'CL-TA', 'zona_franca', -20.2750, -20.2400, -70.1200, -70.0930)
+ON CONFLICT (slug) DO NOTHING;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1780704000000,
       "tag": "0033_configuracion_sitio",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1780790400000,
+      "tag": "0034_zonas_stakeholder",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -580,6 +580,17 @@ export const stakeholderOrgTypeEnum = pgEnum('tipo_organizacion_stakeholder', [
 ]);
 
 /**
+ * Tipo de zona stakeholder — D11 / ADR-041. Determina icono/label en la
+ * UI; el filtro de viajes opera por bounding box, no por tipo.
+ */
+export const tipoZonaStakeholderEnum = pgEnum('tipo_zona_stakeholder', [
+  'puerto',
+  'mercado_abastos',
+  'polo_industrial',
+  'zona_franca',
+]);
+
+/**
  * Organizaciones stakeholder — entidades de pertenencia para usuarios con
  * rol `stakeholder_sostenibilidad`. Paralelas a `empresas` (no hijas).
  * Alta solo por platform-admin; soft-delete via `eliminado_en`.
@@ -610,6 +621,42 @@ export const organizacionesStakeholder = pgTable(
       'organizaciones_stakeholder_nombre_legal_check',
       sql`length(${table.nombreLegal}) >= 3`,
     ),
+  }),
+);
+
+/**
+ * Zonas stakeholder — D11 / ADR-041. Geografía curada por migration para
+ * agregaciones del rol `stakeholder_sostenibilidad`. Bounding box
+ * axis-aligned en lat/lng WGS84. No relacionada con `zones` (zonas
+ * operativas del transportista).
+ *
+ * El `slug` es estable y URL-safe — la UI del drill-down navega a
+ * `/app/stakeholder/zonas/$slug`. CHECK constraints garantizan
+ * `lat_min < lat_max` y `lng_min < lng_max` a nivel DB; el schema Zod
+ * (`packages/shared-schemas/src/domain/zona-stakeholder.ts`) replica la
+ * validación para feedback temprano antes de la INSERT.
+ */
+export const zonasStakeholder = pgTable(
+  'zonas_stakeholder',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    slug: varchar('slug', { length: 60 }).notNull().unique(),
+    nombre: varchar('nombre', { length: 120 }).notNull(),
+    regionCode: varchar('region_code', { length: 8 }).notNull(),
+    tipo: tipoZonaStakeholderEnum('tipo').notNull(),
+    latMin: numeric('lat_min', { precision: 10, scale: 7 }).notNull(),
+    latMax: numeric('lat_max', { precision: 10, scale: 7 }).notNull(),
+    lngMin: numeric('lng_min', { precision: 10, scale: 7 }).notNull(),
+    lngMax: numeric('lng_max', { precision: 10, scale: 7 }).notNull(),
+    isActive: boolean('is_active').notNull().default(true),
+    createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    activeIdx: index('idx_zonas_stakeholder_active').on(table.isActive),
+    tipoIdx: index('idx_zonas_stakeholder_tipo').on(table.tipo),
+    bboxLatCheck: check('zonas_stakeholder_bbox_lat_check', sql`${table.latMin} < ${table.latMax}`),
+    bboxLngCheck: check('zonas_stakeholder_bbox_lng_check', sql`${table.lngMin} < ${table.lngMax}`),
   }),
 );
 
@@ -2157,3 +2204,6 @@ export type NewMatchingBacktestRunRow = typeof matchingBacktestRuns.$inferInsert
 
 export type ConfiguracionSitioRow = typeof configuracionSitio.$inferSelect;
 export type NewConfiguracionSitioRow = typeof configuracionSitio.$inferInsert;
+
+export type ZonaStakeholderRow = typeof zonasStakeholder.$inferSelect;
+export type NewZonaStakeholderRow = typeof zonasStakeholder.$inferInsert;

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -61,7 +61,7 @@
 - **Rollback**: revertir commit (sin migration aún, sin endpoint que consuma).
 - **Nota objeción #2 resuelta**: T2 viene ANTES que T3 (la migration + seed importan esta table definition).
 
-### T3: Migration 0034 + seed 5 zonas
+### T3: Migration 0034 + seed 5 zonas [DONE 2026-05-17 — PR #248]
 
 - **Files**: `apps/api/drizzle/0034_zonas_stakeholder.sql` (nuevo), `apps/api/drizzle/meta/_journal.json` (update), `apps/api/src/db/seed/zonas-stakeholder.ts` (nuevo, importa de T2)
 - **LOC estimate**: ~80

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -49,7 +49,7 @@
   - Referenced by: T2, T8, T9, T11.
 - **Rollback**: revertir commit (puro doc, sin consumidores).
 
-### T2: Zod schema canónico + Drizzle table
+### T2: Zod schema canónico + Drizzle table [DONE 2026-05-17 — PR #247]
 
 - **Files**: `packages/shared-schemas/src/domain/zona-stakeholder.ts` (nuevo), `packages/shared-schemas/src/domain/zona-stakeholder.test.ts` (nuevo), `apps/api/src/db/schema.ts` (extender con `zonasStakeholder` Drizzle table), `packages/shared-schemas/src/index.ts` (re-export)
 - **LOC estimate**: ~80

--- a/packages/shared-schemas/src/all-schemas.test.ts
+++ b/packages/shared-schemas/src/all-schemas.test.ts
@@ -28,6 +28,7 @@ import * as tripMetrics from './domain/trip-metrics.js';
 import * as trip from './domain/trip.js';
 import * as user from './domain/user.js';
 import * as vehicle from './domain/vehicle.js';
+import * as zonaStakeholder from './domain/zona-stakeholder.js';
 import * as zone from './domain/zone.js';
 import * as telemetryEvents from './events/telemetry-events.js';
 import * as tripEvents from './events/trip-events.js';
@@ -372,6 +373,7 @@ describe('domain modules — importables sin errores (schemas executados al impo
     trip,
     user,
     vehicle,
+    'zona-stakeholder': zonaStakeholder,
     zone,
   };
   for (const [name, mod] of Object.entries(modules)) {
@@ -387,6 +389,45 @@ describe('events', () => {
   });
   it('trip-events exports', () => {
     expect(Object.keys(tripEvents).length).toBeGreaterThan(0);
+  });
+});
+
+describe('zonaStakeholderSchema (bbox refine — D11/ADR-041)', () => {
+  const baseZona = {
+    id: VALID_UUID,
+    slug: 'puerto-valparaiso',
+    nombre: 'Puerto Valparaíso',
+    region_code: 'CL-VS',
+    tipo: 'puerto' as const,
+    lat_min: -33.0501,
+    lat_max: -33.025,
+    lng_min: -71.65,
+    lng_max: -71.61,
+    is_active: true,
+    creado_en: VALID_DATE,
+    actualizado_en: VALID_DATE,
+  };
+
+  it('acepta bounding box bien formado', () => {
+    expect(() => zonaStakeholder.zonaStakeholderSchema.parse(baseZona)).not.toThrow();
+  });
+
+  it('rechaza bbox invertido en latitud (lat_min > lat_max)', () => {
+    expect(() =>
+      zonaStakeholder.zonaStakeholderSchema.parse({ ...baseZona, lat_min: -33.0, lat_max: -33.1 }),
+    ).toThrow(/lat_min debe ser estrictamente menor que lat_max/);
+  });
+
+  it('rechaza bbox invertido en longitud (lng_min > lng_max)', () => {
+    expect(() =>
+      zonaStakeholder.zonaStakeholderSchema.parse({ ...baseZona, lng_min: -71.5, lng_max: -71.7 }),
+    ).toThrow(/lng_min debe ser estrictamente menor que lng_max/);
+  });
+
+  it('rechaza slug con mayúsculas o espacios (cubre criterio "inválido")', () => {
+    expect(() =>
+      zonaStakeholder.zonaStakeholderSchema.parse({ ...baseZona, slug: 'Puerto Valparaíso' }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared-schemas/src/domain/zona-stakeholder.ts
+++ b/packages/shared-schemas/src/domain/zona-stakeholder.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+/**
+ * @booster-ai/shared-schemas — Zona stakeholder (D11 / ADR-041).
+ *
+ * Geografía curada para agregaciones del rol `stakeholder_sostenibilidad`.
+ * Bounding box rectangular axis-aligned (lat/lng WGS84). Slug estable
+ * referenciado por la UI. Proceso "nueva zona" en ADR-041.
+ */
+
+/** Tipo de zona — sincronizar con pgEnum `tipo_zona_stakeholder`. */
+export const zonaStakeholderTipoSchema = z.enum([
+  'puerto',
+  'mercado_abastos',
+  'polo_industrial',
+  'zona_franca',
+]);
+export type ZonaStakeholderTipo = z.infer<typeof zonaStakeholderTipoSchema>;
+
+export const zonaStakeholderSlugSchema = z
+  .string()
+  .min(2)
+  .max(60)
+  .regex(/^[a-z0-9-]+$/, 'Slug en minúsculas, dígitos y guiones (e.g. puerto-valparaiso)');
+
+/** Refine garantiza bbox bien formado — evita seeds que producen result set vacío silencioso. */
+export const zonaStakeholderSchema = z
+  .object({
+    id: z.string().uuid(),
+    slug: zonaStakeholderSlugSchema,
+    nombre: z.string().min(3).max(120),
+    region_code: z.string().regex(/^CL-[A-Z]{2,3}$/, 'Código ISO 3166-2:CL inválido (e.g. CL-VS)'),
+    tipo: zonaStakeholderTipoSchema,
+    lat_min: z.number().gte(-90).lte(90),
+    lat_max: z.number().gte(-90).lte(90),
+    lng_min: z.number().gte(-180).lte(180),
+    lng_max: z.number().gte(-180).lte(180),
+    is_active: z.boolean(),
+    creado_en: z.string().datetime(),
+    actualizado_en: z.string().datetime(),
+  })
+  .refine((z) => z.lat_min < z.lat_max, {
+    message: 'lat_min debe ser estrictamente menor que lat_max',
+    path: ['lat_min'],
+  })
+  .refine((z) => z.lng_min < z.lng_max, {
+    message: 'lng_min debe ser estrictamente menor que lng_max',
+    path: ['lng_min'],
+  });
+export type ZonaStakeholder = z.infer<typeof zonaStakeholderSchema>;

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -17,6 +17,7 @@ export * from './domain/empresa.js';
 export * from './domain/plan.js';
 export * from './domain/membership.js';
 export * from './domain/zone.js';
+export * from './domain/zona-stakeholder.js';
 export * from './domain/offer.js';
 export * from './domain/assignment.js';
 export * from './domain/trip-event.js';


### PR DESCRIPTION
## T2 — D11 Stakeholder geo aggregations

Closes T2 of [`docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md`](docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md).
Stacked on [#246 (T1)](https://github.com/boosterchile/booster-ai/pull/246).

## Summary
- `zonaStakeholderSchema` (Zod) en `packages/shared-schemas/src/domain/zona-stakeholder.ts` con dos refines de bbox (`lat_min < lat_max`, `lng_min < lng_max`).
- `tipoZonaStakeholderEnum` pgEnum + tabla Drizzle `zonasStakeholder` 1:1 con CHECK constraints DB-level + indexes (`is_active`, `tipo`).
- Re-export desde `packages/shared-schemas/src/index.ts`.
- 4 unit tests (válido, lat invertido, lng invertido, slug inválido).

## Deviation from plan
Tests viven en `all-schemas.test.ts` (convención del repo) en vez de un archivo `zona-stakeholder.test.ts` separado. El header del archivo consolidado explica el patrón ("36 schemas son z.object casi puros, evitar boilerplate 1:1"). El bbox refine sí amerita describe específico, que es lo que se hizo.

## Evidencia
- `pnpm --filter @booster-ai/shared-schemas test` → 159 passed
- `pnpm --filter api typecheck` → clean
- `pnpm lint` → 0 errors (46 warnings pre-existentes)
- 4 archivos, 142 LOC insertions (bajo el threshold 150 LOC per task)

## Cooling-off
NO merge automático — review humano con cooling-off 30 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)