### PR TITLE
feat(api): T1 — infra de tests integration en apps/api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,11 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --passWithNoTests"
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "test:integration:lint": "node ./scripts/check-no-concurrent-in-integration.mjs",
+    "pretest:integration": "pnpm run test:integration:lint",
+    "test:integration": "vitest run --config vitest.integration.config.ts --passWithNoTests",
+    "test:all": "pnpm run test && pnpm run test:integration"
   },
   "dependencies": {
     "@booster-ai/carbon-calculator": "workspace:*",

--- a/apps/api/scripts/check-no-concurrent-in-integration.mjs
+++ b/apps/api/scripts/check-no-concurrent-in-integration.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Lint rule del plan §D3 (test-integration-infra-apps-api v2):
+ *   - Integration tests deben correr serialmente sobre un schema único.
+ *   - `test.concurrent`, `it.concurrent`, `describe.concurrent` rompen
+ *     ese contrato. Biome v1.9 no soporta `noRestrictedSyntax` para
+ *     method chains arbitrarios, así que este check vive como script
+ *     enganchado a `pretest:integration`.
+ *
+ * Falla con exit 1 si encuentra `\b(test|it|describe)\.concurrent\b` en
+ * cualquier archivo bajo `apps/api/test/integration/`.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TARGET_DIR = new URL('../test/integration', import.meta.url).pathname;
+const FORBIDDEN = /\b(test|it|describe)\.concurrent\b/;
+
+function walk(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return out;
+    }
+    throw err;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...walk(full));
+    } else if (/\.(test|spec)\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const offenders = [];
+for (const file of walk(TARGET_DIR)) {
+  const content = readFileSync(file, 'utf-8');
+  const lines = content.split('\n');
+  lines.forEach((line, idx) => {
+    if (FORBIDDEN.test(line)) {
+      offenders.push({ file, line: idx + 1, text: line.trim() });
+    }
+  });
+}
+
+if (offenders.length > 0) {
+  console.error('Integration tests no pueden usar .concurrent (plan §D3):');
+  for (const o of offenders) {
+    console.error(`  ${o.file}:${o.line}  ${o.text}`);
+  }
+  process.exit(1);
+}
+process.exit(0);

--- a/apps/api/test/helpers/test-db.ts
+++ b/apps/api/test/helpers/test-db.ts
@@ -1,0 +1,43 @@
+import { type NodePgDatabase, drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import * as schema from '../../src/db/schema.js';
+
+export type TestDb = NodePgDatabase<typeof schema>;
+
+export interface TestDbHandle {
+  db: TestDb;
+  pool: pg.Pool;
+  url: string;
+}
+
+/**
+ * Crea un pool de Postgres dedicado a integration tests apuntando a
+ * `TEST_DATABASE_URL` del environment. Rechaza si la URL parece apuntar
+ * a producción o staging — el script T0 estableció que el reset incluye
+ * `DROP SCHEMA public CASCADE` + `DROP SCHEMA drizzle CASCADE`, una operación
+ * irreversible si se ejecuta contra una BD real.
+ *
+ * Devuelve también `url` para diagnostics — los helpers de cleanup la
+ * usan para incluirla en mensajes de error.
+ */
+export function createTestDb(): TestDbHandle {
+  const url = process.env.TEST_DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      'TEST_DATABASE_URL no está definido. Exporta una conexión a Postgres local antes de correr tests integration. Ver apps/api/test/integration/README.md (T5b).',
+    );
+  }
+  if (/prod|staging/i.test(url)) {
+    throw new Error(
+      `TEST_DATABASE_URL parece apuntar a una BD compartida (prod/staging). Aborto. URL: ${url.replace(/:[^:@]*@/, ':***@')}`,
+    );
+  }
+
+  const pool = new pg.Pool({
+    connectionString: url,
+    max: 2,
+    connectionTimeoutMillis: 5_000,
+  });
+  const db = drizzle(pool, { schema });
+  return { db, pool, url };
+}

--- a/apps/api/test/integration/health-db.integration.test.ts
+++ b/apps/api/test/integration/health-db.integration.test.ts
@@ -1,0 +1,19 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { type TestDbHandle, createTestDb } from '../helpers/test-db.js';
+
+describe('integration: health-db', () => {
+  let handle: TestDbHandle;
+
+  beforeAll(() => {
+    handle = createTestDb();
+  });
+
+  afterAll(async () => {
+    await handle.pool.end();
+  });
+
+  test('Postgres responde a SELECT 1', async () => {
+    const result = await handle.pool.query<{ ok: number }>('SELECT 1 AS ok');
+    expect(result.rows).toEqual([{ ok: 1 }]);
+  });
+});

--- a/apps/api/test/setup.integration.ts
+++ b/apps/api/test/setup.integration.ts
@@ -1,0 +1,46 @@
+import { vi } from 'vitest';
+
+// ADR-038: mismo mock de google-auth-library que setup.ts para evitar que
+// importar módulos de prod (config, services/firebase) dispare
+// `new GoogleAuth()` real.
+vi.mock('google-auth-library', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('google-auth-library')>();
+  class MockGoogleAuth {
+    async getClient() {
+      return {
+        async getAccessToken() {
+          return { token: 'test-access-token' };
+        },
+      };
+    }
+  }
+  return { ...actual, GoogleAuth: MockGoogleAuth };
+});
+
+// Integration tests sí necesitan una BD real, así que NO stubeamos
+// DATABASE_URL ni TEST_DATABASE_URL — el helper `createTestDb` los lee
+// del shell y aborta si TEST_DATABASE_URL no está definido.
+//
+// El resto del env va con defaults inocuos para que `parseEnv` no haga
+// `process.exit(1)` al evaluar config en imports indirectos.
+process.env.NODE_ENV ??= 'test';
+process.env.SERVICE_NAME ??= 'booster-ai-api';
+process.env.SERVICE_VERSION ??= '0.0.0-test';
+process.env.LOG_LEVEL ??= 'error';
+process.env.GOOGLE_CLOUD_PROJECT ??= 'booster-ai-test';
+// DATABASE_URL placeholder para parseEnv — los tests integration no lo usan,
+// usan TEST_DATABASE_URL via createTestDb. Si algún import indirecto necesita
+// DATABASE_URL real, ese test debe sobreescribir process.env.DATABASE_URL
+// con TEST_DATABASE_URL en su propio beforeAll.
+process.env.DATABASE_URL ??= 'postgresql://test:test@localhost:5432/test';
+process.env.DATABASE_POOL_MAX ??= '5';
+process.env.DATABASE_CONNECT_TIMEOUT_MS ??= '5000';
+process.env.REDIS_HOST ??= 'localhost';
+process.env.REDIS_PORT ??= '6379';
+process.env.REDIS_TLS ??= 'false';
+process.env.CORS_ALLOWED_ORIGINS ??= 'http://localhost:5173';
+process.env.FIREBASE_PROJECT_ID ??= 'booster-ai-test';
+process.env.JWT_ISSUER ??= 'booster-ai';
+process.env.API_AUDIENCE ??= 'https://api.test.boosterchile.com';
+process.env.ALLOWED_CALLER_SA ??= 'test-caller@booster-ai-test.iam.gserviceaccount.com';
+process.env.BOOSTER_PLATFORM_ADMIN_EMAILS ??= 'dev@boosterchile.com';

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./test/setup.ts'],
     include: ['src/**/*.{test,spec}.ts', 'test/**/*.{test,spec}.ts'],
+    // Integration tests viven en su propia config (vitest.integration.config.ts)
+    // y se corren via `pnpm test:integration`. Excluirlos aquí evita que el
+    // default `pnpm test` intente correrlos sin TEST_DATABASE_URL.
+    exclude: ['node_modules/**', 'dist/**', 'test/integration/**'],
     // Bump default 5s → 15s. CI bajo coverage instrumentation tarda más
     // en cargar el module graph (transform 4-6s + import 27s observado).
     // Tests individuales son rápidos (<300ms localmente) pero el primer

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Config separada para tests integration. Corre con `pnpm test:integration`,
+ * no participa del `pnpm test` default (que cubre solo unit con BD stubbeada).
+ *
+ * Decisiones del plan v2 `2026-05-17-test-integration-infra-apps-api.md` §D2/D3:
+ *   - `pool: 'forks'` + `poolOptions.forks.singleFork: true` — un único worker
+ *     vitest para que las suites compartan globalSetup (que se introduce en
+ *     T1b) y no compitan por advisory locks de Drizzle.
+ *   - `sequence.concurrent: false` — refuerza serial; un test que use
+ *     `test.concurrent` rompería el aislamiento de la BD compartida.
+ *   - `include: ['test/integration/**']` — no toca `src/` ni `test/unit/`.
+ *   - `globalSetup` queda vacío en T1 (no hay migrations todavía); T1b lo
+ *     apunta a `test/integration/setup-global.ts`.
+ *
+ * Coverage stays out of this config — integration coverage se mide por
+ * separado si T6 lo requiere; por defecto los integration tests son
+ * "smoke" sobre paths reales, no apuntan a cubrir lógica.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    setupFiles: ['./test/setup.integration.ts'],
+    include: ['test/integration/**/*.{test,spec}.ts'],
+    // Vitest 4: poolOptions se movieron a top-level. `pool: 'forks'` +
+    // `forks.singleFork: true` garantiza un único worker para serializar
+    // el acceso a la BD compartida.
+    pool: 'forks',
+    forks: {
+      singleFork: true,
+    },
+    sequence: {
+      concurrent: false,
+    },
+    testTimeout: 30_000,
+  },
+});

--- a/docs/handoff/CURRENT.md
+++ b/docs/handoff/CURRENT.md
@@ -1,8 +1,20 @@
 # Estado actual del proyecto — Booster AI
 
-**Última actualización**: 2026-05-17 ~06:50 UTC (post D11 v2 plan + handoff fresco — 10 PRs mergeados post-restart, infra completa, T8-T12 v2 pendientes en sesión fresca)
+**Última actualización**: 2026-05-17 ~08:20 UTC (D11 v2 T8 abort → bloqueo formal T8-T12 pendiente test-integration-infra)
 **Documento vivo**: este archivo refleja el estado en `main` al momento de la última actualización. Para snapshots históricos ver `docs/handoff/YYYY-MM-DD-*.md`.
 **Plan de referencia**: [`docs/plans/2026-05-12-identidad-universal-y-dashboard-conductor.md`](../plans/2026-05-12-identidad-universal-y-dashboard-conductor.md)
+
+---
+
+## Bloqueo D11 v2 T8-T12 (2026-05-17)
+
+**Estado**: D11 v2 T8 fue implementado en branch `fix/d11-t8-stakeholder-zonas-endpoint` (HEAD `d88085f`, worktree `naughty-sinoussi-c8ddf8`) y **NO se mergeó**. Sesión de cierre descubrió que el test staged era unit con DB mockeada, no integration con DB real como exige plan v2 §192 y handoff lección #3. Auditoría reveló que `apps/api/test/integration/` no existe en el repo — no hay patrón ni helper de DB real en ninguna app.
+
+**Decisión PO**: bloquear T8-T12 hasta que exista infra de integration testing. Nueva spec [`docs/specs/2026-05-17-test-integration-infra-apps-api.md`](../specs/2026-05-17-test-integration-infra-apps-api.md) en Draft. Una vez implementada esa infra (con su propio ADR-043), re-abrir T8 contra el patrón real.
+
+**Trabajo preservado**: código de la route (`apps/api/src/routes/stakeholder.ts`, 115 LOC) sirve como referencia en el working tree del worktree. El test unit-mocked se descarta cuando se re-implemente.
+
+**Plan D11 v2 actualizado**: [`docs/plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md`](../plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md) — Status: BLOCKED, sección "Status post-build T8 v2" añadida, T8-T12 headers marcados `[BLOCKED 2026-05-17]`.
 
 ---
 

--- a/docs/handoff/CURRENT.md
+++ b/docs/handoff/CURRENT.md
@@ -8,13 +8,46 @@
 
 ## Bloqueo D11 v2 T8-T12 (2026-05-17)
 
-**Estado**: D11 v2 T8 fue implementado en branch `fix/d11-t8-stakeholder-zonas-endpoint` (HEAD `d88085f`, worktree `naughty-sinoussi-c8ddf8`) y **NO se mergeó**. Sesión de cierre descubrió que el test staged era unit con DB mockeada, no integration con DB real como exige plan v2 §192 y handoff lección #3. Auditoría reveló que `apps/api/test/integration/` no existe en el repo — no hay patrón ni helper de DB real en ninguna app.
+**Estado al cierre de sesión 2026-05-17 ~09:10 UTC**:
 
-**Decisión PO**: bloquear T8-T12 hasta que exista infra de integration testing. Nueva spec [`docs/specs/2026-05-17-test-integration-infra-apps-api.md`](../specs/2026-05-17-test-integration-infra-apps-api.md) en Draft. Una vez implementada esa infra (con su propio ADR-043), re-abrir T8 contra el patrón real.
+- D11 v2 T8 implementado en `fix/d11-t8-stakeholder-zonas-endpoint` con test unit-mocked → **NO mergeable** por violación de CLAUDE.md §1/§2 (test no ejerce el SQL real).
+- Pivote a spec + plan separados para crear infra de integration testing en `apps/api`.
 
