### PR TITLE
feat(api): stakeholder-aggregations hora del día + horario pico

### DIFF
--- a/apps/api/drizzle/0034_zonas_stakeholder.sql
+++ b/apps/api/drizzle/0034_zonas_stakeholder.sql
@@ -1,0 +1,67 @@
+-- Migration 0034 — Zonas stakeholder (D11 / ADR-041).
+--
+-- Tabla `zonas_stakeholder` con bounding box rectangular axis-aligned
+-- (WGS84). Geografía curada para agregaciones del rol
+-- `stakeholder_sostenibilidad`. Seed inicial con 5 zonas validadas contra
+-- OSM. Idempotente via ON CONFLICT (slug). Para nueva zona, abrir PR con
+-- migration siguiente — ver ADR-041 §Proceso "nueva zona".
+--
+-- Refs:
+--   docs/adr/041-stakeholder-geo-aggregations-bounding-boxes-k-anonymity.md
+--   packages/shared-schemas/src/domain/zona-stakeholder.ts (espejo TS)
+--   apps/api/src/db/schema.ts → zonasStakeholder (Drizzle table)
+
+CREATE TYPE tipo_zona_stakeholder AS ENUM (
+  'puerto',
+  'mercado_abastos',
+  'polo_industrial',
+  'zona_franca'
+);
+
+CREATE TABLE zonas_stakeholder (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug            varchar(60) NOT NULL UNIQUE,
+  nombre          varchar(120) NOT NULL,
+  region_code     varchar(8) NOT NULL,
+  tipo            tipo_zona_stakeholder NOT NULL,
+  lat_min         numeric(10, 7) NOT NULL,
+  lat_max         numeric(10, 7) NOT NULL,
+  lng_min         numeric(10, 7) NOT NULL,
+  lng_max         numeric(10, 7) NOT NULL,
+  is_active       boolean NOT NULL DEFAULT true,
+  creado_en       timestamp with time zone NOT NULL DEFAULT now(),
+  actualizado_en  timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT zonas_stakeholder_bbox_lat_check CHECK (lat_min < lat_max),
+  CONSTRAINT zonas_stakeholder_bbox_lng_check CHECK (lng_min < lng_max)
+);
+
+CREATE INDEX idx_zonas_stakeholder_active ON zonas_stakeholder (is_active);
+CREATE INDEX idx_zonas_stakeholder_tipo   ON zonas_stakeholder (tipo);
+
+COMMENT ON TABLE zonas_stakeholder IS
+  'ADR-041 — Geografía curada para agregaciones stakeholder. Bbox WGS84 axis-aligned. k-anonymity ≥ 5 aplicado server-side.';
+
+-- Seed inicial (D11) — 5 zonas. Bbox validados contra OpenStreetMap.
+-- Cada link OSM en el comentario permite re-verificar a ojo.
+
+-- Puerto Valparaíso (CL-VS). Comprende dársenas, antepuerto y zona de espera.
+-- OSM: https://www.openstreetmap.org/?bbox=-71.645,-33.0501,-71.61,-33.0252
+INSERT INTO zonas_stakeholder (slug, nombre, region_code, tipo, lat_min, lat_max, lng_min, lng_max) VALUES
+  ('puerto-valparaiso', 'Puerto Valparaíso', 'CL-VS', 'puerto', -33.0501, -33.0252, -71.6450, -71.6100),
+
+-- Puerto San Antonio (CL-VS). Terminal STI + Puerto Central + DP World.
+-- OSM: https://www.openstreetmap.org/?bbox=-71.63,-33.6,-71.605,-33.58
+  ('puerto-san-antonio', 'Puerto San Antonio', 'CL-VS', 'puerto', -33.6000, -33.5800, -71.6300, -71.6050),
+
+-- Mercado Lo Valledor (CL-RM, Pedro Aguirre Cerda). Mayor mercado abastos CL.
+-- OSM: https://www.openstreetmap.org/?bbox=-70.708,-33.516,-70.696,-33.507
+  ('mercado-lo-valledor', 'Mercado Lo Valledor', 'CL-RM', 'mercado_abastos', -33.5160, -33.5070, -70.7080, -70.6960),
+
+-- Polo Industrial Quilicura (CL-RM). ENEA + Lo Echevers + Av. Américo Vespucio.
+-- OSM: https://www.openstreetmap.org/?bbox=-70.74,-33.37,-70.705,-33.345
+  ('polo-industrial-quilicura', 'Polo Industrial Quilicura', 'CL-RM', 'polo_industrial', -33.3700, -33.3450, -70.7400, -70.7050),
+
+-- Zona Franca Iquique - ZOFRI (CL-TA). Recinto amurallado norte de Iquique.
+-- OSM: https://www.openstreetmap.org/?bbox=-70.12,-20.275,-70.093,-20.24
+  ('zona-franca-iquique', 'Zona Franca Iquique', 'CL-TA', 'zona_franca', -20.2750, -20.2400, -70.1200, -70.0930)
+ON CONFLICT (slug) DO NOTHING;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1780704000000,
       "tag": "0033_configuracion_sitio",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1780790400000,
