### PR TITLE
feat(api): stakeholder-aggregations tipo carga + combustible

### DIFF
--- a/apps/api/src/services/stakeholder-aggregations.ts
+++ b/apps/api/src/services/stakeholder-aggregations.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@booster-ai/logger';
+import type { CargoType, FuelType } from '@booster-ai/shared-schemas';
 
 /** Helpers puros para endpoints /stakeholder/zonas — D11/ADR-041. Timezone CL. */
 const HORA_FMT = new Intl.DateTimeFormat('en-US', {
@@ -9,6 +10,8 @@ const HORA_FMT = new Intl.DateTimeFormat('en-US', {
 
 export interface ViajeAgregable {
   pickup_at: Date;
+  tipo_carga: CargoType;
+  fuel_type: FuelType;
   carbon_emissions_kgco2e_actual: number | null;
   carbon_emissions_kgco2e_estimated: number | null;
 }
@@ -20,6 +23,16 @@ export interface BucketHora {
 export interface HorarioPico {
   inicio: number;
   fin: number;
+}
+export interface BucketTipoCarga {
+  tipo: CargoType;
+  viajes: number;
+  co2e_kg: number;
+}
+export interface BucketCombustible {
+  fuel_type: FuelType;
+  viajes: number;
+  co2e_kg: number;
 }
 
 /** Hora 0..23 en America/Santiago para un timestamp UTC. */
@@ -88,4 +101,48 @@ export function calcularHorarioPico(viajes: readonly ViajeAgregable[]): HorarioP
     }
   }
   return { inicio, fin: inicio + 3 };
+}
+
+/** Helper genérico de agrupación: bucketea por una key callback y suma CO2e. */
+function agruparPorClave<K extends string>(
+  viajes: readonly ViajeAgregable[],
+  key: (v: ViajeAgregable) => K,
+  logger?: Logger,
+): { clave: K; viajes: number; co2e_kg: number }[] {
+  const acc = new Map<K, { viajes: number; co2e_kg: number }>();
+  for (const v of viajes) {
+    const k = key(v);
+    const bucket = acc.get(k) ?? { viajes: 0, co2e_kg: 0 };
+    bucket.viajes += 1;
+    const c = resolveCo2e(v, logger);
+    if (c != null) {
+      bucket.co2e_kg += c;
+    }
+    acc.set(k, bucket);
+  }
+  return Array.from(acc.entries()).map(([clave, b]) => ({ clave, ...b }));
+}
+
+/** Bucketea por tipo de carga. Sólo aparecen tipos con ≥1 viaje. */
+export function agregarPorTipoCarga(
+  viajes: readonly ViajeAgregable[],
+  logger?: Logger,
+): BucketTipoCarga[] {
+  return agruparPorClave(viajes, (v) => v.tipo_carga, logger).map((b) => ({
+    tipo: b.clave,
+    viajes: b.viajes,
+    co2e_kg: b.co2e_kg,
+  }));
+}
+
+/** Bucketea por combustible del vehículo. Sólo aparecen tipos con ≥1 viaje. */
+export function agregarPorCombustible(
+  viajes: readonly ViajeAgregable[],
+  logger?: Logger,
+): BucketCombustible[] {
+  return agruparPorClave(viajes, (v) => v.fuel_type, logger).map((b) => ({
+    fuel_type: b.clave,
+    viajes: b.viajes,
+    co2e_kg: b.co2e_kg,
+  }));
 }

--- a/apps/api/test/unit/stakeholder-aggregations.test.ts
+++ b/apps/api/test/unit/stakeholder-aggregations.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   type ViajeAgregable,
+  agregarPorCombustible,
   agregarPorHoraDelDia,
+  agregarPorTipoCarga,
   calcularHorarioPico,
 } from '../../src/services/stakeholder-aggregations.js';
 
-const mk = (iso: string, actual?: number | null, estimated?: number | null): ViajeAgregable => ({
+const mk = (
+  iso: string,
+  actual?: number | null,
+  estimated?: number | null,
+  tipo_carga: ViajeAgregable['tipo_carga'] = 'carga_seca',
+  fuel_type: ViajeAgregable['fuel_type'] = 'diesel',
+): ViajeAgregable => ({
   pickup_at: new Date(iso),
+  tipo_carga,
+  fuel_type,
   carbon_emissions_kgco2e_actual: actual ?? null,
   carbon_emissions_kgco2e_estimated: estimated ?? null,
 });
@@ -64,5 +74,51 @@ describe('calcularHorarioPico', () => {
       ...repeat(2, () => mk('2026-05-17T02:00:00Z')),
     ];
     expect(calcularHorarioPico(viajes)).toEqual({ inicio: 5, fin: 8 });
+  });
+});
+
+describe('agregarPorTipoCarga', () => {
+  it('vacío → []', () => {
+    expect(agregarPorTipoCarga([])).toEqual([]);
+  });
+  it('suma CO2e por tipo; fallback estimated y warn cuando ambos null', () => {
+    const warn = vi.fn();
+    const logger = { warn, error: vi.fn(), info: vi.fn(), debug: vi.fn() } as never;
+    const viajes = [
+      mk('2026-05-17T12:00:00Z', 100, null, 'carga_seca'),
+      mk('2026-05-17T12:00:00Z', null, 50, 'carga_seca'),
+      mk('2026-05-17T12:00:00Z', null, null, 'carga_seca'), // warn, no suma
+      mk('2026-05-17T12:00:00Z', 200, null, 'refrigerada'),
+    ];
+    const r = agregarPorTipoCarga(viajes, logger);
+    const seca = r.find((b) => b.tipo === 'carga_seca');
+    const refr = r.find((b) => b.tipo === 'refrigerada');
+    expect(seca).toEqual({ tipo: 'carga_seca', viajes: 3, co2e_kg: 150 });
+    expect(refr).toEqual({ tipo: 'refrigerada', viajes: 1, co2e_kg: 200 });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('agregarPorCombustible', () => {
+  it('vacío → []', () => {
+    expect(agregarPorCombustible([])).toEqual([]);
+  });
+  it('agrupa por fuel_type', () => {
+    const viajes = [
+      mk('2026-05-17T12:00:00Z', 100, null, 'carga_seca', 'diesel'),
+      mk('2026-05-17T12:00:00Z', 80, null, 'carga_seca', 'diesel'),
+      mk('2026-05-17T12:00:00Z', 0, null, 'carga_seca', 'electrico'),
+    ];
+    const r = agregarPorCombustible(viajes);
+    expect(r.find((b) => b.fuel_type === 'diesel')).toEqual({
+      fuel_type: 'diesel',
+      viajes: 2,
+      co2e_kg: 180,
+    });
+    expect(r.find((b) => b.fuel_type === 'electrico')).toEqual({
+      fuel_type: 'electrico',
+      viajes: 1,
+      co2e_kg: 0,
+    });
   });
 });

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -95,7 +95,7 @@
   - Tests: cero viajes, exactamente k, k+1, distribución bimodal.
 - **Rollback**: revertir commit (helpers no expuestos por endpoint todavía).
 
-### T6: Aggregations helpers — tipo carga + combustible
+### T6: Aggregations helpers — tipo carga + combustible [DONE 2026-05-17 — PR #251]
 
 - **Files**: `apps/api/src/services/stakeholder-aggregations.ts` (extender), `apps/api/test/unit/stakeholder-aggregations.test.ts` (extender)
 - **LOC estimate**: ~80


### PR DESCRIPTION
## T6 — D11 Stakeholder geo aggregations

Closes T6 of [`docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md`](docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md).
Stacked on [#250 (T5)](https://github.com/boosterchile/booster-ai/pull/250).

## Summary
- `agregarPorTipoCarga(viajes, logger?)` — bucket por `CargoType` con CO₂e fallback chain.
- `agregarPorCombustible(viajes, logger?)` — bucket por `FuelType`.
- Helper interno `agruparPorClave<K>` para DRY entre los dos.
- `ViajeAgregable` extendida con `tipo_carga + fuel_type` (importados de shared-schemas — single source of truth).
- 4 tests nuevos (vacío, suma con fallback, warn ambos null, agrupación múltiple).

## Evidencia
- `pnpm --filter api test stakeholder-aggregations` → 11 passed
- `pnpm --filter api typecheck` → clean
- `pnpm biome check` → 0 errors
- 114 LOC (bajo threshold 150)

## Cooling-off
NO merge automático — review humano con cooling-off 30 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)