### PR TITLE
docs(handoff): outreach cliente piloto + .private/ gitignored (T10 of S0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,12 @@
 # Zero-trust por defecto: solo lo necesario se trackea.
 # ==============================================================================
 
+# -------- Trabajo privado / comercial sensible (no commitea) --------
+# .private/ — info comercial sensible: prospects piloto, respuestas a RFPs,
+# data sample para auditores externos. Sub-stubs publicos resumidos viven
+# en docs/handoff/ o docs/compliance/ con conteos agregados.
+.private/
+
 # -------- Credenciales y secretos (CRÍTICO) --------
 # Service accounts GCP / Firebase
 *service-account*.json

--- a/.specs/s0-housekeeping/plan.md
+++ b/.specs/s0-housekeeping/plan.md
@@ -101,7 +101,7 @@
 > **T9b (medición budget)** se difiere a **S2** — requiere métricas de tráfico reales que aún no se han instrumentado para esto específicamente. Cubre la parte cuantitativa de SC-30 del plan maestro.
 > **T9c (criterios drill)** se incorpora a la **spec de S3** como parte del SC-30 del plan maestro.
 
-### T10: outreach cliente piloto — identificar ≥5 prospects + dry-run PO + primer contacto
+### T10: outreach cliente piloto — identificar ≥5 prospects + dry-run PO + primer contacto [DONE-doc 2026-05-18 — dry-run PO + envíos pendientes]
 - **Files**:
   - `.private/piloto-prospects.md` (gitignored). **OQ-S0.1 resuelta: privada**.
   - `.gitignore` (edit: agregar `.private/` si no está).

--- a/docs/handoff/2026-05-18-piloto-outreach.md
+++ b/docs/handoff/2026-05-18-piloto-outreach.md
@@ -1,0 +1,70 @@
+# Cliente piloto — kickoff outreach (Sprint S0 T10)
+
+**Fecha**: 2026-05-18
+**Sprint**: S0 production-readiness · Task T10
+**Spec**: [`.specs/s0-housekeeping/spec.md`](../../.specs/s0-housekeeping/spec.md) SC-S0.10
+**Cubre objetivo**: SC-27a (≥1 cliente piloto firmado y operando) de la spec maestra [`.specs/production-readiness/spec.md`](../../.specs/production-readiness/spec.md). Outreach kickoff = lane externa cliente piloto activada.
+
+---
+
+## Resumen
+
+Outreach inicial a prospects de cliente piloto identificados para Booster AI. Sigue convención **privada por defecto** (decisión OQ-S0.1 resuelta): detalle de prospects, contactos, comunicaciones y status en `.private/piloto-prospects.md` (gitignored). Este stub público solo expone conteos agregados sin información comercial sensible.
+
+## Conteos al momento del PR (2026-05-18)
+
+| Métrica | Conteo |
+|---|---|
+| Prospects identificados | **≥ 5** (shortlist primaria) |
+| Prospects backup adicionales | **≥ 5** (si shortlist primaria no responde en 2 sem) |
+| Prospects contactados | **0** (pendiente PO dry-run + envíos) |
+| Respuestas recibidas | **0** (pre-envío) |
+| Reuniones agendadas | **0** |
+| Contratos firmados | **0** |
+
+## Distribución sectorial de la shortlist primaria
+
+- Retail con flota propia
+- Forestal / celulosa / madera (2 candidatos por densidad de transporte forestal Chile)
+- Minería (litio / cobre con presión ESG por trazabilidad)
+- Distribución bebidas / alimentos
+
+## Criterios de fit aplicados
+
+- **Flota** ≥ 20 vehículos o operación recurrente con backhaul significativo.
+- **Compromiso ESG público** verificable (sustainability report, science-based targets, B-Corp, etc.).
+- **Caso de uso GLEC justificable** — huella de carbono es métrica relevante para el cliente.
+- **Canal de intro** preferentemente warm (LinkedIn + intros mutuas) sobre cold email.
+
+## Estado del workflow
+
+1. ✅ Shortlist redactada por el agente (5 primarios + 5 backup, categorías + criterios fit + scores 1-5).
+2. ⏸ **Pendiente PO dry-run**: validar candidatos, completar contactos reales, marcar `PO approved: <fecha>` en el doc privado.
+3. ⏸ Pendiente envío emails (post-aprobación).
+4. ⏸ Pendiente tracking respuestas.
+5. ⏸ Pendiente firma piloto (criterio bloqueante SC-27a cierre spec maestra).
+
+## Reconocimiento de irreversibilidad
+
+Spec S0 §11 reconoce explícitamente que el **outreach es acción irreversible**: emails enviados a prospects no se rollbackean. Por eso:
+
+- Dry-run PO obligatorio **antes** de enviar (parte de SC-S0.10).
+- Criterios de fit explícitos por prospect — no se contacta candidatos sin caso de uso justificable.
+- Si un prospect inicia diálogo y luego no se procede, cierre formal con email de "no fit en este momento".
+
+## Próximos pasos
+
+| Quien | Acción | Plazo objetivo |
+|---|---|---|
+| **PO (Felipe)** | Revisar shortlist en `.private/piloto-prospects.md`, validar/ajustar, completar contactos reales | Semana 2026-05-19 |
+| **PO** | Marcar `PO approved` en el doc privado | Semana 2026-05-19 |
+| **PO** | Enviar emails usando template, personalizando "razón específica" por prospect | Semana 2026-05-19 |
+| **PO** | Actualizar tabla "Tracking respuestas" en el doc privado conforme lleguen respuestas | Continuo |
+| **PO** | Actualizar este stub público con conteos progresivos (sin info sensible) | Mensual |
+| **PO + agente** | Sub-PR cuando se firme contrato piloto (cierre SC-27a) | Sprint S13 del roadmap |
+
+## Referencias
+
+- **Spec sprint S0**: [`.specs/s0-housekeeping/spec.md`](../../.specs/s0-housekeeping/spec.md) SC-S0.10
+- **Spec maestra**: [`.specs/production-readiness/spec.md`](../../.specs/production-readiness/spec.md) SC-27a + lane externa cliente piloto
+- **Doc privado**: `.private/piloto-prospects.md` (gitignored — solo accesible localmente)


### PR DESCRIPTION
## Summary

Cierra T10 del sprint S0: kickoff outreach a cliente piloto. Sigue convención **privada por defecto** (decisión OQ-S0.1 resuelta): el detalle comercial (nombres, contactos, status outreach) vive en `.private/piloto-prospects.md` (gitignored, presente solo en mi disco local); en repo público solo hay conteos agregados.

- **`.gitignore`** (+6 LOC) — agrega `.private/` para info comercial sensible.
- **`.private/piloto-prospects.md`** (~190 LOC, **gitignored, no en este PR**) — shortlist 5 prospects iniciales (Walmart Chile, CMPC, SQM, Coca-Cola Andina, Arauco) + 5 backup + criterios fit + scores + template mensaje en español + workflow PO + tabla tracking respuestas.
- **`docs/handoff/2026-05-18-piloto-outreach.md`** (70 LOC) — stub público con conteos agregados (sin nombres), distribución sectorial, criterios fit aplicados, estado del workflow, próximos pasos PO.

## Trazabilidad

- Closes T10 of `.specs/s0-housekeeping/plan.md`
- Cubre SC-S0.10 (sprint S0) + kickoff lane externa cliente piloto (SC-27a spec maestra; criterio bloqueante cierre Sprint S13)
- Pre-build articulation en ledger
- Reconoce irreversibilidad del outreach (spec S0 §11): dry-run PO obligatorio + criterios fit explícitos

## Test plan

- [x] `.gitignore` contiene `.private/`.
- [x] `.private/` localmente existe y NO está trackeada (`git status` la ignora).
- [x] Stub público en `docs/handoff/` con conteos sin info sensible.
- [x] Plan marcado `[DONE-doc 2026-05-18 — dry-run PO + envíos pendientes]`.
- [x] Pre-commit ADR check passes.

## Acción PO requerida post-merge

1. **Revisar shortlist** en `.private/piloto-prospects.md` localmente. Validar fit comercial real, ajustar/descartar/sustituir según conocimiento de mercado.
2. **Completar contactos reales** (LinkedIn, email, intros mutuas).
3. **Marcar `PO approved: <fecha>`** en el doc privado.
4. **Enviar emails** usando template `.private/` §"Mensaje template", personalizando "razón específica" por prospect.
5. **Trackear respuestas** en tabla `.private/` §"Tracking respuestas".
6. **Actualizar stub público** mensualmente con conteos progresivos (sin info sensible).
7. **Sub-PR cuando se firme contrato piloto** (cierra SC-27a → cierra spec maestra production-readiness).

## Notas

- **Patrón paralelo a T6/T7** (GLEC RFP, pentest RFP): doc + dry-run agente, envíos reales PO.
- **Por qué privado**: nombres de prospects en cold/warm outreach son info comercial sensible que conviene mantener fuera de repo público hasta que haya conversación establecida (mismo razonamiento que T7 shortlist vendors pentest).
- **`docs/handoff/CURRENT.md` no se actualiza acá** — eso es T11 (wrap final del sprint S0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)