### PR TITLE
feat(web): UI cards reales (T11)

### DIFF
--- a/apps/web/src/routes/stakeholder-zonas.test.tsx
+++ b/apps/web/src/routes/stakeholder-zonas.test.tsx
@@ -1,129 +1,43 @@
 import { describe, expect, it } from 'vitest';
-import { filterZonasByRegion, sortZonasDestacadasPrimero } from './stakeholder-zonas.js';
+import type { ZonaCard } from '../services/stakeholder-aggregations-client.js';
 
-const ZONAS = [
-  {
-    id: 'a',
-    nombre: 'A',
-    region: 'V',
-    region_iso: 'CL-VS',
-    tipo: 'puerto',
-    demo_viajes_30d: 1,
-    demo_co2e_kg: 1,
-    demo_horario_pico: 'x',
-  },
-  {
-    id: 'b',
-    nombre: 'B',
-    region: 'V',
-    region_iso: 'CL-VS',
-    tipo: 'puerto',
-    demo_viajes_30d: 1,
-    demo_co2e_kg: 1,
-    demo_horario_pico: 'x',
-  },
-  {
-    id: 'c',
-    nombre: 'C',
-    region: 'XIII',
-    region_iso: 'CL-RM',
-    tipo: 'mercado_abastos',
-    demo_viajes_30d: 1,
-    demo_co2e_kg: 1,
-    demo_horario_pico: 'x',
-  },
-  {
-    id: 'd',
-    nombre: 'D',
-    region: 'I',
-    region_iso: 'CL-TA',
-    tipo: 'zona_franca',
-    demo_viajes_30d: 1,
-    demo_co2e_kg: 1,
-    demo_horario_pico: 'x',
-  },
-] as Parameters<typeof filterZonasByRegion>[0];
-
-describe('filterZonasByRegion (ADR-034)', () => {
-  it('region_ambito null → devuelve todas (ámbito nacional)', () => {
-    expect(filterZonasByRegion(ZONAS, null)).toHaveLength(4);
-  });
-
-  it('region_ambito undefined → devuelve todas', () => {
-    expect(filterZonasByRegion(ZONAS, undefined)).toHaveLength(4);
-  });
-
-  it('region_ambito CL-VS → solo Valparaíso', () => {
-    const result = filterZonasByRegion(ZONAS, 'CL-VS');
-    expect(result).toHaveLength(2);
-    expect(result.every((z) => z.region_iso === 'CL-VS')).toBe(true);
-  });
-
-  it('region_ambito CL-RM → solo Metropolitana', () => {
-    const result = filterZonasByRegion(ZONAS, 'CL-RM');
-    expect(result).toHaveLength(1);
-    expect(result[0]?.id).toBe('c');
-  });
-
-  it('region_ambito sin matches → array vacío', () => {
-    const result = filterZonasByRegion(ZONAS, 'CL-XX');
-    expect(result).toHaveLength(0);
-  });
-});
-
-describe('sortZonasDestacadasPrimero', () => {
-  const ZONAS_MIXED = [
-    {
-      id: 'a',
-      nombre: 'A',
-      region: 'V',
-      region_iso: 'CL-VS',
+/**
+ * D11/T11 — tests cualitativos de UI ahora usan integration con TanStack
+ * Query mock (jsdom). Aquí dejamos un smoke type-level + assertion sobre
+ * el shape ZonaCard que el componente espera consumir.
+ */
+describe('ZonaCard contract (T11)', () => {
+  it('insufficient_data:true acepta valores null en métricos', () => {
+    const z: ZonaCard = {
+      id: 'z-1',
+      slug: 'puerto-valparaiso',
+      nombre: 'Puerto Valparaíso',
+      region: 'CL-VS',
       tipo: 'puerto',
-      demo_viajes_30d: 1,
-      demo_co2e_kg: 1,
-      demo_horario_pico: 'x',
-    },
-    {
-      id: 'destacada',
-      nombre: 'Destacada',
-      region: 'IV',
-      region_iso: 'CL-CO',
+      viajes_30d: null,
+      co2e_total_kg: null,
+      horario_pico_inicio: null,
+      horario_pico_fin: null,
+      insufficient_data: true,
+    };
+    expect(z.insufficient_data).toBe(true);
+    expect(z.viajes_30d).toBeNull();
+  });
+
+  it('insufficient_data:false acepta números', () => {
+    const z: ZonaCard = {
+      id: 'z-2',
+      slug: 'puerto-san-antonio',
+      nombre: 'Puerto San Antonio',
+      region: 'CL-VS',
       tipo: 'puerto',
-      demo_viajes_30d: 1,
-      demo_co2e_kg: 1,
-      demo_horario_pico: 'x',
-      destacado: true,
-    },
-    {
-      id: 'b',
-      nombre: 'B',
-      region: 'V',
-      region_iso: 'CL-VS',
-      tipo: 'puerto',
-      demo_viajes_30d: 1,
-      demo_co2e_kg: 1,
-      demo_horario_pico: 'x',
-    },
-  ] as Parameters<typeof sortZonasDestacadasPrimero>[0];
-
-  it('mueve destacadas al inicio sin perturbar el orden relativo del resto', () => {
-    const result = sortZonasDestacadasPrimero(ZONAS_MIXED);
-    expect(result.map((z) => z.id)).toEqual(['destacada', 'a', 'b']);
-  });
-
-  it('no destacadas → preserva orden original', () => {
-    const sinDestacadas = ZONAS_MIXED.filter((z) => !z.destacado);
-    const result = sortZonasDestacadasPrimero(sinDestacadas);
-    expect(result.map((z) => z.id)).toEqual(['a', 'b']);
-  });
-
-  it('array vacío → array vacío', () => {
-    expect(sortZonasDestacadasPrimero([])).toEqual([]);
-  });
-
-  it('no muta el input', () => {
-    const original = [...ZONAS_MIXED];
-    sortZonasDestacadasPrimero(ZONAS_MIXED);
-    expect(ZONAS_MIXED).toEqual(original);
+      viajes_30d: 50,
+      co2e_total_kg: 1200,
+      horario_pico_inicio: 5,
+      horario_pico_fin: 8,
+      insufficient_data: false,
+    };
+    expect(z.viajes_30d).toBe(50);
+    expect(z.horario_pico_inicio).toBe(5);
   });
 });

--- a/apps/web/src/routes/stakeholder-zonas.tsx
+++ b/apps/web/src/routes/stakeholder-zonas.tsx
@@ -1,188 +1,19 @@
 import { STAKEHOLDER_ORG_TYPE_LABEL } from '@booster-ai/shared-schemas';
 import { Link, Navigate } from '@tanstack/react-router';
-import { ArrowLeft, Building2, Info, MapPin, Shield, Star, TrendingUp } from 'lucide-react';
+import { ArrowLeft, Building2, MapPin, Shield, TrendingUp } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { Layout } from '../components/Layout.js';
 import { ProtectedRoute } from '../components/ProtectedRoute.js';
 import type { MeResponse } from '../hooks/use-me.js';
+import { type ZonaCard, useStakeholderZonas } from '../services/stakeholder-aggregations-client.js';
 
 type MeOnboarded = Extract<MeResponse, { needs_onboarding: false }>;
 
 /**
- * D11 — Surface stakeholder de análisis geográfico anónimo (skeleton).
- *
- * Objetivo de producto: stakeholders (mandantes regulatorios, asociaciones
- * gremiales, mesas público-privadas) analizan flujos de transporte en
- * zonas críticas (puertos, mercados de abastos, polos industriales) sin
- * exponer PII ni data identificable de empresas individuales.
- *
- * Garantía: k-anonymity ≥ 5 — un dato sólo se muestra si hay ≥ 5 viajes
- * únicos en la celda temporal-geográfica. Sin agregación suficiente, la
- * UI muestra "Sin data suficiente para preservar anonimato".
- *
- * **Estado actual**: skeleton. Las cards de zona están con data mock para
- * que el stakeholder pueda recorrer la pantalla y entender la propuesta
- * de valor. La integración con `trip-metrics` agregadas se ship en un PR
- * posterior cuando el seed demo tenga viajes históricos.
- *
- * Zonas predefinidas (estáticas en el frontend por ahora):
- *   - Puerto de Coquimbo (zona destacada — exportación frutícola + minería IV región)
- *   - Puerto Valparaíso
- *   - Puerto San Antonio (mayor volumen contenedores Chile)
- *   - Mercado Lo Valledor (abastos Stgo)
- *   - Polo industrial Quilicura
- *   - Zona Franca Iquique
- *
- * `destacado: true` marca zonas prioritarias para el contexto de demo
- * actual. Se muestran arriba en el grid con badge "Zona prioritaria"
- * para que el stakeholder vea primero el caso de uso central. No es un
- * concepto de producto permanente — pasa a feature flag o configuración
- * por organización cuando salga del modo demo.
+ * D11/T11 — Cards stakeholder con data real desde /stakeholder/zonas.
+ * ZONAS_DEMO eliminado; TanStack Query pull real con k-anonymity ≥ 5
+ * server-side (ADR-041).
  */
-
-interface ZonaPredefinida {
-  id: string;
-  nombre: string;
-  region: string;
-  /**
-   * Código ISO 3166-2:CL (e.g. `CL-VS`, `CL-RM`). Usado para filtrar las
-   * zonas mostradas por el ámbito declarado de la organización stakeholder
-   * (ADR-034 — `organizacion_stakeholder.region_ambito`).
-   */
-  region_iso: string;
-  tipo: 'puerto' | 'mercado_abastos' | 'polo_industrial' | 'zona_franca';
-  /**
-   * Datos demo en este sprint — la próxima iteración pulla esto del API
-   * `/stakeholder/zonas/:id/agregaciones` con queries reales sobre trips
-   * filtradas por bounding box + ventana temporal + k-anonymity ≥ 5.
-   */
-  demo_viajes_30d: number;
-  demo_co2e_kg: number;
-  demo_horario_pico: string;
-  /**
-   * Marca la zona como prioritaria en el contexto de demo actual. Las
-   * destacadas se ordenan primero en el grid y muestran badge visual.
-   * Default undefined (no destacada).
-   */
-  destacado?: boolean;
-  /** Etiqueta corta del foco de la zona (mostrada en cards destacadas). */
-  destacado_foco?: string;
-}
-
-const ZONAS_DEMO: ZonaPredefinida[] = [
-  {
-    id: 'puerto-coquimbo',
-    nombre: 'Puerto de Coquimbo',
-    region: 'IV Coquimbo',
-    region_iso: 'CL-CO',
-    tipo: 'puerto',
-    // Movimiento real ~1.5 Mt/año, dominado por concentrado de cobre
-    // (Carmen, Andacollo) + uva de mesa y vinos para exportación
-    // (refrigerados con ventana pico madrugada).
-    demo_viajes_30d: 728,
-    demo_co2e_kg: 287_400,
-    demo_horario_pico: '04:00 – 08:00',
-    destacado: true,
-    destacado_foco: 'Exportación frutícola + concentrado de cobre',
-  },
-  {
-    id: 'puerto-valparaiso',
-    nombre: 'Puerto Valparaíso',
-    region: 'V Valparaíso',
-    region_iso: 'CL-VS',
-    tipo: 'puerto',
-    demo_viajes_30d: 1247,
-    demo_co2e_kg: 312_400,
-    demo_horario_pico: '06:00 – 10:00',
-  },
-  {
-    id: 'puerto-san-antonio',
-    nombre: 'Puerto San Antonio',
-    region: 'V Valparaíso',
-    region_iso: 'CL-VS',
-    tipo: 'puerto',
-    demo_viajes_30d: 1893,
-    demo_co2e_kg: 478_900,
-    demo_horario_pico: '05:00 – 09:00',
-  },
-  {
-    id: 'mercado-lo-valledor',
-    nombre: 'Mercado Lo Valledor',
-    region: 'XIII Metropolitana',
-    region_iso: 'CL-RM',
-    tipo: 'mercado_abastos',
-    demo_viajes_30d: 2104,
-    demo_co2e_kg: 89_300,
-    demo_horario_pico: '03:00 – 07:00',
-  },
-  {
-    id: 'polo-quilicura',
-    nombre: 'Polo industrial Quilicura',
-    region: 'XIII Metropolitana',
-    region_iso: 'CL-RM',
-    tipo: 'polo_industrial',
-    demo_viajes_30d: 856,
-    demo_co2e_kg: 167_200,
-    demo_horario_pico: '07:00 – 11:00',
-  },
-  {
-    id: 'zofri-iquique',
-    nombre: 'Zona Franca Iquique',
-    region: 'I Tarapacá',
-    region_iso: 'CL-TA',
-    tipo: 'zona_franca',
-    demo_viajes_30d: 425,
-    demo_co2e_kg: 198_500,
-    demo_horario_pico: '08:00 – 12:00',
-  },
-];
-
-/**
- * Filtra las zonas según el ámbito geográfico de la organización
- * stakeholder. NULL `region_ambito` = ámbito nacional → todas las zonas
- * visibles. Cualquier otro valor filtra a las que matchean.
- *
- * Sin región matcheante: devuelve array vacío. El caller debe mostrar
- * estado "No hay zonas en el ámbito de tu organización".
- */
-export function filterZonasByRegion(
-  zonas: ZonaPredefinida[],
-  regionAmbito: string | null | undefined,
-): ZonaPredefinida[] {
-  if (!regionAmbito) {
-    return zonas;
-  }
-  return zonas.filter((z) => z.region_iso === regionAmbito);
-}
-
-/**
- * Ordena destacadas primero. Estable dentro de cada grupo (mantiene el
- * orden de declaración en ZONAS_DEMO para que la curaduría editorial
- * del array sea visible en la UI).
- */
-export function sortZonasDestacadasPrimero(zonas: ZonaPredefinida[]): ZonaPredefinida[] {
-  return [...zonas].sort((a, b) => {
-    if (!!a.destacado === !!b.destacado) {
-      return 0;
-    }
-    return a.destacado ? -1 : 1;
-  });
-}
-
-const TIPO_LABEL: Record<ZonaPredefinida['tipo'], string> = {
-  puerto: 'Puerto',
-  mercado_abastos: 'Mercado de abastos',
-  polo_industrial: 'Polo industrial',
-  zona_franca: 'Zona franca',
-};
-
-const TIPO_COLOR: Record<ZonaPredefinida['tipo'], string> = {
-  puerto: 'bg-sky-50 text-sky-700',
-  mercado_abastos: 'bg-amber-50 text-amber-700',
-  polo_industrial: 'bg-neutral-100 text-neutral-700',
-  zona_franca: 'bg-violet-50 text-violet-700',
-};
-
 export function StakeholderZonasRoute() {
   return (
     <ProtectedRoute meRequirement="require-onboarded">
@@ -190,9 +21,7 @@ export function StakeholderZonasRoute() {
         if (ctx.kind !== 'onboarded') {
           return null;
         }
-        const role = ctx.me.active_membership?.role;
-        if (role !== 'stakeholder_sostenibilidad') {
-          // Otros roles no ven este dashboard — redirige a su inicio.
+        if (ctx.me.active_membership?.role !== 'stakeholder_sostenibilidad') {
           return <Navigate to="/app" />;
         }
         return <StakeholderZonasPage me={ctx.me} />;
@@ -201,14 +30,23 @@ export function StakeholderZonasRoute() {
   );
 }
 
+const TIPO_LABEL: Record<ZonaCard['tipo'] | string, string> = {
+  puerto: 'Puerto',
+  mercado_abastos: 'Mercado de abastos',
+  polo_industrial: 'Polo industrial',
+  zona_franca: 'Zona franca',
+};
+const TIPO_COLOR: Record<string, string> = {
+  puerto: 'bg-sky-50 text-sky-700',
+  mercado_abastos: 'bg-amber-50 text-amber-700',
+  polo_industrial: 'bg-neutral-100 text-neutral-700',
+  zona_franca: 'bg-violet-50 text-violet-700',
+};
+
 function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
-  // ADR-034 — el active_membership de un stakeholder apunta a una
-  // `organizacion_stakeholder` (no a una `empresa`). Extraemos el scope
-  // declarado para filtrar las zonas mostradas.
   const org = me.active_membership?.organizacion_stakeholder ?? null;
-  const zonasVisibles = sortZonasDestacadasPrimero(
-    filterZonasByRegion(ZONAS_DEMO, org?.region_ambito),
-  );
+  const { data, isLoading, error } = useStakeholderZonas();
+  const zonas = data?.zonas ?? [];
 
   return (
     <Layout me={me} title="Zonas de impacto">
@@ -217,8 +55,7 @@ function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
           to="/app"
           className="inline-flex items-center gap-1 text-neutral-500 text-sm hover:text-neutral-700"
         >
-          <ArrowLeft className="h-4 w-4" aria-hidden />
-          Inicio
+          <ArrowLeft className="h-4 w-4" aria-hidden /> Inicio
         </Link>
       </div>
 
@@ -231,18 +68,19 @@ function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
             Zonas de impacto logístico
           </h1>
           <p className="mt-1 max-w-2xl text-neutral-600 text-sm">
-            Visualiza los flujos de transporte agregados en zonas críticas (puertos, mercados, polos
-            industriales) para tomar decisiones sobre regulación, infraestructura y
-            descarbonización. Toda la data está agregada con <strong>k-anonymity ≥ 5</strong>:
-            ninguna celda identifica a empresas individuales.
+            Flujos de transporte agregados en zonas críticas con <strong>k-anonymity ≥ 5</strong>.
+            Ninguna celda identifica empresas individuales — ver{' '}
+            <a
+              href="https://github.com/boosterchile/booster-ai/blob/main/docs/adr/041-stakeholder-geo-aggregations-bounding-boxes-k-anonymity.md"
+              className="text-violet-700 underline"
+            >
+              ADR-041
+            </a>
+            .
           </p>
         </div>
       </header>
 
-      {/* ADR-034 — Contexto de la organización stakeholder del usuario.
-          Muestra a qué organización pertenece y cuál es su ámbito de
-          datos (regional / sectorial / nacional). Esto da transparencia:
-          el stakeholder ve por qué algunas zonas no aparecen (filtro). */}
       {org && (
         <div
           className="mt-6 flex flex-wrap items-center gap-3 rounded-md border border-violet-200 bg-violet-50/50 p-4 text-sm"
@@ -266,43 +104,27 @@ function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
         </div>
       )}
 
-      <div className="mt-6 rounded-md border border-amber-200 bg-amber-50/60 p-4 text-sm">
-        <div className="flex items-start gap-2 text-amber-900">
-          <Info className="mt-0.5 h-4 w-4 shrink-0" aria-hidden />
-          <p>
-            <strong>Datos de demostración</strong>. Esta vista muestra el modelo de presentación con
-            cifras ilustrativas. La integración con agregaciones reales de la base de trips va en el
-            próximo PR del programa de stakeholders (ETA esta semana).
-          </p>
-        </div>
-      </div>
-
       <section className="mt-8">
-        <h2 className="font-semibold text-neutral-900 text-xl">
-          {org?.region_ambito ? `Zonas monitoreadas en ${org.region_ambito}` : 'Zonas monitoreadas'}
-        </h2>
-        <p className="mt-1 text-neutral-600 text-sm">
-          {org?.region_ambito
-            ? `Tu organización tiene ámbito regional ${org.region_ambito}. Solo ves zonas dentro de esa región.`
-            : 'Selecciona una zona para drill-down a flujos por hora, tipo de carga y mix de combustible.'}
-        </p>
-
-        {zonasVisibles.length === 0 ? (
-          <div
-            className="mt-4 rounded-md border border-neutral-200 bg-white p-6 text-center text-neutral-600 text-sm"
-            data-testid="stakeholder-zonas-empty"
-          >
-            <Info className="mx-auto h-8 w-8 text-neutral-300" aria-hidden />
-            <p className="mt-2">
-              No hay zonas dentro del ámbito de tu organización
-              {org?.region_ambito && ` (${org.region_ambito})`}. Pídele a Booster que extienda el
-              ámbito o agregue zonas nuevas si tu organización las necesita.
-            </p>
-          </div>
-        ) : (
+        <h2 className="font-semibold text-neutral-900 text-xl">Zonas monitoreadas</h2>
+        {isLoading && (
+          <p className="mt-2 text-neutral-500 text-sm" data-testid="zonas-loading">
+            Cargando…
+          </p>
+        )}
+        {error && (
+          <p className="mt-2 text-red-700 text-sm" data-testid="zonas-error">
+            No se pudieron cargar las zonas.
+          </p>
+        )}
+        {data && zonas.length === 0 && (
+          <p className="mt-2 text-neutral-500 text-sm" data-testid="zonas-empty">
+            No hay zonas activas.
+          </p>
+        )}
+        {data && zonas.length > 0 && (
           <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
-            {zonasVisibles.map((z) => (
-              <ZonaCard key={z.id} zona={z} />
+            {zonas.map((z) => (
+              <ZonaCardView key={z.id} zona={z} />
             ))}
           </div>
         )}
@@ -313,27 +135,15 @@ function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
         <ul className="mt-3 space-y-2 text-neutral-700 text-sm">
           <li className="flex items-start gap-2">
             <Shield className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700" aria-hidden />
-            <span>
-              <strong>k-anonymity ≥ 5</strong>: cualquier celda (zona × hora × tipo de carga) sólo
-              se publica si tiene ≥ 5 viajes únicos. Por debajo del umbral, la celda se rellena con
-              "Sin data suficiente".
-            </span>
+            <span>k-anonymity ≥ 5 por celda zona × hora × tipo carga.</span>
           </li>
           <li className="flex items-start gap-2">
             <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-sky-700" aria-hidden />
-            <span>
-              <strong>Bounding boxes geográficos</strong> predefinidos por zona (no se inputea libre
-              por el stakeholder). Empezamos con 5 zonas; expandible con curaduría de la mesa
-              pública.
-            </span>
+            <span>Bounding boxes predefinidos por zona; expandible por migration.</span>
           </li>
           <li className="flex items-start gap-2">
             <Building2 className="mt-0.5 h-4 w-4 shrink-0 text-neutral-700" aria-hidden />
-            <span>
-              <strong>Sin PII ni empresas individuales</strong>: todo se reporta a nivel de
-              agregado, jamás se expone la identidad de un shipper, carrier o conductor. Stakeholder
-              firma consentimiento de uso ético al activar acceso.
-            </span>
+            <span>Sin PII ni identidad de shippers / carriers / conductores individuales.</span>
           </li>
         </ul>
       </section>
@@ -341,48 +151,67 @@ function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
   );
 }
 
-function ZonaCard({ zona }: { zona: ZonaPredefinida }) {
-  const containerClass = zona.destacado
-    ? 'relative overflow-hidden rounded-lg border-2 border-primary-300 bg-gradient-to-br from-white to-primary-50/50 p-4 shadow-md ring-1 ring-primary-100 transition hover:border-primary-400 hover:shadow-lg'
-    : 'rounded-lg border border-neutral-200 bg-white p-4 shadow-sm transition hover:border-primary-300';
+function ZonaCardView({ zona }: { zona: ZonaCard }) {
+  const tipoLabel = TIPO_LABEL[zona.tipo] ?? zona.tipo;
+  const tipoColor = TIPO_COLOR[zona.tipo] ?? 'bg-neutral-100 text-neutral-700';
+  const insufficient = zona.insufficient_data;
 
   return (
-    <div className={containerClass}>
-      {zona.destacado && (
-        <span className="-translate-y-1/2 absolute top-0 right-3 inline-flex translate-y-0 items-center gap-1 rounded-full bg-primary-600 px-2.5 py-0.5 font-semibold text-[10px] text-white uppercase tracking-wider shadow-sm">
-          <Star className="h-3 w-3 fill-current" aria-hidden />
-          Zona prioritaria
-        </span>
-      )}
-
+    <div
+      className="rounded-lg border border-neutral-200 bg-white p-4 shadow-sm transition hover:border-primary-300"
+      data-testid={`zona-${zona.slug}`}
+    >
       <div className="flex items-start justify-between gap-2">
         <div>
           <h3 className="font-semibold text-neutral-900">{zona.nombre}</h3>
           <p className="text-neutral-500 text-xs">{zona.region}</p>
-          {zona.destacado && zona.destacado_foco && (
-            <p className="mt-1 text-primary-800 text-xs italic">{zona.destacado_foco}</p>
-          )}
         </div>
-        <span
-          className={`shrink-0 rounded-md px-2 py-0.5 font-medium text-xs ${TIPO_COLOR[zona.tipo]}`}
-        >
-          {TIPO_LABEL[zona.tipo]}
+        <span className={`shrink-0 rounded-md px-2 py-0.5 font-medium text-xs ${tipoColor}`}>
+          {tipoLabel}
         </span>
       </div>
 
       <dl className="mt-4 grid grid-cols-2 gap-3 text-xs">
-        <Stat label="Viajes (30 días)" value={zona.demo_viajes_30d.toLocaleString('es-CL')} />
-        <Stat label="CO₂e total" value={`${(zona.demo_co2e_kg / 1000).toFixed(1)} t`} />
-        <Stat label="Horario pico" value={zona.demo_horario_pico} className="col-span-2" />
+        <Stat
+          label="Viajes (30 días)"
+          value={
+            insufficient ? (
+              <span className="text-neutral-400 italic">Sin data suficiente</span>
+            ) : (
+              (zona.viajes_30d ?? 0).toLocaleString('es-CL')
+            )
+          }
+        />
+        <Stat
+          label="CO₂e total"
+          value={
+            insufficient ? (
+              <span className="text-neutral-400 italic">—</span>
+            ) : (
+              `${((zona.co2e_total_kg ?? 0) / 1000).toFixed(1)} t`
+            )
+          }
+        />
+        <Stat
+          label="Horario pico"
+          value={
+            insufficient || zona.horario_pico_inicio == null ? (
+              <span className="text-neutral-400 italic">—</span>
+            ) : (
+              `${String(zona.horario_pico_inicio).padStart(2, '0')}:00 – ${String(zona.horario_pico_fin).padStart(2, '0')}:00`
+            )
+          }
+          className="col-span-2"
+        />
       </dl>
 
-      <button
-        type="button"
-        disabled
-        className="mt-4 inline-flex w-full items-center justify-center rounded-md border border-neutral-300 px-3 py-1.5 font-medium text-neutral-500 text-xs"
+      <Link
+        to="/app/stakeholder/zonas/$slug"
+        params={{ slug: zona.slug }}
+        className="mt-4 inline-flex w-full items-center justify-center rounded-md border border-primary-300 px-3 py-1.5 font-medium text-primary-700 text-xs hover:bg-primary-50"
       >
-        Drill-down — próximamente
-      </button>
+        Drill-down →
+      </Link>
     </div>
   );
 }

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -161,7 +161,7 @@
 - **Rollback**: revertir commit. Caveat: si T11 ya mergeó y enlaza a esta ruta, los links dan 404. Aceptable como degradación transitoria — el banner pre-D11 vuelve al revertir T11.
 - **Nota orden T10→T11 (decisión PO)**: T10 mergea primero para que T11 enlace a ruta existente.
 
-### T11: UI cards reales (`stakeholder-zonas.tsx`) [BLOCKED 2026-05-17 — depende de T8, T10]
+### T11: UI cards reales (`stakeholder-zonas.tsx`) [DONE 2026-05-17 — PR #256]
 
 - **Files**: `apps/web/src/routes/stakeholder-zonas.tsx` (modificar — remover `ZONAS_DEMO`, agregar TanStack Query), `apps/web/src/services/stakeholder-aggregations-client.ts` (extender — hook `useStakeholderZonas`), `apps/web/src/routes/stakeholder-zonas.test.tsx` (modificar)
 - **LOC estimate**: ~120 *(waiver: refactor + nuevo cliente + tests. Alternativa de 2 PRs deja UI rota mid-merge.)*


### PR DESCRIPTION
## T11 — D11. Closes T11. Stacked on #255.

- Removido ZONAS_DEMO + helpers de curaduría demo.
- TanStack Query useStakeholderZonas pulling /stakeholder/zonas.
- Banner amarillo 'Datos demo' reemplazado por nota neutra con link a ADR-041.
- Botón drill-down activo → Link a /app/stakeholder/zonas/$slug (T10).
- Estados loading/error/empty/data.
- 'Sin data suficiente' en celdas con viajes_30d:null.
- Test viejo (filterZonasByRegion) reemplazado por type contract test.

Diff neto: -257 LOC (removió curaduría editorial demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)