### PR TITLE
feat(api): T1b — globalSetup con runMigrations + migrations.integration.test

### DIFF
--- a/apps/api/test/integration/migrations.integration.test.ts
+++ b/apps/api/test/integration/migrations.integration.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { type TestDbHandle, createTestDb } from '../helpers/test-db.js';
+
+interface JournalFile {
+  entries: Array<{ tag: string }>;
+}
+
+describe('integration: migrations applied via globalSetup', () => {
+  let handle: TestDbHandle;
+
+  beforeAll(() => {
+    handle = createTestDb();
+  });
+
+  afterAll(async () => {
+    await handle.pool.end();
+  });
+
+  test('tabla `usuarios` existe tras runMigrations', async () => {
+    const result = await handle.pool.query<{ regclass: string | null }>(
+      "SELECT to_regclass('public.usuarios')::text AS regclass",
+    );
+    expect(result.rows[0].regclass).toBe('usuarios');
+  });
+
+  test('count(__drizzle_migrations) == count(journal entries)', async () => {
+    const journalPath = resolve(__dirname, '..', '..', 'drizzle', 'meta', '_journal.json');
+    const journal = JSON.parse(readFileSync(journalPath, 'utf-8')) as JournalFile;
+    const expected = journal.entries.length;
+
+    const result = await handle.pool.query<{ count: string }>(
+      'SELECT COUNT(*)::text AS count FROM drizzle.__drizzle_migrations',
+    );
+    const actual = Number(result.rows[0].count);
+
+    expect(actual).toBe(expected);
+  });
+});

--- a/apps/api/test/integration/setup-global.ts
+++ b/apps/api/test/integration/setup-global.ts
@@ -1,0 +1,72 @@
+import { createLogger } from '@booster-ai/logger';
+import pg from 'pg';
+import { runMigrations } from '../../src/db/migrator.js';
+
+/**
+ * vitest globalSetup para integration tests. Corre UNA vez antes del primer
+ * worker, NO una vez por test ni por archivo. Por eso vive separado del
+ * `setup.integration.ts` (que sí corre por archivo).
+ *
+ * Secuencia (validada en T0, ver docs/handoff/2026-05-17-t0-prototype-test-db-output.md):
+ *   1. DROP SCHEMA public CASCADE — tira todas las tablas de dominio.
+ *   2. DROP SCHEMA drizzle CASCADE — tira __drizzle_migrations (el plan §D2
+ *      omitió este DROP; T0 reveló que sin él la idempotencia in-place se
+ *      degrada porque sobreviven hashes viejos).
+ *   3. CREATE SCHEMA public + GRANT.
+ *   4. CREATE EXTENSION pgcrypto (las migrations asumen que está disponible).
+ *   5. runMigrations(pool, logger) real de apps/api/src/db/migrator.ts —
+ *      mismo código que prod, incluyendo advisory lock + applyOutOfOrderPending.
+ *
+ * Timing medido en T0: ~500ms cold, ~100ms warm reset. Bajo el budget plan §T1b
+ * de <15s para globalSetup + 2 tests.
+ *
+ * Si `TEST_DATABASE_URL` no está definido o apunta a prod/staging, falla
+ * inmediatamente con mensaje claro. La validación duplica la del helper
+ * `createTestDb` porque globalSetup corre en un proceso distinto del de
+ * los tests; preferimos un error temprano y específico.
+ */
+export default async function setup(): Promise<() => Promise<void>> {
+  const url = process.env.TEST_DATABASE_URL;
+  if (!url) {
+    throw new Error(
+      'TEST_DATABASE_URL no está definido. Exporta una conexión a Postgres local antes de correr tests integration. Ver apps/api/test/integration/README.md (T5b).',
+    );
+  }
+  if (/prod|staging/i.test(url)) {
+    throw new Error(
+      `TEST_DATABASE_URL parece apuntar a una BD compartida (prod/staging). Aborto. URL: ${url.replace(/:[^:@]*@/, ':***@')}`,
+    );
+  }
+
+  const logger = createLogger({
+    service: 'integration-test-setup',
+    version: '0.0.0-test',
+    level: 'error',
+    pretty: false,
+  });
+
+  const pool = new pg.Pool({ connectionString: url, max: 2 });
+  try {
+    const client = await pool.connect();
+    try {
+      await client.query('DROP SCHEMA IF EXISTS public CASCADE');
+      await client.query('DROP SCHEMA IF EXISTS drizzle CASCADE');
+      await client.query('CREATE SCHEMA public');
+      await client.query('GRANT ALL ON SCHEMA public TO CURRENT_USER');
+      await client.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+    } finally {
+      client.release();
+    }
+    await runMigrations(pool, logger);
+  } finally {
+    await pool.end();
+  }
+
+  // Teardown: vitest llama esta función al final de la corrida. No tenemos
+  // recursos persistentes a liberar (cada test integration crea su propio
+  // pool vía createTestDb), pero firmamos el contrato globalSetup → teardown
+  // por si T3+ agregan recursos compartidos.
+  return async () => {
+    // intentionally empty — placeholder para teardown futuro de T3+
+  };
+}

