### PR TITLE
feat(api): T1 — infra de tests integration en apps/api

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,7 +10,11 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --passWithNoTests",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage --passWithNoTests"
+    "test:coverage": "vitest run --coverage --passWithNoTests",
+    "test:integration:lint": "node ./scripts/check-no-concurrent-in-integration.mjs",
+    "pretest:integration": "pnpm run test:integration:lint",
+    "test:integration": "vitest run --config vitest.integration.config.ts --passWithNoTests",
+    "test:all": "pnpm run test && pnpm run test:integration"
   },
   "dependencies": {
     "@booster-ai/carbon-calculator": "workspace:*",

--- a/apps/api/scripts/check-no-concurrent-in-integration.mjs
+++ b/apps/api/scripts/check-no-concurrent-in-integration.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Lint rule del plan §D3 (test-integration-infra-apps-api v2):
+ *   - Integration tests deben correr serialmente sobre un schema único.
+ *   - `test.concurrent`, `it.concurrent`, `describe.concurrent` rompen
+ *     ese contrato. Biome v1.9 no soporta `noRestrictedSyntax` para
+ *     method chains arbitrarios, así que este check vive como script
+ *     enganchado a `pretest:integration`.
+ *
+ * Falla con exit 1 si encuentra `\b(test|it|describe)\.concurrent\b` en
+ * cualquier archivo bajo `apps/api/test/integration/`.
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const TARGET_DIR = new URL('../test/integration', import.meta.url).pathname;
+const FORBIDDEN = /\b(test|it|describe)\.concurrent\b/;
+
+function walk(dir) {
+  const out = [];
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return out;
+    }
+    throw err;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...walk(full));
+    } else if (/\.(test|spec)\.tsx?$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const offenders = [];
+for (const file of walk(TARGET_DIR)) {
+  const content = readFileSync(file, 'utf-8');
+  const lines = content.split('\n');
+  lines.forEach((line, idx) => {
+    if (FORBIDDEN.test(line)) {
+      offenders.push({ file, line: idx + 1, text: line.trim() });
+    }
+  });
+}
+
+if (offenders.length > 0) {
+  console.error('Integration tests no pueden usar .concurrent (plan §D3):');
+  for (const o of offenders) {
+    console.error(`  ${o.file}:${o.line}  ${o.text}`);
+  }
+  process.exit(1);
+}
+process.exit(0);

--- a/apps/api/test/helpers/test-db.ts
+++ b/apps/api/test/helpers/test-db.ts
@@ -1,0 +1,43 @@
+import { type NodePgDatabase, drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import * as schema from '../../src/db/schema.js';
+
+export type TestDb = NodePgDatabase<typeof schema>;
+
+export interface TestDbHandle {
+  db: TestDb;
+  pool: pg.Pool;
+  url: string;
+}
+
+/**
+ * Crea un pool de Postgres dedicado a integration tests apuntando a
+ * `TEST_DATABASE_URL` del environment. Rechaza si la URL parece apuntar
+ * a producción o staging — el script T0 estableció que el reset incluye
+ * `DROP SCHEMA public CASCADE` + `DROP SCHEMA drizzle CASCADE`, una operación
+ * irreversible si se ejecuta contra una BD real.
+ *
+ * Devuelve también `url` para diagnostics — los helpers de cleanup la
+ * usan para incluirla en mensajes de error.
+ */
+export function createTestDb(): TestDbHandle {
+  const url = process.env.TEST_DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      'TEST_DATABASE_URL no está definido. Exporta una conexión a Postgres local antes de correr tests integration. Ver apps/api/test/integration/README.md (T5b).',
+    );
+  }
+  if (/prod|staging/i.test(url)) {
+    throw new Error(
+      `TEST_DATABASE_URL parece apuntar a una BD compartida (prod/staging). Aborto. URL: ${url.replace(/:[^:@]*@/, ':***@')}`,
+    );
+  }
+
+  const pool = new pg.Pool({
+    connectionString: url,
+    max: 2,
+    connectionTimeoutMillis: 5_000,
+  });
+  const db = drizzle(pool, { schema });
+  return { db, pool, url };
+}

--- a/apps/api/test/integration/health-db.integration.test.ts
+++ b/apps/api/test/integration/health-db.integration.test.ts
@@ -1,0 +1,19 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { type TestDbHandle, createTestDb } from '../helpers/test-db.js';
+
+describe('integration: health-db', () => {
+  let handle: TestDbHandle;
+
+  beforeAll(() => {
+    handle = createTestDb();
+  });
+
+  afterAll(async () => {
+    await handle.pool.end();
+  });
+
+  test('Postgres responde a SELECT 1', async () => {
+    const result = await handle.pool.query<{ ok: number }>('SELECT 1 AS ok');
+    expect(result.rows).toEqual([{ ok: 1 }]);
+  });
+});

