### PR TITLE
fix(d11/t6): tipo carga + combustible + drop-sub-k wrapper (replaces #251)

### DIFF
--- a/apps/api/src/services/stakeholder-aggregations.ts
+++ b/apps/api/src/services/stakeholder-aggregations.ts
@@ -21,6 +21,22 @@ export interface ViajeAgregable {
   pickupWindowStart: Date;
   carbonEmissionsKgco2eActual: number | null;
   carbonEmissionsKgco2eEstimated: number | null;
+  /** Tipo de carga del cargo_request asociado (denormalizado al construir ViajeAgregable). */
+  tipoCarga: string;
+  /** fuel_type del vehículo asignado (denormalizado al construir ViajeAgregable). */
+  fuelType: string;
+}
+
+export interface BucketTipoCarga {
+  tipo: string;
+  viajes: number;
+  co2e_kg: number;
+}
+
+export interface BucketCombustible {
+  fuel_type: string;
+  viajes: number;
+  co2e_kg: number;
 }
 
 export interface BucketHora {
@@ -150,4 +166,77 @@ export function calcularHorarioPico(viajes: readonly ViajeAgregable[]): HorarioP
     return null;
   }
   return { inicio, fin: inicio + 3 };
+}
+
+/**
+ * Helper genérico de agrupación: bucketea por una key callback y suma CO2e.
+ *
+ * NOTA (decisión PO 2026-05-17, review #251): si `resolveCo2e()` retorna `null`,
+ * el viaje cuenta en `viajes` pero NO contribuye a `co2e_kg`. Esto refleja
+ * honestamente la cobertura del dato CO2e sin sub-reportar volumen.
+ */
+function agruparPorClave<K extends string>(
+  viajes: readonly ViajeAgregable[],
+  key: (v: ViajeAgregable) => K,
+  logger?: Logger,
+): { clave: K; viajes: number; co2e_kg: number }[] {
+  const acc = new Map<K, { viajes: number; co2e_kg: number }>();
+  for (const v of viajes) {
+    const k = key(v);
+    const bucket = acc.get(k) ?? { viajes: 0, co2e_kg: 0 };
+    bucket.viajes += 1;
+    const c = resolveCo2e(v, logger);
+    if (c != null) {
+      bucket.co2e_kg += c;
+    }
+    acc.set(k, bucket);
+  }
+  return Array.from(acc.entries()).map(([clave, b]) => ({ clave, ...b }));
+}
+
+/**
+ * Bucketea por tipo de carga. Sólo aparecen tipos con ≥1 viaje en el dataset.
+ * El caller debe aplicar k-anonymity con `aplicarKAnonymityQuasiId` antes de
+ * serializar — la presencia del bucket leak quasi-identifier (ADR-042 §6 nivel 3).
+ */
+export function agregarPorTipoCarga(
+  viajes: readonly ViajeAgregable[],
+  logger?: Logger,
+): BucketTipoCarga[] {
+  return agruparPorClave(viajes, (v) => v.tipoCarga, logger).map((b) => ({
+    tipo: b.clave,
+    viajes: b.viajes,
+    co2e_kg: b.co2e_kg,
+  }));
+}
+
+/**
+ * Bucketea por combustible del vehículo. Sólo aparecen tipos con ≥1 viaje.
+ * El caller debe aplicar k-anonymity con `aplicarKAnonymityQuasiId` antes de
+ * serializar — la presencia del bucket leak quasi-identifier (ADR-042 §6 nivel 3).
+ */
+export function agregarPorCombustible(
+  viajes: readonly ViajeAgregable[],
+  logger?: Logger,
+): BucketCombustible[] {
+  return agruparPorClave(viajes, (v) => v.fuelType, logger).map((b) => ({
+    fuel_type: b.clave,
+    viajes: b.viajes,
+    co2e_kg: b.co2e_kg,
+  }));
+}
+
+/**
+ * Wrapper k-anonymity para buckets cuya CLAVE de agrupación es un
+ * quasi-identifier (e.g. tipo_carga, fuel_type). Usa `dropSubKBuckets: true`
+ * para FILTRAR del output los buckets con count<k, en vez de enmascarar.
+ *
+ * Razón (ADR-042 §6 nivel 3): si zona tiene 7 viajes total y 2 son `gnv`, dejar
+ * `{fuel_type:'gnv', viajes:null}` revela "hay actividad GNV en esta zona" → re-id
+ * trivial si un solo shipper opera GNV. Suprimir el bucket entero protege.
+ */
+export function aplicarKAnonymityQuasiId<T extends { viajes: number }>(buckets: readonly T[]): T[] {
+  return aplicarKAnonymity(buckets as readonly (T & Record<string, unknown>)[], K_ANON, 'viajes', {
+    dropSubKBuckets: true,
+  }) as T[];
 }

