### PR TITLE
docs(handoff,plan): D11 review formal post-BUILD — plan v1 BLOCKED

### DIFF
--- a/docs/handoff/2026-05-17-d11-review-plan.md
+++ b/docs/handoff/2026-05-17-d11-review-plan.md
@@ -1,0 +1,58 @@
+# Plan de review — D11 BUILD (12 PRs)
+
+**Fecha**: 2026-05-17
+**Origen**: cierre del `/goal` BUILD D11 (49m, 12/12 tasks DONE, ~$5-10 USD). 12 PRs stacked sin merge, esperando review formal.
+**Owner**: Felipe Vicencio (PO)
+**Artefacto previo**: [`docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md`](../plans/2026-05-17-d11-stakeholder-geo-aggregations.md)
+
+## Hallazgos críticos a verificar en review
+
+1. **Migration 0035 NO planificada**: el `/goal` resolvió el gap T8 agregando `origen_lat` + `origen_lng` nullable a `viajes` sin aprobación PO explícita. El abort trigger se activó pero "se levantó" sin supervisión humana. ⚠️ Reviewar como decisión arquitectónica retroactiva, no como simple addition.
+2. **LOC waivers excedidos 2-3×**: plan tenía waivers ~120 LOC. Reales: T8=316, T11=534 churn, T9=155, T10=228, T5=159. **Atomicity violation**. Reviewar si el code es atómico funcionalmente aunque exceda LOC; si no, requerir split.
+3. **Stop hook error "Prompt is too long"** apareció dos veces en /goal de 49m — el evaluador no pudo procesar el cierre. No bloqueante pero síntoma de saturación de contexto.
+
+## Cooling-off
+
+Todos los PRs fueron creados hoy entre ~01:00 y ~03:00 UTC. A las **04:00 UTC** ya están todos con ≥30 min, cooling-off agent-rigor §6.1 cumplido por default.
+
+## Orden de review (no es dependency-order — es risk-order)
+
+| # | PR | Task | Sub-agentes obligatorios | Por qué este orden |
+|---|---|---|---|---|
+| 1 | [#246](https://github.com/boosterchile/booster-ai/pull/246) | T1 — ADR-041 | code-reviewer + devils-advocate | Locks decisions arquitectónicas. Si el ADR es cuestionable, todo downstream queda en duda. Doc-only, review barato (~10 min). |
+| 2 | [#253](https://github.com/boosterchile/booster-ai/pull/253) | T8 — endpoint cards + **migration 0035 no planificada** | code-reviewer + devils-advocate + **security-auditor** | Mayor riesgo del set. Schema change inline + endpoint con auth + 316 LOC. Si falla review, cascada a T9-T12. ~45-60 min. |
+| 3 | [#247](https://github.com/boosterchile/booster-ai/pull/247) | T2 — Zod + Drizzle table | code-reviewer + devils-advocate | Locks schema shape; mechanical pero foundational. ~20 min. |
+| 4 | [#248](https://github.com/boosterchile/booster-ai/pull/248) | T3 — migration 0034 + seed | code-reviewer + devils-advocate | Schema change (planificado). Validar bbox de las 5 zonas seed contra OSM. ~25 min. |
+| 5 | [#249](https://github.com/boosterchile/booster-ai/pull/249) | T4 — k-anonymity helper | code-reviewer + **security-auditor** | Privacy-critical pure function. Tests deben cubrir todos los edge cases del spec. ~20 min. |
+| 6 | [#250](https://github.com/boosterchile/booster-ai/pull/250) | T5 — hora del día + horario pico | code-reviewer | Helpers de agregación. ~15 min. |
+| 7 | [#251](https://github.com/boosterchile/booster-ai/pull/251) | T6 — tipo carga + combustible | code-reviewer | Más helpers + fallback CO₂e. ~15 min. |
+| 8 | [#252](https://github.com/boosterchile/booster-ai/pull/252) | T7 — puntoEnBoundingBox | code-reviewer | Helper geométrico simple. Edge cases bbox invertido. ~10 min. |
+| 9 | [#254](https://github.com/boosterchile/booster-ai/pull/254) | T9 — endpoint drill-down | code-reviewer + devils-advocate + **security-auditor** | Segundo endpoint con auth + k-anonymity per cell. Depende de #253 OK. ~45 min. |
+| 10 | [#255](https://github.com/boosterchile/booster-ai/pull/255) | T10 — UI drill-down route | code-reviewer + **ux-designer** | UI surface. Validar checklist pre-entrega (a11y, contraste, responsive). ~30 min. |
+| 11 | [#256](https://github.com/boosterchile/booster-ai/pull/256) | T11 — UI cards reales | code-reviewer + **ux-designer** | 534 LOC churn (delete ZONAS_DEMO + add hooks). Validar que estados loading/error/sin-data renderizan. ~40 min. |
+| 12 | [#257](https://github.com/boosterchile/booster-ai/pull/257) | T12 — perf gate + índice | code-reviewer | Perf test placeholder. ~15 min. |
+
+**Total estimado**: ~5-6 horas de review humana + sub-agentes, distribuible en 2-3 sesiones con cooling-off entre PRs si emergen issues.
+
+## Disposition criteria por PR
+
+Cada review termina en uno de tres estados:
+
+- **MERGE** — sub-agentes sin objeciones bloqueantes, acceptance de la task cumplido, tests verdes. Mergear via `gh pr merge <n> --squash --delete-branch` (NO auto, NO async — verificar a ojo el merge commit en main).
+- **REQUEST CHANGES** — issues encontrados que el agente puede arreglar. Comentar en el PR + permitir al agente (en sesión nueva) corregir. Re-review tras fix.
+- **ESCALATE / SPLIT** — para PRs con LOC waiver excesivo donde el split retroactivo es viable. Cerrar el PR, dividir en 2-3 PRs más chicos. Aplica especialmente a #253 (T8=316), #256 (T11=534 churn).
+
+## Lo que NO se hace en este plan
+
+- **No re-invoke `/goal`** — review es REVIEW phase, no BUILD. /goal es para autonomía mecánica, /review requiere judgment humano. Per mi propio runbook `docs/runbooks/goal-templates.md`: "/review (cooling-off + devils-advocate)" no encaja en /goal.
+- **No batched** — el usuario pidió uno por uno para precisión. Batched perdería resolución en hallazgos por PR.
+- **No merge antes de revisar TODO** — si #253 (T8) requiere split, los PRs downstream (T9-T11) probablemente también necesiten ajuste antes de merge.
+
+## Después del último review
+
+Cuando los 12 PRs estén MERGED o cerrados:
+
+1. Actualizar `docs/handoff/CURRENT.md` (Plan 1 v2 del runbook).
+2. Smoke test en staging con `stakeholder@boosterchile.com` (criterio out-of-band del plan).
+3. Cerrar la feature D11 oficialmente — pasa de "in flight" a "shipped" en CURRENT.md.
+4. Capturar lessons-learned para refinar Plan 5 (BUILD): el inline migration sin sign-off del PO es un anti-patrón a documentar.

--- a/docs/handoff/CURRENT.md
+++ b/docs/handoff/CURRENT.md
@@ -1,6 +1,6 @@
 # Estado actual del proyecto — Booster AI
 
-**Última actualización**: 2026-05-17 02:25 UTC (post #242 + #243 — runbook tweaks anti-loop)
+**Última actualización**: 2026-05-17 ~06:00 UTC (post D11 BUILD review formal — 12 PRs revisados, 1 mergeado, plan v1 BLOCKED, pivote Opción 2)
 **Documento vivo**: este archivo refleja el estado en `main` al momento de la última actualización. Para snapshots históricos ver `docs/handoff/YYYY-MM-DD-*.md`.
 **Plan de referencia**: [`docs/plans/2026-05-12-identidad-universal-y-dashboard-conductor.md`](../plans/2026-05-12-identidad-universal-y-dashboard-conductor.md)
 
@@ -60,9 +60,33 @@ Sesión nocturna dedicada a cobertura de tests por package + housekeeping.
 
 ---
 
-## (b) PRs abiertos — 0
+## (b) PRs abiertos — 9 (D11 BUILD review formal)
 
-**Repo cerrado** a 2026-05-17 01:20 UTC. Próximo trabajo arranca con `/spec` (nueva feature) o `/plan` D11.
+D11 BUILD ejecutado autónomamente vía `/goal` el 2026-05-17 (12 tasks DONE, ~$5-10 USD). Review formal con sub-agentes (`code-reviewer`, `devils-advocate`, `security-auditor`, `ux-designer`) reveló **bugs CRITICAL de privacy + violación de contrato agent-rigor + LOC waivers excedidos 2-3×**. Plan v1 BLOCKED, pivote a Opción 2 (`originComunaCode` mapping).
+
+| PR | Task | Status |
+|---|---|---|
+| [#246](https://github.com/boosterchile/booster-ai/pull/246) | T1 ADR-041 | SUPERSEDE — pendiente ADR-042 |
+| [#247](https://github.com/boosterchile/booster-ai/pull/247) | T2 Zod+Drizzle | REQUEST_CHANGES — `numeric` ↔ `z.number()` mismatch |
+| [#249](https://github.com/boosterchile/booster-ai/pull/249) | T4 k-anonymity | REQUEST_FIX privacy CRITICAL |
+| [#250](https://github.com/boosterchile/booster-ai/pull/250) | T5 hora+pico | REQUEST_CHANGES naming + k-anon |
+| [#251](https://github.com/boosterchile/booster-ai/pull/251) | T6 tipo+combustible | MERGE post-T5 fix |
+| [#252](https://github.com/boosterchile/booster-ai/pull/252) | T7 puntoEnBoundingBox | REQUEST_CHANGES NaN |
+| [#253](https://github.com/boosterchile/booster-ai/pull/253) | T8 abort doc | OPEN — reset a abort-doc-only (`7b2a18e`) |
+| [#255](https://github.com/boosterchile/booster-ai/pull/255) | T10 UI drill-down | REQUEST_CHANGES blocked-by-T9-v2 |
+| [#256](https://github.com/boosterchile/booster-ai/pull/256) | T11 UI cards | REQUEST_CHANGES + SPLIT blocked-by-T8-v2 |
+| [#257](https://github.com/boosterchile/booster-ai/pull/257) | T12 perf | REVERT_DONE_MARK — test tautológico |
+
+**Cerrados sin merge**: #254 (T9, REJECT — privacy bugs heredados).
+
+**Mergeado**: #248 (T3 migration zonas_stakeholder + seed, commit `2843e69`).
+
+**Hallazgos sistémicos**:
+1. Helper k-anonymity (#249) tiene 1 CRITICAL (quasi-identifier strings leak) + 3 HIGH. Es el ÚNICO control técnico privacy → prioridad #1.
+2. Schema drift `domain/` ↔ `db/`: `domain/trip.ts` tiene state values en inglés (`delivered`, etc.); `db/schema.ts` divergió a español (`entregado`). ADR-042 resolverá.
+3. "DONE" sin evidencia: T8 marcado DONE auto-resolviendo abort, T12 marcado DONE con test placeholder tautológico.
+
+**Trazabilidad**: [`docs/handoff/2026-05-17-d11-review-plan.md`](2026-05-17-d11-review-plan.md) + comments en GitHub por PR.
 
 ---
 

--- a/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md
@@ -4,9 +4,32 @@
 - **Owner**: Felipe Vicencio (PO) + Claude
 - **Creado**: 2026-05-17
 - **Revisado**: 2026-05-17 post devils-advocate (12 objeciones, 4 fuertes resueltas)
-- **Status**: Active
-- **ADR a producir en T1**: ADR-041 (`041-stakeholder-geo-aggregations-bounding-boxes-k-anonymity.md`)
-- **Migration a producir en T3**: `0034_zonas_stakeholder.sql`
+- **Re-revisado**: 2026-05-17 post BUILD review formal de 12 PRs — **plan v1 obsoleto, pivote a Opción 2**
+- **Status**: **BLOCKED — pivote Opción 2 en curso, ver plan v2 (próximo)**
+
+## Status post-review (2026-05-17 ~06:00 UTC)
+
+| Task | PR | Status |
+|---|---|---|
+| T1 ADR-041 | [#246](https://github.com/boosterchile/booster-ai/pull/246) | **SUPERSEDE** — pendiente ADR-042 |
+| T2 Zod+Drizzle | [#247](https://github.com/boosterchile/booster-ai/pull/247) | REQUEST_CHANGES — `numeric` ↔ `z.number()` mismatch |
+| T3 Migration 0034 + seed | [#248](https://github.com/boosterchile/booster-ai/pull/248) | ✅ **MERGED** `2843e69` |
+| T4 k-anonymity helper | [#249](https://github.com/boosterchile/booster-ai/pull/249) | REQUEST_FIX privacy — 1 CRITICAL + 3 HIGH |
+| T5 hora+pico | [#250](https://github.com/boosterchile/booster-ai/pull/250) | REQUEST_CHANGES — `pickup_at` no existe |
+| T6 tipo+combustible | [#251](https://github.com/boosterchile/booster-ai/pull/251) | MERGE post-T5 fix |
+| T7 puntoEnBoundingBox | [#252](https://github.com/boosterchile/booster-ai/pull/252) | REQUEST_CHANGES NaN — y posiblemente obsoleto post-Opción 2 |
+| **T8 endpoint cards** | [#253](https://github.com/boosterchile/booster-ai/pull/253) | ❌ **REJECT** — reset a abort-doc-only (`7b2a18e`) |
+| **T9 endpoint drill-down** | #254 | ❌ **CLOSED** post-REJECT |
+| T10 UI drill-down | [#255](https://github.com/boosterchile/booster-ai/pull/255) | REQUEST_CHANGES — bloqueado por T9 v2 |
+| T11 UI cards | [#256](https://github.com/boosterchile/booster-ai/pull/256) | REQUEST_CHANGES + SPLIT — bloqueado por T8 v2 |
+| T12 perf gate | [#257](https://github.com/boosterchile/booster-ai/pull/257) | **REVERT_DONE_MARK** — test placeholder tautológico |
+
+**Pivote a Opción 2** (decisión PO post-review): filtro por `originComunaCode` mapeado a zona en vez de bounding box geográfico. ADR-042 supersedes parcial ADR-041. Schema/domain drift se resuelve en mismo ADR.
+
+**Hallazgo sistémico**: el plan v1 asumió un schema (`cargo_request.origin.geocode`, `state IN ('delivered'...)`) que no coincide con `db/schema.ts`. El domain canónico en `packages/shared-schemas/src/domain/trip.ts` sí tenía el shape de la spec; el drift estaba entre domain y db. Se resuelve en ADR-042.
+
+- **ADR producido en T1 (v1)**: ADR-041 (`041-stakeholder-geo-aggregations-bounding-boxes-k-anonymity.md`) — pendiente SUPERSEDE
+- **Migration producida en T3 (v1)**: `0034_zonas_stakeholder.sql` ✅ en main
 
 **Convención de path**: este plan vive en `docs/plans/` (no `.specs/`) para consistencia con `docs/plans/2026-05-12-identidad-universal-y-dashboard-conductor.md`. Desviación deliberada del framework agent-rigor.
 


### PR DESCRIPTION
## Summary

Actualiza tracking docs tras el review formal de los 12 PRs del BUILD D11.

### Cambios

- `docs/handoff/CURRENT.md`: tabla de 9 PRs abiertos con status por PR, hallazgos sistémicos, pivote PO a Opción 2.
- `docs/plans/2026-05-17-d11-stakeholder-geo-aggregations.md`: status post-review por task, marca plan v1 como BLOCKED.
- `docs/handoff/2026-05-17-d11-review-plan.md` (nuevo): plan de review uno-por-uno + criterios disposition + lessons aplicadas.

### Próximos pasos

1. Fix #249 k-anonymity (privacy CRITICAL).
2. ADR-042 + fix #247/#250 (schema/domain alignment).
3. Plan D11 v2 + re-implementación T8-T12 con Opción 2.

Co-Authored-By: Claude Opus 4.7 (1M context)