### PR TITLE
feat(domain): T1.2 alinea tripEventTypeSchema con SQL + Hallazgo H-S1a-1 (S1a)

### DIFF
--- a/.specs/s1-drift-coverage-e2e/plan-s1a.md
+++ b/.specs/s1-drift-coverage-e2e/plan-s1a.md
@@ -41,18 +41,45 @@ Bloques A + B de la spec maestra: aplicar metodología ADR-043 (inventario + res
   - Tests cubren los nuevos matches en `drift-inventory.test.mjs`.
 - **Rollback**: revert PR. Script funcional sin mappings extra.
 
-### T1.2a..T1.2n: Resolución Clase A — una sub-task por divergencia (cubre O-1)
+### T1.2: Caso 5 — `tripEventTypeSchema` agregar 2 valores SQL faltantes
 
-- **Plantilla recurrente**: una T1.2x por cada divergencia Clase A en `inventory.md`.
-- **Files por sub-task**: 1-2 archivos en `packages/shared-schemas/src/domain/*` + consumers afectados (`apps/api/src/services/*` o `apps/api/src/routes/*`) + tests existentes ajustados.
-- **LOC por sub-task**: ≤80 (cumple ≤100 LOC sin waiver).
-- **Depends on**: T1.1 + SC-S1.0 gate `APPROVED_BY_PO`. Sub-tasks pueden ejecutar en paralelo entre sí.
-- **Acceptance por sub-task** (parte de T-S1.3):
-  - Identifier/enum value específico en `inventory.md` está alineado a SQL canónico.
-  - `pnpm typecheck` + `pnpm test` verdes post-PR.
-  - `grep -E "<valor inglés viejo>" packages/shared-schemas/src/domain/` retorna 0 hits para esa divergencia.
-- **Acceptance T1.2 global**: todas las sub-tasks Clase A en `Implemented` + `grep -rE "'(delivered|confirmed|completed|pending|active|cancelled)'" packages/shared-schemas/src/domain/` retorna 0 hits totales.
-- **Rollback por sub-task**: revert PR específico. Cero impacto runtime (cambio TS-only).
+> **Scope cerrado post-triage**: T1.2 cubre **solo el Caso 5** (aditivo, Clase A). El Caso 1 (`cargoRequestStatusSchema` TS-only-orphan, eliminación) se mueve a **T1.3 separado** por razones de bisectability + perfil de riesgo distinto (aditivo vs destructivo).
+
+- **Files**:
+  - `packages/shared-schemas/src/domain/trip-event.ts` (edit: agregar `conductor_asignado` + `incidente_reportado` al enum).
+  - `packages/shared-schemas/src/all-schemas.test.ts` (edit: nuevo describe block `tripEvent` con tests).
+  - `.specs/s1-drift-coverage-e2e/t1.2-discovery.md` (nuevo: discovery findings).
+- **LOC estimate**: ~5 (trip-event.ts edit) + ~30 (tests) + ~50 (discovery doc) = ~85.
+- **Depends on**: T1.1 mergeado (gate SC-S1.0 APPROVED) + Discovery T1.2 completado (0 exhaustive matching consumers, 0 runtime parse, 2 valores YA emitidos en services).
+- **Acceptance** (T-S1.3 parcial):
+  - `tripEventTypeSchema` tiene exactamente **14 valores** (12 actuales + `conductor_asignado` + `incidente_reportado`).
+  - Test **whitelist guardrail** en `all-schemas.test.ts` que valida `tripEventTypeSchema.options` contra listado explícito de los 14 valores esperados (detecta remociones silenciosas en refactors futuros).
+  - Test que `tripEventTypeSchema.parse('conductor_asignado')` y `.parse('incidente_reportado')` no lanzan.
+  - `pnpm --filter @booster-ai/shared-schemas test` verde.
+- **Rollback**: revert PR. Cero impacto runtime (Zod no se usa en `.parse()` runtime — ver Hallazgo H-S1a-1 en spec §12.5).
+
+### T1.3: Caso 1 — eliminar `cargoRequestStatusSchema` orphan (Clase A sub-tipo TS-only-orphan)
+
+- **Files**:
+  - `packages/shared-schemas/src/domain/cargo-request.ts` (delete o reducir si `cargoRequestSchema` y otros sub-schemas también son orphan).
+  - `packages/shared-schemas/src/all-schemas.test.ts` (edit: remover import si aplica + remover entries del smoke test loop).
+  - `packages/shared-schemas/src/primitives/ids.ts` (verificar si `cargoRequestIdSchema` queda orphan tras eliminación).
+  - `packages/shared-schemas/src/trip-request.ts` (verificar comentario que menciona `cargoRequest` — actualizar si refiere a concepto eliminado).
+- **LOC estimate**: ~-150 (delete schema + remove imports/refs). Net negative.
+- **Depends on**: T1.2 mergeado.
+- **Pre-discovery obligatorio** (broader que T1.2):
+  - `rg "cargoRequest|CargoRequest" --type ts -l` listar TODOS los archivos.
+  - Verificar consumers transitivos (imports indirectos de tests, primitives, etc.).
+  - Decisión final: eliminar todo el archivo `cargo-request.ts` vs preservar `cargoRequestIdSchema` si tiene uso.
+- **Acceptance** (T-S1.3 parcial):
+  - `rg "cargoRequestStatusSchema|cargoRequestSchema" packages/shared-schemas/` retorna 0 hits post-merge.
+  - `pnpm typecheck` + `pnpm test` verdes.
+  - Si `cargoRequestIdSchema` preservado: docstring explica por qué + uso esperado futuro (link a hipotético S2+).
+- **Rollback**: revert PR. Concepto vuelve al domain como estaba.
+
+### T1.4..T1.n: (placeholder) Resoluciones de divergencias adicionales Clase A/B/C si emergen
+
+Post-T1.2/T1.3, si `T1.0.heuristic-improvement` revela alguna Clase A real adicional (e.g. el caso 4 `transportistaStatus` resulta tener valores propios diferenciados → A real, no H), se agrega T1.4+ siguiendo la misma plantilla atomizada. Baseline actual post-triage: solo Casos 5 y 1 son A reales; T1.4+ probablemente N/A.
 
 ### T1.3a..T1.3n: Resolución Clase B — una sub-task por divergencia breaking API
 

--- a/.specs/s1-drift-coverage-e2e/plan-s1a.md
+++ b/.specs/s1-drift-coverage-e2e/plan-s1a.md
@@ -41,7 +41,7 @@ Bloques A + B de la spec maestra: aplicar metodología ADR-043 (inventario + res
   - Tests cubren los nuevos matches en `drift-inventory.test.mjs`.
 - **Rollback**: revert PR. Script funcional sin mappings extra.
 
-### T1.2: Caso 5 — `tripEventTypeSchema` agregar 2 valores SQL faltantes
+### T1.2: Caso 5 — `tripEventTypeSchema` agregar 2 valores SQL faltantes [DONE 2026-05-18]
 
 > **Scope cerrado post-triage**: T1.2 cubre **solo el Caso 5** (aditivo, Clase A). El Caso 1 (`cargoRequestStatusSchema` TS-only-orphan, eliminación) se mueve a **T1.3 separado** por razones de bisectability + perfil de riesgo distinto (aditivo vs destructivo).
 
@@ -53,7 +53,7 @@ Bloques A + B de la spec maestra: aplicar metodología ADR-043 (inventario + res
 - **Depends on**: T1.1 mergeado (gate SC-S1.0 APPROVED) + Discovery T1.2 completado (0 exhaustive matching consumers, 0 runtime parse, 2 valores YA emitidos en services).
 - **Acceptance** (T-S1.3 parcial):
   - `tripEventTypeSchema` tiene exactamente **14 valores** (12 actuales + `conductor_asignado` + `incidente_reportado`).
-  - Test **whitelist guardrail** en `all-schemas.test.ts` que valida `tripEventTypeSchema.options` contra listado explícito de los 14 valores esperados (detecta remociones silenciosas en refactors futuros).
+  - Test **whitelist guardrail** en `all-schemas.test.ts` que valida `tripEventTypeSchema.options` contra listado explícito de los **19 valores esperados** (17 existentes + 2 nuevos; detecta remociones silenciosas en refactors futuros).
   - Test que `tripEventTypeSchema.parse('conductor_asignado')` y `.parse('incidente_reportado')` no lanzan.
   - `pnpm --filter @booster-ai/shared-schemas test` verde.
 - **Rollback**: revert PR. Cero impacto runtime (Zod no se usa en `.parse()` runtime — ver Hallazgo H-S1a-1 en spec §12.5).

--- a/.specs/s1-drift-coverage-e2e/spec.md
+++ b/.specs/s1-drift-coverage-e2e/spec.md
@@ -249,9 +249,41 @@ Quedantes (no bloquean approve):
 - **OQ-S1.2** (T1.6): `@xstate/test` agregado o no — decisión durante T1.6.
 - **OQ-S1.3** (T1.12): `dorny/paths-filter@v3` vs custom — decisión durante T1.12.
 
+## 12.5 Hallazgos S1a → backlog S2/S3
+
+Observaciones arquitectónicas descubiertas durante el sprint S1a que NO modifican el scope/SCs del sprint actual pero **requieren visibilidad cuando se planifique S2/S3**. Documentadas acá (no en discovery docs sueltos) para que sean encontradas al hacer `/spec` de sprints posteriores.
+
+### Hallazgo H-S1a-1: Zod schemas no enforced en runtime
+
+**Origen**: Discovery T1.2 sobre `tripEventTypeSchema` (2026-05-18).
+
+**Observación**: `tripEventSchema` (parent que contiene `event_type: tripEventTypeSchema`) **tiene 0 llamadas `.parse()` / `.safeParse()` en runtime** en todo el código de `apps/`. El schema vive como **documentación declarativa del dominio**, no como validation activa.
+
+Por extensión muy probable (no verificado, pendiente investigación S2/S3): otros 5-6 schemas Zod en `packages/shared-schemas/src/domain/` tienen la misma propiedad — fuente de verdad teórica que ningún boundary HTTP / DB writer / queue consumer / event handler ejecuta como gate.
+
+**Implicación**:
+
+Alinear TS↔SQL en S1a (objetivo ADR-043) **elimina drift estructural** pero **NO previene** que código emita payloads con valores inválidos en runtime. La defensa real contra drift de runtime es `.parse()` en boundaries (routes, DB writers, etc.).
+
+Si el problema de "drift" que S1 pretende resolver incluye también "código que serializa enum values inventados" (caso real: hoy services emiten `conductor_asignado` / `incidente_reportado` sin que ningún schema los rechace), entonces S1a sola **no resuelve** ese problema — solo resuelve la parte declarativa.
+
+**Acciones diferidas** (S2 o S3, decisión PO en `/spec` del sprint):
+
+1. Auditar boundaries críticos (`apps/api/src/routes/**`, `apps/api/src/services/notify-*`, queue consumers Pub/Sub, etc.) para identificar dónde `.parse()` debería aplicarse.
+2. Decidir política: ¿`safeParse()` en todo boundary HTTP que retorna trip events? ¿`parse()` en DB writers? ¿Validation en consumers Pub/Sub?
+3. Si la respuesta es "sí, enforce runtime", producir sprint dedicado con scope: instrumentar boundaries + tests de boundary + alert si parse falla en prod.
+4. Si la respuesta es "no, drift estructural es suficiente", documentar en ADR-043 que el dominio Zod es **doc-only by design** y eliminar la ambigüedad.
+
+Este hallazgo NO bloquea S1a porque T1.2 cierra el caso 5 (alinear TS con SQL) que es deliverable del sprint. La pregunta "¿sirve para algo?" queda explícita para los siguientes sprints.
+
+**Severidad**: M (estructural — afecta efectividad del drift-elimination program a partir de T1.2). **Owner**: PO. **Sprint objetivo**: S2 o S3.
+
+---
+
 ## 13. Decision log
 
 - **2026-05-18** — Initial draft post-aprobación spec maestra v2 + cierre S0. 14 SCs + 14 tareas.
 - **2026-05-18** — Devils-advocate pass: 5 P0 + 5 P1 + 3 P2 = 13 objeciones (review.md). PO aprobó aplicar **todas (P0 + P1 + P2)**.
 - **2026-05-18** — **Aplicado v2**: SC-S1.0 stop-the-line gate (O-1); SC-S1.7 split en lista nombrada + métrico (O-2); §7.0 orden de ejecución secuencial A→B (O-3); estimación 8-12 días + SC-S1.checkpoint día 5 (O-4); flag `TRIP_STATE_MACHINE_ACTIVATED` obligatorio SC-S1.6b (O-5); SC-S1.8 eliminado (O-6); SC-S1.13 eliminado (O-7); SC-S1.12 reformulado a ≥10 PRs sample (O-8); OQ-S1.4 resuelta pre-approve (O-9); burnout subido a H/M con mitigación accionable (O-10); T1.7 lista IN/OUT-scope explícita + followup doc (O-11); SC-S1.4b RLS en Clase C (O-12); umbral runners distribuidos declarado en §5 + alt E (O-13).
 - **2026-05-18** — **APPROVED por PO**. Pasa a fase PLAN.
+- **2026-05-18** — Post-T1.1 + discovery T1.2: agregada §12.5 con Hallazgo H-S1a-1 (Zod schemas no enforced en runtime — observación arquitectónica que afecta efectividad del drift-elimination program; diferido a S2/S3 con owner PO).

--- a/.specs/s1-drift-coverage-e2e/t1.2-discovery.md
+++ b/.specs/s1-drift-coverage-e2e/t1.2-discovery.md
@@ -1,0 +1,104 @@
+# T1.2 Discovery — `tripEventTypeSchema` consumers
+
+- Task: T1.2 of `.specs/s1-drift-coverage-e2e/plan-s1a.md`
+- Fecha: 2026-05-18
+- Scope: identificar consumers + patrones de uso antes de agregar 2 valores SQL (`conductor_asignado`, `incidente_reportado`) al Zod schema.
+
+---
+
+## Findings
+
+### 1. Imports directos del schema
+
+```bash
+$ rg "tripEventTypeSchema" --type ts -l
+packages/shared-schemas/src/domain/trip-event.ts
+```
+
+**Solo el archivo de definición**. 0 imports en `apps/`.
+
+### 2. Imports del parent `tripEventSchema`
+
+```bash
+$ rg "tripEventSchema" --type ts -l
+packages/shared-schemas/src/domain/trip-event.ts
+packages/shared-schemas/src/primitives/ids.ts
+apps/web/src/routes/cargas.tsx
+apps/api/src/db/schema.ts
+```
+
+4 archivos. `primitives/ids.ts` y `schema.ts` son referencias por nombre (no parse). `cargas.tsx` requiere verificación (frontend).
+
+### 3. Llamadas runtime `.parse()` / `.safeParse()`
+
+```bash
+$ rg "tripEventSchema\.(parse|safeParse)|tripEventTypeSchema\.(parse|safeParse)" --type ts
+(zero hits)
+```
+
+**0 llamadas runtime**. El Zod schema **no se ejecuta** como validation activa en ningún punto.
+
+### 4. Exhaustive matching patterns
+
+```bash
+$ rg "switch.*event_type|switch.*eventType|switch.*TripEventType" --type ts
+(zero hits)
+
+$ rg "Record<TripEventType|\[K in TripEventType\]" --type ts
+(zero hits)
+
+$ rg "assertNever|: never" en archivos que mencionan TripEventType
+(zero hits)
+```
+
+**0 exhaustive matching**. Agregar valores nuevos no rompe TS compile en ningún consumer.
+
+### 5. Estado real del enum
+
+**Corrección post-discovery inicial**: mi primer grep truncó el listado. El enum real:
+
+- **TS (`packages/shared-schemas/src/domain/trip-event.ts`)**: **17 valores** actuales.
+- **SQL (`apps/api/src/db/schema.ts` `tripEventTypeEnum`)**: **19 valores** (17 + 2 que faltan en TS).
+
+Los 2 que faltan en TS y orden exacto SQL:
+- `conductor_asignado` — insertado entre `asignacion_creada` y `recogida_confirmada`. Docstring SQL: _"Carrier asigna (o reasigna) un conductor específico a un assignment. Distinto de 'asignacion_creada'…"_.
+- `incidente_reportado` — al final (después de `disputa_abierta`). Docstring SQL: _"Phase 4 PR-K6 — Conductor reporta incidente operacional durante el viaje vía voice command o botón. Distinto de disputa_abierta (legal); este es informativo + notifica al shipper."_.
+
+### 6. Uso por valor literal en `apps/` (string match)
+
+Verificación de los 2 valores SQL-only:
+
+| Valor | # usos fuera de domain/test | Archivos |
+|---|---|---|
+| **`conductor_asignado`** | **3** | `apps/api/src/services/asignar-conductor-a-assignment.ts` (INSERT real con `eventType: 'conductor_asignado'`) + docstring del mismo file + `apps/api/src/db/schema.ts` (declaración pgEnum). |
+| **`incidente_reportado`** | **3** | `apps/api/src/services/reportar-incidente.ts` (INSERT real) + docstring + `schema.ts` (pgEnum). |
+
+Los 2 valores **ya se emiten en producción** mediante INSERT directos por Drizzle. Agregar al Zod schema es alineación, no introducción de comportamiento nuevo.
+
+---
+
+## Riesgos del cambio T1.2
+
+| Riesgo | Severidad | Mitigación |
+|---|---|---|
+| TS compile break por exhaustive matching | None | 0 exhaustive matching encontrado. Cambio es aditivo. |
+| Runtime parse falla en algún boundary | None | 0 `.parse()` runtime sobre tripEventSchema. Hallazgo colateral H-S1a-1 (spec §12.5). |
+| Algún consumer del frontend (`cargas.tsx`) depende del enum cerrado | Low | Verificación adicional: la referencia en `cargas.tsx` es probable import de type (no de valores específicos). Test post-edit lo confirmará. |
+| Drift inverso (futuro): remover un valor sin querer en refactor | Low (mitigado) | Test **whitelist guardrail** en T1.2 valida los 14 valores explícitos vs `tripEventTypeSchema.options`. |
+
+---
+
+## Hallazgo colateral
+
+El descubrimiento de **0 llamadas runtime `.parse()` / `.safeParse()`** sobre `tripEventSchema` es la observación más importante de este discovery, **fuera del scope T1.2 pero crítica para el sprint S1a como programa**.
+
+Capturado formalmente en [`.specs/s1-drift-coverage-e2e/spec.md` §12.5 Hallazgo H-S1a-1](./spec.md#125-hallazgos-s1a--backlog-s2s3). Owner: PO. Sprint objetivo: S2 o S3.
+
+---
+
+## Plan de commits T1.2
+
+1. **Commit A**: edit `domain/trip-event.ts` agregando 2 valores + nuevo test block en `all-schemas.test.ts` con whitelist guardrail (14 valores explícitos vs `.options`).
+2. **Commit B** (este doc): `t1.2-discovery.md` capturando findings — incluido en mismo PR para trazabilidad pero como commit separado.
+
+Si surge problema post-merge con los 2 valores nuevos, revert del commit A sin tocar el discovery doc.

--- a/packages/shared-schemas/src/all-schemas.test.ts
+++ b/packages/shared-schemas/src/all-schemas.test.ts
@@ -355,6 +355,56 @@ describe('site-settings', () => {
   });
 });
 
+describe('tripEvent — whitelist guardrail (Sprint S1a T1.2)', () => {
+  /**
+   * Listado explícito de los 19 valores esperados en `tripEventTypeSchema`,
+   * alineado con `tripEventTypeEnum` SQL (`apps/api/src/db/schema.ts`).
+   *
+   * Por qué whitelist: un test "los 2 nuevos parsean" no detecta remoción
+   * silenciosa de valores en refactors futuros. Esta lista actúa como
+   * guardrail — cualquier cambio al enum requiere actualizar esta lista
+   * explícitamente. Drift inverso bloqueado.
+   *
+   * Orden idéntico al SQL para que `tripEventTypeSchema.options` haga
+   * match exacto con `toEqual()`.
+   */
+  const EXPECTED_TRIP_EVENT_TYPES = [
+    'intake_iniciado',
+    'intake_capturado',
+    'matching_iniciado',
+    'ofertas_enviadas',
+    'oferta_aceptada',
+    'oferta_rechazada',
+    'oferta_expirada',
+    'asignacion_creada',
+    'conductor_asignado',
+    'recogida_confirmada',
+    'entrega_confirmada',
+    'cancelado',
+    'carbono_calculado',
+    'certificado_emitido',
+    'telemetria_primera_recibida',
+    'telemetria_perdida',
+    'ruta_desviada',
+    'disputa_abierta',
+    'incidente_reportado',
+  ] as const;
+
+  it(`tripEventTypeSchema tiene exactamente ${EXPECTED_TRIP_EVENT_TYPES.length} valores (whitelist)`, () => {
+    expect(tripEvent.tripEventTypeSchema.options).toEqual(EXPECTED_TRIP_EVENT_TYPES);
+  });
+
+  it('valores agregados en T1.2 (caso 5 de inventory) parsean correctamente', () => {
+    expect(tripEvent.tripEventTypeSchema.parse('conductor_asignado')).toBe('conductor_asignado');
+    expect(tripEvent.tripEventTypeSchema.parse('incidente_reportado')).toBe('incidente_reportado');
+  });
+
+  it('rechaza valores fuera del enum', () => {
+    expect(() => tripEvent.tripEventTypeSchema.parse('valor_inventado')).toThrow();
+    expect(() => tripEvent.tripEventTypeSchema.parse('')).toThrow();
+  });
+});
+
 describe('domain modules — importables sin errores (schemas executados al import)', () => {
   const modules = {
     assignment,

--- a/packages/shared-schemas/src/domain/trip-event.ts
+++ b/packages/shared-schemas/src/domain/trip-event.ts
@@ -14,7 +14,8 @@ import {
  * updatea ni borra (un trigger BEFORE UPDATE/DELETE rechaza, slice 2+).
  *
  * Naming bilingüe: los valores del enum están en español snake_case sin
- * tildes — alineados con el naming SQL de la tabla `eventos_viaje`.
+ * tildes — alineados con el naming SQL de la tabla `eventos_viaje`
+ * (ver `apps/api/src/db/schema.ts` `tripEventTypeEnum`).
  *
  * Tipos esperados:
  *   - intake_iniciado: shipper empezó a crear la carga (web/whatsapp)
@@ -24,7 +25,10 @@ import {
  *   - oferta_aceptada: un transportista aceptó
  *   - oferta_rechazada: transportista rechazó
  *   - oferta_expirada: TTL expirado
- *   - asignacion_creada: assignment inicial creada
+ *   - asignacion_creada: assignment inicial creada (driver_user_id típicamente NULL)
+ *   - conductor_asignado: carrier asigna (o reasigna) driver específico al assignment.
+ *     Distinto de asignacion_creada — éste registra la asignación de UN conductor concreto.
+ *     Payload: { assignment_id, previous_driver_user_id, new_driver_user_id, driver_name, acting_user_id }.
  *   - recogida_confirmada: transportista reportó recogida
  *   - entrega_confirmada: transportista reportó entrega
  *   - cancelado: alguien canceló (payload incluye actor + razón)
@@ -33,7 +37,15 @@ import {
  *   - telemetria_primera_recibida: primer ping Codec8 del vehículo
  *   - telemetria_perdida: gap > umbral en pings durante el viaje
  *   - ruta_desviada: vehículo se desvió del corredor planificado
- *   - disputa_abierta: alguna parte abrió una disputa post-entrega
+ *   - disputa_abierta: alguna parte abrió una disputa post-entrega (legal)
+ *   - incidente_reportado: conductor reporta incidente operacional durante el viaje
+ *     (vía voice command "marcar incidente" o botón visual). Distinto de disputa_abierta
+ *     (legal); éste es informativo + notifica al shipper. Subtipo va en payload.incident_type.
+ *
+ * Sprint S1a T1.2 (2026-05-18): alineado con SQL canónico — agregados
+ * `conductor_asignado` e `incidente_reportado` que ya emitían los services
+ * `asignar-conductor-a-assignment.ts` y `reportar-incidente.ts` respectivamente.
+ * El enum total pasó de 17 a 19 valores (paridad exacta con `tripEventTypeEnum` SQL).
  */
 export const tripEventTypeSchema = z.enum([
   'intake_iniciado',
@@ -44,6 +56,7 @@ export const tripEventTypeSchema = z.enum([
   'oferta_rechazada',
   'oferta_expirada',
   'asignacion_creada',
+  'conductor_asignado',
   'recogida_confirmada',
   'entrega_confirmada',
   'cancelado',
@@ -53,6 +66,7 @@ export const tripEventTypeSchema = z.enum([
   'telemetria_perdida',
   'ruta_desviada',
   'disputa_abierta',
+  'incidente_reportado',
 ]);
 export type TripEventType = z.infer<typeof tripEventTypeSchema>;
 


### PR DESCRIPTION
## Summary

Cierra **T1.2** del Sprint S1a (Caso 5 de `inventory.md`): agrega `conductor_asignado` e `incidente_reportado` a `tripEventTypeSchema` para alinear con `tripEventTypeEnum` SQL canónico. Cambio aditivo + low-risk per discovery T1.2 (0 runtime `.parse()`, 0 exhaustive matching, 2 valores ya emitidos en producción).

Adicionalmente, este PR captura el **Hallazgo H-S1a-1** (Zod schemas no enforced en runtime) en `spec.md §12.5` como observación arquitectónica diferida a S2/S3, y separa **T1.3** (eliminación `cargoRequestStatusSchema` orphan) en el plan como tarea independiente de T1.2 por razones de bisectability + perfil de riesgo distinto.

## Commits (2)

1. **`94d67ba` chore(s1a): spec hallazgo colateral + plan T1.2/T1.3 separados** — precursor:
   - `spec.md §12.5` nueva: Hallazgo H-S1a-1 con acciones diferidas a S2/S3.
   - `plan-s1a.md`: T1.2 acotado a Caso 5; T1.3 nuevo separado (Caso 1 orphan); T1.4..T1.n placeholder.

2. **`fc01038` feat(domain): T1.2 alinea tripEventTypeSchema con SQL (Caso 5)** — implementación:
   - `domain/trip-event.ts`: +2 valores en posiciones idénticas al SQL (`conductor_asignado` entre `asignacion_creada` y `recogida_confirmada`; `incidente_reportado` al final). Docstrings actualizadas.
   - `all-schemas.test.ts`: nuevo describe block con 3 tests:
     - **Whitelist guardrail**: `tripEventTypeSchema.options` ↔ listado explícito de 19 valores con `toEqual()` (detecta remociones silenciosas en refactors futuros).
     - Test que los 2 valores nuevos parsean.
     - Test que rechaza valores fuera del enum.
   - `t1.2-discovery.md`: findings completos pre-T1.2.

## Trazabilidad

- Closes T1.2 of `.specs/s1-drift-coverage-e2e/plan-s1a.md`
- Cubre **Caso 5** de `.specs/s1-drift-coverage-e2e/inventory.md` (única Clase A confirmada que T1.2 cubre)
- Captura Hallazgo **H-S1a-1** en spec maestra (visibilidad explícita para `/spec` de S2/S3)
- Separa **T1.3** del scope T1.2 (PO instruction post-#293)
- Plan ajustado: T1.2 = 1 sub-caso (no plantilla recurrente), T1.3 = Caso 1 orphan separado

## Test plan

- [x] `pnpm --filter @booster-ai/shared-schemas test` → 190/190 passed.
- [x] `pnpm --filter @booster-ai/shared-schemas typecheck` → 0 errors.
- [x] Whitelist guardrail: si alguien remueve un valor en refactor futuro, el test `toEqual()` falla y obliga a actualizar la lista explícita.
- [x] Pre-commit hook (ADR + drift gate) OK — gate `APPROVED_BY_PO`.

## Hallazgo colateral (la observación más importante de la sesión)

`tripEventSchema` tiene **0 llamadas `.parse()` / `.safeParse()` en runtime** en todo `apps/`. El Zod schema vive como documentación declarativa del dominio, no como validation activa.

Implicación: alinear TS↔SQL elimina drift estructural pero **no previene** que código emita payloads con valores inválidos en runtime (la defensa real son `.parse()` en boundaries). Esto está documentado en `spec.md §12.5 Hallazgo H-S1a-1` con owner PO y acciones diferidas a S2/S3.

## Notas

- **Posiciones de los 2 valores nuevos**: idénticas al SQL para que `tripEventTypeSchema.options` haga match exacto con `toEqual()` en el whitelist guardrail (sin sort).
- **Rollback**: revert PR. Zero impacto runtime (Zod no se ejecuta — ver Hallazgo H-S1a-1).
- **T1.3 (Caso 1 orphan)** queda en `plan-s1a.md` como tarea siguiente, NO en este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)