-**Trabajo preservado**: código de la route (`apps/api/src/routes/stakeholder.ts`, 115 LOC) sirve como referencia en el working tree del worktree. El test unit-mocked se descarta cuando se re-implemente.
+**Avance de la sesión** (PR [#267](https://github.com/boosterchile/booster-ai/pull/267), 4 commits docs-only):
 
-**Plan D11 v2 actualizado**: [`docs/plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md`](../plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md) — Status: BLOCKED, sección "Status post-build T8 v2" añadida, T8-T12 headers marcados `[BLOCKED 2026-05-17]`.
+| Artefacto | Status | Path |
+|---|---|---|
+| Spec test-integration-infra-apps-api | **Approved** (PO 2026-05-17 ~08:35 UTC) | [`docs/specs/2026-05-17-test-integration-infra-apps-api.md`](../specs/2026-05-17-test-integration-infra-apps-api.md) |
+| Spec devils-advocate review | complete (6 P0 + 11 P1 + 7 P2) | [`docs/specs/2026-05-17-test-integration-infra-apps-api-devils-advocate.md`](../specs/2026-05-17-test-integration-infra-apps-api-devils-advocate.md) |
+| Plan v2 con 9 tasks (T0..T6) | **Approved** (PO 2026-05-17 ~09:05 UTC) | [`docs/plans/2026-05-17-test-integration-infra-apps-api.md`](../plans/2026-05-17-test-integration-infra-apps-api.md) |
+| Plan devils-advocate review | complete (7 P0 + 6 P1 + 5 P2 — 12/13 P0+P1 abordados) | [`docs/plans/2026-05-17-test-integration-infra-apps-api-devils-advocate.md`](../plans/2026-05-17-test-integration-infra-apps-api-devils-advocate.md) |
+| Plan D11 v2 (T8-T12 BLOCKED) | actualizado | [`docs/plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md`](../plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md) |
+
+**Pickup point próxima sesión — T0**:
+
+Cooling-off agent-rigor §6.1 (30 min entre /plan y /build) aplicado al cerrar sesión 2026-05-17 ~09:10 UTC.
+
+Próxima sesión arranca con T0 del plan: script `apps/api/scripts/prototype-test-db.ts` (no-merge) que mide:
+1. Tiempo de `runMigrations` corrida 1 vs corrida 2 (no-op idempotencia).
+2. `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` + extension `pgcrypto` antes de migrate.
+3. Verificar que `applyOutOfOrderPending` no falla en segunda corrida.
+
+Success criterion para arrancar T1: primera corrida <30s, segunda <5s, sin errores. Captura del output queda pegada en el PR body de T1.
+
+**Cómo arrancar próxima sesión**:
+
+```bash
+cd /Volumes/Pendrive128GB/Booster-AI/.claude/worktrees/naughty-sinoussi-c8ddf8
+git pull github fix/d11-t8-stakeholder-zonas-endpoint
+# Verificar PR #267 estado: gh pr view 267 --json state,mergeStateStatus
+# Leer plan v2: docs/plans/2026-05-17-test-integration-infra-apps-api.md
+# Arrancar T0: implementar scripts/prototype-test-db.ts según plan §T0
+```
+
+**Trabajo preservado en working tree** (no commit, untracked):
+- `apps/api/src/routes/stakeholder.ts` (115 LOC) — reusable post-infra.
+- `apps/api/test/unit/stakeholder-zonas-route.test.ts` (94 LOC) — descartable.
+- `apps/api/src/server.ts` (+7 LOC) — wire de la route.
 
 ---
 

--- a/docs/plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md
+++ b/docs/plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md
@@ -7,7 +7,30 @@
 - **Plan v1**: [`2026-05-17-d11-stakeholder-geo-aggregations.md`](2026-05-17-d11-stakeholder-geo-aggregations.md) — BLOCKED, ver §"Status post-review".
 - **Owner**: Felipe Vicencio (PO) + Claude
 - **Creado v2**: 2026-05-17 post review formal (12 PRs) + ADR-042 mergeado.
-- **Status**: Active.
+- **Status**: **BLOCKED** (2026-05-17 ~08:20 UTC) — T8-T12 dependen de [`docs/specs/2026-05-17-test-integration-infra-apps-api.md`](../specs/2026-05-17-test-integration-infra-apps-api.md). Ver §"Status post-build" abajo.
+
+---
+
+## Status post-build T8 v2 (2026-05-17 ~08:20 UTC)
+
+T8 v2 fue implementado en branch `fix/d11-t8-stakeholder-zonas-endpoint` (HEAD `d88085f`) cubriendo route + tests + server wire, total 216 LOC. **No se mergeó.** Razones, en orden de gravedad:
+
+1. **Tipo de test no cumple plan**: el test staged es `apps/api/test/unit/stakeholder-zonas-route.test.ts` con DB mockeada vía `vi.fn()`. El plan v2 §T8 (línea 48) exige `apps/api/test/integration/stakeholder-zonas.test.ts` y §192 explícita *"Tests integration NO mocked-Drizzle — usar test DB real"*. El handoff D11 v2 lección #3 lo refuerza.
+2. **Ausencia de infra**: auditoría descubrió que `apps/api/test/integration/` no existe y no hay helper de DB real en todo el repo. T8 unit-mocked fue forzado por ausencia del patrón, no por decisión técnica documentada.
+3. **Violación contrato**: aceptar T8 unit-mocked sería deuda técnica deliberada — CLAUDE.md §1 ("Cero deuda técnica desde day 0") y §2 ("Evidence over assumption") lo prohíben. El SQL del endpoint (`LEFT JOIN`, `ANY(comuna_codes)`, `now() - interval '30 days'`, `WHERE is_active`) **nunca se ejerce** en CI con el mock actual.
+
+**Decisión PO 2026-05-17**: bloquear T8-T12 hasta que exista la infra de integration testing. Crear spec separada [`docs/specs/2026-05-17-test-integration-infra-apps-api.md`](../specs/2026-05-17-test-integration-infra-apps-api.md) → ADR-043 → implementación → re-abrir T8 contra infra real.
+
+**Working tree preservado**: los archivos `apps/api/src/routes/stakeholder.ts` (115 LOC) + `apps/api/test/unit/stakeholder-zonas-route.test.ts` (94 LOC) + diff `server.ts` (+7) viven en el branch `fix/d11-t8-stakeholder-zonas-endpoint` working tree sin staging ni commit. Sirven como referencia para re-implementación post-infra: el código de la route puede reusarse tal cual; el test se reemplaza por integration real.
+
+**Próximos pasos**:
+
+1. Aprobación PO de [`docs/specs/2026-05-17-test-integration-infra-apps-api.md`](../specs/2026-05-17-test-integration-infra-apps-api.md).
+2. `/plan` sobre esa spec → plan atómico.
+3. `/build` la infra (T-INFRA-1..6).
+4. ADR-043 cierra la decisión arquitectónica.
+5. Re-abrir D11 v2 T8 contra la infra. Recalcular waivers LOC con el patrón real.
+6. Continuar T9-T12 sobre el mismo patrón.
 
 ---
 
@@ -41,7 +64,7 @@
 
 ## Tasks v2 — endpoints + UI + perf (T8–T12)
 
-### T8 v2: Endpoint `GET /stakeholder/zonas` (cards 30d, comuna filter)
+### T8 v2: Endpoint `GET /stakeholder/zonas` (cards 30d, comuna filter) [BLOCKED 2026-05-17 — pending test-integration-infra]
 
 - **Files**:
   - `apps/api/src/routes/stakeholder.ts` (nuevo)
@@ -63,7 +86,7 @@
   - Integration tests con 6 roles (5 negados + 1 admitido).
 - **Rollback**: revertir commit. UI v1 (mock data) sigue funcionando hasta T11 v2.
 
-### T9 v2: Endpoint `GET /stakeholder/zonas/:slug/agregaciones`
+### T9 v2: Endpoint `GET /stakeholder/zonas/:slug/agregaciones` [BLOCKED 2026-05-17 — pending test-integration-infra]
 
 - **Files**:
   - `apps/api/src/routes/stakeholder.ts` (extender T8)
@@ -81,7 +104,7 @@
   - Tests cubren k-anonymity en cada dimensión + zona insufficient + 6 roles.
 - **Rollback**: revertir commit. T10 v2 UI maneja error genérico vía TanStack Query.
 
-### T10 v2: UI drill-down route `/app/stakeholder/zonas/$slug`
+### T10 v2: UI drill-down route `/app/stakeholder/zonas/$slug` [BLOCKED 2026-05-17 — pending T8+T9]
 
 - **Files**:
   - `apps/web/src/routes/stakeholder-zonas.$slug.tsx` (nuevo o re-implementar)
@@ -101,7 +124,7 @@
   - Render tests con TanStack Query + RouterProvider mock: loading / data / insufficient / error.
 - **Rollback**: revertir. T11 v2 enlace al drill-down se rompe (404).
 
-### T11 v2: UI cards `stakeholder-zonas.tsx`
+### T11 v2: UI cards `stakeholder-zonas.tsx` [BLOCKED 2026-05-17 — pending T8+T10]
 
 - **Files**:
   - `apps/web/src/routes/stakeholder-zonas.tsx` (refactor)
@@ -123,7 +146,7 @@
   - Render tests para los 4 estados + screenshot manual.
 - **Rollback**: revertir. UI vuelve a estado pre-D11 mock (cosmetic, no crítico).
 
-### T12 v2: Perf gate — `EXPLAIN ANALYZE` real + script `test:perf` separado
+### T12 v2: Perf gate — `EXPLAIN ANALYZE` real + script `test:perf` separado [BLOCKED 2026-05-17 — pending T8 + test-integration-infra]
 
 - **Files**:
   - `apps/api/test/perf/stakeholder-zonas-explain.test.ts` (re-implementar con DB real)

--- a/docs/plans/2026-05-17-test-integration-infra-apps-api-devils-advocate.md
+++ b/docs/plans/2026-05-17-test-integration-infra-apps-api-devils-advocate.md
@@ -1,0 +1,203 @@
+# Devils-advocate review — plan test-integration-infra-apps-api
+
+**Plan target**: [`./2026-05-17-test-integration-infra-apps-api.md`](./2026-05-17-test-integration-infra-apps-api.md)
+**Reviewer**: `agent-rigor:devils-advocate` (auto-invocado por skill `20-planning-and-task-breakdown` §Step 7)
+**Date**: 2026-05-17 ~08:55 UTC
+
+---
+
+## Resumen ejecutivo
+
+> El plan **no es mergeable as-is**. Tiene 7 P0 que mayoritariamente son **decisiones de arquitectura que el plan declara cerradas (D1-D6) pero que no están probadas con evidencia medida**. La spec §8 dijo "decisión final con prototipo medido" y el plan saltó esa parte.
+
+7 P0 + 6 P1 + 5 P2 = 18 objeciones.
+
+## Tabla de hallazgos críticos verificables
+
+| ID | Hallazgo | Acción tomada en plan v2 |
+|---|---|---|
+| P0-1 | `runMigrations` no idempotente bajo segunda corrida (`applyOutOfOrderPending` hace INSERT raw + `CREATE TYPE` sin `IF NOT EXISTS`) | T1.5 (nuevo) — globalSetup hace `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` antes de `runMigrations`. Verifica idempotencia mediendo. |
+| P0-2 | `singleFork=true` no escala 6 meses (~125s en 250 tests sin paralelismo) | D3 documenta tradeoff y agrega §"Válvula de salida": migrar a schema-per-worker (N=4) cuando suite supere 60s sostenidos. Decisión deferida con criterio explícito. |
+| P0-3 | Vitest `concurrent` dentro de file rompe TRUNCATE aislamiento | T2 agrega `sequence.concurrent: false` global + biome lint rule contra `*.concurrent` en `test/integration/**`. |
+| P0-4 | T1 es horizontal slice (entrega código no ejecutable sin T2) | T1↔T2 reordenadas: T1 entrega config + scripts + test ref con `SELECT 1` (sin migrations todavía). T1b entrega migrations runner. T2 (anterior) absorbida. |
+| P0-5 | T6 DoD circular ("agregar tests si baja") | T6 con DoD numérico: medir `lines/branches/functions` antes y después; si cualquier métrica baja >2 pp, agregar tests; budget LOC 50 con waiver hasta 80. |
+| P0-6 | Plan dice "29/33 routes usan DI" sin enumerar las 4 residuales | T1 acceptance amplía: enumerar las routes que importan `createDb` o `db` global; verificar que ninguna entra en grafo de import de tests integration de T8. |
+| P0-7 | Falta T0 (prototipo medido) — D1-D6 declaradas sin evidencia | T0 (nuevo) — script `scripts/prototype-test-db.ts` que mide `runMigrations` × 2 contra Postgres-16-alpine vacío. Reporta tiempo + idempotencia. Bloquea T1. |
+
+## P1 abordadas en plan v2
+
+| ID | Hallazgo | Acción |
+|---|---|---|
+| P1-1 | T5 180 LOC waiver sospechoso (README + ADR son artefactos distintos) | T5 splittear en T5a (ADR-043, ~100 LOC) + T5b (README integration, ~80 LOC) + T5c (skill `integration-test-writing.md`, ~80 LOC — saca de out-of-band). |
+| P1-2 | CI job integrado sube wall-time a ~8-9min | T4 decide hoy: job separado paralelo `test-integration` con su propio `services.postgres`. |
+| P1-3 | T4 depende de T3 también (sin seed, suite integration es 1 test) | T4 dependencies actualizada: T1, T1b, T2, T3. |
+| P1-5 | `TRUNCATE … CASCADE` puede tirar tablas no listadas | README integration documenta semantics CASCADE + helper `cleanupTables` warnea si detecta CASCADE implicit (no enforce). |
+| P1-6 | Watch mode roto sin mención | README integration declara: **no hay `test:integration:watch`**. Para iterar en un test, correr el archivo: `vitest run test/integration/foo.test.ts --config vitest.integration.config.ts`. |
+
+## P1 residuales (aceptadas)
+
+- **P1-4** (concurrency group del CI): no crítico, no bloquea. Documentado como residual.
+
+## P2 (drift signals)
+
+- **P2-1** "recalibrable tras T1" — drift vocabulary. Reformulado en plan v2 como "medición concreta tras T0".
+- **P2-2** pglite (Alt E) postergada sin razón fuerte — plan v2 agrega criterio de re-evaluación: si en 3 meses el setup local de Docker/Postgres frena onboarding de >1 dev, prototipar pglite.
+- **P2-3** testcontainers descartado con razonamiento débil — plan v2 agrega referencia a la decisión D1 con justificación clara.
+- **P2-4** falta devils-advocate sobre primer PR T0/T1 — plan v2 documenta que cada PR significativo (T0, T1b, T5a) recibe devils-advocate pre-merge.
+- **P2-5** skill `integration-test-writing.md` movido a T5c (P1-1).
+
+---
+
+## Output completo del devils-advocate
+
+> No te voy a felicitar. El plan es **mejor que el promedio** pero tiene huecos lógicos cruciales que la spec no podía cerrar y el plan tampoco cierra. Reporte brutal abajo. 7 P0, 6 P1, 5 P2.
+>
+> ---
+>
+> ## P0 — Bloqueantes (deben resolverse antes de `/build`)
+>
+> ### P0-1. D3 (TRUNCATE selectivo + singleFork) tiene un edge case que rompe la fidelidad con prod: **CREATE TYPE / CREATE EXTENSION son state global del schema/DB, no se "truncan"**
+>
+> Verificado en el repo: las migrations crean **>15 enum types** (`actor_cancelacion`, `estado_viaje`, `estado_oferta`, …) y al menos una `CREATE EXTENSION`. Estos viven a nivel de schema/DB, no de tabla. `TRUNCATE table RESTART IDENTITY CASCADE` **no los toca**.
+>
+> Esto es benigno para el aislamiento de datos, pero el plan vende D3 como "aislamiento entre tests" sin explicitar que **el orden de migrations queda parcial-aplicado entre runs locales sucesivos si el dev re-corre migrations** (ej. cambia una migration, vitest watch re-arranca, y el `CREATE TYPE foo` colisiona con el ya existente porque `runMigrations` no es idempotente sobre tipos sin `IF NOT EXISTS`).
+>
+> Mitigación que el plan omite: en `globalSetup` necesitas decidir entre **(a)** wipe completo (`DROP SCHEMA public CASCADE; CREATE SCHEMA public;` antes de `runMigrations`), o **(b)** detectar "DB ya migrada con journal hash actual" y hacer no-op. El plan dice "runMigrations real" pero no dice qué pasa cuando ya corrió antes. **Lee de nuevo `migrator.ts:75-105`** — `migrate()` de Drizzle es idempotente vía hash en `drizzle.__drizzle_migrations`, OK, pero `applyOutOfOrderPending` lee `_journal.json` y aplica raw SQL en transacción **sin `IF NOT EXISTS`**. Una segunda corrida con la misma DB **fallará** en el INSERT del marker (constraint hash) o en algún `CREATE TYPE` si recovery dispara.
+>
+> **Acción**: el plan debe especificar el estado inicial de la DB del CI/local cada run, no asumirlo.
+>
+> ### P0-2. **`singleFork: true` invalida CR-3 a 6 meses vista y el plan lo trata como un "tradeoff aceptable"**
+>
+> Hoy hay 0 integration tests. Plan dice "recalibrable tras T1". Eso es punteo defensivo. Hagamos el cálculo:
+>
+> - `runMigrations` con 37 SQL files + recovery + advisory lock: medible solo después de T1, pero típico Postgres-16 local con 37 migrations modestas: **3-8s solo el setup**.
+> - Cada test integration que hace seed + assert + cleanup: **150-400ms realistas**.
+> - T8 D11 solo abre 8-12 tests integration sobre `/stakeholder/zonas`.
+> - 50 tests × 250ms promedio + setup global = **15-20s**. OK.
+> - Pero D11 v2 T9-T12 + features futuras → fácilmente **150-300 integration tests en 6 meses**.
+> - 250 × 300ms + setup = **75s + 8s = 83s**. Sin paralelismo. Roza el budget.
+> - 250 × 500ms (algunos tocan múltiples tablas) = **125s + setup → CR-3 violado**.
+>
+> El plan **acepta** este escenario sin diseñar una válvula. Decir "particionar tests" es punteo: ¿particionar cómo, si las tablas son las mismas? `pool: 'threads'` no funciona porque el código de las routes asume su pool, que es proceso-local.
+>
+> **Acción**: el plan necesita definir hoy el **mecanismo de salida** de singleFork. Una alternativa real, hoy verificable: schema-per-worker con `SET search_path TO test_w<N>, public` por conexión en `createTestDb()`. Eso requiere DB-per-worker o schema-per-worker con DDL replicada. El plan descarta schema-per-suite por invasivo, pero **no analiza schema-per-worker** (N=4 workers vitest, no N=numFiles). Esa alternativa no aparece. Hueco real.
+>
+> ### P0-3. **D3 (TRUNCATE) no aísla tests dentro del mismo file que se ejecutan en paralelo**
+>
+> Vitest, incluso con `singleFork: true`, **paraleliza tests dentro de un mismo file** vía `test.concurrent` o cuando el usuario llama `describe.concurrent`. `singleFork` solo serializa archivos.
+>
+> Más importante: vitest 1.x ejecuta `it()` dentro de un `describe` **secuencialmente por default**, pero el plan no documenta esa asunción ni la enforcea. Si en 3 meses alguien agrega `describe.concurrent('...')` para acelerar la suite local, **TRUNCATE entre tests dejará de aislar** y los tests pisarán datos del otro.
+>
+> **Acción**: enforcear el modo secuencial vía `sequence.concurrent: false` global en `vitest.integration.config.ts` y un ESLint/biome rule contra `*.concurrent` en `test/integration/**`. El plan no lo menciona.
+>
+> ### P0-4. **T1 NO es vertical slice, es 3 horizontal slices empaquetadas**
+>
+> T1 entrega:
+> 1. `setup-global.ts` (vitest globalSetup)
+> 2. `test-db.ts` (factory `createTestDb()`)
+> 3. `health-db.integration.test.ts` (test ref)
+>
+> Pero T1 no tiene un script funcional `pnpm test:integration` corriendo todavía — eso es T2. Entonces T1 entrega código que **no puede ejecutarse por nadie**: si T1 se mergea sin T2, ese test no corre en CI, no corre local (no hay script), y el coverage gate ni siquiera lo ve. Eso es **horizontal slice** (capas, no end-to-end). Viola el criterio que el propio plan se aplica en el checklist L189.
+>
+> **Acción**: invertir T1↔T2 o fusionarlos. La vertical slice mínima es: `vitest.integration.config.ts` + script + `setup-global.ts` + un test que corre y prueba `SELECT 1` sin migrations todavía (~80 LOC). Migration runner integrado en una T1b.
+>
+> ### P0-5. **T6 (coverage exclude cleanup) tiene Definition of Done circular y peligrosa**
+>
+> T6 dice: "quitar exclude → si coverage baja, agregar tests específicos en este mismo PR".
+>
+> ¿Cuántos tests? ¿Qué porcentaje hay que recuperar? ¿Y si `client.ts` tiene un branch que solo se ejerce con un pool exhausted (timeout) — agregamos un test que provoca timeout real?
+>
+> `vitest.config.ts:34-39` muestra thresholds **75%/75%/80%/80%** (functions=75 no 80; coverage gate del CI espera **80% en functions** según `ci.yml:23`). Hay **drift documentado en la spec CR-7** y T6 no lo aborda. Si T6 quita los excludes, el denominator sube → el porcentaje baja → posiblemente el CI rojo. El plan dice "agregar tests específicos" como si fuera mecánico, pero **el alcance real de T6 es indeterminado**: 30 LOC del test del migrator + ¿cuánto más?
+>
+> **Acción**: T6 necesita un budget de LOC con waiver explícito y una métrica concreta ("coverage del CI ≥ 80%/75%/80% post-merge, mide con `pnpm test:coverage` antes de PR"). Sin eso, T6 es un cheque en blanco.
+>
+> ### P0-6. **El plan asume `TEST_DATABASE_URL` pero `setup.ts:32` ya stubea `DATABASE_URL` con valor falso, y los routes importan `client.ts` que llama `createDb()` sobre `process.env.DATABASE_URL`**
+>
+> Verificado en código: `apps/api/test/setup.ts:32` hace `process.env.DATABASE_URL ??= 'postgresql://test:test@localhost:5432/test'`. Eso es para unit. Si `setup.integration.ts` no stubea DATABASE_URL y `runMigrations` recibe el pool del helper (OK), **pero los routes bajo test importan `createDb` indirectamente vía `main.ts` chain o el `server.ts` arranca`, ¿pasa qué?**
+>
+> Verificado: 19 routes (`admin-cobra-hoy.ts`, `admin-dispositivos.ts`, `admin-jobs.ts`, …, `auth-driver.ts`, `auth-universal.ts`, …) están marcadas como "SUSPECT" por mi grep — pueden estar importando `createDb` directamente o llamando al pool al primer import. **El plan declara "29/33 routes ya usan DI" pero no nombra las 4 residuales ni verifica el resto**.
+>
+> Si una de esas routes entra en el grafo de imports de un integration test (vía el server full o vía el handler chain), va a abrir un segundo pool con `process.env.DATABASE_URL` apuntando a `localhost:5432/test` o lo que sea. Eso **no es lo que el test quiere**.
+>
+> **Acción**: el plan necesita listar **explícitamente** las 4 routes residuales (D11 v2 ya verificó parte de esto) y los routes en `apps/api/src/routes/admin-*` que el grep sospecha. Hasta que el plan no enumere, "29/33" es una estadística sin trazabilidad.
+>
+> ### P0-7. **Falta T0 — pre-flight de validación de assumptions**
+>
+> El plan asume:
+> - 37 migrations corren limpio contra Postgres-16-alpine vacío en <30s.
+> - `runMigrations` es idempotente bajo segunda llamada (no lo es, ver P0-1).
+> - `applyOutOfOrderPending` no re-ejecuta DDL nunca (asume pero no verifica).
+> - Las 37 SQLs no tienen DDL que GH service container Postgres-16-alpine no soporte (extensiones específicas, `CREATE EXTENSION pgcrypto`).
+>
+> Ninguna de estas asunciones está validada con un prototipo medido. La spec §8 alternativa B/E/F dice literalmente "decisión final entre B/E/F la toma `/plan` con **prototipo medido**". El plan declara D1-D6 **sin prototipo**.
+>
+> **Acción**: T0 (no opcional) — script ad-hoc que arranca `postgres:16-alpine` en Docker local, corre `runMigrations` dos veces seguidas, mide tiempo, verifica idempotencia. Si T0 falla, D2 o D3 cambian. Plan actual saltearía T0 y descubriría el problema en T4 cuando CI esté rojo.
+>
+> ---
+>
+> ## P1 — Riesgos serios (deben quedar registrados, addressing recomendado)
+>
+> ### P1-1. **T5 con 180 LOC de doc + ADR cohesivo es trampa de waiver**
+>
+> El skill establece 100 LOC budget. T5 lo dobla con "doc cohesiva, no scope creep". Pero el contenido es **README (80 LOC) + ADR (100 LOC)** — dos artefactos **distintos**, distintos lectores, distintos ciclos de vida. El ADR es decisión, vive en `docs/adr/`, supersede pattern. El README es operativo, vive en `apps/api/test/integration/`, cambia con cada nuevo template de test. **Splittealos**: T5a (ADR-043, ~100 LOC) y T5b (README, ~80 LOC). Cada uno cabe en budget. El "waiver" es punteo.
+>
+> ### P1-2. **Tiempo CI subestimado en la open question #2**
+>
+> Plan dice "si wall-time del job sube de ~5min hoy a >8min, separar". Pero:
+> - `setup` job (install deps): ~1.5min en cache hit.
+> - Postgres service container startup: 30-60s adicionales **solo en el job test**.
+> - `runMigrations` 37 archivos con recovery validation: 5-15s.
+> - 50-100 integration tests × 200-400ms + 10s coverage report: 30-50s.
+>
+> Realista: el job `test` actual de ~3min se va a ~5-6min con integration. **El umbral "8min" del plan ya está al borde**. Pero más importante: agregando integration al job test **secuencialmente**, bloquea el job `build` (que tiene `needs: [lint, typecheck, test]` en `ci.yml:145`). El wall-clock total del CI sube de **~5min a ~8-9min**.
+>
+> **Acción**: job separado paralelo `test-integration:` ES la respuesta correcta hoy, no "esperar y ver". El plan debería decidirlo.
+>
+> ### P1-3. **Dependencias entre tasks subestimadas: T4 depende de T3 también**
+>
+> T4 (CI step) "depende de T1+T2" per el plan. Pero si T3 (seed) no existe, **¿qué tests integration corren en CI?** Solo `health-db.integration.test.ts` de T1. Eso degrada `pnpm test:integration` en CI a una vanity check de 1 test. Si la idea es validar el patrón completo en CI, T4 también debe esperar T3.
+>
+> **Acción**: T4 → depends on T1, T2, T3. Reordenar o aceptar que T4 ship temprano con cobertura mínima y se "engorda" en T5.
+>
+> ### P1-4. **El plan no menciona el `concurrency` group del CI**
+>
+> `ci.yml:13` tiene `concurrency: cancel-in-progress: true` en el workflow. Si Postgres service container está corriendo y el job se cancela mid-test, **el siguiente push** levanta un nuevo container limpio (OK) pero el patrón de uso del runner cambia. No crítico pero **no fue revisado**.
+>
+> ### P1-5. **`TRUNCATE … CASCADE` puede romper FK que el dev no esperaba**
+>
+> D3 lista "TRUNCATE table1, table2, ... RESTART IDENTITY CASCADE". `CASCADE` propaga a TODAS las tablas con FK hacia las truncadas, **incluyendo las que no listaste**. Si un test toca `usuarios` y olvida listar `memberships` (FK → usuarios), `TRUNCATE usuarios CASCADE` va a vaciar memberships también — esperado, pero ¿el test sabe? Si el siguiente test asume "memberships pobladas en seed previo", se rompe.
+>
+> **Acción**: el helper `cleanupTables` debería **detectar CASCADE implicit** y warnear, o forzar al dev a listar el conjunto cerrado completo. Plan no lo aborda.
+>
+> ### P1-6. **Watch mode (`pnpm test:watch`) explícitamente roto sin mención**
+>
+> `runMigrations` corre en `globalSetup`. En vitest watch, `globalSetup` corre **una vez** por watch session. Si el dev cambia una migration SQL y re-corre, `globalSetup` no re-evalúa. Tampoco se hace `TRUNCATE` entre runs del watch — depende del cleanup del test.
+>
+> Más grave: en `pnpm test:integration:watch` (que el plan no menciona pero existirá), un dev que edita una migration y guarda, **no ve el cambio aplicado a la DB de test** hasta matar el watch.
+>
+> **Acción**: plan debe documentar que **no hay watch para integration** o explicar mecanismo de reload. Open question.
+>
+> ---
+>
+> ## P2 — Drift signals y misc
+>
+> ### P2-1. **"recalibrable tras T1" aparece 2 veces** (L41, L181)
+> Drift vocabulary del agent-rigor. "Recalibrable" es eufemismo de "no decidí esto, lo verás en CI". L41 sobre CR-3 y L181 abiertamente. Aceptable porque está en sección "open questions" la segunda, pero la primera es decisión D3 — sospechosa.
+>
+> ### P2-2. **"si excede, particionar tests o evaluar pglite como overlay opcional"** (L181)
+> "Evaluar pglite como overlay opcional" es **literalmente posponer la decisión de Alt E** que la spec §8 listó como "A evaluar en `/plan`". El plan no la evaluó. La declaró postergada (L23: "postergada — si el dev local sufre fricción"). Pero el devils-advocate review de la spec presumiblemente la pedía como prototype-or-discard. El plan no la prototyped, no la discardea con razón fuerte; la pone en cola.
+>
+> ### P2-3. **"No aporta sobre el approach elegido"** (L24, sobre testcontainers)
+> Razonamiento débil. Testcontainers `withReuse()` resuelve EXACTAMENTE el problema de "Postgres local no disponible para dev". El plan lo descarta con una línea. Sin demostrar trade-offs medidos.
+>
+> ### P2-4. **El plan menciona "30 min cooling-off" pero no menciona el devils-advocate previo a `/build`**
+> CLAUDE.md §3 / agent-rigor habla de devils-advocate sobre plan después de redactarlo, **antes de build** (L209). Es este review. OK. Pero falta menciónar **otra ronda de devils-advocate sobre el primer PR (T1) post-build** — patrón estándar.
+>
+> ### P2-5. **Skill `integration-test-writing.md` queda como "out-of-band"**
+> CLAUDE.md §3: "Si una tarea no tiene un skill definido y es repetible, Claude propone crear el skill **antes** de ejecutar". El plan lo trata como follow-up. ¿Por qué? Si la infra es para que los siguientes 100 integration tests sigan un patrón, el skill **es** el patrón. Debería ser T5c, no out-of-band.
+
+---
+
+## Conclusión
+
+Plan v2 (próxima edición del documento principal) aborda los 7 P0 + 5 P1 listados arriba. P1-4 queda como residual documentado. P2 son drift signals corregidos.

--- a/docs/plans/2026-05-17-test-integration-infra-apps-api.md
+++ b/docs/plans/2026-05-17-test-integration-infra-apps-api.md
@@ -130,7 +130,7 @@ Total: **13 archivos nuevos, 4 modificados**. Cerca del techo de 10 módulos del
 
 ## Tasks
 
-### T0: Prototipo medido (bloquea D1-D6)
+### T0: Prototipo medido (bloquea D1-D6) [DONE 2026-05-17 — PR [#268](https://github.com/boosterchile/booster-ai/pull/268)]
 
 - **Files**:
   - `apps/api/scripts/prototype-test-db.ts` (nuevo, **NO se mergea** — sirve para medir y validar; se descarta tras T1b).
@@ -145,7 +145,7 @@ Total: **13 archivos nuevos, 4 modificados**. Cerca del techo de 10 módulos del
 - **Rollback**: no aplica — el script no se mergea. Si las mediciones invalidan D2/D3, abrir `/plan` v3.
 - **Success criterion para arrancar T1**: primera corrida <30s en local, segunda <5s, sin errores.
 
-### T1: `vitest.integration.config.ts` + scripts + setup.integration + helper test-db + test ref `SELECT 1`
+### T1: `vitest.integration.config.ts` + scripts + setup.integration + helper test-db + test ref `SELECT 1` [DONE 2026-05-17 — PR [#269](https://github.com/boosterchile/booster-ai/pull/269)]
 
 - **Files**:
   - `apps/api/vitest.integration.config.ts` (nuevo) — config con `globalSetup` placeholder (vacío en T1, real en T1b), `setupFiles=['./test/setup.integration.ts']`, `include=['test/integration/**']`, `pool='forks'`, `poolOptions.forks.singleFork=true`, `sequence.concurrent=false`.

--- a/docs/plans/2026-05-17-test-integration-infra-apps-api.md
+++ b/docs/plans/2026-05-17-test-integration-infra-apps-api.md
@@ -7,7 +7,7 @@
 - **Created**: 2026-05-17 ~08:45 UTC
 - **Revised v2**: 2026-05-17 ~09:00 UTC (post devils-advocate del plan v1)
 - **Owner**: Felipe Vicencio (PO) + Claude
-- **Status**: Active v2 (pending PO approval)
+- **Status**: **Approved** (PO, 2026-05-17 ~09:05 UTC — plan v2 post devils-advocate)
 
 ---
 

--- a/docs/plans/2026-05-17-test-integration-infra-apps-api.md
+++ b/docs/plans/2026-05-17-test-integration-infra-apps-api.md
@@ -1,0 +1,300 @@
+# Plan — Test integration infrastructure para `apps/api`
+
+- **Spec**: [`docs/specs/2026-05-17-test-integration-infra-apps-api.md`](../specs/2026-05-17-test-integration-infra-apps-api.md) (Status: Approved 2026-05-17 ~08:35 UTC)
+- **Devils-advocate review de la spec**: [`docs/specs/2026-05-17-test-integration-infra-apps-api-devils-advocate.md`](../specs/2026-05-17-test-integration-infra-apps-api-devils-advocate.md)
+- **Devils-advocate review de este plan**: [`./2026-05-17-test-integration-infra-apps-api-devils-advocate.md`](./2026-05-17-test-integration-infra-apps-api-devils-advocate.md) (7 P0 + 6 P1 + 5 P2 abordados en v2)
+- **ADR**: 043 (a crear en T5a)
+- **Created**: 2026-05-17 ~08:45 UTC
+- **Revised v2**: 2026-05-17 ~09:00 UTC (post devils-advocate del plan v1)
+- **Owner**: Felipe Vicencio (PO) + Claude
+- **Status**: Active v2 (pending PO approval)
+
+---
+
+## Cambios respecto a v1
+
+Tras devils-advocate review del plan v1 (18 objeciones), v2 incorpora:
+
+- **+T0** (nuevo, prototipo medido) — bloquea D1-D6 hasta tener evidencia de tiempos + idempotencia de `runMigrations` × 2.
+- **T1↔T2 fusionadas y reordenadas** — T1 nueva es vertical slice real (config + script + test ref con `SELECT 1`, sin migrations). T1b agrega migrations runner.
+- **T5 splittear** en T5a (ADR-043, ~100 LOC), T5b (README integration, ~80 LOC), T5c (skill `integration-test-writing.md`, ~80 LOC — sale de out-of-band).
+- **T6 con DoD numérico** — coverage del CI ≥80/75/80 post-merge, medido. Budget LOC 50 con waiver hasta 80 si requiere agregar tests.
+- **D3 con válvula de salida** — schema-per-worker (N=4) cuando suite supere 60s sostenidos.
+- **D2 con DROP SCHEMA antes de runMigrations** en globalSetup (resuelve idempotencia P0-1).
+- **T1 acceptance enumera routes residuales** (P0-6).
+- **T4 con job separado paralelo** `test-integration` (P1-2).
+- **`sequence.concurrent: false` + lint rule** en vitest.integration.config.ts (P0-3).
+- **Watch mode declarado fuera de scope** en README (P1-6).
+
+---
+
+## Decisiones arquitectónicas (D1-D6, post devils-advocate)
+
+### D1 — Motor de DB en test: **Postgres real**
+
+CI: `services.postgres` con `postgres:16-alpine`. Local: dev provee Postgres (Docker, Postgres.app o brew). Tres caminos documentados en README integration. Sin dependencia adicional npm.
+
+Descartadas explícitamente:
+- **pglite (Alt E)**: postergada con criterio concreto — si en 3 meses el setup local de Postgres frena onboarding de >1 dev, prototipar pglite como overlay opcional.
+- **testcontainers-node**: agrega dependencia que duplica funcionalidad del service container CI; el setup local con `docker run` directo es equivalente sin la dependencia.
+
+### D2 — Migration runner: **`runMigrations` real, invocado en `globalSetup` con DB pre-limpia**
+
+Resuelve P0-1 (idempotencia bajo segunda corrida) **y** P0-2 fidelidad. Pasos del globalSetup:
+
+```ts
+// pseudo
+const pool = new pg.Pool({ connectionString: process.env.TEST_DATABASE_URL });
+const client = await pool.connect();
+try {
+  await client.query('DROP SCHEMA IF EXISTS public CASCADE;');
+  await client.query('CREATE SCHEMA public;');
+  await client.query(`GRANT ALL ON SCHEMA public TO ${user};`);
+  // Re-instalar extensiones explícitas que las migrations no crean si ya existen.
+  await client.query('CREATE EXTENSION IF NOT EXISTS pgcrypto;');
+} finally {
+  client.release();
+}
+await runMigrations(pool, logger);
+```
+
+El `DROP SCHEMA` + `CREATE SCHEMA` garantiza estado inicial limpio cada run. `runMigrations` corre solo en globalSetup (UNA vez por proceso vitest) → su advisory lock no afecta suites paralelas.
+
+Validable en T0 con medición real.
+
+### D3 — Aislamiento entre tests: **TRUNCATE selectivo + `singleFork: true` con válvula de salida**
+
+Inicial:
+- Schema único `public` (no schema-per-suite — incompatible con `pgTable()` sin `pgSchema()`).
+- Cada test integration `TRUNCATE` las tablas que toca en `beforeEach` vía helper `cleanupTables`.
+- Vitest `pool: 'forks'`, `poolOptions.forks.singleFork: true`, `sequence.concurrent: false` (enforce serial).
+- Biome lint rule contra `.concurrent` en `test/integration/**`.
+
+**Válvula de salida** (P0-2): cuando la suite integration supere **60s sostenidos** en 3 corridas CI consecutivas, migrar a **schema-per-worker** (N=4 workers vitest):
+- `globalSetup` crea N schemas `test_w0`..`test_w3`, aplica migrations en cada uno.
+- `createTestDb(workerId)` retorna db con `SET search_path TO test_w<id>, public`.
+- Limitación: requiere refactor menor de `seed.ts` para parametrizar el workerId.
+
+La válvula entra al spec/plan separado cuando se dispara el criterio. Hoy no se implementa — sólo se documenta como camino conocido.
+
+Alternativas descartadas:
+- **BEGIN/ROLLBACK por test (Alt F del DA spec)**: incompatible con endpoints que abren transacciones internas (`db.transaction()`).
+- **DROP+CREATE schema por suite**: requiere `SET search_path` en cada conexión, invasivo.
+
+### D4 — Inyección DB en routes
+
+Resuelve P0-4 (DA spec) + P0-6 (DA plan). Verificación detallada va en T1 acceptance:
+
+- 29/33 routes ya usan factory pattern (`createXxxRoutes({ db, logger })`).
+- Las 4 residuales **deben enumerarse** en T1 con `grep -L "createXxxRoutes\\|opts\\.db\\|{ db }" apps/api/src/routes/*.ts`.
+- Las routes que importan `createDb` directamente quedan como **bloqueo blando**: si entran en grafo de imports de un test integration, requieren refactor antes.
+
+### D5 — Coverage exclude cleanup
+
+Quitar de `vitest.config.ts` exclude: `src/db/client.ts`, `src/db/migrator.ts`. Mantienen exclude: `src/main.ts`, `src/jobs/**`, `src/server.ts`, `src/db/schema.ts`, `src/**/*.d.ts`, `src/**/index.ts`.
+
+T6 mide antes/después y agrega tests si coverage cae bajo threshold del CI (`lines=80, branches=75, functions=80`).
+
+### D6 — Orden de PRs
+
+Bloque infra (T0-T6) **antes** de re-abrir D11 v2 T8. Confirma decisión PO 2026-05-17 ~08:20.
+
+---
+
+## Módulos tocados
+
+| Módulo / archivo | Tipo de cambio | Tareas |
+|---|---|---|
+| `apps/api/scripts/prototype-test-db.ts` | nuevo (one-shot script, no committed final) | T0 |
+| `apps/api/vitest.integration.config.ts` | nuevo | T1 |
+| `apps/api/test/setup.integration.ts` | nuevo | T1 |
+| `apps/api/test/integration/setup-global.ts` | nuevo | T1b |
+| `apps/api/test/helpers/test-db.ts` | nuevo | T1, T1b |
+| `apps/api/test/helpers/seed.ts` | nuevo | T3 |
+| `apps/api/test/helpers/cleanup.ts` | nuevo | T3 |
+| `apps/api/test/integration/health-db.integration.test.ts` | nuevo | T1 |
+| `apps/api/test/integration/migrations.integration.test.ts` | nuevo | T1b |
+| `apps/api/test/integration/seed.integration.test.ts` | nuevo | T3 |
+| `apps/api/test/integration/migrator-coverage.integration.test.ts` | nuevo (T6 si requiere) | T6 |
+| `apps/api/vitest.config.ts` | modificar | T1, T6 |
+| `apps/api/package.json` | modificar | T1 |
+| `.github/workflows/ci.yml` | modificar | T4 |
+| `apps/api/biome.json` o root `biome.json` | modificar (lint rule integration) | T1 |
+| `apps/api/test/integration/README.md` | nuevo | T5b |
+| `docs/adr/043-integration-testing-infrastructure-apps-api.md` | nuevo | T5a |
+| `skills/core-engineering/integration-test-writing.md` | nuevo | T5c |
+
+Total: **13 archivos nuevos, 4 modificados**. Cerca del techo de 10 módulos del skill — justificable por la naturaleza de infra que toca config + helpers + tests + docs simultáneamente.
+
+---
+
+## Tasks
+
+### T0: Prototipo medido (bloquea D1-D6)
+
+- **Files**:
+  - `apps/api/scripts/prototype-test-db.ts` (nuevo, **NO se mergea** — sirve para medir y validar; se descarta tras T1b).
+- **LOC estimate**: ~70 (script standalone).
+- **Depends on**: nada.
+- **Acceptance**:
+  - Script arranca `postgres:16-alpine` en Docker local con `docker run --rm -d ...` o asume Postgres local existente.
+  - `DROP SCHEMA public CASCADE; CREATE SCHEMA public;` → `runMigrations` × 2 (segunda corrida debe ser no-op via hash idempotencia de Drizzle).
+  - Reporta a stdout: tiempo de primera corrida, tiempo de segunda (no-op), tiempo del DROP+CREATE.
+  - Reporta cualquier error en segunda corrida (especialmente `applyOutOfOrderPending` con `CREATE TYPE` colisionando — si pasa, D2 cambia).
+  - Captura del output queda pegado en el PR de T1 como evidencia.
+- **Rollback**: no aplica — el script no se mergea. Si las mediciones invalidan D2/D3, abrir `/plan` v3.
+- **Success criterion para arrancar T1**: primera corrida <30s en local, segunda <5s, sin errores.
+
+### T1: `vitest.integration.config.ts` + scripts + setup.integration + helper test-db + test ref `SELECT 1`
+
+- **Files**:
+  - `apps/api/vitest.integration.config.ts` (nuevo) — config con `globalSetup` placeholder (vacío en T1, real en T1b), `setupFiles=['./test/setup.integration.ts']`, `include=['test/integration/**']`, `pool='forks'`, `poolOptions.forks.singleFork=true`, `sequence.concurrent=false`.
+  - `apps/api/test/setup.integration.ts` (nuevo) — versión paralela a `setup.ts`: stubea env vars excepto DATABASE_URL/TEST_DATABASE_URL (los lee del shell), mantiene mock de `google-auth-library`.
+  - `apps/api/test/helpers/test-db.ts` (nuevo) — `createTestDb()` retorna `{ pool, db }` apuntando a `TEST_DATABASE_URL`. Rechaza si URL contiene `prod`/`staging`.
+  - `apps/api/test/integration/health-db.integration.test.ts` (nuevo) — `SELECT 1` (NO migrations en T1; eso es T1b).
+  - `apps/api/vitest.config.ts` (modificar) — agregar `'test/integration/**'` al `exclude` del default run.
+  - `apps/api/package.json` (modificar) — scripts `test:integration`, `test:all`.
+  - Root `biome.json` o `apps/api/biome.json` (modificar) — lint rule contra `.concurrent` en `test/integration/**`.
+- **LOC estimate**: ~95 (40 config + 25 setup + 20 helper + 10 test + 5 lint).
+- **Depends on**: T0 (validación previa).
+- **Acceptance**:
+  - `pnpm --filter @booster-ai/api test` corre solo unit (sin integration), sin cambio de tiempo perceptible.
+  - `pnpm --filter @booster-ai/api test:integration` corre `health-db.integration.test.ts` y pasa en <3s local contra `TEST_DATABASE_URL`.
+  - Test rojo si `TEST_DATABASE_URL` contiene `prod`/`staging`.
+  - Lint rule **falla** si un test usa `.concurrent`.
+  - **Enumerar routes residuales**: comando en commit body: `grep -L "createXxxRoutes\\|opts\\.db" apps/api/src/routes/*.ts`. Output documentado. Si hay >0 routes que importan `createDb` directamente, listarlas en commit body como riesgo conocido para T1b/T8 re-open.
+- **Rollback**: revertir commit. Suite unit no se afecta.
+
+### T1b: Migration runner integrado en globalSetup
+
+- **Files**:
+  - `apps/api/test/integration/setup-global.ts` (nuevo) — globalSetup: `DROP SCHEMA + CREATE SCHEMA + runMigrations`.
+  - `apps/api/test/integration/migrations.integration.test.ts` (nuevo) — verifica que tabla `usuarios` existe + count(`drizzle.__drizzle_migrations`) == journal entries count.
+  - `apps/api/vitest.integration.config.ts` (modificar) — apuntar `globalSetup` al nuevo archivo.
+- **LOC estimate**: ~85 (50 globalSetup + 30 test + 5 config edit).
+- **Depends on**: T1, T0.
+- **Acceptance**:
+  - `pnpm test:integration` corre globalSetup + 2 tests (health + migrations) en <15s local.
+  - Re-correr `pnpm test:integration` SEGUNDA vez consecutiva pasa (DROP+CREATE + runMigrations idempotente).
+  - Count de migrations aplicadas == count de archivos `.sql` (37 al 2026-05-17).
+  - Si `applyOutOfOrderPending` dispara, log warning visible.
+- **Rollback**: revertir commit. T1 sigue funcionando (sin migrations).
+
+### T3: Helper `seed()` + `cleanupTables()` + test ref
+
+- **Files**:
+  - `apps/api/test/helpers/seed.ts` (nuevo) — primitivas para `usuarios`, `empresas`, `viajes`, `zonas_stakeholder`, `metricas_viaje`. Keys = nombres SQL en español, defaults válidos por FK.
+  - `apps/api/test/helpers/cleanup.ts` (nuevo) — `cleanupTables(db, tables)` con `TRUNCATE ... RESTART IDENTITY CASCADE`. Warnea (`logger.warn`) si detecta que CASCADE va a tirar tablas no listadas (consulta `pg_constraint`).
+  - `apps/api/test/integration/seed.integration.test.ts` (nuevo) — verifica conteo + FK + cleanup CASCADE warning.
+- **LOC estimate**: ~100 (60 seed + 25 cleanup + 15 test). Exacto al límite.
+- **Depends on**: T1, T1b.
+- **Acceptance**:
+  - `seed(db, { usuarios: 2 })` retorna `{ usuarios: [{ id, ... }, ...] }` con FK válidos.
+  - `cleanupTables(db, ['usuarios'])` log warn listando `memberships` (FK → usuarios) como tabla colateral.
+  - `pnpm test:integration` pasa con 3 tests.
+- **Rollback**: revertir commit.
+
+### T4: GitHub Actions job separado `test-integration` (paralelo a `test`)
+
+- **Files**:
+  - `.github/workflows/ci.yml` (modificar) — agregar job `test-integration` con `services.postgres`, `needs: [setup]`, `env.TEST_DATABASE_URL`, step `pnpm --filter @booster-ai/api test:integration`. `build` job actualizado a `needs: [lint, typecheck, test, test-integration]`.
+- **LOC estimate**: ~40 (block YAML del job).
+- **Depends on**: T1, T1b, T3 (sin T3 el job corre con solo 2 tests).
+- **Acceptance**:
+  - CI verde en PR de T4.
+  - Job `test-integration` corre paralelo a `test` (no en serie).
+  - Wall-clock CI total NO sube más de 2 min (medido antes/después).
+  - Si test integration falla, `build` no corre (verificable introduciendo test rojo y revirtiendo).
+- **Rollback**: revertir commit. Otros jobs siguen funcionando.
+
+### T5a: ADR-043
+
+- **Files**: `docs/adr/043-integration-testing-infrastructure-apps-api.md` (nuevo).
+- **LOC estimate**: ~100.
+- **Depends on**: T1, T1b, T3, T4 (necesita hechos verificables).
+- **Acceptance**:
+  - Secciones: Context, Decision, Consequences, Alternatives (B, E, F del DA spec), Status.
+  - Cita números medidos en T0/T1b (tiempo runMigrations, idempotencia verificada).
+  - Documenta válvula de salida `singleFork → schema-per-worker`.
+- **Rollback**: revertir commit. La infra funciona, queda sin ADR explícito (riesgo doc).
+
+### T5b: README `apps/api/test/integration/`
+
+- **Files**: `apps/api/test/integration/README.md` (nuevo).
+- **LOC estimate**: ~80.
+- **Depends on**: T1, T1b, T3.
+- **Acceptance**:
+  - Cubre 3 caminos de setup local (Docker, Postgres.app, brew).
+  - Template para escribir un nuevo integration test.
+  - Sección "Watch mode" declarando **fuera de scope** (P1-6 DA plan).
+  - Sección "TRUNCATE CASCADE semantics" (P1-5 DA plan) con ejemplo.
+  - 5 troubleshooting comunes.
+- **Rollback**: revertir commit.
+
+### T5c: Skill `integration-test-writing.md`
+
+- **Files**: `skills/core-engineering/integration-test-writing.md` (nuevo).
+- **LOC estimate**: ~80.
+- **Depends on**: T5b (README es contenido referencial).
+- **Acceptance**:
+  - Estructura per CLAUDE.md §3: When to use, Core process (5-7 pasos), Anti-rationalizations, Exit criteria.
+  - Referencia explícita a README integration y ADR-043.
+- **Rollback**: revertir commit.
+
+### T6: Coverage exclude cleanup (con DoD numérico)
+
+- **Files**:
+  - `apps/api/vitest.config.ts` (modificar) — quitar `'src/db/client.ts'` y `'src/db/migrator.ts'` del exclude.
+  - `apps/api/test/integration/migrator-coverage.integration.test.ts` (nuevo, opcional según medición).
+- **LOC estimate**: ~50 baseline (5 config + 45 tests si requiere). **Waiver hasta 80** si la medición exige más tests.
+- **Depends on**: T1b, T3.
+- **Acceptance — DoD numérico**:
+  - Antes del PR: capturar `pnpm --filter @booster-ai/api test --coverage --reporter=json-summary` → registrar `lines/branches/functions/statements`.
+  - Después del PR: capturar las mismas métricas.
+  - **Si cualquier métrica baja >2 puntos porcentuales** o **cae bajo el threshold del CI** (`lines=80, branches=75, functions=80`), agregar tests específicos hasta restaurar.
+  - Output del coverage report **pegado en el PR body** (sección Evidencia).
+- **Rollback**: revertir commit; exclude vuelve al estado previo.
+
+---
+
+## Out-of-band tasks
+
+- **Actualizar `docs/handoff/CURRENT.md`** tras cada merge de T0-T6.
+- **Actualizar `apps/api/test/setup.ts`** comentario explicando que `DATABASE_URL` stubea aquí es para unit (integration usa `TEST_DATABASE_URL` vía `setup.integration.ts`).
+- **Re-abrir D11 v2 T8** una vez T1b+T3+T4 estén merged (resto opcional pero recomendado antes).
+
+---
+
+## Open questions
+
+Todas las P0/P1 críticas resueltas en §"Decisiones arquitectónicas" arriba o en task acceptance. Quedan estos residuales:
+
+1. **P1-4 (DA plan)**: `concurrency.cancel-in-progress: true` del workflow puede dejar containers Postgres huérfanos en cancelaciones. Mitigación: documentar en T4 que GH se encarga del cleanup; medir post-merge.
+2. **Skill `integration-test-writing.md`** ya está en T5c — no más open.
+3. **Tiempo real de la suite** será medido en T0 y T1b, no es open question sino acceptance.
+
+---
+
+## Verificación del plan (skill checklist)
+
+- [x] T0-T6 son vertical slices reales (T1 corre `SELECT 1` end-to-end sin migrations; T1b agrega migrations; T3 agrega seed; T4 lleva al CI; T5a/b/c documentan; T6 cierra coverage).
+- [x] Todas las tasks ≤ 100 LOC estimate (T0=70, T1=95, T1b=85, T3=100, T4=40, T5a=100, T5b=80, T5c=80, T6=50/80).
+- [x] T5 splittear (no waiver inflado).
+- [x] Acceptance traza a spec §3 (CR-1..CR-10) para cada task.
+- [x] Rollback explícito para cada task.
+- [x] Devils-advocate output captured en archivo adjunto.
+- [ ] Aprobación PO explícita — pendiente.
+
+---
+
+## Estimación total
+
+- 9 tasks (T0 + T1 + T1b + T3 + T4 + T5a + T5b + T5c + T6) × ~80 LOC promedio = **~620 LOC netas**.
+- 8 PRs encadenados (T0 no produce PR — sus mediciones se documentan en T1 PR body).
+- Tiempo estimado: 4-6 horas focado distribuidas en 2-3 sesiones.
+
+## Solo-developer adaptation
+
+- Cooling-off 30 min entre cada task.
+- Devils-advocate sobre PR de T0/T1, T1b, T5a (las decisiones cerradas).
+- Cada task se mergea + mide CI antes de la siguiente.

--- a/docs/specs/2026-05-17-test-integration-infra-apps-api-devils-advocate.md
+++ b/docs/specs/2026-05-17-test-integration-infra-apps-api-devils-advocate.md
@@ -1,0 +1,153 @@
+# Devils-advocate review — test-integration-infra-apps-api
+
+**Spec target**: [`2026-05-17-test-integration-infra-apps-api.md`](./2026-05-17-test-integration-infra-apps-api.md)
+**Reviewer**: `agent-rigor:devils-advocate` (auto-invocado por skill `11-spec-driven-development` §Step 4)
+**Date**: 2026-05-17
+
+---
+
+## Verificaciones de hecho independientes (post-review)
+
+| Claim del devils-advocate | Verificación | Conclusión |
+|---|---|---|
+| Migrations son 35 | `ls apps/api/drizzle/*.sql \| wc -l` → **37** | DA equivocado por 2; CR-2 con "≥36" técnicamente cumple pero criterio frágil. |
+| Colisión 0009 | `ls apps/api/drizzle/0009*.sql` → 2 archivos | **Confirmado**. `0009_metricas_viaje_dual_source_adr028.sql` y `0009_stakeholder_access_log.sql`. |
+| Coverage CI vs vitest divergente | CI: `lines=80 branches=75 functions=80`. vitest: `lines=80 functions=75 branches=75 statements=80` | **Confirmado drift**: functions threshold no coincide (CI=80, vitest=75). |
+| `migrator.ts` toma advisory lock | Verificable en `apps/api/src/db/migrator.ts` | Pendiente lectura directa en /plan. |
+| `pgTable()` sin `pgSchema()` | Verificable en `apps/api/src/db/schema.ts` | Pendiente lectura directa en /plan. |
+| `src/db/client.ts` inicializa pool a nivel módulo | Verificable en `apps/api/src/db/client.ts` | Pendiente lectura directa en /plan. |
+
+---
+
+## Output del devils-advocate
+
+> Tengo munición concreta. Hechos cruzados que la spec contradice o pasa por alto:
+>
+> - Migrations reales son **35** archivos (no 36+ como dice CR-2). Hay además un **colisión 0009** (`0009_metricas_viaje_dual_source_adr028.sql` y `0009_stakeholder_access_log.sql`) — ya hay un bug real con orden out-of-order documentado en `migrator.ts`.
+> - `migrator.ts` toma un `pg.Pool` y un `Logger` (no es trivial de invocar desde un test), corre un advisory lock, lee `meta/_journal.json` y aplica recovery — **mucho más complejo que aplicar `*.sql` en orden**. CR-2 simplifica esto a "aplica todas las migrations en `apps/api/drizzle/*.sql`", que es semánticamente distinto a lo que hace prod (que usa journal, hash y advisory lock).
+> - `pg.app` no existe como tal (es Postgres.app). Detalle, pero la spec menciona "`pg.app`/Postgres.app" como dos cosas.
+> - CI workflow trabaja con `pnpm test` global (no por package). No hay forma trivial de "solo correr integration en api" sin pensar en Turbo filters.
+> - Coverage gate del root es `lines 80 / branches 75 / functions 80`. La spec dice `80/75/75/80` en CR-7 — **no coincide con el CI real** (functions es 80, no 75).
+> - `vitest.config.ts` excluye `src/db/migrator.ts` y `src/db/client.ts` de coverage. Si ahora ambos se ejercitan vía integration tests, hay incentivo perverso a borrar la exclusión, lo cual sube el denominador y puede tirar el coverage gate por debajo del threshold. La spec no menciona esto.
+>
+> Ahora ataco.
+>
+> ---
+>
+> ### 1) Objeciones críticas (P0) — rompen la spec
+>
+> **P0-1. Hay error de hecho en CR-2: son 35 migrations, no "≥36"**
+> `ls apps/api/drizzle/*.sql | wc -l` da **35** hoy (no 36). El umbral elegido (≥36) está mal calibrado y al merge ya estás violando tu propio success criterion. Peor: usar conteo de archivos como criterio es frágil (rebases, merges, etc.). Usá `journal.entries.length === migrations_count_on_disk` o el hash del journal. Cambia el criterio a algo semánticamente significativo o quítalo.
+>
+> **P0-2. CR-2 y CR-10 son contradictorios entre sí**
+> - CR-2 dice "el helper aplica automáticamente todas las migrations en `apps/api/drizzle/*.sql`".
+> - CR-10 dice "Migration runner usado en test es el **mismo** que producción (`apps/api/src/db/migrator.ts` o equivalente)".
+>
+> Pero `runMigrations(pool, logger)` de `migrator.ts` (a) toma un advisory lock `938472561` (en CI multi-suite paralelo va a **serializar todas las suites**, matando el paralelismo de la decisión B), (b) lee `meta/_journal.json` y hace recovery out-of-order via hash, (c) requiere un `Logger` de `@booster-ai/logger`. Si la spec quiere fidelidad (CR-10), la decisión B (schema-per-suite con paralelismo) **no funciona** porque el advisory lock es a nivel de sesión Postgres → todas las suites se serializan. O renuncias a paralelismo, o renuncias a fidelidad. Hoy CR-2/CR-10 quieren ambos. Resolvé esto antes de plan.
+>
+> **P0-3. Schema-per-suite no soporta el código actual: las tablas Drizzle no usan `pgSchema()`**
+> El código de producción usa `pgTable('usuarios', …)` sin schema explícito → cae en `public`. Si en test creas un schema dedicado `test_<random>` y le aplicas las migrations ahí, **el code-under-test no las va a encontrar** a menos que cambies el `search_path` por conexión, o que reescribas todas las migrations para que sean schema-aware, o que el helper rebale `db` con un wrapper que setee `SET search_path` por cada query. La spec no menciona ninguna de las tres. Lo más probable es que termines con DB-per-suite (pesado, 2-3s cada uno × N suites) o con prefijo de tabla (rompe todas las migrations). Decisión B está descrita en una línea sin tocar este punto. Es la objeción técnica más grave.
+>
+> **P0-4. La conexión a DB se inicializa a nivel de módulo en `src/db/client.ts`**
+> Si el endpoint bajo test importa `db` (cliente real) desde `@/db/client`, el pool se crea **una sola vez al primer import** del proceso vitest. Schema-per-suite implica que cada suite necesita su propia conexión apuntada a su propio search_path. O bien (a) el helper devuelve una `db` que se **inyecta** al code-under-test (entonces hay que refactorizar todas las routes para aceptar `db` por parámetro/DI — trabajo enorme no contemplado), o (b) cada suite arranca un proceso vitest nuevo (`--isolate` o `pool: 'forks'`), lo que dispara el costo total. La spec asume (sin decirlo) que existe un mecanismo de inyección que **no existe en el repo**. Si vas a inyectar, eso es trabajo aguas arriba con scope mayor que la propia infra de tests.
+>
+> **P0-5. CR-7: el threshold del CI no es 80/75/75/80, es 80/75/80**
+> El CI ya define `COVERAGE_MIN_LINES=80`, `COVERAGE_MIN_BRANCHES=75`, `COVERAGE_MIN_FUNCTIONS=80`. El `vitest.config.ts` declara `lines 80 / functions 75 / branches 75 / statements 80`. Hay **divergencia ya existente** entre CI y vitest.config (functions: 80 vs 75). La spec cita "80/75/75/80" como si fuera la verdad, pero no lo es. CR-7 obliga a mantener un threshold que no está consistente hoy → criterio inverificable.
+>
+> **P0-6. `migrator.ts` y `db/client.ts` están actualmente excluidos del coverage**
+> `vitest.config.ts` línea 27-28: excluidos por "cubierto vía integration tests" y "wrapper trivial". Cuando esta infra exista, esa justificación cae. Si los **incluyes** en coverage (correcto), el denominador crece y el numerador podría no crecer al mismo ritmo → coverage real cae. La spec no anticipa esto. Mínimo: CR-7 debe especificar **qué archivos van a salir del exclude** y qué impacto numérico esperan.
+>
+> ---
+>
+> ### 2) Objeciones materiales (P1) — debilitan la spec sustantivamente
+>
+> **P1-1. Decisión A descarta `testcontainers-node` por argumento débil**
+> "Cada suite arranca su propio container (~3-5s)" — falso. `testcontainers-node` tiene patrón de **reuse** vía `withReuse()` que arranca **un solo container** por test session. El "overhead operacional" es exactamente lo mismo que tener Docker para el dev local (que igual vas a exigirle). La razón real para no usar testcontainers podría ser: agrega una dependencia más, latencia de pull la primera vez, y semantics de cleanup. Pero los argumentos dados son cosméticos. Alternativa B descartada con razonamiento débil.
+>
+> **P1-2. No considera Alternativa E: el `pg` embebido (`@embedded-postgres/postgres`) o `electric-sql/pglite`**
+> - **pglite** (WASM Postgres real, mismo binario en proceso): arranque <1s, fork del Postgres real, soporta `ANY(array)`, intervals, JSON, pgcrypto. No requiere Docker en local. Sería un cambio dramático en facilidad de onboarding. La spec lo ignora.
+> - **embedded-postgres** (node package que descarga el binario Postgres y lo levanta en un puerto): no requiere Docker pero da Postgres real.
+>
+> No tienen que ser la elegida, pero el ADR-043 va a salir débil si no se mencionan y se rechazan con razón explícita. Alternativas C (SQLite) está bien rechazada; A y B no agotan el espacio.
+>
+> **P1-3. No considera Alternativa F: shared DB, transacción por test con rollback**
+> Patrón común (Rails, Django, knex, jest-fixtures): UNA DB, UNA conexión por test, todo dentro de `BEGIN`/`ROLLBACK`. No requiere schema-per-suite. No requiere drop. Limitaciones reales (no funciona con código que abre su propia transacción, dificulta paralelismo de tests dentro del mismo file), pero rendimiento es muy superior. La spec no lo discute. Esto es la alternativa Industrial-Standard que más gente usa y la spec la omite.
+>
+> **P1-4. Riesgo ausente: orden de tests cambia comportamiento aunque schemas estén aislados**
+> Si dos suites paralelas hablan con el **mismo Postgres** (Decisión B), comparten cache de planner, advisory locks (¡como el del migrator!), `pg_stat_statements`, y secuencias globales. Si una migration usa `CREATE SEQUENCE` global o `CREATE EXTENSION pgcrypto IF NOT EXISTS` (que dice en migrations existentes), la segunda suite puede colisionar al instalar extensiones. La spec no menciona extensiones ni `CREATE TYPE` (que el migrator.ts mismo cita como fuente de duplicate-key races).
+>
+> **P1-5. Riesgo ausente: migrations no idempotentes**
+> El comentario gigante del `migrator.ts` describe explícitamente que ya **hay bugs reales** con migraciones out-of-order (0009 duplicado en el repo, dos archivos con prefijo 0009). El helper que aplica migrations en test **va a heredar ese bug**. Si CR-10 demanda usar el mismo runner, vas a heredar la recovery path y el advisory lock. Si NO usas el mismo runner, hay un riesgo de divergencia (que CR-10 prohíbe). La doble naturaleza del migrator (Drizzle + recovery custom) no está reflejada en la spec.
+>
+> **P1-6. Riesgo ausente: pool exhaustion**
+> `DATABASE_POOL_MAX=5` en `test/setup.ts`. Si schema-per-suite + paralelismo, cada suite abre su propio pool. Vitest por defecto usa N workers = N cores (en GH runner ubuntu-latest, 4 cores). 4 suites × 5 conexiones = 20 conexiones simultáneas al Postgres del service container. Postgres default `max_connections=100`. Probable que funcione, pero el budget no está calculado en la spec. Más grave: si una suite hace migrations (pool client #1) y otra hace seed (pool client #2..N), el advisory lock del migrator va a serializarlas → no es paralelismo real.
+>
+> **P1-7. CR-6 promete "GitHub Actions service container Postgres es gratis"**
+> Verificá. Es gratis en runners hosted, sí, pero **agrega 30-90s al startup del job** (pull image, start postgres, healthcheck). El budget de "≤90s integration suite" no incluye este overhead. El gate real es ~5min wall-clock. Debería estar explícito.
+>
+> **P1-8. Open question #2 ("orden de PRs") debería ser una decisión, no una pregunta**
+> Si T8-T12 están bloqueadas hasta que esta infra exista, la respuesta es obvia: infra primero, T8 después. Mantener esto como "open question" implica que el plan v2 va a quedar en negociación de nuevo. Definí en spec: "infra mergea standalone, T8 abre PR encadenado".
+>
+> **P1-9. Falta criterio sobre `seed.ts` que respete las reglas de naming bilingüe (CLAUDE.md)**
+> CR-5 menciona `usuarios, empresas, viajes, zonas_stakeholder, trip_metrics`. Pero `trip_metrics` violaría la regla bilingüe (la tabla real es `metricas_viaje` según las migrations 0008/0009/0011/0012). La spec mezcla snake_case español con inglés sin justificación. Si el seed helper expone keys en inglés y SQL en español → es un buen patrón pero hay que decidir y documentarlo. Si el seed expone los nombres SQL como están → CLAUDE.md está siendo respetado pero la spec usa nombres incorrectos.
+>
+> **P1-10. La spec no dice qué hace con `setup.ts` actual**
+> `apps/api/test/setup.ts` stubea env vars y mockea `google-auth-library` global. La infra de integration va a necesitar **no** stubear `DATABASE_URL` (porque ahora va a uno real), pero va a seguir necesitando el mock de google-auth-library. ¿Hay dos `setup.ts` (uno para unit, uno para integration)? CR-4 menciona `vitest.integration.config.ts` separado, pero no dice si comparte setup o no. Detalle, pero crítico para que funcione.
+>
+> **P1-11. No hay criterio sobre lo que pasa cuando se rompe el helper en main**
+> Si alguien commitea una migration que rompe la infra de testing (ej. nueva extensión Postgres que el service container no tiene), ¿cómo se detecta? CR-6 no exige una "smoke test" que valide que el helper sigue funcionando independiente del resto.
+>
+> ---
+>
+> ### 3) Cuestionamientos (P2) — el PO debería saber pero no bloquean
+>
+> **P2-1. Supuesto implícito: esta spec desbloquea D11 v2 T8. ¿Y si no?**
+> Esta spec da infra. T8 sigue requiriendo (a) escribir el endpoint, (b) escribir el test integration usando esta infra. Si el endpoint mismo tiene problemas de diseño (LEFT JOIN ineficiente, opt-in cookie no resuelto, kanonimización de stakeholder), la infra de tests **no los soluciona**. La spec implícitamente vende "haz esto y D11 desbloquea". En realidad: hace esto y T8 puede ser implementado correctamente. T9-T12 cada uno trae sus propios riesgos no relacionados. No vendas más de lo que entrega.
+>
+> **P2-2. Costo de oportunidad: ¿es esto lo siguiente correcto?**
+> Argumentos en contra:
+> - 35 migrations sin test integration significa que **todas las features previas** (Wave 1, 2, 3 de telemetría; pricing v2; factoring; sucursales; conductores; demo seed) shippearon sin esta infra. Es decir, el negocio sigue funcionando hoy. La urgencia para esta semana es D11; D11 podría aterrizarse **con migración progresiva** (un primer integration test específico para `/stakeholder/zonas`, y la infra reusable emerge inductivamente).
+> - Otras urgencias más demostrables podrían ser: (a) staging real con seed datos al día (ya parcialmente cubierto por T6), (b) auditoría completa T-SEC-* siguiendo la racha de commits recientes, (c) Wave 3 v2 secuencia documentada como skill.
+>
+> Argumentos a favor (que la spec da bien):
+> - Sin esta infra, T8-T12 ship con cero evidencia de SQL correctness.
+>
+> Pero el PO debería decidir explícitamente. La spec asume que está claro.
+>
+> **P2-3. ADR-043 número**
+> Verificá que 043 es el siguiente libre. La spec dice "ADR a crear: 043" sin validar.
+>
+> **P2-4. CR-3 dice "tiempo total <30s local, <90s CI"**
+> Los 90s incluyen startup del Postgres container (~30s). El test mismo tiene 60s. ¿Realista para una suite de 6 tests? Probablemente sí; verificable solo midiendo. Hoy es un guess. Marcalo como "objetivo, a recalibrar tras T-INFRA-1".
+>
+> **P2-5. Mantener tests unit-mocked existentes (CR-7) crea drift**
+> La spec dice "mocks unit existentes no se borran (coexisten)". Esto significa que `routes/*.test.ts` que ya están sobre `vi.fn()` se quedan ahí, y nuevos `routes/*.integration.test.ts` se agregan. Termina con dos suites paralelas testeando lo mismo, con un mock-suite que mente. Es una decisión válida (gradualismo) pero la spec debería decir cuándo se purga el unit-mock: ¿cuando la integration cubre el mismo path? ¿cuándo la cobertura del integration test supera X%? Sin regla, esto se va a quedar para siempre.
+>
+> **P2-6. Skill / playbook ausente**
+> CLAUDE.md §3 ("Process over knowledge") obliga a crear skill si la tarea es repetible. "Escribir un test integration con DB real" es repetible, futura, y cada feature en el repo va a usarlo. La spec menciona "template documentado para escribir un integration test" en §4 pero no exige que sea un skill en `skills/core-engineering/` con la estructura When/Process/Anti-rationalizations/Exit. Sin skill, el primer dev que tope con la infra va a hacerla mal.
+>
+> **P2-7. Open question #3 (coverage de la infra)**
+> Cobertura del helper de test es metainfra; tratar como código normal es razonable, pero merece criterio explícito.
+>
+> ---
+>
+> ### Verdict
+>
+> - **Strong objections (must address)**: P0-1 (CR-2 error fáctico de conteo), P0-2 (CR-2/CR-10 contradictorios sobre fidelidad del runner), P0-3 (schema-per-suite incompatible con tablas sin `pgSchema()`), P0-4 (cliente DB se inicializa a nivel módulo, no hay DI), P0-5 (umbral de coverage citado mal), P0-6 (coverage exclusion de `migrator.ts`/`client.ts` no anticipada).
+> - **Residual risks (accept and document)**: testcontainers/pglite rechazados sin razón fuerte (P1-1, P1-2); patrón rollback-por-test no considerado (P1-3); extensiones Postgres pueden colisionar entre suites paralelas (P1-4); migration runner es buggy upstream y la infra lo hereda (P1-5); pool exhaustion bajo paralelismo no calculado (P1-6); 90s budget no incluye startup del service container (P1-7); coverage de `migrator.ts`/`client.ts` puede tirar el gate al incluirlos (P0-6 también).
+> - **Out of scope for this review**: si T8-T12 tienen otros problemas además de tests (P2-1); decisión de orden con otros work-items urgentes (P2-2); skill formal para escribir tests integration (P2-6).
+>
+> **Conclusión sin diplomacia**: la spec va por el camino correcto pero **tiene al menos 6 P0 que no son cosméticos**. El más grave es P0-3 (schema-per-suite no funciona con el código actual sin refactor) y P0-2 (CR-2/CR-10 piden cosas mutuamente excluyentes). Si se mergea así, en /build descubrís el problema cuando ya invertiste 3 horas. Resolvelo en /plan antes: define explícitamente si CR-10 cede (usás `migrate` de drizzle directo, no `runMigrations` con su advisory lock) o si CR-paralelismo cede (Decisión B baja a "una DB compartida, tests seriales, schema único"). No se pueden tener ambos.
+
+---
+
+## Acción tomada en la spec tras este review
+
+- CR-2 corregido para usar criterio semánticamente significativo (no conteo de archivos).
+- CR-7 corregido para reflejar los thresholds reales del CI (80/75/80) y mencionar el drift con `vitest.config.ts`.
+- §9 expandida con P1-4, P1-5, P1-6, P1-7.
+- §12 expandida con P0-2, P0-3, P0-4, P0-6 como open questions de bloqueo a resolver en `/plan`.
+- §8 expandida con Alternativas E (`pglite`/`embedded-postgres`) y F (transaction-rollback per test).
+- §13 referencia este archivo.
+
+P2 dejadas para discusión PO en el momento de aprobar la spec.

--- a/docs/specs/2026-05-17-test-integration-infra-apps-api.md
+++ b/docs/specs/2026-05-17-test-integration-infra-apps-api.md
@@ -1,0 +1,147 @@
+# Spec — Test integration infrastructure para `apps/api`
+
+- **Author**: Felipe Vicencio (PO) + Claude (agent-rigor)
+- **Date**: 2026-05-17
+- **Status**: Draft
+- **Linked**: D11 v2 plan T8-T12 bloqueadas por ausencia de esta infra
+- **ADR a crear**: `043-integration-testing-infrastructure-apps-api.md`
+
+---
+
+## 1. Objetivo
+
+Establecer la infraestructura de **integration testing con base de datos real** en `apps/api`: un mecanismo que arranca Postgres aislado por suite, aplica todas las migrations Drizzle (`apps/api/drizzle/*.sql`) contra ese Postgres, expone helpers de seed reusables y permite a cada test ejercer queries reales del code under test sin mockear el query builder. El propósito es desbloquear D11 v2 (T8-T12) y futuras features cuyo correctness depende del SQL ejecutado, no de la lógica in-memory.
+
+## 2. Why now
+
+Auditoría 2026-05-17 sobre `apps/api/test/`: el repo no tiene **ninguna** prueba de integración con DB real. El único acceso a DB es `health.test.ts` (ping). El plan v2 D11 §192 exige *"Tests integration NO mocked-Drizzle — usar test DB real (per spec §10)"* y el handoff D11 v2 lección #3 lo refuerza, pero la implementación de T8 quedó forzada a unit-mocked (`vi.fn()` sobre el query builder) porque no existe el patrón. Resultado: el SQL del endpoint `/stakeholder/zonas` (`LEFT JOIN`, `ANY(comuna_codes)`, `now() - interval '30 days'`, `WHERE is_active`) nunca se ejerce en CI. Si se merge así, T9-T12 heredan el patrón y D11 entera ship con cero evidencia de correctness del SQL — violación directa de CLAUDE.md §2 ("Evidence over assumption"). El bloqueo es pre-requisito de D11 v2.
+
+## 3. Success criteria
+
+Cada criterio verificable por test, output o file existente.
+
+- [ ] **CR-1**: Existe un helper `createTestDb()` en `apps/api/test/helpers/test-db.ts` que retorna `{ db: Db, cleanup: () => Promise<void> }`. La instancia es Postgres real (no mock, no pg-mem) y aislada por suite (schema dedicado o database dedicada).
+- [ ] **CR-2**: El helper aplica automáticamente **todas** las migrations Drizzle antes de retornar la `db`. Criterio verificable: tras invocar el helper, `SELECT COUNT(*) FROM drizzle.__drizzle_migrations` debe coincidir con el conteo de entries en `apps/api/drizzle/meta/_journal.json` y con `ls apps/api/drizzle/*.sql | wc -l` (al 2026-05-17: 37 archivos `.sql`, incluyendo colisión `0009_*` doble — ver open question §12 sobre estrategia de runner).
+- [ ] **CR-3**: Existe `apps/api/test/integration/` con al menos **un** test de referencia (ej. `health-db.integration.test.ts`) que: arranca DB, aplica migrations, hace un INSERT + SELECT real, valida resultado, limpia. Tiempo total <30s en local, <90s en CI.
+- [ ] **CR-4**: `vitest.config.ts` distingue **suites unit vs integration** vía glob (`include`/`exclude`) o tag. `pnpm test` corre unit (rápido, default). `pnpm test:integration` corre integration explícitamente. CI corre **ambos** y reporta cobertura unificada.
+- [ ] **CR-5**: Helper `seed(db, fixtures)` con primitivas para insertar `usuarios`, `empresas`, `viajes`, `zonas_stakeholder`, `trip_metrics` con valores válidos por defecto (cumpliendo NOT NULL constraints) y overrides parcial por test.
+- [ ] **CR-6**: Postgres en CI provisto vía **GitHub Actions service container** (`services.postgres`) con imagen `postgres:16-alpine` (alineado con prod GCP Cloud SQL). En local, opciones documentadas: (a) Docker Desktop, (b) `pg.app`/Postgres.app, (c) `pg-ext` instalado. Documentación en `apps/api/test/integration/README.md`.
+- [ ] **CR-7**: Coverage gate del CI **no se relaja** por la nueva suite. Thresholds reales del CI (`.github/workflows/ci.yml`): `lines=80, branches=75, functions=80`. Hay drift conocido con `apps/api/vitest.config.ts` (functions=75 vs CI 80) — esta spec **no resuelve** el drift; sólo exige que el threshold efectivo del CI se mantenga. Tests integration cuentan en coverage; mocks unit existentes no se borran (coexisten — ver P2-5 del devils-advocate review para criterio futuro de retiro).
+- [ ] **CR-8**: `apps/api/test/integration/README.md` documenta: cómo correr local, cómo correr en CI, cómo escribir un test integration (template), troubleshooting de errores comunes (puerto ocupado, role no existe, schema not found).
+- [ ] **CR-9**: `ADR-043` registra: decisión (Postgres real vs pg-mem vs testcontainers JS), trade-offs, qué tests **deben** ser integration (regla: cualquier ruta que ejecute SQL no trivial) vs unit (lógica pura).
+- [ ] **CR-10**: Migration runner usado en test es el **mismo** que producción (`apps/api/src/db/migrator.ts` o equivalente). Cualquier divergencia (skip de migrations, orden distinto) prohibida y verificable en review.
+
+## 4. User-visible behaviour
+
+Cero usuarios finales afectados — esto es infra de testing. Cambios visibles para el desarrollador:
+
+- **BEFORE**: `pnpm test` corre solo unit-mocked. Imposible verificar SQL real sin desplegar a staging.
+- **AFTER**:
+  - `pnpm test` corre unit (sin cambio de tiempo perceptible).
+  - `pnpm test:integration` corre suite integration con DB real.
+  - `pnpm test:all` corre ambos.
+  - CI corre ambos y falla si cualquiera falla.
+  - Nuevo template documentado para escribir un integration test.
+
+## 5. Out of scope
+
+Explícitamente **NO** cubre:
+
+- **Migrar tests unit-mocked existentes a integration**. Esta spec crea la infra; la migración progresiva es trabajo de cada feature subsecuente.
+- **Tests E2E con frontend** (Playwright/Cypress). Esos son otra capa y otra spec.
+- **Test data factory (Factory Bot / Faker patterns)**. Helpers de seed primitivos son suficientes; framework de factories puede emerger después si hay demanda.
+- **Performance tests** (`apps/api/test/perf/`). T12 D11 los necesita pero es scope separado.
+- **DB testing para apps no-api** (`apps/web`, `apps/matching-engine`, etc.). Cada app decide su estrategia; esta spec aplica solo a `apps/api`.
+- **Sustituir Postgres por base distinta**. Cloud SQL Postgres es el target prod; test usa mismo motor.
+- **Reset/rollback intra-test** vía savepoints. Cleanup por suite (drop schema) es suficiente; savepoints introducen complejidad sin beneficio demostrado todavía.
+
+## 6. Constraints
+
+- **Performance**: integration suite total ≤90s en CI. Si excede, particionar por dominio o usar schema-per-suite + paralelismo.
+- **Reproducibilidad**: tests deterministas. Sin `now()` no-mockeado en assertions; cualquier dato dependiente de tiempo usa `INSERT` con timestamp explícito o el test fija el reloj.
+- **Aislamiento**: ningún test integration debe leer/escribir estado dejado por otro test. Schema-per-suite o DROP+CREATE entre suites.
+- **Compatibilidad**: pg `16-alpine` mismo major que prod Cloud SQL. Si prod cambia, test sigue.
+- **Costos CI**: GH Actions service container Postgres es gratis dentro del runner. Sin costos extra.
+- **Seguridad**: tests **nunca** apuntan a DBs reales (staging, prod). El connection string viene de un env var dedicado (`TEST_DATABASE_URL`) y el helper falla si detecta `staging`/`prod` en el host.
+- **Compliance**: tests no procesan datos reales de usuarios. Fixtures son sintéticos.
+
+## 7. Approach
+
+Dos decisiones técnicas centrales que el ADR-043 documentará:
+
+**Decisión A — Motor de DB en test**: Postgres real (vía service container en CI, Docker/Postgres.app en local), no `pg-mem` ni `testcontainers-node`. Razón: paridad con prod. `pg-mem` no soporta `ANY(array)`, intervals complejos ni varios features de Postgres 16 que el código de Booster AI usa. `testcontainers-node` añade dependencia, complejidad de lifecycle y requiere Docker tanto en local como CI (ya tenemos Docker en CI, pero local sería fricción).
+
+**Decisión B — Aislamiento por suite**: cada suite (file) recibe un **schema** dedicado (`test_<random>`) dentro de la misma DB, no una DB nueva. Razón: crear DB es lento (>2s); crear schema es <100ms. Cleanup vía `DROP SCHEMA ... CASCADE` al final de la suite. Esto permite paralelismo seguro y mantiene la suite <90s.
+
+**Files que se tocan**:
+
+- `apps/api/package.json` — scripts `test:integration`, `test:all`, dependency `pg` ya existe.
+- `apps/api/vitest.config.ts` — `exclude` para integration en el run default + `vitest.integration.config.ts` separado.
+- `apps/api/test/helpers/test-db.ts` (nuevo) — helper `createTestDb()`.
+- `apps/api/test/helpers/seed.ts` (nuevo) — primitivas de seed.
+- `apps/api/test/integration/README.md` (nuevo) — documentación.
+- `apps/api/test/integration/health-db.integration.test.ts` (nuevo) — test de referencia.
+- `.github/workflows/ci.yml` — agregar service `postgres` + step `pnpm test:integration`.
+- `docs/adr/043-integration-testing-infrastructure-apps-api.md` (nuevo) — ADR de decisión.
+
+## 8. Alternatives considered
+
+- **A. `pg-mem` (in-memory pure JS Postgres-compatible)** — Rechazada: no implementa `ANY(array)` con types como `text[]`, no soporta `interval`, no honra el resto de extensiones que las migrations usan (`pgcrypto`, etc.). Sería un mock-elaborado que aceptaría queries falsas como válidas — el mismo problema que motivó esta spec.
+- **B. `testcontainers-node` con imagen Postgres** — Rechazada **con razón débil** (devils-advocate P1-1): `testcontainers-node` tiene `withReuse()` que arranca un solo container por test session, así que el overhead no es por-suite. Razones reales para no usarlo: agrega una dependencia más, primera latencia de pull, y dependencia de Docker en local que ya tendría que estar disponible. Decisión a confirmar en `/plan` después de pesar `pglite` (Alternativa E) — testcontainers podría volver a estar en juego.
+- **C. SQLite en memoria con drizzle-kit `sqlite` driver** — Rechazada: cambiar de dialecto rompe el SQL del producto (Drizzle genera SQL distinto, `serial` vs `autoincrement`, sin `interval`, sin enums Postgres). Es una pérdida de paridad inadmisible.
+- **D. Tests integration corren **solo** en CI, no en local** — Rechazada: rompe el ciclo de feedback corto del desarrollador. Solo-developer mode (CLAUDE.md §6) requiere poder iterar local antes de push.
+- **E. `electric-sql/pglite` (WASM Postgres real, in-process)** — **A evaluar en `/plan`**: WASM build del Postgres real, arranque <1s, mismo dialecto, soporta `ANY(array)`, intervals, extensiones (`pgcrypto`, `uuid-ossp`). Sin Docker en local. Limitaciones reportadas: extensiones que requieren shared libs nativos, paralelismo limitado (proceso único), foreign data wrappers. Si el conjunto de features que Booster AI usa cabe dentro de pglite, sería la opción de menor fricción para dev local. Pendiente verificación con el set real de migrations.
+- **F. Shared DB + transacción por test con `BEGIN`/`ROLLBACK`** — **A evaluar en `/plan`**: patrón industrial (Rails, Django, knex test helpers). UNA DB, cada test envuelve su trabajo en `BEGIN ... ROLLBACK`, sin DROP entre tests. Ventajas: 5-10x más rápido que schema-per-suite, no requiere coordinación de paralelismo. Desventajas: rompe con código que abre sus propias transacciones; el endpoint de Booster AI probablemente abre transacciones internas (vía Drizzle `db.transaction`), lo cual entra en conflicto con la transacción externa del test. Verificable solo midiendo. La decisión final entre B/E/F la toma `/plan` con prototipo medido.
+
+## 9. Risks and mitigations
+
+| Riesgo | Probabilidad | Impacto | Mitigación |
+|---|---|---|---|
+| Tests integration flaky por timing/orden | Media | Alto (CI rojo intermitente) | Schema-per-suite + cleanup obligatorio + sin paralelismo intra-suite; assertions deterministas (timestamps explícitos). |
+| Postgres local no disponible para dev nuevos | Alta | Medio (fricción onboarding) | README con tres caminos (Docker, Postgres.app, brew install postgresql@16); script `pnpm test:integration:setup` que valida y guía. |
+| Suite integration crece sin control y excede 90s CI | Media | Medio (CI lento) | Budget explícito en CR-1 (90s). Si excede, ADR-043 §evolución obliga particionar. |
+| Drift entre migration runner test vs prod | Baja | Alto (test verde, prod rojo) | CR-10: mismo runner. Test que valida lista de migrations aplicadas == lista en `apps/api/drizzle/*.sql`. |
+| Dependencias adicionales (Docker, pg client) crean fricción | Media | Bajo | Documentación + script setup. Si dev no tiene Docker, Postgres.app cubre el caso. |
+| Tests integration usados como "todo es integration" → erosionan unit suite | Baja | Medio | ADR-043 fija la regla: unit para lógica pura, integration para rutas/queries. Code review aplica. |
+| **Extensiones Postgres colisionan entre suites paralelas** (devils-advocate P1-4) | Media | Alto (CI rojo intermitente difícil de debuggear) | Las migrations existentes hacen `CREATE EXTENSION IF NOT EXISTS` y `CREATE TYPE`. Schemas aislados no aíslan extensiones (son a nivel de DB). Mitigación: precrear extensiones en el container Postgres antes del primer test (init script en GH service `volumes`); secuenciar `CREATE TYPE` con `IF NOT EXISTS` o try/catch. Validable con T-INFRA-3 (paralelismo). |
+| **Migration runner hereda bug de 0009 duplicado** (devils-advocate P1-5) | Alta (ya existe en main) | Medio | `apps/api/drizzle/0009_*.sql` tiene dos archivos con mismo prefijo; `migrator.ts` ya implementa recovery out-of-order vía hash. La infra de test heredará el mismo path: o usa `runMigrations` (advisory lock + recovery, fidelidad pero serializa) o `drizzle-orm/postgres-js/migrator` directo (rápido pero no fideliza el bug-recovery). Decisión a tomar en `/plan` y registrar en ADR-043. |
+| **Pool exhaustion bajo paralelismo** (devils-advocate P1-6) | Media | Medio | Cálculo: 4 workers vitest × 5 conexiones (`DATABASE_POOL_MAX=5`) = 20 conns vs `max_connections=100` Postgres default. Margen amplio. Pero el advisory lock del migrator serializa de facto si se invoca por suite. Reducir `DATABASE_POOL_MAX=2` en test, o consolidar migrations en setup global single-shot. |
+| **Service container Postgres añade ~30-90s de startup CI** (devils-advocate P1-7) | Alta (cada job) | Bajo (predecible) | El budget de 90s de CR-3 cubre el wall-time de **la suite**, no el startup del job. Documentar en ADR-043 que el wall-clock total del job es ~5min y eso es aceptable (la suite unit añade ~2min hoy). |
+
+## 10. Test list
+
+- **T-INFRA-1**: `health-db.integration.test.ts` arranca DB, aplica migrations, hace `SELECT 1`, cleanup. Pasa en <5s local.
+- **T-INFRA-2**: `seed.integration.test.ts` invoca `seed(db, { usuarios: 2, empresas: 1, viajes: 3 })`, verifica conteo y FK integridad.
+- **T-INFRA-3**: Helper `createTestDb()` con TWO concurrent suites (paralelismo vitest) no se pisan — cada una ve solo su schema.
+- **T-INFRA-4**: Helper rechaza connection string con `prod`/`staging` en host (test de seguridad).
+- **T-INFRA-5**: Migration runner aplica `0001` a `00XX` (todas las que existan al momento) sin errores.
+- **T-INFRA-6**: CI workflow `.github/workflows/ci.yml` ejecuta `pnpm test:integration` y falla si test integration falla (verificado introduciendo un test rojo a propósito y revirtiendo).
+
+## 11. Rollout
+
+- **Feature-flagged?** No. Infra de test es código que solo corre en CI/local, no afecta runtime.
+- **Migration needed?** No (las migrations existen ya; este trabajo las aplica en test, no las modifica).
+- **Rollback plan**: si la infra introduce flaky o lentitud CI inaceptable, revertir el PR. Los tests unit existentes siguen pasando porque coexisten. Sin pérdida de cobertura.
+- **Monitoring**: tiempo total CI antes/después del merge. Si excede 5min global, abrir issue de optimización. % de tests integration vs unit semanal.
+
+## 12. Open questions
+
+Bloqueantes (deben resolverse en `/plan` antes de `/build`):
+
+1. **P0-2 — CR-2 vs CR-10 (fidelidad vs paralelismo)**: usar `runMigrations` de `migrator.ts` (real-prod, advisory lock `938472561` que serializa todas las suites) o `migrate()` de `drizzle-orm/postgres-js/migrator` (rápido, sin advisory lock, pierde el recovery custom de 0009-duplicate). Decisión cierra `/plan` y se documenta en ADR-043.
+2. **P0-3 — Aislamiento real con tablas en `public`**: las tablas Drizzle usan `pgTable('usuarios', ...)` sin `pgSchema()`, todas caen en `public`. Schema-per-suite (Decisión B §7) **no funciona** sin: (a) wrapper que setea `SET search_path TO test_<random>, public` por conexión, (b) reescribir todo `schema.ts` con `pgSchema()` (cambio invasivo), o (c) caer a DB-per-suite (más caro). `/plan` decide cuál y prototipea.
+3. **P0-4 — Inyección de DB en el code-under-test**: `src/db/client.ts` inicializa `pg.Pool` a nivel de módulo al primer import. Para que el test integration use un schema dedicado, el endpoint debe **aceptar `db` por parámetro** (la route `createStakeholderRoutes({ db, logger })` ya lo hace — bien) o vitest debe correr cada suite en proceso separado (`pool: 'forks'`, costoso). Validar que **todas** las routes futuras siguen el patrón de inyección.
+4. **P0-6 — Quitar `migrator.ts`/`client.ts` del coverage exclude**: hoy `vitest.config.ts` los excluye con justificación "cubierto vía integration tests" (excluído pero no realmente cubierto). Cuando esta infra exista, el exclude pierde justificación y se debería quitar. Pero hacerlo sube el denominador y posiblemente tira el threshold. `/plan` decide si se quita en este sprint (con tests adicionales que compensen) o se difiere.
+5. **Posición en el orden de PRs**: la spec asume "infra primero, T8 después". Confirmado por el bloqueo formal de T8-T12 en plan v2 D11. No es realmente abierto — registrarlo como decisión explícita en `/plan`.
+
+No bloqueantes (se pueden cerrar durante `/plan` o quedar como residuales):
+
+6. **Coverage de la infra misma**: ¿gate explícito (ej. 90% del helper) o se confía en que se usa por todos los tests integration? Default propuesto: gate normal del package.
+7. **`setup.ts` único o split unit/integration** (devils-advocate P1-10): el current stubea env vars y mockea `google-auth-library`. Integration necesita NO stubear `DATABASE_URL`. Probable: dos setup files (`setup.ts` para unit, `setup.integration.ts` para integration) que comparten el mock de google-auth-library.
+8. **Skill formal para escribir tests integration** (devils-advocate P2-6): CLAUDE.md §3 obliga si la tarea es repetible. Crear `skills/core-engineering/integration-test-writing.md` como parte de esta spec o como follow-up.
+9. **ADR-043 número libre**: verificar que 043 es el siguiente disponible (último ADR identificado en el repo: 042). Confirmar antes de redactar el ADR.
+
+## 13. Decision log
+
+- 2026-05-17 — Initial draft (Claude bajo agent-rigor) tras auditoría que reveló ausencia de infra integration en `apps/api` durante intento de cerrar D11 v2 T8.
+- 2026-05-17 — Devils-advocate review pasado vía sub-agente `agent-rigor:devils-advocate`. Output completo en [`./2026-05-17-test-integration-infra-apps-api-devils-advocate.md`](./2026-05-17-test-integration-infra-apps-api-devils-advocate.md). Hallazgos verificados de hecho: 37 migrations (no 36+ ni 35); colisión `0009_*` confirmada; drift coverage CI/vitest confirmado. Spec actualizada: CR-2 reformulado, CR-7 reformulado con threshold real del CI, §8 alternativas E y F agregadas, §9 riesgos P1-4..P1-7 agregados, §12 open questions P0-2/3/4/6 agregadas como bloqueantes de `/plan`. P2 quedan para conversación PO.

--- a/docs/specs/2026-05-17-test-integration-infra-apps-api.md
+++ b/docs/specs/2026-05-17-test-integration-infra-apps-api.md
@@ -2,7 +2,7 @@
 
 - **Author**: Felipe Vicencio (PO) + Claude (agent-rigor)
 - **Date**: 2026-05-17
-- **Status**: Draft
+- **Status**: **Approved** (PO, 2026-05-17 ~08:35 UTC — opción (a) tras devils-advocate review)
 - **Linked**: D11 v2 plan T8-T12 bloqueadas por ausencia de esta infra
 - **ADR a crear**: `043-integration-testing-infrastructure-apps-api.md`
 
@@ -145,3 +145,4 @@ No bloqueantes (se pueden cerrar durante `/plan` o quedar como residuales):
 
 - 2026-05-17 — Initial draft (Claude bajo agent-rigor) tras auditoría que reveló ausencia de infra integration en `apps/api` durante intento de cerrar D11 v2 T8.
 - 2026-05-17 — Devils-advocate review pasado vía sub-agente `agent-rigor:devils-advocate`. Output completo en [`./2026-05-17-test-integration-infra-apps-api-devils-advocate.md`](./2026-05-17-test-integration-infra-apps-api-devils-advocate.md). Hallazgos verificados de hecho: 37 migrations (no 36+ ni 35); colisión `0009_*` confirmada; drift coverage CI/vitest confirmado. Spec actualizada: CR-2 reformulado, CR-7 reformulado con threshold real del CI, §8 alternativas E y F agregadas, §9 riesgos P1-4..P1-7 agregados, §12 open questions P0-2/3/4/6 agregadas como bloqueantes de `/plan`. P2 quedan para conversación PO.
+- 2026-05-17 ~08:35 UTC — **PO aprueba spec** (opción (a) tras leer Draft + devils-advocate output). Status: `Draft` → `Approved`. Habilita inicio de `/plan` phase. P0-2/3/4/6 quedan como entrada bloqueante de `/plan` — el plan debe abordarlos con decisión concreta antes de iniciar `/build`.


### PR DESCRIPTION
## Summary

T1 del plan v2 [test-integration-infra-apps-api](docs/plans/2026-05-17-test-integration-infra-apps-api.md): infra base para correr tests integration contra Postgres real, separada del default `pnpm test`.

**Stacked sobre [#268](https://github.com/boosterchile/booster-ai/pull/268)** (T0 evidencia), que a su vez stackea sobre [#267](https://github.com/boosterchile/booster-ai/pull/267) (spec+plan). Cuando #267→#268→este mergeen, base sube a main automáticamente.

## Cambios

| Archivo | Tipo | LOC |
|---|---|---:|
| `apps/api/vitest.integration.config.ts` | nuevo | 39 |
| `apps/api/test/setup.integration.ts` | nuevo | 46 |
| `apps/api/test/helpers/test-db.ts` | nuevo | 43 |
| `apps/api/test/integration/health-db.integration.test.ts` | nuevo | 19 |
| `apps/api/scripts/check-no-concurrent-in-integration.mjs` | nuevo | 61 |
| `apps/api/vitest.config.ts` | modify | +4 |
| `apps/api/package.json` | modify | +6 |
| **Total** | | **217** |

## LOC overshoot (plan estimaba ~95)

El plan §T1 estimó "5 LOC lint rule" asumiendo Biome. **Biome v1.9.4 no soporta `noRestrictedSyntax` para method chains arbitrarios** (`test.concurrent`), así que el lint vive como script Node de 61 LOC enganchado a `pretest:integration`. Resto coherente con estimación.

## Acceptance (plan §T1)

- [x] `pnpm test` corre 1105 unit en ~5 s **sin** integration (exclude `test/integration/**` funciona)
- [x] `TEST_DATABASE_URL=... pnpm test:integration` corre `SELECT 1` en **270 ms** local (acceptance <3 s)
- [x] Sin `TEST_DATABASE_URL`: error claro `\"TEST_DATABASE_URL no está definido. Exporta una conexión a Postgres local antes de correr tests integration. Ver apps/api/test/integration/README.md (T5b).\"`
- [x] Guard `/prod|staging/i` rechaza URLs sospechosas
- [x] Lint rule rechaza `.concurrent` con file:line:texto

## Enumeración routes residuales (acceptance T1)

```
$ grep -L 'export function create.*Routes?(opts:.*db' apps/api/src/routes/*.ts
```

- **32/33** routes: factory `createXxxRoutes({ db, ... })`
- **1/33** route: `health.ts` con `createHealthRouter({ pool, ... })` — factory pero recibe pool, intencional (health ping directo)
- **0/33** routes: import directo de `createDb`

Cero bloqueo blando para T1b. Integration tests pueden instanciar cualquier route con test pool/db.

## Evidencia

### `pnpm test` (default, sin integration)

```
 Test Files  92 passed (92)
      Tests  1105 passed | 2 skipped (1107)
   Duration  4.73s
```

### `pnpm test:integration` (con TEST_DATABASE_URL)

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  270ms (transform 43ms, setup 18ms, import 183ms, tests 14ms)
```

### Lint rule rechaza `.concurrent`

```
$ # con test/integration/_bad.test.ts conteniendo test.concurrent(...)
$ pnpm test:integration
Integration tests no pueden usar .concurrent (plan §D3):
  …/test/integration/_bad.test.ts:3  test.concurrent('should not be allowed', () => {});
 ELIFECYCLE  Command failed with exit code 1.
```

## Test plan

- [x] Unit suite 1105/1107 verde (sin regresión)
- [x] Integration suite 1/1 verde
- [x] Lint rule positive + negative (manual)
- [x] TEST_DATABASE_URL missing → mensaje útil
- [x] TEST_DATABASE_URL prod/staging → reject
- [x] Typecheck verde repo-wide
- [x] Biome check verde en archivos T1

🤖 Generated with [Claude Code](https://claude.com/claude-code)