--- a/apps/api/test/unit/stakeholder-aggregations.test.ts
+++ b/apps/api/test/unit/stakeholder-aggregations.test.ts
@@ -1,17 +1,39 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   type ViajeAgregable,
+  agregarPorCombustible,
   agregarPorHoraDelDia,
+  agregarPorTipoCarga,
   aplicarKAnonymityHorario,
+  aplicarKAnonymityQuasiId,
   calcularHorarioPico,
   resolveCo2e,
 } from '../../src/services/stakeholder-aggregations.js';
 
-const mk = (iso: string, actual?: number | null, estimated?: number | null): ViajeAgregable => ({
-  pickupWindowStart: new Date(iso),
-  carbonEmissionsKgco2eActual: actual ?? null,
-  carbonEmissionsKgco2eEstimated: estimated ?? null,
-});
+interface MkOptions {
+  actual?: number | null;
+  estimated?: number | null;
+  tipoCarga?: string;
+  fuelType?: string;
+}
+
+const mk = (
+  iso: string,
+  actualOrOpts?: number | null | MkOptions,
+  estimated?: number | null,
+): ViajeAgregable => {
+  const opts: MkOptions =
+    typeof actualOrOpts === 'object' && actualOrOpts !== null
+      ? actualOrOpts
+      : { actual: actualOrOpts, estimated };
+  return {
+    pickupWindowStart: new Date(iso),
+    carbonEmissionsKgco2eActual: opts.actual ?? null,
+    carbonEmissionsKgco2eEstimated: opts.estimated ?? null,
+    tipoCarga: opts.tipoCarga ?? 'carga_seca',
+    fuelType: opts.fuelType ?? 'diesel',
+  };
+};
 const repeat = (n: number, fn: () => ViajeAgregable) => Array.from({ length: n }, fn);
 
 describe('resolveCo2e', () => {
@@ -132,5 +154,92 @@ describe('calcularHorarioPico', () => {
     ];
     // Ventana 15..18 tiene 7 viajes (> 5). Gana sobre ventana 4..7 (5 viajes).
     expect(calcularHorarioPico(viajes)).toEqual({ inicio: 15, fin: 18 });
+  });
+});
+
+describe('agregarPorTipoCarga', () => {
+  it('agrupa por tipo y suma CO2e (CARGA_SECA + GNV)', () => {
+    const viajes = [
+      ...repeat(3, () => mk('2026-05-17T10:00:00Z', { actual: 100, tipoCarga: 'carga_seca' })),
+      ...repeat(2, () => mk('2026-05-17T10:00:00Z', { actual: 50, tipoCarga: 'refrigerada' })),
+    ];
+    const r = agregarPorTipoCarga(viajes);
+    expect(r.find((b) => b.tipo === 'carga_seca')).toEqual({
+      tipo: 'carga_seca',
+      viajes: 3,
+      co2e_kg: 300,
+    });
+    expect(r.find((b) => b.tipo === 'refrigerada')).toEqual({
+      tipo: 'refrigerada',
+      viajes: 2,
+      co2e_kg: 100,
+    });
+  });
+
+  it('viaje sin CO2e cuenta en viajes pero no en co2e_kg (decisión PO)', () => {
+    const warn = vi.fn();
+    const logger = { warn, error: vi.fn(), info: vi.fn(), debug: vi.fn() } as never;
+    const viajes = [
+      mk('2026-05-17T10:00:00Z', { actual: 100, tipoCarga: 'carga_seca' }),
+      mk('2026-05-17T10:00:00Z', { actual: null, estimated: null, tipoCarga: 'carga_seca' }),
+    ];
+    const r = agregarPorTipoCarga(viajes, logger);
+    expect(r[0]).toEqual({ tipo: 'carga_seca', viajes: 2, co2e_kg: 100 });
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
+  it('fallback actual → estimated', () => {
+    const viajes = [
+      mk('2026-05-17T10:00:00Z', { actual: null, estimated: 80, tipoCarga: 'carga_seca' }),
+    ];
+    expect(agregarPorTipoCarga(viajes)[0]?.co2e_kg).toBe(80);
+  });
+});
+
+describe('agregarPorCombustible', () => {
+  it('agrupa por fuel_type y suma CO2e (diesel + electrico)', () => {
+    const viajes = [
+      ...repeat(3, () => mk('2026-05-17T10:00:00Z', { actual: 100, fuelType: 'diesel' })),
+      ...repeat(2, () => mk('2026-05-17T10:00:00Z', { actual: 5, fuelType: 'electrico' })),
+    ];
+    const r = agregarPorCombustible(viajes);
+    expect(r.find((b) => b.fuel_type === 'diesel')).toEqual({
+      fuel_type: 'diesel',
+      viajes: 3,
+      co2e_kg: 300,
+    });
+    expect(r.find((b) => b.fuel_type === 'electrico')).toEqual({
+      fuel_type: 'electrico',
+      viajes: 2,
+      co2e_kg: 10,
+    });
+  });
+});
+
+describe('aplicarKAnonymityQuasiId (ADR-042 §6 nivel 3)', () => {
+  it('filtra (drop) buckets con count < k — preserva privacy de quasi-identifier', () => {
+    const buckets = [
+      { tipo: 'carga_seca', viajes: 6, co2e_kg: 600 },
+      { tipo: 'refrigerada', viajes: 3, co2e_kg: 150 }, // < k, debe DROP
+      { tipo: 'gnv', viajes: 1, co2e_kg: 30 }, // < k, debe DROP
+    ];
+    const r = aplicarKAnonymityQuasiId(buckets);
+    expect(r).toEqual([{ tipo: 'carga_seca', viajes: 6, co2e_kg: 600 }]);
+  });
+
+  it('todos buckets >= k → no filtra', () => {
+    const buckets = [
+      { fuel_type: 'diesel', viajes: 10, co2e_kg: 1000 },
+      { fuel_type: 'gnv', viajes: 5, co2e_kg: 200 },
+    ];
+    expect(aplicarKAnonymityQuasiId(buckets)).toEqual(buckets);
+  });
+
+  it('all sub-k → array vacío (zona sin tipos con suficientes viajes)', () => {
+    const buckets = [
+      { tipo: 'a', viajes: 2, co2e_kg: 20 },
+      { tipo: 'b', viajes: 3, co2e_kg: 30 },
+    ];
+    expect(aplicarKAnonymityQuasiId(buckets)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Replaces #251

#251 quedó stacked sobre \`feat/d11-t5-aggregations-hora\` (cerrada por merge de #263). Este PR es la continuación con base correcta = main + alineación ADR-042.

## Cambios

1. **\`ViajeAgregable\` extendido**: \`tipoCarga\` + \`fuelType\` (camelCase per ADR-042 §4).
2. **\`agregarPorTipoCarga\` + \`agregarPorCombustible\`**: copiados de #251 con naming alineado.
3. **🆕 \`aplicarKAnonymityQuasiId\`** — wrapper que usa \`dropSubKBuckets:true\` del helper #259. ADR-042 §6 nivel 3: SUPRIMIR buckets sub-k en vez de enmascarar (la clave del bucket es quasi-identifier).
4. **Docstring \`agruparPorClave\`**: aclara decisión PO — viaje sin CO2e cuenta en \`viajes\` pero no en \`co2e_kg\`.

## Test plan

- [x] \`pnpm --filter @booster-ai/api test -- --run test/unit/stakeholder-aggregations.test.ts\` → 22/22 passed.
- [x] \`pnpm --filter @booster-ai/api typecheck\` → 0 errors.

Co-Authored-By: Claude Opus 4.7 (1M context)