### PR TITLE
refactor(drift-inventory): separate auto-generated from PO-curated metadata (C+)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -26,18 +26,20 @@ node scripts/repo-checks/check-adr-numbering.mjs --allow-legacy 028,034,035 || {
 }
 
 # T1.1 of S1a: bloquea commits que tocan packages/shared-schemas/src/domain/
-# si el drift inventory tiene gate: PENDING_PO (cubre SC-S1.0 enforcement).
-INVENTORY_FILE=".specs/s1-drift-coverage-e2e/inventory.md"
+# si el drift gate tiene PENDING_PO (cubre SC-S1.0 enforcement).
+# Post refactor C+: gate vive en inventory-classification.md (PO-curated),
+# no en inventory.md (auto-generated por script T1.1).
+CLASSIFICATION_FILE=".specs/s1-drift-coverage-e2e/inventory-classification.md"
 DOMAIN_DIR_PATTERN="packages/shared-schemas/src/domain/"
-if [ -f "$INVENTORY_FILE" ]; then
+if [ -f "$CLASSIFICATION_FILE" ]; then
   DOMAIN_STAGED=$(git diff --cached --name-only | grep "^${DOMAIN_DIR_PATTERN}" || true)
   if [ -n "$DOMAIN_STAGED" ]; then
-    GATE=$(head -3 "$INVENTORY_FILE" | grep '^gate:' | awk '{print $2}')
+    GATE=$(head -5 "$CLASSIFICATION_FILE" | grep '^gate:' | awk '{print $2}')
     if [ "$GATE" = "PENDING_PO" ]; then
       echo ""
       echo "[ERROR] Commits que tocan ${DOMAIN_DIR_PATTERN} bloqueados por gate SC-S1.0."
-      echo "        $INVENTORY_FILE tiene 'gate: PENDING_PO'."
-      echo "        Acción: revisar $INVENTORY_FILE + .specs/s1-drift-coverage-e2e/inventory-classification.md"
+      echo "        $CLASSIFICATION_FILE tiene 'gate: PENDING_PO'."
+      echo "        Accion: revisar inventory.md (auto) + $CLASSIFICATION_FILE (curated)."
       echo "        Tras clasificar A/B/C, cambiar 'gate: PENDING_PO' por 'gate: APPROVED_BY_PO <fecha>'."
       exit 1
     fi

--- a/.specs/s1-drift-coverage-e2e/inventory-classification.md
+++ b/.specs/s1-drift-coverage-e2e/inventory-classification.md
@@ -1,3 +1,10 @@
+---
+gate: APPROVED_BY_PO 2026-05-18
+triaged_at: 2026-05-18T14:45:00Z
+divergences_post_triage_real: 2 (Clase A) + 1 diferido (Clase B+, caso 8 tripState)
+heuristic_false_positives: 6 (Clase H — casos 2, 3, 4, 6, 7, 9, 10)
+---
+
 # Drift inventory — Triage manual + clasificación (T1.1)
 
 - Auto-generado: [`inventory.md`](./inventory.md)

--- a/.specs/s1-drift-coverage-e2e/inventory.md
+++ b/.specs/s1-drift-coverage-e2e/inventory.md
@@ -1,10 +1,10 @@
 <!-- AUTO-GENERATED FILE — do not edit by hand. -->
 <!-- Curated metadata (gate, triage stats, decisions) lives in inventory-classification.md -->
 ---
-generated_at: 2026-05-18T14:22:30.670Z
+generated_at: 2026-05-18T22:52:06.035Z
 source_domain: packages/shared-schemas/src/domain
 source_schema: apps/api/src/db/schema.ts
-divergences_total: 10
+divergences_total: 9
 gate_threshold: 10
 ---
 
@@ -12,13 +12,13 @@ gate_threshold: 10
 
 Generado por `scripts/repo-checks/drift-inventory.mjs`. Cubre SC-S1.1 + gate SC-S1.0 del sprint S1.
 
-**Total divergencias detectadas**: 10 (threshold gate: 10).
+**Total divergencias detectadas**: 9 (threshold gate: 10).
 
 ## Acción del PO
 
 Clasificar cada divergencia como **Clase A** (TS-only refactor), **Clase B** (breaking API → flag + sunset + ADR), o **Clase C** (cambio SQL → ADR de excepción).
 
-Tras clasificar, cambiar frontmatter `gate: PENDING_PO` → `gate: APPROVED_BY_PO <fecha>` para permitir que pre-commit hook acepte commits `feat(domain)`.
+Tras clasificar, cambiar `gate: PENDING_PO` → `gate: APPROVED_BY_PO <fecha>` en el frontmatter de [`inventory-classification.md`](./inventory-classification.md) (gate vive ahí post refactor C+; este archivo es auto-generado por el script T1.1).
 
 ## Divergencias
 
@@ -28,12 +28,11 @@ Tras clasificar, cambiar frontmatter `gate: PENDING_PO` → `gate: APPROVED_BY_P
 | 2 | `licenseClassSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
 | 3 | `telemetrySourceSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
 | 4 | `transportistaStatusSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