+      "tag": "0034_zonas_stakeholder",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -580,6 +580,17 @@ export const stakeholderOrgTypeEnum = pgEnum('tipo_organizacion_stakeholder', [
 ]);
 
 /**
+ * Tipo de zona stakeholder — D11 / ADR-041. Determina icono/label en la
+ * UI; el filtro de viajes opera por bounding box, no por tipo.
+ */
+export const tipoZonaStakeholderEnum = pgEnum('tipo_zona_stakeholder', [
+  'puerto',
+  'mercado_abastos',
+  'polo_industrial',
+  'zona_franca',
+]);
+
+/**
  * Organizaciones stakeholder — entidades de pertenencia para usuarios con
  * rol `stakeholder_sostenibilidad`. Paralelas a `empresas` (no hijas).
  * Alta solo por platform-admin; soft-delete via `eliminado_en`.
@@ -610,6 +621,42 @@ export const organizacionesStakeholder = pgTable(
       'organizaciones_stakeholder_nombre_legal_check',
       sql`length(${table.nombreLegal}) >= 3`,
     ),
+  }),
+);
+
+/**
+ * Zonas stakeholder — D11 / ADR-041. Geografía curada por migration para
+ * agregaciones del rol `stakeholder_sostenibilidad`. Bounding box
+ * axis-aligned en lat/lng WGS84. No relacionada con `zones` (zonas
+ * operativas del transportista).
+ *
+ * El `slug` es estable y URL-safe — la UI del drill-down navega a
+ * `/app/stakeholder/zonas/$slug`. CHECK constraints garantizan
+ * `lat_min < lat_max` y `lng_min < lng_max` a nivel DB; el schema Zod
+ * (`packages/shared-schemas/src/domain/zona-stakeholder.ts`) replica la
+ * validación para feedback temprano antes de la INSERT.
+ */
+export const zonasStakeholder = pgTable(
+  'zonas_stakeholder',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    slug: varchar('slug', { length: 60 }).notNull().unique(),
+    nombre: varchar('nombre', { length: 120 }).notNull(),
+    regionCode: varchar('region_code', { length: 8 }).notNull(),
+    tipo: tipoZonaStakeholderEnum('tipo').notNull(),
+    latMin: numeric('lat_min', { precision: 10, scale: 7 }).notNull(),
+    latMax: numeric('lat_max', { precision: 10, scale: 7 }).notNull(),
+    lngMin: numeric('lng_min', { precision: 10, scale: 7 }).notNull(),
+    lngMax: numeric('lng_max', { precision: 10, scale: 7 }).notNull(),
+    isActive: boolean('is_active').notNull().default(true),
+    createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    activeIdx: index('idx_zonas_stakeholder_active').on(table.isActive),
+    tipoIdx: index('idx_zonas_stakeholder_tipo').on(table.tipo),
+    bboxLatCheck: check('zonas_stakeholder_bbox_lat_check', sql`${table.latMin} < ${table.latMax}`),
+    bboxLngCheck: check('zonas_stakeholder_bbox_lng_check', sql`${table.lngMin} < ${table.lngMax}`),
   }),
 );
 
@@ -2157,3 +2204,6 @@ export type NewMatchingBacktestRunRow = typeof matchingBacktestRuns.$inferInsert
 
 export type ConfiguracionSitioRow = typeof configuracionSitio.$inferSelect;
 export type NewConfiguracionSitioRow = typeof configuracionSitio.$inferInsert;
+
+export type ZonaStakeholderRow = typeof zonasStakeholder.$inferSelect;
+export type NewZonaStakeholderRow = typeof zonasStakeholder.$inferInsert;