--- a/apps/api/test/setup.integration.ts
+++ b/apps/api/test/setup.integration.ts
@@ -1,0 +1,46 @@
+import { vi } from 'vitest';
+
+// ADR-038: mismo mock de google-auth-library que setup.ts para evitar que
+// importar módulos de prod (config, services/firebase) dispare
+// `new GoogleAuth()` real.
+vi.mock('google-auth-library', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('google-auth-library')>();
+  class MockGoogleAuth {
+    async getClient() {
+      return {
+        async getAccessToken() {
+          return { token: 'test-access-token' };
+        },
+      };
+    }
+  }
+  return { ...actual, GoogleAuth: MockGoogleAuth };
+});
+
+// Integration tests sí necesitan una BD real, así que NO stubeamos
+// DATABASE_URL ni TEST_DATABASE_URL — el helper `createTestDb` los lee
+// del shell y aborta si TEST_DATABASE_URL no está definido.
+//
+// El resto del env va con defaults inocuos para que `parseEnv` no haga
+// `process.exit(1)` al evaluar config en imports indirectos.
+process.env.NODE_ENV ??= 'test';
+process.env.SERVICE_NAME ??= 'booster-ai-api';
+process.env.SERVICE_VERSION ??= '0.0.0-test';
+process.env.LOG_LEVEL ??= 'error';
+process.env.GOOGLE_CLOUD_PROJECT ??= 'booster-ai-test';
+// DATABASE_URL placeholder para parseEnv — los tests integration no lo usan,
+// usan TEST_DATABASE_URL via createTestDb. Si algún import indirecto necesita
+// DATABASE_URL real, ese test debe sobreescribir process.env.DATABASE_URL
+// con TEST_DATABASE_URL en su propio beforeAll.
+process.env.DATABASE_URL ??= 'postgresql://test:test@localhost:5432/test';
+process.env.DATABASE_POOL_MAX ??= '5';
+process.env.DATABASE_CONNECT_TIMEOUT_MS ??= '5000';
+process.env.REDIS_HOST ??= 'localhost';
+process.env.REDIS_PORT ??= '6379';
+process.env.REDIS_TLS ??= 'false';
+process.env.CORS_ALLOWED_ORIGINS ??= 'http://localhost:5173';
+process.env.FIREBASE_PROJECT_ID ??= 'booster-ai-test';
+process.env.JWT_ISSUER ??= 'booster-ai';
+process.env.API_AUDIENCE ??= 'https://api.test.boosterchile.com';
+process.env.ALLOWED_CALLER_SA ??= 'test-caller@booster-ai-test.iam.gserviceaccount.com';
+process.env.BOOSTER_PLATFORM_ADMIN_EMAILS ??= 'dev@boosterchile.com';

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./test/setup.ts'],
     include: ['src/**/*.{test,spec}.ts', 'test/**/*.{test,spec}.ts'],
+    // Integration tests viven en su propia config (vitest.integration.config.ts)
+    // y se corren via `pnpm test:integration`. Excluirlos aquí evita que el
+    // default `pnpm test` intente correrlos sin TEST_DATABASE_URL.
+    exclude: ['node_modules/**', 'dist/**', 'test/integration/**'],
     // Bump default 5s → 15s. CI bajo coverage instrumentation tarda más
     // en cargar el module graph (transform 4-6s + import 27s observado).
     // Tests individuales son rápidos (<300ms localmente) pero el primer

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Config separada para tests integration. Corre con `pnpm test:integration`,
+ * no participa del `pnpm test` default (que cubre solo unit con BD stubbeada).
+ *
+ * Decisiones del plan v2 `2026-05-17-test-integration-infra-apps-api.md` §D2/D3:
+ *   - `pool: 'forks'` + `poolOptions.forks.singleFork: true` — un único worker
+ *     vitest para que las suites compartan globalSetup (que se introduce en
+ *     T1b) y no compitan por advisory locks de Drizzle.
+ *   - `sequence.concurrent: false` — refuerza serial; un test que use
+ *     `test.concurrent` rompería el aislamiento de la BD compartida.
+ *   - `include: ['test/integration/**']` — no toca `src/` ni `test/unit/`.
+ *   - `globalSetup` queda vacío en T1 (no hay migrations todavía); T1b lo
+ *     apunta a `test/integration/setup-global.ts`.
+ *
+ * Coverage stays out of this config — integration coverage se mide por
+ * separado si T6 lo requiere; por defecto los integration tests son
+ * "smoke" sobre paths reales, no apuntan a cubrir lógica.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+    setupFiles: ['./test/setup.integration.ts'],
+    include: ['test/integration/**/*.{test,spec}.ts'],
+    // Vitest 4: poolOptions se movieron a top-level. `pool: 'forks'` +
+    // `forks.singleFork: true` garantiza un único worker para serializar
+    // el acceso a la BD compartida.
+    pool: 'forks',
+    forks: {
+      singleFork: true,
+    },
+    sequence: {
+      concurrent: false,
+    },
+    testTimeout: 30_000,
+  },
+});