-| 5 | `tripEventTypeSchema` | `tripEventTypeEnum` (`tipo_evento_viaje`) | value-mismatch | (none) | conductor_asignado, incidente_reportado | _TBD_ |
-| 6 | `nivelCertificacionSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
-| 7 | `tripMetricsSourceSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
-| 8 | `tripStateSchema` | `tripStatusEnum` (`estado_viaje`) | value-mismatch | requested, offered_to_carrier, accepted, driver_assigned, driver_en_route, pickup_completed, in_transit, delivered, confirmed_by_shipper, completed_rated, carrier_rejected, carrier_timed_out, driver_rejected, cancelled_by_shipper, cancelled_by_carrier, failed, disputed | borrador, esperando_match, emparejando, ofertas_enviadas, asignado, en_proceso, entregado, cancelado, expirado | _TBD_ |
-| 9 | `roleSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
-| 10 | `zonaStakeholderTipoSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
+| 5 | `nivelCertificacionSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
+| 6 | `tripMetricsSourceSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
+| 7 | `tripStateSchema` | `tripStatusEnum` (`estado_viaje`) | value-mismatch | requested, offered_to_carrier, accepted, driver_assigned, driver_en_route, pickup_completed, in_transit, delivered, confirmed_by_shipper, completed_rated, carrier_rejected, carrier_timed_out, driver_rejected, cancelled_by_shipper, cancelled_by_carrier, failed, disputed | borrador, esperando_match, emparejando, ofertas_enviadas, asignado, en_proceso, entregado, cancelado, expirado | _TBD_ |
+| 8 | `roleSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
+| 9 | `zonaStakeholderTipoSchema` | _no match_ | no-sql-match | (none) | (none) | _TBD_ |
 
 ## Tabla LOC adaptive (T1.5)
 

--- a/.specs/s1-drift-coverage-e2e/inventory.md
+++ b/.specs/s1-drift-coverage-e2e/inventory.md
@@ -1,14 +1,11 @@
+<!-- AUTO-GENERATED FILE — do not edit by hand. -->
+<!-- Curated metadata (gate, triage stats, decisions) lives in inventory-classification.md -->
 ---
-gate: APPROVED_BY_PO 2026-05-18
 generated_at: 2026-05-18T14:22:30.670Z
-triaged_at: 2026-05-18T14:45:00Z
 source_domain: packages/shared-schemas/src/domain
 source_schema: apps/api/src/db/schema.ts
 divergences_total: 10
-divergences_post_triage_real: 2 (Clase A) + 1 diferido (Clase B+, caso 8 tripState)
-heuristic_false_positives: 6 (Clase H — casos 2, 3, 4, 6, 7, 9, 10; ver inventory-classification.md)
 gate_threshold: 10
-classification_doc: inventory-classification.md
 ---
 
 # Drift inventory schema/domain — Sprint S1 T1.1

--- a/scripts/repo-checks/drift-inventory.mjs
+++ b/scripts/repo-checks/drift-inventory.mjs
@@ -161,8 +161,11 @@ export function findDivergences(domainEnums, sqlEnums) {
  */
 export function renderMarkdown(divergences, args) {
   const lines = [];
+  lines.push('<!-- AUTO-GENERATED FILE — do not edit by hand. -->');
+  lines.push(
+    '<!-- Curated metadata (gate, triage stats, decisions) lives in inventory-classification.md -->',
+  );
   lines.push('---');
-  lines.push('gate: PENDING_PO');
   lines.push(`generated_at: ${new Date().toISOString()}`);
   lines.push(`source_domain: ${args.domainDir}`);
   lines.push(`source_schema: ${args.schemaFile}`);
@@ -187,7 +190,7 @@ export function renderMarkdown(divergences, args) {
   );
   lines.push('');
   lines.push(
-    'Tras clasificar, cambiar frontmatter `gate: PENDING_PO` → `gate: APPROVED_BY_PO <fecha>` para permitir que pre-commit hook acepte commits `feat(domain)`.',
+    'Tras clasificar, cambiar `gate: PENDING_PO` → `gate: APPROVED_BY_PO <fecha>` en el frontmatter de [`inventory-classification.md`](./inventory-classification.md) (gate vive ahí post refactor C+; este archivo es auto-generado por el script T1.1).',
   );
   lines.push('');
   lines.push('## Divergencias');

--- a/scripts/repo-checks/drift-inventory.test.mjs
+++ b/scripts/repo-checks/drift-inventory.test.mjs
@@ -146,9 +146,21 @@ describe('findDivergences', () => {
 });
 
 describe('renderMarkdown', () => {
-  it('produces frontmatter with gate=PENDING_PO', () => {
+  it('opens with AUTO-GENERATED banner (post refactor C+)', () => {
     const md = renderMarkdown([], { domainDir: 'd', schemaFile: 's' });
-    expect(md).toMatch(/^---\ngate: PENDING_PO/);
+    expect(md.startsWith('<!-- AUTO-GENERATED FILE')).toBe(true);
+    expect(md).toContain('inventory-classification.md');
+  });
+
+  it('frontmatter has NO gate field (gate vive en classification.md post C+)', () => {
+    const md = renderMarkdown([], { domainDir: 'd', schemaFile: 's' });
+    // Extract frontmatter block.
+    const frontmatterMatch = md.match(/---\n([\s\S]*?)\n---/);
+    expect(frontmatterMatch).not.toBeNull();
+    const frontmatter = frontmatterMatch[1];
+    expect(frontmatter).not.toMatch(/^gate:/m);
+    expect(frontmatter).toMatch(/^generated_at:/m);
+    expect(frontmatter).toMatch(/^gate_threshold:/m);
   });
 
   it('includes divergence count in frontmatter', () => {


### PR DESCRIPTION
Cierra la contradicción de diseño descubierta en P5 (diagnóstico pre-CI integration): `inventory.md` mezclaba campos auto-generated por el script T1.1 con campos PO-curated (gate, triage stats), causando que cada regen wipeara la curación.

Decisión PO: **variante C+** — separar concerns. `inventory.md` queda como puro output mecánico (regenerable sin pérdida); `inventory-classification.md` se vuelve el home único de toda la curación.

## 4 commits dentro del PR (cada uno safe intermediate state)

| # | Commit | SHA | Cambio |
|---|---|---|---|
| a/4 | Migrate curated fields to classification.md frontmatter (additive) | `53d8ec4` | Agrega YAML frontmatter a classification.md. inventory.md NO se toca — fields duplicados durante el ordering interno para que el hook siga funcionando. |
| b/4 | Update hook to read gate from classification.md | `e4b3e43` | `.husky/pre-commit` apunta a classification.md. Funciona porque commit a ya tiene el gate ahí. |
| c/4 | Banner in script + remove curated fields from inventory.md + update test | `c0e606f` | Script emite `<!-- AUTO-GENERATED FILE -->` banner antes del frontmatter; ya no incluye `gate` en el output; body text apunta a classification.md para cambio de gate. inventory.md editado manualmente. Test actualizado (+1 nuevo test). |
| d/4 | Regenerate inventory.md via script | `cf7fcc0` | Corre script para regenerar inventory.md desde scratch. Confirma que el shape matchea exactamente el output del script. Captura el drift real `divergences_total: 10 → 9` (T1.2 ya fixeó Caso 5 hace horas pero el file estaba stale). |

## Verificaciones ejecutadas localmente

1. **Hook lee gate correctamente** post-migración:
   ```
   $ head -5 .specs/.../inventory-classification.md | grep '^gate:'
   gate: APPROVED_BY_PO 2026-05-18
   ```

2. **Simulación de `feat(domain)` commit** con el hook actual:
   ```
   Detected gate value: 'APPROVED_BY_PO'
   Hook would ALLOW commit (gate is APPROVED_BY_PO, not PENDING_PO)
   ```

3. **Script regen idempotency** — re-correr el script NO destruye classification.md:
   ```
   classification.md sha256 IDENTICAL before/after regen — script does NOT touch it
   ```

4. **inventory.md post-final regen** — solo cambia el timestamp (Class B benigno):
   ```
   .specs/.../inventory.md | 2 +-
   1 file changed, 1 insertion(+), 1 deletion(-)
   ```

## Tests

- 92 tests pasan en `scripts/repo-checks/` (+1 nuevo: `'frontmatter has NO gate field'`).
- Test viejo `'produces frontmatter with gate=PENDING_PO'` reformulado a `'opens with AUTO-GENERATED banner'` + se agregó la verificación de que el frontmatter NO contiene `gate:` post-C+.

## Qué cambia operacionalmente

| Antes | Después |
|---|---|
| `inventory.md` tenía gate + triage stats curados + auto-fields mezclados | `inventory.md` solo auto-fields; banner declara la naturaleza del file |
| Regenerar wipe la curación PO (4+ fields, gate inclusive) | Regenerar solo actualiza auto-fields; classification.md intacto |
| Hook leía gate de inventory.md (lo que el script regenera como PENDING_PO default) | Hook lee gate de classification.md (curated, persistente) |
| Re-correr el script en CI hubiera dropeado el gate APPROVED_BY_PO silenciosamente | Re-correr el script en CI es seguro (no toca classification.md) |

## Constraints respetadas

- ✅ NO modifica `.github/workflows/*` (boundary PAT documentado).
- ✅ NO modifica lógica de drift detection (solo banner + frontmatter shape).
- ✅ Tests pasan.
- ✅ Hook funciona después de cada commit intermedio (no broken state).
- ✅ Script regen verificado no-destructivo respecto a classification.md.

## Habilita

Después de este merge, queda safe la próxima iteración de CI integration (la tarea P5 original): correr `drift-inventory.mjs` en CI es operacional sin riesgo de drop del gate.

## Sin auto-merge

PR esperando review PO.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>