### PR TITLE
feat(api): puntoEnBoundingBox helper

### DIFF
--- a/apps/api/src/services/stakeholder-aggregations.ts
+++ b/apps/api/src/services/stakeholder-aggregations.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@booster-ai/logger';
-import type { CargoType, FuelType } from '@booster-ai/shared-schemas';
+import type { CargoType, FuelType, ZonaStakeholder } from '@booster-ai/shared-schemas';
 
 /** Helpers puros para endpoints /stakeholder/zonas — D11/ADR-041. Timezone CL. */
 const HORA_FMT = new Intl.DateTimeFormat('en-US', {
@@ -145,4 +145,24 @@ export function agregarPorCombustible(
     viajes: b.viajes,
     co2e_kg: b.co2e_kg,
   }));
+}
+
+/**
+ * True si el punto cae dentro del bbox de la zona (inclusivo en todos los
+ * bordes). Defensive: false si la zona tiene bbox invertido (la migration
+ * lo previene con CHECK constraint pero el helper no asume).
+ */
+export function puntoEnBoundingBox(
+  point: { lat: number; lng: number },
+  zona: Pick<ZonaStakeholder, 'lat_min' | 'lat_max' | 'lng_min' | 'lng_max'>,
+): boolean {
+  if (zona.lat_min >= zona.lat_max || zona.lng_min >= zona.lng_max) {
+    return false;
+  }
+  return (
+    point.lat >= zona.lat_min &&
+    point.lat <= zona.lat_max &&
+    point.lng >= zona.lng_min &&
+    point.lng <= zona.lng_max
+  );
 }

--- a/apps/api/test/unit/stakeholder-aggregations.test.ts
+++ b/apps/api/test/unit/stakeholder-aggregations.test.ts
@@ -5,6 +5,7 @@ import {
   agregarPorHoraDelDia,
   agregarPorTipoCarga,
   calcularHorarioPico,
+  puntoEnBoundingBox,
 } from '../../src/services/stakeholder-aggregations.js';
 
 const mk = (
@@ -96,6 +97,29 @@ describe('agregarPorTipoCarga', () => {
     expect(seca).toEqual({ tipo: 'carga_seca', viajes: 3, co2e_kg: 150 });
     expect(refr).toEqual({ tipo: 'refrigerada', viajes: 1, co2e_kg: 200 });
     expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe('puntoEnBoundingBox', () => {
+  // Bbox Puerto Valparaíso (mismo que migration 0034).
+  const zona = { lat_min: -33.0501, lat_max: -33.0252, lng_min: -71.645, lng_max: -71.61 };
+
+  it('dentro del bbox → true', () => {
+    expect(puntoEnBoundingBox({ lat: -33.04, lng: -71.62 }, zona)).toBe(true);
+  });
+  it('fuera del bbox (lat menor que lat_min) → false', () => {
+    expect(puntoEnBoundingBox({ lat: -33.1, lng: -71.62 }, zona)).toBe(false);
+  });
+  it('en el borde lat=lat_min y lng=lng_max → true (inclusivo)', () => {
+    expect(puntoEnBoundingBox({ lat: -33.0501, lng: -71.61 }, zona)).toBe(true);
+  });
+  it('bbox invertido (defensive) → false', () => {
+    expect(
+      puntoEnBoundingBox(
+        { lat: -33.04, lng: -71.62 },
+        { lat_min: -33.0, lat_max: -33.1, lng_min: -71.6, lng_max: -71.7 },
+      ),
+    ).toBe(false);
   });
 });
 

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -106,7 +106,7 @@
   - Tests: fallback CO₂e `actual` → `estimated` → skip + warning log.
 - **Rollback**: revertir commit.
 
-### T7: `puntoEnBoundingBox` helper
+### T7: `puntoEnBoundingBox` helper [DONE 2026-05-17 — PR #252]
 
 - **Files**: `apps/api/src/services/stakeholder-aggregations.ts` (extender), `apps/api/test/unit/stakeholder-aggregations.test.ts` (extender)
 - **LOC estimate**: ~50


### PR DESCRIPTION
## T7 — D11 Stakeholder geo aggregations

Closes T7 of [`docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md`](docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md).
Stacked on [#251 (T6)](https://github.com/boosterchile/booster-ai/pull/251).

## Summary
- `puntoEnBoundingBox(point, zona)` retorna `boolean` — inclusivo en bordes.
- Defensive: si `lat_min >= lat_max` o `lng_min >= lng_max`, retorna `false` (CHECK constraint DB previene, helper no asume).
- Acepta `Pick<ZonaStakeholder, 'lat_min'|'lat_max'|'lng_min'|'lng_max'>` para no acoplar al schema completo.
- 4 tests: dentro, fuera, borde inclusivo, bbox invertido.

## Evidencia
- `pnpm --filter api test stakeholder-aggregations` → 15 passed
- `pnpm --filter api typecheck` → clean
- 45 LOC

## Cooling-off
NO merge automático — review humano con cooling-off 30 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)