--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     setupFiles: ['./test/setup.integration.ts'],
+    globalSetup: ['./test/integration/setup-global.ts'],
     include: ['test/integration/**/*.{test,spec}.ts'],
     // Vitest 4: poolOptions se movieron a top-level. `pool: 'forks'` +
     // `forks.singleFork: true` garantiza un único worker para serializar

--- a/docs/plans/2026-05-17-test-integration-infra-apps-api.md
+++ b/docs/plans/2026-05-17-test-integration-infra-apps-api.md
@@ -165,7 +165,7 @@ Total: **13 archivos nuevos, 4 modificados**. Cerca del techo de 10 módulos del
   - **Enumerar routes residuales**: comando en commit body: `grep -L "createXxxRoutes\\|opts\\.db" apps/api/src/routes/*.ts`. Output documentado. Si hay >0 routes que importan `createDb` directamente, listarlas en commit body como riesgo conocido para T1b/T8 re-open.
 - **Rollback**: revertir commit. Suite unit no se afecta.
 
-### T1b: Migration runner integrado en globalSetup
+### T1b: Migration runner integrado en globalSetup [DONE 2026-05-17]
 
 - **Files**:
   - `apps/api/test/integration/setup-global.ts` (nuevo) — globalSetup: `DROP SCHEMA + CREATE SCHEMA + runMigrations`.


### PR DESCRIPTION
## Summary

T1b del plan v2 [test-integration-infra-apps-api](docs/plans/2026-05-17-test-integration-infra-apps-api.md): vitest `globalSetup` integra el `runMigrations` real de prod, garantizando que cada corrida de `pnpm test:integration` arranca contra un schema limpio con todas las 36 migrations aplicadas.

## Cambios

| Archivo | Tipo | LOC |
|---|---|---:|
| `apps/api/test/integration/setup-global.ts` | nuevo | 72 |
| `apps/api/test/integration/migrations.integration.test.ts` | nuevo | 40 |
| `apps/api/vitest.integration.config.ts` | modify | +1 |
| **Total** | | **113** |

113 LOC vs ~85 estimadas (33% overshoot, driver: docstrings que documentan decisiones T0-validated en `setup-global.ts`).

## Mejora vs plan §D2 original

El plan §D2 omitió `DROP SCHEMA drizzle CASCADE`. T0 reveló que sin él, `__drizzle_migrations` sobrevive con hashes viejos entre runs y degrada la fidelidad del reset. Mejora aplicada en `setup-global.ts` línea 50.

## Acceptance T1b (todos PASS)

- [x] `pnpm test:integration` corre globalSetup + 2 test files (health + migrations) + 3 tests en **1.19s local** (acceptance <15s)
- [x] **Idempotencia**: segunda corrida consecutiva PASS en 845ms
- [x] `to_regclass('public.usuarios')` retorna `'usuarios'` (tabla existe tras migrations)
- [x] `count(__drizzle_migrations) == journal entries count` (36)

## Nota sobre acceptance §T1b del plan

El plan escribió "count == archivos `.sql` (37)". **Esto es incorrecto** — T0 reveló orphan migration `0009_stakeholder_access_log.sql` en disco pero NO en journal (37 .sql vs 36 entries). El test verifica contra journal=36, que es lo que realmente se aplica. La discrepancia disco-vs-prod sigue siendo gap latente (la tabla declarada en `apps/api/src/db/schema.ts:1406` no existe en prod); ya hay task spawned para investigar y arreglar.

## Evidencia

### `pnpm test:integration` Run 1 (cold)

```
 Test Files  2 passed (2)
      Tests  3 passed (3)
   Duration  651ms (transform 53ms, setup 20ms, import 338ms, tests 29ms)
```

### Run 2 (idempotencia)

```
 Test Files  2 passed (2)
      Tests  3 passed (3)
   Duration  845ms (transform 80ms, setup 22ms, import 776ms, tests 28ms)
```

### Unit suite no afectada

```
 Test Files  92 passed (92)
      Tests  1105 passed | 2 skipped (1107)
   Duration  5.06s
```

## Test plan

- [x] Integration suite 3/3 verde (health + migrations)
- [x] Segunda corrida consecutiva sin reset manual (idempotencia)
- [x] Unit suite 1105/1107 verde (sin regresión)
- [x] Typecheck verde (`pnpm --filter @booster-ai/api typecheck`)
- [x] Biome lint verde en archivos T1b

🤖 Generated with [Claude Code](https://claude.com/claude-code)