--- a/apps/api/src/services/stakeholder-aggregations.ts
+++ b/apps/api/src/services/stakeholder-aggregations.ts
@@ -1,0 +1,91 @@
+import type { Logger } from '@booster-ai/logger';
+
+/** Helpers puros para endpoints /stakeholder/zonas — D11/ADR-041. Timezone CL. */
+const HORA_FMT = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/Santiago',
+  hour: 'numeric',
+  hour12: false,
+});
+
+export interface ViajeAgregable {
+  pickup_at: Date;
+  carbon_emissions_kgco2e_actual: number | null;
+  carbon_emissions_kgco2e_estimated: number | null;
+}
+export interface BucketHora {
+  hora: number;
+  viajes: number;
+  co2e_kg: number;
+}
+export interface HorarioPico {
+  inicio: number;
+  fin: number;
+}
+
+/** Hora 0..23 en America/Santiago para un timestamp UTC. */
+export function horaEnChile(ts: Date): number {
+  const part = HORA_FMT.formatToParts(ts).find((p) => p.type === 'hour');
+  const h = part ? Number.parseInt(part.value, 10) : 0;
+  return h === 24 ? 0 : h;
+}
+
+/** Spec criterio 7: actual → estimated → null+warn. */
+export function resolveCo2e(viaje: ViajeAgregable, logger?: Logger): number | null {
+  if (viaje.carbon_emissions_kgco2e_actual != null) {
+    return viaje.carbon_emissions_kgco2e_actual;
+  }
+  if (viaje.carbon_emissions_kgco2e_estimated != null) {
+    return viaje.carbon_emissions_kgco2e_estimated;
+  }
+  logger?.warn(
+    { pickup_at: viaje.pickup_at.toISOString() },
+    'stakeholder-aggregations: viaje sin CO2e; omitido del total',
+  );
+  return null;
+}
+
+/** 24 buckets CL — vacíos vienen con viajes:0, co2e_kg:0 (UI predecible). */
+export function agregarPorHoraDelDia(
+  viajes: readonly ViajeAgregable[],
+  logger?: Logger,
+): BucketHora[] {
+  const buckets: BucketHora[] = Array.from({ length: 24 }, (_, hora) => ({
+    hora,
+    viajes: 0,
+    co2e_kg: 0,
+  }));
+  for (const v of viajes) {
+    const b = buckets[horaEnChile(v.pickup_at)];
+    if (!b) {
+      continue;
+    }
+    b.viajes += 1;
+    const c = resolveCo2e(v, logger);
+    if (c != null) {
+      b.co2e_kg += c;
+    }
+  }
+  return buckets;
+}
+
+/** Ventana 4h consecutivas con más pickups; null si <5 totales; empate → más temprana. */
+export function calcularHorarioPico(viajes: readonly ViajeAgregable[]): HorarioPico | null {
+  if (viajes.length < 5) {
+    return null;
+  }
+  const c = new Array<number>(24).fill(0);
+  for (const v of viajes) {
+    const h = horaEnChile(v.pickup_at);
+    c[h] = (c[h] ?? 0) + 1;
+  }
+  let inicio = 0;
+  let total = -1;
+  for (let i = 0; i <= 20; i += 1) {
+    const t = (c[i] ?? 0) + (c[i + 1] ?? 0) + (c[i + 2] ?? 0) + (c[i + 3] ?? 0);
+    if (t > total) {
+      inicio = i;
+      total = t;
+    }
+  }
+  return { inicio, fin: inicio + 3 };
+}

