### PR TITLE
feat(shared-schemas): aplicarKAnonymity helper puro

### DIFF
--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -73,7 +73,7 @@
   - `SELECT COUNT(*) FROM zonas_stakeholder WHERE is_active = true` retorna 5.
 - **Rollback**: revertir commit + ejecutar `DROP TABLE zonas_stakeholder` si aplicada. **Caveat (objeción #11 resuelta)**: una vez T8/T9 estén en `main`, este rollback rompe los endpoints. Si T8 ya mergeó, revertir T3 requiere revertir también T8/T9 como unidad.
 
-### T4: k-anonymity helper puro
+### T4: k-anonymity helper puro [DONE 2026-05-17 — PR #249]
 
 - **Files**: `packages/shared-schemas/src/aggregations/k-anonymity.ts` (nuevo), `packages/shared-schemas/src/aggregations/k-anonymity.test.ts` (nuevo), `packages/shared-schemas/src/index.ts` (re-export)
 - **LOC estimate**: ~90 (≈30 helper + ≈60 tests)

--- a/packages/shared-schemas/src/aggregations/k-anonymity.test.ts
+++ b/packages/shared-schemas/src/aggregations/k-anonymity.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { aplicarKAnonymity } from './k-anonymity.js';
+
+describe('aplicarKAnonymity', () => {
+  it('preserva bucket cuando count >= k (k=5, count=10)', () => {
+    const buckets = [{ hora: 9, viajes: 10, co2e_kg: 250.5 }];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes', { preserveFields: ['hora'] });
+    expect(result).toEqual([{ hora: 9, viajes: 10, co2e_kg: 250.5 }]);
+  });
+
+  it('reemplaza métricos por null cuando count < k, preserva dimensión hora', () => {
+    const buckets = [{ hora: 9, viajes: 4, co2e_kg: 90.2 }];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes', { preserveFields: ['hora'] });
+    expect(result).toEqual([{ hora: 9, viajes: null, co2e_kg: null }]);
+  });
+
+  it('caso borde count exactamente k → preservado', () => {
+    const buckets = [{ tipo: 'general', viajes: 5, co2e_kg: 120 }];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes');
+    expect(result).toEqual([{ tipo: 'general', viajes: 5, co2e_kg: 120 }]);
+  });
+
+  it('caso borde count k-1 → nulled', () => {
+    const buckets = [{ fuel_type: 'diesel', viajes: 4, co2e_kg: 80 }];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes');
+    expect(result).toEqual([{ fuel_type: 'diesel', viajes: null, co2e_kg: null }]);
+  });
+
+  it('k=1 → viajes=0 se nullea', () => {
+    const buckets = [{ hora: 3, viajes: 0, co2e_kg: 0 }];
+    const result = aplicarKAnonymity(buckets, 1, 'viajes', { preserveFields: ['hora'] });
+    expect(result).toEqual([{ hora: 3, viajes: null, co2e_kg: null }]);
+  });
+
+  it('k=0 → ningún bucket se nullea (todos count >= 0)', () => {
+    const buckets = [{ hora: 0, viajes: 0, co2e_kg: 0 }];
+    const result = aplicarKAnonymity(buckets, 0, 'viajes', { preserveFields: ['hora'] });
+    expect(result).toEqual([{ hora: 0, viajes: 0, co2e_kg: 0 }]);
+  });
+
+  it('array vacío retorna array vacío', () => {
+    expect(aplicarKAnonymity([], 5, 'viajes')).toEqual([]);
+  });
+
+  it('preserva no-numéricos (string, boolean, null) en buckets nulled', () => {
+    const buckets = [
+      { slug: 'puerto-x', viajes: 3, co2e_kg: 50, es_activo: true, comentario: null },
+    ];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes');
+    expect(result).toEqual([
+      { slug: 'puerto-x', viajes: null, co2e_kg: null, es_activo: true, comentario: null },
+    ]);
+  });
+
+  it('mix: invariante por bucket — algunos preservados, otros nulled', () => {
+    const buckets = [
+      { hora: 8, viajes: 10, co2e_kg: 200 },
+      { hora: 9, viajes: 3, co2e_kg: 60 },
+      { hora: 10, viajes: 7, co2e_kg: 140 },
+    ];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes', { preserveFields: ['hora'] });
+    expect(result[0]).toEqual({ hora: 8, viajes: 10, co2e_kg: 200 });
+    expect(result[1]).toEqual({ hora: 9, viajes: null, co2e_kg: null });
+    expect(result[2]).toEqual({ hora: 10, viajes: 7, co2e_kg: 140 });
+  });
+
+  it('no muta el input array ni sus buckets', () => {
+    const original = [{ hora: 9, viajes: 4, co2e_kg: 90 }];
+    const snapshot = JSON.parse(JSON.stringify(original));
+    aplicarKAnonymity(original, 5, 'viajes', { preserveFields: ['hora'] });
+    expect(original).toEqual(snapshot);
+  });
+});

--- a/packages/shared-schemas/src/aggregations/k-anonymity.ts
+++ b/packages/shared-schemas/src/aggregations/k-anonymity.ts
@@ -1,0 +1,50 @@
+/**
+ * @booster-ai/shared-schemas — k-anonymity invariant (D11 / ADR-041).
+ *
+ * Helper puro: dada una lista de buckets de agregación, reemplaza los
+ * campos métricos (numéricos) de cada bucket cuyo `countField` sea < k
+ * por `null`. Las dimensiones (campos no-numéricos o numéricos listados
+ * en `preserveFields`) se mantienen para que la UI muestre "Sin data
+ * suficiente" en la celda correcta — sin perder la identidad del bucket.
+ *
+ * Devuelve un array nuevo — no muta el input. Pensado para correr
+ * server-side antes de serializar la respuesta del endpoint.
+ */
+
+/**
+ * Misma forma que `T` pero campos numéricos posiblemente `null` runtime.
+ */
+export type KAnonymized<T> = {
+  [K in keyof T]: T[K] extends number ? T[K] | null : T[K];
+};
+
+export interface KAnonymityOptions<T> {
+  /**
+   * Campos numéricos que son dimensiones (e.g. `hora` 0..23) — se
+   * preservan aún cuando count < k. Default: ninguno; todos los campos
+   * numéricos se nullean.
+   */
+  preserveFields?: ReadonlyArray<keyof T>;
+}
+
+export function aplicarKAnonymity<T extends Record<string, unknown>>(
+  buckets: readonly T[],
+  k: number,
+  countField: keyof T,
+  options: KAnonymityOptions<T> = {},
+): KAnonymized<T>[] {
+  const preserve = new Set<keyof T>(options.preserveFields ?? []);
+  return buckets.map((bucket) => {
+    const count = bucket[countField];
+    if (typeof count !== 'number' || count >= k) {
+      return { ...bucket } as KAnonymized<T>;
+    }
+    const masked: Record<string, unknown> = { ...bucket };
+    for (const key of Object.keys(masked)) {
+      if (!preserve.has(key as keyof T) && typeof masked[key] === 'number') {
+        masked[key] = null;
+      }
+    }
+    return masked as KAnonymized<T>;
+  });
+}

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -59,3 +59,6 @@ export * from './avl-ids/index.js';
 
 // Site Settings — configuración runtime editable de marca y copy (ADR-039)
 export * from './site-settings.js';
+
+// Aggregations — privacy invariants compartidos backend/frontend (D11/ADR-041)
+export * from './aggregations/k-anonymity.js';


### PR DESCRIPTION
## T4 — D11 Stakeholder geo aggregations

Closes T4 of [`docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md`](docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md).
Stacked on [#248 (T3)](https://github.com/boosterchile/booster-ai/pull/248).

## Summary
- `packages/shared-schemas/src/aggregations/k-anonymity.ts` — helper puro `aplicarKAnonymity<T>(buckets, k, countField, options?)`.
- `options.preserveFields` permite proteger dimensiones numéricas (e.g. `hora` 0..23) cuando `count < k`.
- Type `KAnonymized<T>` para que los consumidores reflejen la nullability en sus tipos sin castear.
- 10 tests (k=5/k=1/k=0, exactly-k, k-1, vacío, mix, no-mutation, preserva no-numéricos).
- Re-export desde `packages/shared-schemas/src/index.ts`.

## Refinamiento vs plan literal
Plan: `aplicarKAnonymity<T>(buckets, k, countField)`. La implementación adicionalmente acepta `{ preserveFields }` porque el spec criterio 4 exige que `hora` (numérico, dimensión) NO se nullee — solo `viajes` y `co2e_kg`. Sin este refinamiento la UI no sabría a qué celda corresponde un bucket nulled.

## Evidencia
- `pnpm --filter @booster-ai/shared-schemas test` → 169 passed
- `pnpm --filter api typecheck` → clean
- 126 LOC (50 helper + 73 tests + 3 index re-export)

## Cooling-off
NO merge automático — review humano con cooling-off 30 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)