--- a/docs/plans/2026-05-17-test-integration-infra-apps-api.md
+++ b/docs/plans/2026-05-17-test-integration-infra-apps-api.md
@@ -130,7 +130,7 @@ Total: **13 archivos nuevos, 4 modificados**. Cerca del techo de 10 módulos del
 
 ## Tasks
 
-### T0: Prototipo medido (bloquea D1-D6)
+### T0: Prototipo medido (bloquea D1-D6) [DONE 2026-05-17 — PR [#268](https://github.com/boosterchile/booster-ai/pull/268)]
 
 - **Files**:
   - `apps/api/scripts/prototype-test-db.ts` (nuevo, **NO se mergea** — sirve para medir y validar; se descarta tras T1b).
@@ -145,7 +145,7 @@ Total: **13 archivos nuevos, 4 modificados**. Cerca del techo de 10 módulos del
 - **Rollback**: no aplica — el script no se mergea. Si las mediciones invalidan D2/D3, abrir `/plan` v3.
 - **Success criterion para arrancar T1**: primera corrida <30s en local, segunda <5s, sin errores.
 
-### T1: `vitest.integration.config.ts` + scripts + setup.integration + helper test-db + test ref `SELECT 1`
+### T1: `vitest.integration.config.ts` + scripts + setup.integration + helper test-db + test ref `SELECT 1` [DONE 2026-05-17 — PR [#269](https://github.com/boosterchile/booster-ai/pull/269)]
 
 - **Files**:
   - `apps/api/vitest.integration.config.ts` (nuevo) — config con `globalSetup` placeholder (vacío en T1, real en T1b), `setupFiles=['./test/setup.integration.ts']`, `include=['test/integration/**']`, `pool='forks'`, `poolOptions.forks.singleFork=true`, `sequence.concurrent=false`.


### PR DESCRIPTION
> Re-creación de [#269](https://github.com/boosterchile/booster-ai/pull/269) (auto-cerrada cuando #267 mergeó y borró su branch base). Mismo contenido, base re-targeteada a main vía rebase + cherry-pick.

## Summary

T1 del plan v2 [test-integration-infra-apps-api](docs/plans/2026-05-17-test-integration-infra-apps-api.md): infra base para correr tests integration contra Postgres real, separada del default `pnpm test`.

## Cambios

| Archivo | Tipo | LOC |
|---|---|---:|
| `apps/api/vitest.integration.config.ts` | nuevo | 39 |
| `apps/api/test/setup.integration.ts` | nuevo | 46 |
| `apps/api/test/helpers/test-db.ts` | nuevo | 43 |
| `apps/api/test/integration/health-db.integration.test.ts` | nuevo | 19 |
| `apps/api/scripts/check-no-concurrent-in-integration.mjs` | nuevo | 61 |
| `apps/api/vitest.config.ts` | modify | +4 |
| `apps/api/package.json` | modify | +6 |
| **Total** | | **217** |

## LOC overshoot (plan estimaba ~95)

El plan §T1 estimó "5 LOC lint rule" asumiendo Biome. **Biome v1.9.4 no soporta `noRestrictedSyntax` para method chains arbitrarios** (`test.concurrent`), así que el lint vive como script Node de 61 LOC enganchado a `pretest:integration`. Resto coherente con estimación.

## Acceptance (plan §T1)

- [x] `pnpm test` corre 1105 unit en ~5 s **sin** integration (exclude `test/integration/**` funciona)
- [x] `TEST_DATABASE_URL=... pnpm test:integration` corre `SELECT 1` en **270 ms** local (acceptance <3 s)
- [x] Sin `TEST_DATABASE_URL`: error claro apuntando al README integration (T5b)
- [x] Guard `/prod|staging/i` rechaza URLs sospechosas
- [x] Lint rule rechaza `.concurrent` con file:line:texto

## Enumeración routes residuales (acceptance T1)

- **32/33** routes: factory `createXxxRoutes({ db, ... })`
- **1/33** route: `health.ts` con `createHealthRouter({ pool, ... })` — factory pero recibe pool, intencional
- **0/33** routes: import directo de `createDb`

Cero bloqueo blando para T1b.

## Evidencia

### `pnpm test` (default, sin integration)

```
 Test Files  92 passed (92)
      Tests  1105 passed | 2 skipped (1107)
   Duration  4.73s
```

### `pnpm test:integration` (con TEST_DATABASE_URL)

```
 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  270ms
```

### Lint rule rechaza `.concurrent`

```
Integration tests no pueden usar .concurrent (plan §D3):
  …/test/integration/_bad.test.ts:3  test.concurrent('should not be allowed', () => {});
 ELIFECYCLE  Command failed with exit code 1.
```

## Test plan

- [x] Unit suite 1105/1107 verde (sin regresión)
- [x] Integration suite 1/1 verde
- [x] Lint rule positive + negative (manual)
- [x] TEST_DATABASE_URL missing → mensaje útil
- [x] TEST_DATABASE_URL prod/staging → reject
- [x] Typecheck verde repo-wide
- [x] Biome check verde en archivos T1

🤖 Generated with [Claude Code](https://claude.com/claude-code)