--- a/apps/api/test/unit/stakeholder-aggregations.test.ts
+++ b/apps/api/test/unit/stakeholder-aggregations.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  type ViajeAgregable,
+  agregarPorHoraDelDia,
+  calcularHorarioPico,
+} from '../../src/services/stakeholder-aggregations.js';
+
+const mk = (iso: string, actual?: number | null, estimated?: number | null): ViajeAgregable => ({
+  pickup_at: new Date(iso),
+  carbon_emissions_kgco2e_actual: actual ?? null,
+  carbon_emissions_kgco2e_estimated: estimated ?? null,
+});
+const repeat = (n: number, fn: () => ViajeAgregable) => Array.from({ length: n }, fn);
+
+describe('agregarPorHoraDelDia', () => {
+  it('cero viajes → 24 entries con viajes=0 y co2e=0', () => {
+    const r = agregarPorHoraDelDia([]);
+    expect(r).toHaveLength(24);
+    expect(r.every((b, i) => b.hora === i && b.viajes === 0 && b.co2e_kg === 0)).toBe(true);
+  });
+
+  it('exactamente k=5 a la misma hora suma CO2e usando actual', () => {
+    expect(agregarPorHoraDelDia(repeat(5, () => mk('2026-05-17T10:00:00Z', 50)))[6]).toEqual({
+      hora: 6,
+      viajes: 5,
+      co2e_kg: 250,
+    });
+  });
+
+  it('k+1: fallback estimated cuando actual null + warn cuando ambos null', () => {
+    const warn = vi.fn();
+    const logger = { warn, error: vi.fn(), info: vi.fn(), debug: vi.fn() } as never;
+    const viajes = [
+      ...repeat(5, () => mk('2026-05-17T10:00:00Z', 50)),
+      mk('2026-05-17T10:00:00Z', null, 40),
+      mk('2026-05-17T10:00:00Z'),
+    ];
+    expect(agregarPorHoraDelDia(viajes, logger)[6]).toEqual({ hora: 6, viajes: 7, co2e_kg: 290 });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('distribución bimodal: dos picos en horas distintas', () => {
+    const viajes = [
+      ...repeat(3, () => mk('2026-05-17T12:00:00Z', 30)),
+      ...repeat(3, () => mk('2026-05-17T22:00:00Z', 30)),
+    ];
+    const r = agregarPorHoraDelDia(viajes);
+    expect(r[8].viajes).toBe(3); // 12 UTC = 8 CL
+    expect(r[18].viajes).toBe(3); // 22 UTC = 18 CL
+  });
+});
+
+describe('calcularHorarioPico', () => {
+  it('null cuando <5 viajes (k-anonymity)', () => {
+    expect(calcularHorarioPico(repeat(4, () => mk('2026-05-17T12:00:00Z')))).toBeNull();
+  });
+  it('5 viajes a 8 CL → ventana 5..8 más temprana (12 UTC = 8 CL)', () => {
+    const r = calcularHorarioPico(repeat(5, () => mk('2026-05-17T12:00:00Z')));
+    expect(r).toEqual({ inicio: 5, fin: 8 });
+  });
+  it('pico claro vs ruido', () => {
+    const viajes = [
+      ...repeat(6, () => mk('2026-05-17T12:00:00Z')),
+      ...repeat(2, () => mk('2026-05-17T02:00:00Z')),
+    ];
+    expect(calcularHorarioPico(viajes)).toEqual({ inicio: 5, fin: 8 });
+  });
+});

--- a/docs/adr/041-stakeholder-geo-aggregations-bounding-boxes-k-anonymity.md
+++ b/docs/adr/041-stakeholder-geo-aggregations-bounding-boxes-k-anonymity.md
@@ -1,0 +1,86 @@
+# ADR-041 — Stakeholder geo aggregations: bounding boxes predefinidos + k-anonymity ≥ 5
+
+**Fecha**: 2026-05-17
+**Estado**: Accepted
+**Refs**: `docs/specs/2026-05-11-stakeholder-geo-aggregations-d11.md`, `docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md`, ADR-034 (`stakeholder-organizations`), ADR-021 (`glec-v3-compliance`)
+
+## Contexto
+
+El rol `stakeholder_sostenibilidad` (ADR-034) accede a la surface `/app/stakeholder/zonas` para auditar agregaciones de viajes en zonas geográficas relevantes (puertos, mercados de abastos, polos industriales, zonas francas). El sprint demo (PR #157) entregó la página con 5 zonas hardcoded en el frontend y datos `demo_*` inventados. Esto bloquea:
+
+1. Demos a mandantes regulatorios (mesa público-privada, gremios) — los números no resisten preguntas.
+2. Compliance ESG bajo GLEC v3.0 / GHG Protocol — el reporte debe ser reproducible desde la BD.
+3. La promesa pública de la surface ("ninguna celda identifica a empresas individuales") — sin código que la garantice es marketing.
+
+D11 reemplaza el skeleton por agregaciones reales. La decisión sobre **cómo** se delimita una "zona" y **cómo** se garantiza la no-identificabilidad tiene impacto en privacidad, auditabilidad y roadmap. Esta ADR fija ambos.
+
+## Decisión
+
+### 1. Bounding boxes predefinidos curados por migration
+
+Las zonas viven en la tabla `zonas_stakeholder` con columnas `lat_min, lat_max, lng_min, lng_max` (rectángulo lat/lng axis-aligned). Se pueblan vía seed migration (`0034_zonas_stakeholder.sql`, T3 del plan) con bounding boxes validados manualmente contra OpenStreetMap. La columna `slug` (unique) es estable y referenciada por la UI.
+
+**No se acepta input arbitrario de polígonos desde el cliente.** El admin que quiera agregar una zona abre un PR con una nueva fila de migration. Roadmap futuro: admin endpoint protegido para curar zonas — fuera del scope de D11.
+
+### 2. k-anonymity ≥ 5 a nivel de servidor
+
+El backend aplica `aplicarKAnonymity(buckets, k=5, countField='viajes')` (helper puro en `packages/shared-schemas/src/aggregations/k-anonymity.ts`, T4 del plan) sobre cada celda numérica antes de serializar la respuesta. Si `count < 5` los campos numéricos del bucket se reemplazan por `null` y el endpoint adjunta `insufficient_data: true` en cards o `viajes: null` en celdas de drill-down.
+
+El threshold k=5 es **invariante por diseño**, codificado en el helper y verificado por test. No es parámetro de query.
+
+### 3. Ventana fija de 30 días
+
+Las queries filtran `pickup_at >= now() - interval '30 days'`. El param `?window=30d` se valida en el endpoint y rechaza cualquier otro valor con 400. La spec puede expandirse a 7d/90d en iteración 2 si la mesa pública lo pide formalmente.
+
+## Alternativas consideradas y rechazadas
+
+| Alternativa | Razón rechazo |
+|---|---|
+| **Geohash** (prefix de N caracteres) | Resolución no-uniforme (cells distintos sizes según latitud). Buscar "todos los geohashes de un puerto" requiere multiple prefixes, complicando query. No traceable visualmente sin tooling. |
+| **H3 hex grid** (Uber) | Resolución uniforme pero requiere dependency adicional (`h3-js`) y traduce a queries con joins contra una tabla de cells precomputed. Overkill para 5 zonas curadas; útil si tuviéramos 500+. |
+| **Polygon input libre desde frontend** | Vector de ataque: un stakeholder malicioso ajusta el polygon hasta que solo cae 1 empresa dentro → bypasea k-anonymity por carving. Requiere defensa server-side compleja (mínimo área, mínimo k post-recorte). Bounding boxes curados eliminan el ataque. |
+| **PostGIS `ST_Within(geom, polygon)`** | PostGIS aún no está habilitado en este proyecto. Habilitarlo es decisión cross-feature (afecta backups, latency, costos). Bounding box rectangular se resuelve con `BETWEEN` sobre `lat`/`lng` numéricos — suficiente para D11. |
+| **k=3 o k=10 en vez de k=5** | k=5 es el umbral defendido en literatura clásica (Samarati 1998) como balance entre privacidad y utilidad. k=3 es porous; k=10 deja la mayoría de celdas con `null` en nuestro volumen actual (~50 viajes/día). |
+
+## Trade-offs aceptados
+
+| Eje | Costo | Beneficio |
+|---|---|---|
+| **Precisión geográfica** | Bbox rectangular incluye edges no-pertenecientes a la zona real (ej. el bbox del Puerto Valparaíso incluye unos metros de mar). | Query trivial (`BETWEEN`), zero dependencies, debuggable a ojo. |
+| **Privacidad** | Pierde utilidad analítica cuando los buckets son pequeños (zona con 4 viajes en 30d → todos los breakdowns en `null`). | Garantía formal de no-identificabilidad ≥ 5. Auditable por test unitario. |
+| **Auditabilidad** | Documentar el bbox de cada zona como comentario SQL es manual y puede driftear vs. el rectángulo real. | Cualquier humano puede copiar/pegar las 4 coordenadas a OSM y verificar. Reproducible. |
+| **Evolución** | Crecer a 100 zonas requiere o migration por cada una, o el admin endpoint del roadmap. | Para las 5 iniciales de D11 (más expansión esperada gradual), migration es suficiente. |
+
+## Proceso "nueva zona"
+
+Hasta que exista admin endpoint:
+
+1. Identificar bbox sobre OSM (`https://www.openstreetmap.org/`).
+2. Verificar que `lat_min < lat_max` y `lng_min < lng_max`.
+3. Validar contra Zod schema (test unit del schema captura bbox invertido).
+4. PR con migration nueva (`NNNN_zona_<slug>.sql`) que hace `INSERT INTO zonas_stakeholder (...) VALUES (...)`. Comment SQL con link OSM del bbox.
+5. Review code-reviewer + security-auditor (bbox no-ataque vector).
+6. Merge → deploy → smoke test desde stakeholder.
+
+## Consecuencias
+
+### Positivas
+
+- Privacidad garantizada por construcción server-side; el frontend no puede romperla.
+- Surface auditable: schemas Zod, helpers puros con tests, ADR referenciable desde la metodología visible al usuario (link en banner reemplazado).
+- Sin dependencias nuevas (no h3, no PostGIS) — superficie de cambio mínima.
+
+### Negativas / riesgos
+
+- **Zonas con `null` por k < 5** generan UX "Sin data suficiente" en volumen bajo. Mitigación: ventana de 30 días suaviza variabilidad.
+- **Migration por cada nueva zona** no escala más allá de ~20 zonas. Mitigación: roadmap admin endpoint cuando la presión llegue.
+- **Bbox manualmente curado** puede driftear si el operador modifica sin re-verificar OSM. Mitigación: comment SQL con link al rectángulo en OSM (auditable a ojo).
+
+## Referenced by
+
+- T2 (Zod + Drizzle schema)
+- T3 (Migration 0034 + seed)
+- T4 (k-anonymity helper)
+- T8 (endpoint cards 30d)
+- T9 (endpoint agregaciones drill-down)
+- T11 (UI cards — link al ADR desde nota metodológica)

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -61,7 +61,7 @@
 - **Rollback**: revertir commit (sin migration aún, sin endpoint que consuma).
 - **Nota objeción #2 resuelta**: T2 viene ANTES que T3 (la migration + seed importan esta table definition).
 
-### T3: Migration 0034 + seed 5 zonas
+### T3: Migration 0034 + seed 5 zonas [DONE 2026-05-17 — PR #248]
 
 - **Files**: `apps/api/drizzle/0034_zonas_stakeholder.sql` (nuevo), `apps/api/drizzle/meta/_journal.json` (update), `apps/api/src/db/seed/zonas-stakeholder.ts` (nuevo, importa de T2)
 - **LOC estimate**: ~80

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -84,7 +84,7 @@
 - **Rollback**: revertir commit. Caveat: si T8/T9 ya consumen, ese rollback rompe los endpoints — revertir T8/T9 también.
 - **Nota objeción #3**: la firma `aplicarKAnonymity<T>(buckets, k, countField)` es decisión de API pública. Si tras T8 se descubre que la firma no escala, el cambio cascade a T8/T9. Mitigación: tests cubren los casos de uso reales antes de T8.
 
-### T5: Aggregations helpers — hora del día + horario pico
+### T5: Aggregations helpers — hora del día + horario pico [DONE 2026-05-17 — PR #250]
 
 - **Files**: `apps/api/src/services/stakeholder-aggregations.ts` (nuevo), `apps/api/test/unit/stakeholder-aggregations.test.ts` (nuevo)
 - **LOC estimate**: ~100

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -73,7 +73,7 @@
   - `SELECT COUNT(*) FROM zonas_stakeholder WHERE is_active = true` retorna 5.
 - **Rollback**: revertir commit + ejecutar `DROP TABLE zonas_stakeholder` si aplicada. **Caveat (objeción #11 resuelta)**: una vez T8/T9 estén en `main`, este rollback rompe los endpoints. Si T8 ya mergeó, revertir T3 requiere revertir también T8/T9 como unidad.
 
-### T4: k-anonymity helper puro
+### T4: k-anonymity helper puro [DONE 2026-05-17 — PR #249]
 
 - **Files**: `packages/shared-schemas/src/aggregations/k-anonymity.ts` (nuevo), `packages/shared-schemas/src/aggregations/k-anonymity.test.ts` (nuevo), `packages/shared-schemas/src/index.ts` (re-export)
 - **LOC estimate**: ~90 (≈30 helper + ≈60 tests)

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -49,7 +49,7 @@
   - Referenced by: T2, T8, T9, T11.
 - **Rollback**: revertir commit (puro doc, sin consumidores).
 
-### T2: Zod schema canónico + Drizzle table
+### T2: Zod schema canónico + Drizzle table [DONE 2026-05-17 — PR #247]
 
 - **Files**: `packages/shared-schemas/src/domain/zona-stakeholder.ts` (nuevo), `packages/shared-schemas/src/domain/zona-stakeholder.test.ts` (nuevo), `apps/api/src/db/schema.ts` (extender con `zonasStakeholder` Drizzle table), `packages/shared-schemas/src/index.ts` (re-export)
 - **LOC estimate**: ~80

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -36,7 +36,7 @@
 
 ## Tasks
 
-### T1: ADR-041 — decisiones arquitectónicas
+### T1: ADR-041 — decisiones arquitectónicas [DONE 2026-05-17 — PR #246]
 
 - **Files**: `docs/adr/041-stakeholder-geo-aggregations-bounding-boxes-k-anonymity.md` (nuevo)
 - **LOC estimate**: ~80

--- a/packages/shared-schemas/src/aggregations/k-anonymity.test.ts
+++ b/packages/shared-schemas/src/aggregations/k-anonymity.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { aplicarKAnonymity } from './k-anonymity.js';
+
+describe('aplicarKAnonymity', () => {
+  it('preserva bucket cuando count >= k (k=5, count=10)', () => {
+    const buckets = [{ hora: 9, viajes: 10, co2e_kg: 250.5 }];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes', { preserveFields: ['hora'] });
+    expect(result).toEqual([{ hora: 9, viajes: 10, co2e_kg: 250.5 }]);
+  });
+
+  it('reemplaza métricos por null cuando count < k, preserva dimensión hora', () => {
+    const buckets = [{ hora: 9, viajes: 4, co2e_kg: 90.2 }];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes', { preserveFields: ['hora'] });
+    expect(result).toEqual([{ hora: 9, viajes: null, co2e_kg: null }]);
+  });
+
+  it('caso borde count exactamente k → preservado', () => {
+    const buckets = [{ tipo: 'general', viajes: 5, co2e_kg: 120 }];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes');
+    expect(result).toEqual([{ tipo: 'general', viajes: 5, co2e_kg: 120 }]);
+  });
+
+  it('caso borde count k-1 → nulled', () => {
+    const buckets = [{ fuel_type: 'diesel', viajes: 4, co2e_kg: 80 }];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes');
+    expect(result).toEqual([{ fuel_type: 'diesel', viajes: null, co2e_kg: null }]);
+  });
+
+  it('k=1 → viajes=0 se nullea', () => {
+    const buckets = [{ hora: 3, viajes: 0, co2e_kg: 0 }];
+    const result = aplicarKAnonymity(buckets, 1, 'viajes', { preserveFields: ['hora'] });
+    expect(result).toEqual([{ hora: 3, viajes: null, co2e_kg: null }]);
+  });
+
+  it('k=0 → ningún bucket se nullea (todos count >= 0)', () => {
+    const buckets = [{ hora: 0, viajes: 0, co2e_kg: 0 }];
+    const result = aplicarKAnonymity(buckets, 0, 'viajes', { preserveFields: ['hora'] });
+    expect(result).toEqual([{ hora: 0, viajes: 0, co2e_kg: 0 }]);
+  });
+
+  it('array vacío retorna array vacío', () => {
+    expect(aplicarKAnonymity([], 5, 'viajes')).toEqual([]);
+  });
+
+  it('preserva no-numéricos (string, boolean, null) en buckets nulled', () => {
+    const buckets = [
+      { slug: 'puerto-x', viajes: 3, co2e_kg: 50, es_activo: true, comentario: null },
+    ];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes');
+    expect(result).toEqual([
+      { slug: 'puerto-x', viajes: null, co2e_kg: null, es_activo: true, comentario: null },
+    ]);
+  });
+
+  it('mix: invariante por bucket — algunos preservados, otros nulled', () => {
+    const buckets = [
+      { hora: 8, viajes: 10, co2e_kg: 200 },
+      { hora: 9, viajes: 3, co2e_kg: 60 },
+      { hora: 10, viajes: 7, co2e_kg: 140 },
+    ];
+    const result = aplicarKAnonymity(buckets, 5, 'viajes', { preserveFields: ['hora'] });
+    expect(result[0]).toEqual({ hora: 8, viajes: 10, co2e_kg: 200 });
+    expect(result[1]).toEqual({ hora: 9, viajes: null, co2e_kg: null });
+    expect(result[2]).toEqual({ hora: 10, viajes: 7, co2e_kg: 140 });
+  });
+
+  it('no muta el input array ni sus buckets', () => {
+    const original = [{ hora: 9, viajes: 4, co2e_kg: 90 }];
+    const snapshot = JSON.parse(JSON.stringify(original));
+    aplicarKAnonymity(original, 5, 'viajes', { preserveFields: ['hora'] });
+    expect(original).toEqual(snapshot);
+  });
+});

--- a/packages/shared-schemas/src/aggregations/k-anonymity.ts
+++ b/packages/shared-schemas/src/aggregations/k-anonymity.ts
@@ -1,0 +1,50 @@
+/**
+ * @booster-ai/shared-schemas — k-anonymity invariant (D11 / ADR-041).
+ *
+ * Helper puro: dada una lista de buckets de agregación, reemplaza los
+ * campos métricos (numéricos) de cada bucket cuyo `countField` sea < k
+ * por `null`. Las dimensiones (campos no-numéricos o numéricos listados
+ * en `preserveFields`) se mantienen para que la UI muestre "Sin data
+ * suficiente" en la celda correcta — sin perder la identidad del bucket.
+ *
+ * Devuelve un array nuevo — no muta el input. Pensado para correr
+ * server-side antes de serializar la respuesta del endpoint.
+ */
+
+/**
+ * Misma forma que `T` pero campos numéricos posiblemente `null` runtime.
+ */
+export type KAnonymized<T> = {
+  [K in keyof T]: T[K] extends number ? T[K] | null : T[K];
+};
+
+export interface KAnonymityOptions<T> {
+  /**
+   * Campos numéricos que son dimensiones (e.g. `hora` 0..23) — se
+   * preservan aún cuando count < k. Default: ninguno; todos los campos
+   * numéricos se nullean.
+   */
+  preserveFields?: ReadonlyArray<keyof T>;
+}
+
+export function aplicarKAnonymity<T extends Record<string, unknown>>(
+  buckets: readonly T[],
+  k: number,
+  countField: keyof T,
+  options: KAnonymityOptions<T> = {},
+): KAnonymized<T>[] {
+  const preserve = new Set<keyof T>(options.preserveFields ?? []);
+  return buckets.map((bucket) => {
+    const count = bucket[countField];
+    if (typeof count !== 'number' || count >= k) {
+      return { ...bucket } as KAnonymized<T>;
+    }
+    const masked: Record<string, unknown> = { ...bucket };
+    for (const key of Object.keys(masked)) {
+      if (!preserve.has(key as keyof T) && typeof masked[key] === 'number') {
+        masked[key] = null;
+      }
+    }
+    return masked as KAnonymized<T>;
+  });
+}

--- a/packages/shared-schemas/src/all-schemas.test.ts
+++ b/packages/shared-schemas/src/all-schemas.test.ts
@@ -28,6 +28,7 @@ import * as tripMetrics from './domain/trip-metrics.js';
 import * as trip from './domain/trip.js';
 import * as user from './domain/user.js';
 import * as vehicle from './domain/vehicle.js';
+import * as zonaStakeholder from './domain/zona-stakeholder.js';
 import * as zone from './domain/zone.js';
 import * as telemetryEvents from './events/telemetry-events.js';
 import * as tripEvents from './events/trip-events.js';
@@ -372,6 +373,7 @@ describe('domain modules — importables sin errores (schemas executados al impo
     trip,
     user,
     vehicle,
+    'zona-stakeholder': zonaStakeholder,
     zone,
   };
   for (const [name, mod] of Object.entries(modules)) {
@@ -387,6 +389,45 @@ describe('events', () => {
   });
   it('trip-events exports', () => {
     expect(Object.keys(tripEvents).length).toBeGreaterThan(0);
+  });
+});
+
+describe('zonaStakeholderSchema (bbox refine — D11/ADR-041)', () => {
+  const baseZona = {
+    id: VALID_UUID,
+    slug: 'puerto-valparaiso',
+    nombre: 'Puerto Valparaíso',
+    region_code: 'CL-VS',
+    tipo: 'puerto' as const,
+    lat_min: -33.0501,
+    lat_max: -33.025,
+    lng_min: -71.65,
+    lng_max: -71.61,
+    is_active: true,
+    creado_en: VALID_DATE,
+    actualizado_en: VALID_DATE,
+  };
+
+  it('acepta bounding box bien formado', () => {
+    expect(() => zonaStakeholder.zonaStakeholderSchema.parse(baseZona)).not.toThrow();
+  });
+
+  it('rechaza bbox invertido en latitud (lat_min > lat_max)', () => {
+    expect(() =>
+      zonaStakeholder.zonaStakeholderSchema.parse({ ...baseZona, lat_min: -33.0, lat_max: -33.1 }),
+    ).toThrow(/lat_min debe ser estrictamente menor que lat_max/);
+  });
+
+  it('rechaza bbox invertido en longitud (lng_min > lng_max)', () => {
+    expect(() =>
+      zonaStakeholder.zonaStakeholderSchema.parse({ ...baseZona, lng_min: -71.5, lng_max: -71.7 }),
+    ).toThrow(/lng_min debe ser estrictamente menor que lng_max/);
+  });
+
+  it('rechaza slug con mayúsculas o espacios (cubre criterio "inválido")', () => {
+    expect(() =>
+      zonaStakeholder.zonaStakeholderSchema.parse({ ...baseZona, slug: 'Puerto Valparaíso' }),
+    ).toThrow();
   });
 });
 

--- a/packages/shared-schemas/src/domain/zona-stakeholder.ts
+++ b/packages/shared-schemas/src/domain/zona-stakeholder.ts
@@ -1,0 +1,50 @@
+import { z } from 'zod';
+
+/**
+ * @booster-ai/shared-schemas — Zona stakeholder (D11 / ADR-041).
+ *
+ * Geografía curada para agregaciones del rol `stakeholder_sostenibilidad`.
+ * Bounding box rectangular axis-aligned (lat/lng WGS84). Slug estable
+ * referenciado por la UI. Proceso "nueva zona" en ADR-041.
+ */
+
+/** Tipo de zona — sincronizar con pgEnum `tipo_zona_stakeholder`. */
+export const zonaStakeholderTipoSchema = z.enum([
+  'puerto',
+  'mercado_abastos',
+  'polo_industrial',
+  'zona_franca',
+]);
+export type ZonaStakeholderTipo = z.infer<typeof zonaStakeholderTipoSchema>;
+
+export const zonaStakeholderSlugSchema = z
+  .string()
+  .min(2)
+  .max(60)
+  .regex(/^[a-z0-9-]+$/, 'Slug en minúsculas, dígitos y guiones (e.g. puerto-valparaiso)');
+
+/** Refine garantiza bbox bien formado — evita seeds que producen result set vacío silencioso. */
+export const zonaStakeholderSchema = z
+  .object({
+    id: z.string().uuid(),
+    slug: zonaStakeholderSlugSchema,
+    nombre: z.string().min(3).max(120),
+    region_code: z.string().regex(/^CL-[A-Z]{2,3}$/, 'Código ISO 3166-2:CL inválido (e.g. CL-VS)'),
+    tipo: zonaStakeholderTipoSchema,
+    lat_min: z.number().gte(-90).lte(90),
+    lat_max: z.number().gte(-90).lte(90),
+    lng_min: z.number().gte(-180).lte(180),
+    lng_max: z.number().gte(-180).lte(180),
+    is_active: z.boolean(),
+    creado_en: z.string().datetime(),
+    actualizado_en: z.string().datetime(),
+  })
+  .refine((z) => z.lat_min < z.lat_max, {
+    message: 'lat_min debe ser estrictamente menor que lat_max',
+    path: ['lat_min'],
+  })
+  .refine((z) => z.lng_min < z.lng_max, {
+    message: 'lng_min debe ser estrictamente menor que lng_max',
+    path: ['lng_min'],
+  });
+export type ZonaStakeholder = z.infer<typeof zonaStakeholderSchema>;

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -17,6 +17,7 @@ export * from './domain/empresa.js';
 export * from './domain/plan.js';
 export * from './domain/membership.js';
 export * from './domain/zone.js';
+export * from './domain/zona-stakeholder.js';
 export * from './domain/offer.js';
 export * from './domain/assignment.js';
 export * from './domain/trip-event.js';

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -59,3 +59,6 @@ export * from './avl-ids/index.js';
 
 // Site Settings — configuración runtime editable de marca y copy (ADR-039)
 export * from './site-settings.js';
+
+// Aggregations — privacy invariants compartidos backend/frontend (D11/ADR-041)
+export * from './aggregations/k-anonymity.js';


### PR DESCRIPTION
## T5 — D11 Stakeholder geo aggregations

Closes T5 of [`docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md`](docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md). Stacked on [#249 (T4)](https://github.com/boosterchile/booster-ai/pull/249).

## Summary
- `apps/api/src/services/stakeholder-aggregations.ts` — helpers puros, sin acceso DB.
- `horaEnChile(ts)` — usa `Intl.DateTimeFormat` con `America/Santiago` (DST-aware).
- `resolveCo2e(viaje, logger?)` — prioridad actual → estimated → null + warn (spec criterio 7).
- `agregarPorHoraDelDia(viajes, logger?)` — 24 buckets siempre, vacíos con 0 (UI predecible).
- `calcularHorarioPico(viajes)` — ventana 4h consecutivas con más pickups; null si <5; empate → más temprana.

## Waiver LOC
159 LOC (vs threshold goal 150). Costo realista de:
- Boilerplate `Intl.DateTimeFormat` (~10 LOC)
- Cadena de fallback CO₂e (criterio 7, ~12 LOC)
- `useBlockStatements` enforcement de Biome (+9 LOC braces obligatorios)

Sin scope creep — exact minimum para los 2 helpers + criterios 7 y 8.

## Evidencia
- `pnpm --filter api test stakeholder-aggregations` → 7 passed
- `pnpm --filter api typecheck` → clean
- `pnpm biome check` → 0 errors

## Cooling-off
NO merge automático — review humano con cooling-off 30 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)