### PR TITLE
feat(arquitecto-maestro): migra meta-orquestador a skill versionada

### DIFF
--- a/docs/adr/ADR-054-arquitecto-maestro-migration.md
+++ b/docs/adr/ADR-054-arquitecto-maestro-migration.md
@@ -1,0 +1,134 @@
+# ADR-054: Migración del Arquitecto Maestro de Project Instructions (claude.ai) a Skill versionada en repo
+
+**Status**: Accepted
+**Date**: 2026-05-19
+**Owner**: Felipe Vicencio · `dev@boosterchile.com`
+**Supersedes**: N/A
+**Superseded by**: N/A
+**Related**:
+- ADR-001 (stack canónico Booster AI)
+- ADR-043 (drift-inventory enforcement)
+- [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) (marco de referencia)
+- CLAUDE.md §3 (Process over knowledge), §4 (Decisiones en ADRs)
+- Sesión auditoría `21c07e7c-e6f9-4de9-9c1d-f819e6b5d5d7` (2026-05-19)
+
+---
+
+## Context
+
+Entre 2026-05-18 y 2026-05-19 se evaluó arquitectónicamente el setup operativo del "Arquitecto Maestro" — meta-orquestador encargado de diseñar Execution Plans deterministas para misiones complejas del proyecto Booster AI (misiones que afectan >1 app/package, requieren ADR, o cruzan dimensiones architecture/security/performance/compliance).
+
+El setup original consistía en:
+
+- Un Claude Project hospedado en `claude.ai` (`Booster AI — Arquitecto Claude Code`).
+- Project Instructions definiendo la persona meta-orquestadora + 4 reglas operativas inquebrantables (anti-alucinación, máquina de estados, plantilla Execution Blueprint, protocolo Auto-Dream de consolidación de memoria).
+- Memoria conversacional acotada al scope del Project + opción de Project Knowledge con archivos como `Memoria_Proyecto.md`.
+- Flujo de trabajo: PO conversa con Arquitecto en `claude.ai` → Arquitecto produce Execution Blueprint en Markdown → PO copia/pega Blueprint en sesión de Claude Code CLI → agente ejecuta.
+
+La auditoría arquitectónica del 2026-05-19 (sesión `21c07e7c-e6f9-4de9-9c1d-f819e6b5d5d7`, 6 subagents paralelos + 1 refactor-advisor) reveló inconsistencias estructurales del setup:
+
+1. **Violación de Principio §3 (Process over knowledge)** — el Arquitecto vivía como memoria conversacional + plantillas en context window, no como proceso versionado bajo `skills/`. CLAUDE.md §3 declara explícitamente: *"El agente no confía en su memoria — sigue los workflows definidos en `skills/` y los hooks de `agent-rigor` para cada operación"*.
+2. **Stack drift confirmado empíricamente** — durante la sesión se detectaron 5 divergencias entre el stack declarado en Project Instructions (Neon Postgres, HashRouter, `maps.config.ts`, npm, pgvector) y el stack real verificado en el repo (Cloud SQL, `@tanstack/react-router`, `packages/config` + Secret Manager, pnpm 9, sin pgvector). El medio (memoria en context) no permite verificación contra filesystem real; el drift es inherente al diseño.
+3. **Sin versionado en git** — las Project Instructions viven en `claude.ai` sin historial trazable, sin diff, sin PR, sin blame. Cualquier cambio es opaco para revisores posteriores.
+4. **No compartible con el equipo** — el Project en `claude.ai` es propiedad personal del usuario individual; no se hereda al clonar el repo. Inviable si el equipo crece >1 desarrollador.
+5. **Redundancia con agent-rigor** — el repo ya tiene framework de rigor con ledger en `.claude/ledger/` y workflows estructurados en `skills/`. El Arquitecto reimplementaba parcialmente la máquina de estados (Regla 2 del setup original = tracker manual; agent-rigor lo provee nativamente).
+6. **Composición limitada con primitivas existentes** — el Arquitecto en `claude.ai` podía describir subagents/hooks/MCPs pero no invocarlos directamente. La auditoría 2026-05-19 dejó 6 subagents reusables en `.claude/agents/`; aprovecharlos requiere una skill que los componga, no una persona conversacional que los referencie.
+
+---
+
+## Decision
+
+El "Arquitecto Maestro" deja de vivir como Project Instructions en `claude.ai` y se transforma en una skill versionada bajo el repo, complementada por documentación viva del estado del proyecto:
+
+### Cambios estructurales
+
+| Componente original | Reemplazo en repo |
+|---|---|
+| Project Instructions (persona) | `skills/arquitecto-maestro/SKILL.md` (formato addyosmani/agent-skills) |
+| Project Knowledge (`Memoria_Proyecto.md`) | `docs/handoff/CURRENT.md` (estado vivo) |
+| Regla 1 (anti-alucinación + consulta de conocimiento) | Fase 1 read-first del workflow de la skill (lee CLAUDE.md + CURRENT.md + ADRs + drift-inventory) |
+| Regla 2 (máquina de estados con tracker manual) | agent-rigor ledger en `.claude/ledger/<YYYY-MM-DD>/<session-uuid>.md` |
+| Regla 3 (plantilla Execution Blueprint copy-paste) | `.specs/<feature-slug>/spec.md` versionado en git |
+| Regla 4 (Auto-Dream con output a chat) | Sub-workflow `/auto-dream` con output como PR al repo (`docs/handoff/CURRENT.md` + ledger) |
+
+### Redefinición del Project en `claude.ai`
+
+El Project original (`Booster AI — Arquitecto Claude Code`) se renombra a **`Booster AI — Exploration Workspace`** con propósito acotado:
+
+- Brainstorming temprano sobre requerimientos antes de comprometerlos a skills/specs del repo.
+- Trabajo meta-arquitectónico exploratorio que no toca código.
+- Borradores conversacionales de ADRs antes de redactarlos formalmente.
+
+**No es** meta-orquestador permanente, ni fuente de verdad operativa, ni reemplazo del flujo skill+spec del repo.
+
+---
+
+## Consequences
+
+### Positivas
+
+- **Coherencia filosófica completa** — alineado con Principio §3 (Process over knowledge) y §4 (Decisiones en ADRs). Elimina la tensión interna del proyecto.
+- **Cero drift estructural** — la skill lee filesystem real en cada activación (CLAUDE.md, CURRENT.md, ADRs activos, drift-inventory). No puede operar contra stack obsoleto.
+- **Versionado completo** — cada cambio al Arquitecto pasa por PR + diff + blame + posibles ADR superseding. Auditable a perpetuidad.
+- **Heredable por equipo** — todos los devs que clonen el repo obtienen la skill automáticamente. Escala más allá de 1 dev.
+- **Composición nativa con subagents** — la skill invoca directamente los 6 subagents de `.claude/agents/` (explore-architecture, dependency-auditor, security-scanner, performance-analyzer, tech-debt-detector, refactor-advisor) en vez de describirlos.
+- **Trazabilidad por sesión** — agent-rigor ledger captura inicio + decisiones + cierre de cada misión orquestada con timestamp y session UUID.
+- **Reproducibilidad** — el mismo prompt + el mismo repo en HEAD producen el mismo plan. Project Instructions en `claude.ai` no garantizaban esto.
+
+### Negativas
+
+- **Pérdida de conversación libre como entrada al flujo** — el Project en `claude.ai` permitía iterar sobre un requerimiento ambiguo antes de escribir spec. Mitigación: el Project se conserva como "exploration workspace" para esta función.
+- **Curva de creación más alta** — cada nueva sub-rutina del Arquitecto debe escribirse como skill estructurada (formato canónico: When to use / Core process / Anti-rationalizations / Exit criteria), no como prompt libre. Trade-off aceptado.
+- **Memoria conversacional reducida** — `claude.ai` Projects tienen memoria nativa cross-chat; CURRENT.md requiere actualización explícita post-misión. Mitigación: sub-workflow `/auto-dream` automatiza la consolidación.
+- **Posible fricción operativa inicial** — durante las primeras misiones post-migración puede haber tentación de "saltar a `claude.ai`" por costumbre. Mitigación: durante 30 días post-merge, monitorear cuántas misiones se inician en el Project vs. en Claude Code CLI; si la migración no toma tracción, revisar el diseño de la skill.
+
+### Riesgos identificados y mitigaciones
+
+| Riesgo | Probabilidad | Impacto | Mitigación |
+|---|---|---|---|
+| Drift entre `CURRENT.md` y realidad del repo | Media | Medio | Sub-workflow `/auto-dream` post-misión + hook `PostToolUse` opcional que recuerda actualizar CURRENT.md |
+| Skill `arquitecto-maestro` se vuelve obsoleta sin que nadie lo note | Baja | Medio | Versionado semántico (1.0.0 inicial) + revisión cada 3 meses como mantenimiento de skill |
+| Equipo (cuando crezca) no descubre la skill | Baja | Bajo | Documentación en CLAUDE.md §3 + README del repo + onboarding spec en `.specs/onboarding/` |
+
+---
+
+## Migration plan
+
+1. **2026-05-19** — Creación de `docs/handoff/CURRENT.md` con estado consolidado post-auditoría arquitectónica. **[Completado en este PR]**
+2. **2026-05-19** — Creación de `skills/arquitecto-maestro/SKILL.md` v1.0.0 con workflow completo (6 fases, 9 anti-rationalizations, 9 exit criteria, sub-workflow `/auto-dream`). **[Completado en este PR]**
+3. **2026-05-19** — Redacción de este ADR (ADR-054) documentando la transición. **[Completado en este PR]**
+4. **+7 días desde merge** — Test de humo invocando `/arquitecto-maestro <misión>` en sesión nueva de Claude Code para validar activación correcta. Si falla, abrir PR de fix sobre la skill.
+5. **+30 días desde merge** — Revisión retrospectiva: ¿la skill captura todos los casos de uso del Arquitecto original? ¿Hay sub-rutinas que requieran spin-off a skills específicas? Documentar hallazgos como follow-up.
+6. **Permanente** — El Project `Booster AI — Exploration Workspace` queda como espacio de exploración temprana únicamente. No se promueve trabajo desde ahí sin pasar por skill+spec en repo.
+
+---
+
+## Validation criteria
+
+Esta migración se considera **exitosa** cuando, dentro de 30 días post-merge:
+
+- [ ] Test de humo de la skill pasa (output esperado: `.specs/<feature>/spec.md` emitido + STOP esperando aprobación).
+- [ ] ≥1 misión real de Sprint 1 fue orquestada vía `/arquitecto-maestro` produciendo spec versionada.
+- [ ] `docs/handoff/CURRENT.md` se actualizó al menos 1 vez tras cierre de misión vía `/auto-dream`.
+- [ ] Agent-rigor ledger contiene registros completos (inicio + decisiones + cierre) de las misiones orquestadas.
+- [ ] Cero misiones de producción ejecutadas tomando Execution Blueprints desde el Project en `claude.ai`.
+
+Si cualquier criterio falla a los 30 días, abrir ADR-055 de revisión.
+
+---
+
+## References
+
+- `docs/handoff/CURRENT.md` — estado vivo del proyecto, consolidación inicial post-auditoría.
+- `skills/arquitecto-maestro/SKILL.md` — skill resultante v1.0.0.
+- `audit-outputs/SUMMARY.md` — síntesis ejecutiva auditoría 2026-05-19.
+- `audit-outputs/EXTENSIONS_RECOMMENDATIONS.md` — catálogo de subagents/hooks/MCPs/skills reusables.
+- `audit-outputs/CLAUDE.md` (propuesto) — constitución del repo derivada de la auditoría.
+- Sesión de auditoría: `21c07e7c-e6f9-4de9-9c1d-f819e6b5d5d7` (2026-05-19).
+- [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) — marco de referencia para skills production-grade.
+- ADR-001 — stack canónico Booster AI.
+- ADR-043 — drift-inventory enforcement.
+
+---
+
+*Fin de ADR-054.*

--- a/docs/handoff/CURRENT.md
+++ b/docs/handoff/CURRENT.md
@@ -1,334 +1,234 @@
-# Estado actual del proyecto — Booster AI
+# Booster AI — Estado vivo del proyecto
 
-**Última actualización**: 2026-05-18 (Sprint **S1a Bloque A complete; Bloque B deferred to S2 con sub-spec tripstate-alignment como pre-requisito** — firma PO Opción A + 3 condiciones, ver [`s1a-cierre.md`](../../.specs/s1-drift-coverage-e2e/s1a-cierre.md) §11)
-**Documento vivo**: este archivo refleja el estado en `main` al momento de la última actualización. Para snapshots históricos ver `docs/handoff/YYYY-MM-DD-*.md`.
-**Plan de referencia**: [`.specs/production-readiness/roadmap.md`](../../.specs/production-readiness/roadmap.md) (S0 cerrado, S1a Bloque A cerrado, pickup S1b) + [`docs/plans/2026-05-12-identidad-universal-y-dashboard-conductor.md`](../plans/2026-05-12-identidad-universal-y-dashboard-conductor.md) (plan histórico waves 1-6)
+> **Documento vivo**. Se actualiza en cada misión significativa, sprint review o decisión arquitectónica.
+> **Última actualización**: 2026-05-19 — consolidación post-auditoría sesión `21c07e7c-e6f9-4de9-9c1d-f819e6b5d5d7`.
+> **Updater**: skill `arquitecto-maestro` (workflow `/auto-dream`).
+> **Branch de referencia**: `chore/ci-integration-drift-scripts` @ `5d025f1`.
 
 ---
 
-## Sprint S1a drift schema/domain — CERRADO (2026-05-18, firma PO Opción A)
+## 1. Identidad
 
-Sub-sprint: [`.specs/s1-drift-coverage-e2e/plan-s1a.md`](../../.specs/s1-drift-coverage-e2e/plan-s1a.md). Cierre formal en [`s1a-cierre.md`](../../.specs/s1-drift-coverage-e2e/s1a-cierre.md) — **gate APPROVED_BY_PO 2026-05-18, Opción A con 3 condiciones vinculantes** (ver §11).
+| Campo | Valor |
+|---|---|
+| Display name | Booster AI |
+| Slug técnico | `booster-ai` |
+| GCP project | `booster-ai-494222` (single project, no multi-env) |
+| Owner humano | Felipe Vicencio · `dev@boosterchile.com` |
+| Origen | Reescritura greenfield de **Booster 2.0** con cero deuda día 0 |
+| Estado objetivo | TRL 10 (probado, certificado, listo para despliegue comercial) |
+| Branch principal | `main` (protegida, requiere PR) |
 
-**S1a Bloque A complete; Bloque B deferred to S2 con sub-spec tripstate-alignment como pre-requisito.**
+**Misión del producto**: marketplace B2B de logística sostenible. Conecta generadores de carga con transportistas, optimiza retornos vacíos, certifica huella de carbono bajo GLEC v3.0 / GHG Protocol / ISO 14064.
 
-### Cierre por tarea (Bloque A)
+**Compliance requerido**: DTE SII Chile, Carta Porte Ley 18.290 (retención legal 6 años), GLEC v3.0 (evidencia para CDP / SBTi).
 
-| Task | PR | LOC (+/-) | Estado |
-|---|---|---|---|
-| T1.1 — Inventario drift schema/domain + pre-commit hook | [#293](https://github.com/boosterchile/booster-ai/pull/293) | +736/-2 | ✅ Merged |
-| T1.2 — Caso 5 `tripEventTypeSchema` (alinea 2 valores SQL) | [#294](https://github.com/boosterchile/booster-ai/pull/294) | +242/-15 | ✅ Merged |
-| T1.3-discovery — Discovery broader pre-reclasificación | [#295](https://github.com/boosterchile/booster-ai/pull/295) | +205/-0 | ✅ Merged |
-| T1.3 — Caso 1 `cargoRequestStatusSchema` → Clase I + annotación | [#296](https://github.com/boosterchile/booster-ai/pull/296) | +86/-32 | ✅ Merged |
-| T1.5 — Integration tests Pattern A + B + H-S1a-1 partial cov | [#297](https://github.com/boosterchile/booster-ai/pull/297) | +168/-1 | ✅ Merged |
-| Spec/plan v2 + reviews (pre-S1a) | [#292](https://github.com/boosterchile/booster-ai/pull/292) | +968/-0 | ✅ Merged |
+---
 
-**Baseline drift final**: 1 A (resuelta) + 1 I (annotada) + 1 B+ (diferida) + 0 C + 6 H = **0 drift estructural accionable**.
+## 2. Stack canónico (ADR-001 verificado 2026-05-19)
 
-### Bloque B — diferido a S2 (firma PO Opción A + 3 condiciones, [`s1a-cierre.md`](../../.specs/s1-drift-coverage-e2e/s1a-cierre.md) §11)
-
-T1.6 (XState scaffold) + T1.7a/b/c/d (wiring 3 services + followup doc) **no ejecutadas**. Ejecutan en S2 (lane paralela a S1b).
-
-**Condición 1**: sub-spec `.specs/tripstate-alignment/spec.md` con acceptance material (§boundary-translation con 17 TS / 5 machine / 9 SQL mapping + §scope cut + §SCs measurable + §risks ≥3 reales + gate explícito). El trigger de avance es **completitud de las 5 sub-bullets + gate `APPROVED_BY_PO` del sub-spec**, no calendario. Sin eso, S2 sigue bloqueado y el spec quedó como artefacto administrativo.
-
-**Condición 2**: spike `spike/tripstate-machine-exploration` permitido como exploración, NO mergeable. Sirve solo como insumo del sub-spec. Ejecutar T1.6/T1.7 disfrazado de spike sería laundering C disfrazado de A.
-
-**Condición 3**: tras merge de PR #298, S1a está cerrado. `tripstate` work posterior vive en sub-spec / plan-s2 / spike — no en "todavía estamos cerrando S1a".
-
-Razones del PO para descartar B (mezcla concerns S1b worse off) y C (sprint discipline + sub-spec necesaria independiente del timing + estimado optimista) en §11.
-
-### Taxonomía drift extendida (deliverable durable)
-
-ADR-043 define A/B/C; el triage T1.1 + discovery T1.3 amplió a:
-- **Clase H** — Falso positivo heurístico (script reporta divergencia pero SQL existe con naming distinto).
-- **Clase I** — Intentional pre-materialization (TS schema deliberadamente antes que SQL counterpart, con dependencias estructurales documentadas en ADRs vivos).
-
-Ambas son **categorías operacionales del proyecto Booster AI**, no modificaciones al ADR-043. Tracking en [`inventory-classification.md`](../../.specs/s1-drift-coverage-e2e/inventory-classification.md) §Nomenclatura.
-
-### Follow-ups no bloqueantes (heredados)
-
-| Follow-up | Sprint objetivo | Tracking |
+| Pieza | Versión / herramienta | Notas |
 |---|---|---|
-| T1.0.heuristic-improvement (mejorar `normalizeForMatch`) | S2 | `plan-s1a.md` §T1.0 |
-| T1.x.parser (`@drift-status` parsing en drift-inventory script) | S2 (post-T1.0) | `plan-s1a.md` §T1.x.parser |
-| Sub-spec `.specs/tripstate-alignment/` (caso 8) | S2 — pre-requisito de Bloque B (avance gated por readiness, no calendario) | `inventory-classification.md` Caso 8 + `s1a-cierre.md` §6 |
-| H-S1a-1 segunda mitad (`.parse()` en boundaries HTTP/DB/queue) | S2 o S3 | `spec.md` §12.5 |
-| Bloque B (XState scaffold + wiring) | S2 (lane paralela a S1b) — recomendación Opción A `s1a-cierre.md` §9, pendiente firma PO | `s1a-cierre.md` §6 |
+| Runtime | Node.js 22 LTS (`.nvmrc=22`, `engines.node>=22`) | ⚠️ CI hardcodea Node 24 — drift R-004 abierto |
+| Package manager | pnpm 9.15.4 (`packageManager` field) | Workspace + lockfile estricto |
+| Build orchestrator | Turborepo 2.9.8 | Pipeline: build/dev/lint/typecheck/test/test:coverage/test:e2e/db:migrate/clean |
+| Lenguaje | TypeScript 5.8.2 | `strict` + `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes` |
+| Linter | Biome 1.9.4 | `noExplicitAny=error`, `noConsole=error` |
+| Backend HTTP | Hono 4 + `@hono/node-server` + tsup | Cloud Run serverless |
+| Base de datos | **Cloud SQL Postgres** + `pg` 8 + Drizzle ORM | Extensión activa: `pgcrypto`. **NO** Neon, **NO** pgvector. |
+| Frontend | React 18 + Vite 6 | PWA con `vite-plugin-pwa` + Workbox InjectManifest |
+| Router frontend | **@tanstack/react-router** | Routing manual hoy (no file-based aunque plugin instalado) |
+| Frontend libs | TanStack Query, react-hook-form, zod, Tremor, lucide-react, Firebase, workbox, idb*, zustand* | `*` declarados sin uso real |
+| Auth | Firebase Admin `verifyIdToken(token, true)` + `google-auth-library` SA-to-SA | RS256/ES256 + JWKS |
+| Config llaves | `packages/config` (Zod env validation) + Secret Manager via Terraform | **NO** `.env` locales en frontend, **NO** `maps.config.ts` |
+| Testing | vitest 4 + Playwright 1.49 + axe-core | Coverage v8, gate ≥80%/75%/80% |
+| Linters custom | `scripts/lint-rls.mjs` (RLS) + `scripts/repo-checks/*` (ADR numbering, drift-inventory, spec-canonical-drift) | |
+| CI/CD | GitHub Actions (4 workflows) + Cloud Build (3 pipelines) + Workload Identity Federation | Sin SA keys |
+| IaC | Terraform flat (18 `.tf`) + 3 módulos (`cloud-run-job`, `cloud-run-service`, `iap-bastion`) | NO layout `main.tf` + `environments/` |
+| WAF | Cloud Armor con bypass total para `api.boosterchile.com` | Trade-off documentado (RUTs chilenos rompen reglas SQLi) — R-015 abierto |
+
+**Stack supersedido (NO usar sin ADR explícito)**: `express`, `prisma`, `eslint`, `prettier`, `react-router-dom`, `next`.
 
 ---
 
----
+## 3. Topología del monorepo
 
-## Sprint S0 production-readiness — CERRADO (2026-05-18)
-
-Sprint maestro: [`.specs/s0-housekeeping/spec.md`](../../.specs/s0-housekeeping/spec.md) + [`.specs/s0-housekeeping/plan.md`](../../.specs/s0-housekeeping/plan.md) (Approved 2026-05-17).
-
-### Cierre por tarea
-
-| # | Tarea | PR | Cubre SC-S0 | Estado |
-|---|---|---|---|---|
-| T1 | ADR-043 metodología drift schema/domain | [#278](https://github.com/boosterchile/booster-ai/pull/278) | .1 | ✅ Merged |
-| T2 | Archivar `AUDIT.md`/`PLAN-PHASE-0.md`/`DESIGN.md` a `docs/archive/` | [#280](https://github.com/boosterchile/booster-ai/pull/280) | .2 | ✅ Merged |
-| T3 | `scripts/repo-checks/check-adr-numbering` + workspace + pre-commit hook | [#281](https://github.com/boosterchile/booster-ai/pull/281) | .3 | ✅ Merged |
-| T4 | ADR-046 colisiones históricas (028,034,035) TTL perpetuo | [#282](https://github.com/boosterchile/booster-ai/pull/282) | .4 | ✅ Merged |
-| T5 | Eliminar `.gitlab-ci.yml` — GitHub canonical | [#283](https://github.com/boosterchile/booster-ai/pull/283) | .5 | ✅ Merged |
-| T6 | RFP auditor GLEC v3.0 + `docs/compliance/` scaffold | [#284](https://github.com/boosterchile/booster-ai/pull/284) | .6 (doc) | ✅ Merged · ⚠️ envíos PO pendientes |
-| T7 | RFP vendor pentest pre-launch + shortlist por categoría | [#285](https://github.com/boosterchile/booster-ai/pull/285) | .7 (doc) | ✅ Merged · ⚠️ envíos PO pendientes |
-| T8 | ADR-047 load testing tool (k6) + smoke scaffold | [#286](https://github.com/boosterchile/booster-ai/pull/286) | .8 | ✅ Merged |
-| T9a | ADR-048 microservices extraction strategy (conceptual) | [#287](https://github.com/boosterchile/booster-ai/pull/287) | .9a | ✅ Merged |
-| T10 | Outreach cliente piloto + `.private/` gitignored | [#288](https://github.com/boosterchile/booster-ai/pull/288) | .10 (doc) | ✅ Merged · ⚠️ dry-run + envíos PO pendientes |
-| T11 | Wrap CURRENT.md (este PR) | _pending_ | .11 | ⏩ In progress |
-
-11/11 tareas materializadas. **3 SCs cierran a nivel doc + acción PO** (.6 GLEC, .7 pentest, .10 piloto) — los envíos reales corren en lanes externas paralelas, no bloquean el cierre del sprint.
-
-### ADRs nuevos producidos (4)
-
-| ADR | Título | Decisión clave | Consecuencia sobre roadmap |
-|---|---|---|---|
-| [043](../adr/043-drift-schema-domain.md) | Drift schema ↔ domain — metodología | SQL canónico (español); domain alinea. Clasificación A/B/C por migración. | S1 ejecuta el inventario detallado + migration; tests integration sobre infra T1+T2. |
-| [046](../adr/046-historical-adr-numbering-collisions.md) | Historical ADR numbering collisions (028/034/035) | **TTL perpetuo** — las 3 colisiones legacy no se renumeran. Flag `--allow-legacy` permanente en pre-commit. | Disciplina "un número por archivo" desde ADR-040 enforced. Modificaciones a allowlist requieren supersede ADR. |
-| [047](../adr/047-load-testing-tool-k6.md) | Load testing tool: k6 | k6 + scripts JS + OTEL nativa. **Reversible hasta S8**. | S8 ejecuta suite real (50 RPS sostenido api, 200 RPS pico, 1000+ TCP gateway). Smoke actual es throwaway. |
-| [048](../adr/048-microservices-extraction-strategy.md) | Microservices extraction strategy | Strangler con mirroring **staging** + cutover prod con flag por endpoint + monolito fallback 2 sem. Split T9b/T9c diferido. | S3/S4 ejecutan extracción; cada microservicio produce sub-ADR. T9b (budget USD/sem) en S2; T9c (criterios drill) en spec S3. |
-
-### Sub-spec dependiente
-
-- [`.specs/stubs-decision/spec.md`](../../.specs/stubs-decision/spec.md) — **Approved 2026-05-17**. 8 decisiones binarias: eliminar `ai-provider` + `document-indexer`; promover `trip-state-machine` (S1) + `ui-components` parcial (S2) + 3 apps (S3/S4) + `carta-porte-generator` (S4).
-
-### Velocity check (SC-S0.28 spec maestra)
-
-- Estimación: 8–10 días lane Felipe (post devils-advocate v2).
-- Real: 11 PRs producidos en **~5 horas de sesión** (densidad alta porque la mayoría son doc-only o scaffolds; el único código real fue T3 ~110 LOC).
-- **Conclusión**: velocity observada >> 0.7× nominal en este sprint. Sin replan formal de S1-S13. Re-evaluar al cierre de S1 (tarea pendiente: `docs/handoff/<fecha>-velocity-check-post-S2.md`).
-
-### Lanes externas activadas
-
-| Lane | Activada por | Fecha esperada respuesta | Owner |
-|---|---|---|---|
-| **GLEC audit** (cubre SC-23 post-Impl) | T6 — RFP a SGS Chile / Bureau Veritas Chile / DNV LATAM | Respuestas vendors: ≤2 sem; contrato firmado: ≤4 sem; certificado: ≤8 sem post-firma | **PO acción**: enviar emails con template `docs/compliance/glec-rfp.md` §7.2 |
-| **Pentest pre-launch** (cubre SC-24) | T7 — RFP a 3 categorías de vendor (Global EMEA / Boutique LATAM / Pentest-as-a-Service) | Respuestas: ≤2 sem; contrato: ≤4 sem; audit final: ≤6 sem post-firma | **PO acción**: enviar emails con template `docs/audits/security-rfp.md` §7.2 |
-| **Cliente piloto** (cubre SC-27a) | T10 — shortlist 5+5 prospects en `.private/piloto-prospects.md` | Respuestas: variable (warm 1-2 sem, cold 2-4 sem); contrato firmado: en sprint S13 | **PO acción**: dry-run shortlist + envíos con template `.private/` §"Mensaje template" |
-
-### Objections devils-advocate cerradas en S0
-
-| Obj | Severidad | Status | Cubierta por |
-|---|---|---|---|
-| O-1 | P0 | ✅ Closed | Split T9a/T9b/T9c en ADR-048 |
-| O-2 | P0 | ✅ Closed | SC-S0.1 acotado a metodología (sin enumeración) |
-| O-3 | P0 | ✅ Closed | SC-S0.10 reforzado con criterios fit + dry-run PO + irreversibilidad |
-| O-4 | P0 | ✅ Closed | OQ-S0.1 resuelta (privada) + OQ-S0.2 verificada por agente |
-| O-5 | P0 | ✅ Closed | Estimación movida a 8-10 días; orden re-secuenciado |
-| O-8 | P1 | ✅ Closed | ADR-046 TTL perpetuo explícito |
-| O-9 | P1 | ✅ Closed | ADR-047 reversibilidad hasta S8 explícita |
-
-### Open questions remaining (post-S0)
-
-- **OQ-S0.3** — Reapuntar remote `origin` (sigue GitLab) a GitHub o eliminar. NO bloquea S1; decisión PO antes de S2.
-- **SC-S0.9b** (en S2) — Medir tráfico actual de `notify-*.ts`, `matching*.ts`, `documentos.ts` para producir tabla USD/sem budget mirroring.
-- **SC-S0.9c** (en spec S3) — Criterios concretos de rollback drill para primer microservicio (`notification-service`).
-
----
-
-## Pickup point S1b (branches coverage + Playwright + sharding)
-
-**Plan**: [`.specs/s1-drift-coverage-e2e/plan-s1b.md`](../../.specs/s1-drift-coverage-e2e/plan-s1b.md) (Approved 2026-05-18) — arranque **condicional** a firma PO sobre `s1a-cierre.md` §9.
-
-**Scope S1b**:
-
-- **T1.8** — Identificar branches uncovered + lista nombrada (≥10 error paths reales).
-- **T1.9a..T1.9j** — Tests añadidos por path; meta: `apps/api` branches coverage ≥80% (actual: 75.01%).
-- **T1.10** — 4 specs Playwright críticos en CI por PR (shipper-publica-carga, carrier-acepta-oferta, login-universal-rut-clave-numerica, public-tracking-via-link) + axe-core (0 violations P0/P1) + sharding + path-based filter en `ci.yml` (cubre SC-29 ≤10 min p95 CI).
-
-**Cubre SCs maestros**: SC-2 (parcial), SC-4, SC-15 (parcial 4/8), SC-16 (parcial), SC-29.
-
-**Bloque B Sprint S1** (XState `trip-state-machine` + wiring): **diferido** a sub-spec `.specs/tripstate-alignment/` cuando arranque T1.x dedicado (ver `s1a-cierre.md` §6 — pendiente firma PO).
-
-**Acción inmediata PO** (S1a firma ya aplicada; S1b listo para arrancar):
-
-1. **Enviar RFP GLEC** (template en `docs/compliance/glec-rfp.md` §7.2). Razón: lead time auditor 4-8 sem.
-2. **Enviar RFP pentest** (template en `docs/audits/security-rfp.md` §7.2). Razón: lead time vendor 4-6 sem.
-3. **Dry-run + envíos cliente piloto** (`.private/piloto-prospects.md`). Razón: lead time outreach piloto el más largo.
-4. **Decidir OQ-S0.3** (qué hacer con remote `origin` GitLab).
-
-**Próxima sesión de agente** (post-merge #298): `/spec tripstate-alignment` siguiendo Condición 1 de [`s1a-cierre.md`](../../.specs/s1-drift-coverage-e2e/s1a-cierre.md) §11. Avance gated por readiness (5 sub-bullets + gate `APPROVED_BY_PO` del sub-spec), no calendario.
-
----
-
-## Bloqueo D11 v2 T8-T12 (2026-05-17)
-
-**Estado al cierre de sesión 2026-05-17 ~09:10 UTC**:
-
-- D11 v2 T8 implementado en `fix/d11-t8-stakeholder-zonas-endpoint` con test unit-mocked → **NO mergeable** por violación de CLAUDE.md §1/§2 (test no ejerce el SQL real).
-- Pivote a spec + plan separados para crear infra de integration testing en `apps/api`.
-
-**Avance de la sesión** (PR [#267](https://github.com/boosterchile/booster-ai/pull/267), 4 commits docs-only):
-
-| Artefacto | Status | Path |
-|---|---|---|
-| Spec test-integration-infra-apps-api | **Approved** (PO 2026-05-17 ~08:35 UTC) | [`docs/specs/2026-05-17-test-integration-infra-apps-api.md`](../specs/2026-05-17-test-integration-infra-apps-api.md) |
-| Spec devils-advocate review | complete (6 P0 + 11 P1 + 7 P2) | [`docs/specs/2026-05-17-test-integration-infra-apps-api-devils-advocate.md`](../specs/2026-05-17-test-integration-infra-apps-api-devils-advocate.md) |
-| Plan v2 con 9 tasks (T0..T6) | **Approved** (PO 2026-05-17 ~09:05 UTC) | [`docs/plans/2026-05-17-test-integration-infra-apps-api.md`](../plans/2026-05-17-test-integration-infra-apps-api.md) |
-| Plan devils-advocate review | complete (7 P0 + 6 P1 + 5 P2 — 12/13 P0+P1 abordados) | [`docs/plans/2026-05-17-test-integration-infra-apps-api-devils-advocate.md`](../plans/2026-05-17-test-integration-infra-apps-api-devils-advocate.md) |
-| Plan D11 v2 (T8-T12 BLOCKED) | actualizado | [`docs/plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md`](../plans/2026-05-17-d11-v2-stakeholder-geo-aggregations.md) |
-
-**T0 — PASS (2026-05-17 ~09:10 UTC)**:
-
-Mediciones contra Postgres@16 local (brew, `booster_test_prototype`):
-
-- Run 1 cold (DROP+CREATE+migrate): **472 ms** (<30 s objetivo)
-- Run 2 full reset: 115 ms
-- Run 3 in-place sin DROP: **4 ms** (<5 s objetivo)
-- Sin errores; 36/36/36 migrations consistentes
-
-Evidencia completa: [`2026-05-17-t0-prototype-test-db-output.md`](2026-05-17-t0-prototype-test-db-output.md). El script `apps/api/scripts/prototype-test-db.ts` queda untracked (no se mergea por diseño T0).
-
-**Hallazgo colateral**: `0009_stakeholder_access_log.sql` existe en disco pero NO está en `meta/_journal.json` (37 .sql vs 36 entradas journal). La tabla `stakeholderAccessLog` está declarada en `schema.ts:1406`. En prod la tabla probablemente NO existe. Task separada flagueada (no bloquea T1). Justifica retroactivamente la decisión PO de exigir T0 antes de T1.
-
-**Pickup point próxima sesión — T1**:
-
-Próxima sesión arranca con T1 del plan v2: `vitest.integration.config.ts` + scripts + setup.integration + helper test-db + test ref `SELECT 1`. Acceptance enumerada en plan §T1 (LOC ~95). Sin bloqueos de T0.
-
-**Cómo arrancar próxima sesión**:
-
-```bash
-cd /Volumes/Pendrive128GB/Booster-AI/.claude/worktrees/naughty-sinoussi-c8ddf8
-git pull github fix/d11-t8-stakeholder-zonas-endpoint
-# Verificar Postgres local sigue corriendo: pg_isready -h localhost
-# Si no: brew services start postgresql@16
-# Leer plan v2: docs/plans/2026-05-17-test-integration-infra-apps-api.md
-# Arrancar T1: vitest.integration.config.ts + setup.integration.ts + helpers/test-db.ts + health-db.integration.test.ts
+```
+booster-ai/
+├── apps/                   # 9 apps (6 funcionales + 3 skeleton)
+│   ├── api/                # Hono — 101 .ts/.tsx, ~26.493 LOC
+│   ├── web/                # React PWA — 231 .ts/.tsx, ~28.185 LOC
+│   ├── telemetry-tcp-gateway/   # TCP server Codec8 (GKE Autopilot)
+│   ├── telemetry-processor/     # Pub/Sub consumer
+│   ├── whatsapp-bot/       # Hono webhook Meta + xstate FSM
+│   ├── sms-fallback-gateway/    # Hono webhook Twilio
+│   ├── document-service/   # SKELETON (R-011 / ADR-051 pendiente)
+│   ├── matching-engine/    # SKELETON
+│   └── notification-service/    # SKELETON
+│
+├── packages/               # 21 packages (15 implementados + 5 stubs + 1 ui-tokens)
+│   # Implementados:
+│   ├── shared-schemas/     # 18 Zod schemas dominio
+│   ├── logger/             # Pino + redactores PII (≥30 paths)
+│   ├── config/             # env Zod validation
+│   ├── carbon-calculator/  # GLEC v3.0
+│   ├── matching-algorithm/ # multifactor v2
+│   ├── codec8-parser/      # Teltonika
+│   ├── pricing-engine/, factoring-engine/, driver-scoring/, coaching-generator/
+│   ├── certificate-generator/   # PDF KMS+signpdf (R-016: pdf-lib stale)
+│   ├── dte-provider/       # SII Chile
+│   ├── whatsapp-client/    # Twilio Content Templates
+│   ├── notification-fan-out/    # formatters puros
+│   └── ui-tokens/
+│   # Stubs (R-011 / ADR-051):
+│   └── {ai-provider, trip-state-machine, carta-porte-generator, document-indexer, ui-components}
+│
+├── infrastructure/         # Terraform FLAT (18 .tf + 3 módulos)
+├── docs/adr/               # 50 ADRs (001..048 + colisiones legacy 028/034/035 en ADR-046)
+├── docs/handoff/CURRENT.md # este archivo
+├── .specs/                 # specs por feature (Plan-Phase, sub-specs)
+├── skills/                 # workflows estructurados (6 categorías activas)
+├── .claude/                # agentes, ledger agent-rigor, settings
+├── .husky/                 # pre-commit 5 stages + commit-msg
+├── scripts/repo-checks/    # linters custom (ADR-numbering, drift-inventory, etc.)
+└── .github/workflows/      # ci.yml + security.yml + release.yml + e2e-staging.yml
 ```
 
-**Trabajo preservado en working tree** (no commit, untracked):
-- `apps/api/src/routes/stakeholder.ts` (115 LOC) — reusable post-infra.
-- `apps/api/test/unit/stakeholder-zonas-route.test.ts` (94 LOC) — descartable.
-- `apps/api/src/server.ts` (+7 LOC) — wire de la route.
+---
+
+## 4. Principios rectores activos
+
+Resumidos. Detalle completo en `CLAUDE.md` §Principios rectores.
+
+1. **Cero deuda técnica desde day 0** — sin `any` productivo (Biome lo bloquea), sin `console.*`, sin secretos en repo, sin features sin tests, sin infra manual, sin `*.tfplan`/`*.tfstate`/`*.tfvars.local` en git.
+2. **Evidence over assumption** — cada afirmación con output verificable. No afirma sin evidencia.
+3. **Process over knowledge** — el agente sigue workflows en `skills/` y hooks `agent-rigor`. No confía en su memoria.
+4. **Decisiones en ADRs, no en conversación** — `docs/adr/` es la fuente de verdad arquitectónica.
+5. **Type safety end-to-end** — Drizzle schema → `packages/shared-schemas` (Zod) → TanStack Query types inferidos. Sin frontera de tipos perdidos.
+6. **Observabilidad desde el primer endpoint** — `correlationId` + span OTel + métrica custom desde T=0. **⚠️ GAP P0 ABIERTO (R-001)**.
+7. **Seguridad por defecto** — validación Zod en toda input externa, queries parametrizadas (Drizzle/pg), ADC + OAuth (nunca API keys salvo legacy ADR-009), PII redacción Pino, pre-commit gitleaks + 5 stages.
 
 ---
 
-## (a) Waves 1-6 — estado de merge
+## 5. Estado de auditoría arquitectónica (2026-05-19)
 
-Las seis waves del plan de identidad universal + dashboard conductor están **completas y mergeadas en `main`**.
+**Veredicto**: Booster AI cumple materialmente con 6/7 principios rectores. TRL 10 bloqueado por 1 hallazgo P0 + 14 P1.
 
-| Wave | Alcance | PRs mergeados | Fecha cierre |
+| Severidad | Count | Esfuerzo agregado | Ventana objetivo |
+|---|---:|---|---|
+| **P0** — bloquea TRL 10 | 1 | M (1–3 días) | Sprint 1 |
+| **P1** — degrada calidad o riesgo conocido | 14 | mezcla S/M + 1 L | Sprints 1–2 |
+| **P2** — deuda incremental | 10 | mayormente S/M | Sprint 3+ |
+| **Total** | **25** | ~3 sprints | ~6 semanas |
+
+**Métricas de salud verificadas**:
+- 0 vulnerabilidades críticas/altas en producción (2 moderates dev-only fixables con `pnpm overrides`).
+- 0 secrets en cleartext en repo (2 keys públicas Firebase Web + Maps allowlisteadas en `.gitleaks.toml`).
+- 0 drift en vocabulario sobre 446 commits últimos 30 días (Conventional Commits limpios).
+- 4 `any` productivos detectados — todos adaptadores externos con `biome-ignore` justificada.
+
+### 5.1 El único P0
+
+**R-001 — Cablear OpenTelemetry + `pino-http` en `apps/api`** (esfuerzo M, 1–3 días).
+
+`apps/api/package.json` declara 7 paquetes OTel + `pino-http` con **0 imports en `src/`**. `main.ts` no preload-ea `NodeSDK`. Viola CLAUDE.md §6 ("Observabilidad desde el primer endpoint"). Auditoría externa pre-TRL 10 lo flageará de inmediato.
+
+Fix: `apps/api/src/instrumentation.ts` con `NodeSDK` + `OTLPTraceExporter` → Cloud Trace + middleware Hono para `correlationId` + cableo `pino-http`. Alternativa: ADR-050 superseding §6 (no recomendado).
+
+### 5.2 8 hallazgos cross-cutting
+
+| Code | Tema | Dimensiones | Recom. |
 |---|---|---|---|
-| **Wave 1** | Conductor identity + split dashboard (`/app/conductor` vs `/app/conductor/configuracion`) + migration 0029 + sweep español neutro | [#179](https://github.com/boosterchile/booster-ai/pull/179), [#189](https://github.com/boosterchile/booster-ai/pull/189) (smoke script) | 2026-05-13 |
-| **Wave 2** | Tests + sweep i18n argentinismos → neutro | Integrado en [#179](https://github.com/boosterchile/booster-ai/pull/179) (+24 specs) | 2026-05-13 |
-| **Wave 3** | Stakeholder organizations + ADR-034 (entidad XOR con empresas, migrations 0030/0031) + zonas filtradas por región + UI miembros | [#180](https://github.com/boosterchile/booster-ai/pull/180) → [#198](https://github.com/boosterchile/booster-ai/pull/198) (reabierto), [#199](https://github.com/boosterchile/booster-ai/pull/199) (zonas), [#203](https://github.com/boosterchile/booster-ai/pull/203) (UI miembros) | 2026-05-13 |
-| **Wave 4** | Auth universal RUT + clave numérica + ADR-035 (foundation → UI selector → rotación clave → activación flag) | [#181](https://github.com/boosterchile/booster-ai/pull/181) (foundation 1/3), [#185](https://github.com/boosterchile/booster-ai/pull/185) (UI 2/3), [#187](https://github.com/boosterchile/booster-ai/pull/187) (rotación 3/3), [#190](https://github.com/boosterchile/booster-ai/pull/190) (`AUTH_UNIVERSAL_V1_ACTIVATED=true` en prod) | 2026-05-13 |
-| **Wave 5** | Wake-word "Oye Booster" foundation + ADR-036 — service stub, flag `WAKE_WORD_VOICE_ACTIVATED=false` | [#183](https://github.com/boosterchile/booster-ai/pull/183) (foundation 1/2). **PR 2/2 ([#186](https://github.com/boosterchile/booster-ai/pull/186)) cerrado sin merge** — wire real bloqueado por Picovoice (ver §c). | 2026-05-13 (foundation) |
-| **Wave 6** | Research cultura conductor chileno + guion entrevistas (input para refinamientos UI y Wave 5) | [#182](https://github.com/boosterchile/booster-ai/pull/182) | 2026-05-13 |
+| CC-1 (P0) | OTel declarado sin cablear | deps + arch + tech-debt | R-001 |
+| CC-2 (P1) | Bundle frontend inflado: 38 rutas eager + 4 deps muertas | perf + deps | R-002 + R-010 |
+| CC-3 (P1) | 8 stubs by-passan gate cobertura | arch + tech-debt + ci | R-003 + R-011 |
+| CC-4 (P1) | Node 22 (ADR-001) vs Node 24 (CI) | arch + reproducibilidad | R-004 |
+| CC-5 (P2) | `haversineKm` en service en vez de `packages/` | arch + perf + tech-debt | R-012 |
+| CC-6 (P1) | CLAUDE.md describe Terraform inexistente + `.tfplan`/`.tfvars.local` en git | arch + security | R-013 + R-014 |
+| CC-7 (P1) | Bypass total WAF Cloud Armor para `api.boosterchile.com` | security | R-015 |
+| CC-8 (P1) | `pdf-lib` 4 años sin commits, usado en firma legal con retención 6 años | deps + compliance | R-016 |
 
-**Soporte transversal mergeado el mismo día**:
-- [#184](https://github.com/boosterchile/booster-ai/pull/184) — bump `@opentelemetry/*` a 0.218 (cierra 4 HIGH vulns, desbloquea `npm audit` en CI).
-- [#191](https://github.com/boosterchile/booster-ai/pull/191) — GCP cost efficiency TRL 10 (right-sizing + log exclusion, ADR-034/035).
-- [#192](https://github.com/boosterchile/booster-ai/pull/192) — handoff con orden de merge consolidado.
+### 5.3 Roadmap consolidado
 
-**Verificación**: `gh pr list --state merged --search "wave" --limit 50` (ejecutado 2026-05-16).
+- **Sprint 1** (2 semanas) — "Cierre del gap observable": R-001 P0 + 9 quick wins (R-003, R-004, R-005, R-006, R-007, R-008, R-009, R-014, R-024).
+- **Sprint 2** (2 semanas) — "Frontend y boundaries": R-002, R-010, R-011, R-013, R-015 + quick wins R-012, R-018, R-022, R-025.
+- **Sprint 3+** — "Mantenimiento deps y deuda calidad": R-016 (L), R-017, R-019, R-020, R-021, R-023.
 
-### Mergeados 2026-05-16 (post-handoff inicial)
+### 5.4 ADRs propuestos (pendientes redactar + PR)
 
-- [#166](https://github.com/boosterchile/booster-ai/pull/166) (commit `b5d1f18`, 22:26 UTC) — `docs(telemetry): Wave 3 v2 — preload CA root + ADR-040`. Rebased sobre main, ADR renumerado de 033→040 por colisión con `033-matching-algorithm-v2`. `npm audit (HIGH+)` resuelto vía bump OpenTelemetry de #184. Files: `docs/adr/040-wave-3-tls-ca-preload-fmc150.md` (+90), `docs/handoff/2026-05-11-wave-3-incidente-rollback.md` (+180), `docs/research/teltonika-fmc150/INSTRUCTIVO-WAVE-3.md` (±37/2), `docs/runbooks/wave-2-3-deploy.md` (±24/2).
-- [#226](https://github.com/boosterchile/booster-ai/pull/226) (commit `641288d`, 22:26 UTC) — `docs(handoff): snapshot CURRENT.md estado proyecto 2026-05-16` (primera versión de este documento, +130 líneas).
-- [#227](https://github.com/boosterchile/booster-ai/pull/227) (commit `d5e2e06`, 22:34 UTC) — `docs(handoff): actualizar CURRENT.md post-merge #166 + #226`. Reduce el documento a 1 PR abierto (#164), agrega la sección "Mergeados 2026-05-16" y "Housekeeping ADRs", clarifica que #164 no contiene archivo ADR todavía (solo spec) y recomienda ADR-041.
-- [#228](https://github.com/boosterchile/booster-ai/pull/228) (commit `fa03246`, 22:53 UTC) — `docs(runbooks): plantillas /goal v2 con lessons de la sesion 2026-05-16`. Añade `docs/runbooks/goal-templates.md` (+255 líneas) con los aprendizajes operativos del flujo `/goal` aplicado a esta sesión.
-- [#229](https://github.com/boosterchile/booster-ai/pull/229) (commit `c8ce2a3`, 23:05 UTC) — `docs(handoff): refresh CURRENT.md post-merge #227 + #228`. Segunda iteración del documento aplicando Plan 1 v2 vía `/goal` (9 min, 12.6k tokens, 0 errores fácticos — validó las plantillas v2 en producción).
-- [#164](https://github.com/boosterchile/booster-ai/pull/164) (commit `2429f86`, 23:14 UTC) — `docs(spec): D11 stakeholder geo aggregations — cards + drill-down + ADR-033`. Spec D11 formalizada en `main` tras 5 días en DRAFT. Habilita `/plan` y `/build` cuando el PO decida. Files: `docs/specs/2026-05-11-stakeholder-geo-aggregations-d11.md` (+136 líneas).
+- **ADR-049 (R-A1)** — reemplazo `pdf-lib` por mantenimiento congelado.
+- **ADR-050 (R-A2)** — política observabilidad obligatoria + cableado OTel.
+- **ADR-051 (R-A3)** — resolución 8 stubs (implementar/extraer/eliminar).
+- **ADR-052 (R-A4)** — estructura definitiva Terraform (flat vs environments).
+- **ADR-053 (R-A5)** — frontend security headers + CSP.
 
-### Mergeados 2026-05-16/17 (post-coverage batch)
+### 5.5 Artefactos completos en `audit-outputs/`
 
-Sesión nocturna dedicada a cobertura de tests por package + housekeeping.
-
-| PR | SHA | UTC | Título | Files |
-|---|---|---|---|---|
-| [#230](https://github.com/boosterchile/booster-ai/pull/230) | `786a5b3` | 23:17 | `docs(handoff): cierre sesion 2026-05-16 — 0 PRs abiertos` | `docs/handoff/CURRENT.md` (+12/−34) |
-| [#231](https://github.com/boosterchile/booster-ai/pull/231) | `94155fe` | 23:22 | `refactor(d11-spec): renumerar ADR-033→041 y migration 0027→0034` | `docs/specs/…-d11.md` (±8/8), `docs/handoff/CURRENT.md` (±3/6) |
-| [#232](https://github.com/boosterchile/booster-ai/pull/232) | `48c3d04` | 23:52 | `chore(coverage): infra de coverage en 15 packages + floor baseline` | 15 × `vitest.config.ts` + 15 × `package.json` + `pnpm-lock.yaml` |
-| [#233](https://github.com/boosterchile/booster-ai/pull/233) | `fa301d3` | 23:58 | `test(ui-tokens): cobertura 100/100/100/100` | `tokens.test.ts` (+207), `vitest.config.ts` (±5/9) |
-| [#234](https://github.com/boosterchile/booster-ai/pull/234) | `96e10c5` | 00:07 | `test(logger): cobertura 93/92/100/93 — createLogger + redaction` | `createLogger.test.ts` (+129), `redaction.test.ts` (+52) |
-| [#235](https://github.com/boosterchile/booster-ai/pull/235) | `4a758e6` | 00:13 | `test(config): cobertura 100/100/100/100 — parseEnv + 5 schemas` | `parseEnv.test.ts` + 5 × `schemas/*.test.ts` (+243 total) |
-| [#236](https://github.com/boosterchile/booster-ai/pull/236) | `09dc62f` | 00:19 | `test(whatsapp-client): cobertura 95/91/86/97 — WhatsAppClient HTTP` | `client.test.ts` (+156) |
-| [#237](https://github.com/boosterchile/booster-ai/pull/237) | `5bd0228` | 00:39 | `test(certificate-generator): cobertura 97.82/80.15/100/97.82` | 5 × test (`ca-self-signed`, `emitir-certificado`, `firmar-kms`, `firmar-pades`, `storage`) + ajuste `generar-pdf-base.test.ts` (+734) |
-| [#238](https://github.com/boosterchile/booster-ai/pull/238) | `ba0ee10` | 00:50 | `test(shared-schemas): cobertura 98.53/87.5/94.11/98.52` | `all-schemas.test.ts` (+428) |
-| [#239](https://github.com/boosterchile/booster-ai/pull/239) | `756e9b4` | 01:06 | `fix(certificate-generator): CO2e ASCII en section title (subscript crash)` | `generar-pdf-base.ts` (±7/2), `generar-pdf-base.test.ts` (+34) — fix de bug descubierto en #237 + regression test (cert-gen subió a 99.63/82.53/100/99.63) |
-| [#240](https://github.com/boosterchile/booster-ai/pull/240) | `a1419a2` | 01:18 | `docs(runbooks): sanity check zero anti-Stop-hook-loop` | `goal-templates.md` (±16/2) |
-| [#241](https://github.com/boosterchile/booster-ai/pull/241) | `def7e64` | 01:46 | `docs(handoff): refresh CURRENT.md post-coverage batch` | `docs/handoff/CURRENT.md` (+23/−2) |
-| [#242](https://github.com/boosterchile/booster-ai/pull/242) | `21a3d37` | 02:15 | `docs(runbooks): terse post-abort en sanity check zero` | `goal-templates.md` (±3/1) |
-| [#243](https://github.com/boosterchile/booster-ai/pull/243) | `69534d3` | 02:21 | `docs(runbooks): embeber terse-post-abort en /goal text de Plans 3-5` | `goal-templates.md` (+10/0) |
-
-**Resultado coverage**: los 15 packages no-stub pasan **≥80/80/80/80** (statements/branches/functions/lines). Lowest: certificate-generator branches=80.15%. Stubs (`ai-provider`, `carta-porte-generator`, `document-indexer`, `trip-state-machine`, `ui-components`) siguen exemptados hasta tener lógica real (PO-aprobado).
+Sesión `21c07e7c-e6f9-4de9-9c1d-f819e6b5d5d7` produjo 12 markdown + 1 log:
+`SESSION_CLAUDE.md`, `Implementation_Plan.md`, `01_ARCHITECTURE.md`, `02_DEPENDENCIES.md`, `03_SECURITY_FINDINGS.md`, `04_PERFORMANCE_FINDINGS.md`, `05_TECH_DEBT_REGISTRY.md`, `06_REFACTOR_PRIORITIES.md`, `PROJECT_OVERVIEW.md`, `CLAUDE.md` (propuesto, no promovido), `EXTENSIONS_RECOMMENDATIONS.md`, `SUMMARY.md`, `.execution.log`.
 
 ---
 
-## (b) PRs abiertos — 9 (D11 BUILD review formal)
+## 6. Decisiones humanas pendientes (NO automatizables por agentes)
 
-D11 BUILD ejecutado autónomamente vía `/goal` el 2026-05-17 (12 tasks DONE, ~$5-10 USD). Review formal con sub-agentes (`code-reviewer`, `devils-advocate`, `security-auditor`, `ux-designer`) reveló **bugs CRITICAL de privacy + violación de contrato agent-rigor + LOC waivers excedidos 2-3×**. Plan v1 BLOCKED, pivote a Opción 2 (`originComunaCode` mapping).
-
-| PR | Task | Status |
-|---|---|---|
-| [#246](https://github.com/boosterchile/booster-ai/pull/246) | T1 ADR-041 | SUPERSEDE — pendiente ADR-042 |
-| [#247](https://github.com/boosterchile/booster-ai/pull/247) | T2 Zod+Drizzle | REQUEST_CHANGES — `numeric` ↔ `z.number()` mismatch |
-| [#249](https://github.com/boosterchile/booster-ai/pull/249) | T4 k-anonymity | REQUEST_FIX privacy CRITICAL |
-| [#250](https://github.com/boosterchile/booster-ai/pull/250) | T5 hora+pico | REQUEST_CHANGES naming + k-anon |
-| [#251](https://github.com/boosterchile/booster-ai/pull/251) | T6 tipo+combustible | MERGE post-T5 fix |
-| [#252](https://github.com/boosterchile/booster-ai/pull/252) | T7 puntoEnBoundingBox | REQUEST_CHANGES NaN |
-| [#253](https://github.com/boosterchile/booster-ai/pull/253) | T8 abort doc | OPEN — reset a abort-doc-only (`7b2a18e`) |
-| [#255](https://github.com/boosterchile/booster-ai/pull/255) | T10 UI drill-down | REQUEST_CHANGES blocked-by-T9-v2 |
-| [#256](https://github.com/boosterchile/booster-ai/pull/256) | T11 UI cards | REQUEST_CHANGES + SPLIT blocked-by-T8-v2 |
-| [#257](https://github.com/boosterchile/booster-ai/pull/257) | T12 perf | REVERT_DONE_MARK — test tautológico |
-
-**Cerrados sin merge**: #254 (T9, REJECT — privacy bugs heredados).
-
-**Mergeado**: #248 (T3 migration zonas_stakeholder + seed, commit `2843e69`).
-
-**Hallazgos sistémicos**:
-1. Helper k-anonymity (#249) tiene 1 CRITICAL (quasi-identifier strings leak) + 3 HIGH. Es el ÚNICO control técnico privacy → prioridad #1.
-2. Schema drift `domain/` ↔ `db/`: `domain/trip.ts` tiene state values en inglés (`delivered`, etc.); `db/schema.ts` divergió a español (`entregado`). ADR-042 resolverá.
-3. "DONE" sin evidencia: T8 marcado DONE auto-resolviendo abort, T12 marcado DONE con test placeholder tautológico.
-
-**Trazabilidad**: [`docs/handoff/2026-05-17-d11-review-plan.md`](2026-05-17-d11-review-plan.md) + comments en GitHub por PR.
+1. **Promoción del `audit-outputs/CLAUDE.md` propuesto al `CLAUDE.md` del repo** — requiere ADR de transición + PR humano. El propio documento se marca como "no promover automáticamente".
+2. **Resolución de los 8 stubs** (5 packages + 3 apps skeleton): decidir por cada uno entre **implementar | extraer del monorepo | eliminar**. Genera ADR-051.
+3. **Estructura Terraform definitiva**: confirmar flat actual o migrar a `environments/{dev,staging,prod}/`. Genera ADR-052.
+4. **Aprobación del Sprint 1** (10 items, ~7–10 días con dedicación).
 
 ---
 
-## Housekeeping ADRs
+## 7. Framework de trabajo activo
 
-**D11 numeración ya alineada con `main`**: el spec en `docs/specs/2026-05-11-stakeholder-geo-aggregations-d11.md` referencia **ADR-041** y **migration 0034** (siguientes libres). El título del PR original #164 menciona "ADR-033" — quedó como artefacto histórico del merge commit, sin impacto en el contenido del spec.
+- **Marco de referencia**: [addyosmani/agent-skills](https://github.com/addyosmani/agent-skills) — production-grade engineering skills para AI coding agents.
+- **agent-rigor**: ledger en `.claude/ledger/` registra sesiones, decisiones, cierres.
+- **Skills estructuradas** en `skills/` con formato canónico (When to use / Core process / Anti-rationalizations / Exit criteria).
+- **specs por feature** en `.specs/` (Plan-Phase + sub-specs).
+- **Pre-commit (5 stages)**: gitleaks + lint-staged + ADR numbering + drift gate + spec-canonical-drift.
+- **CI completo**: lint + typecheck + test+coverage gate + drift-checks + build + security (gitleaks history full, pnpm audit HIGH, CodeQL, Trivy fs+config, SBOM CycloneDX).
+- **Workload Identity Federation** (sin SA keys) para deploy + DWD sin keys via Workspace Identity Federation.
 
-`main` arrastra colisiones históricas de numeración ADR en 028 (`dual-source-data-model-teltonika-vs-maps` + `rbac-auth-firebase-multi-tenant-with-consent-grants`), 034 (`gcp-cost-efficiency-2026-05` + `stakeholder-organizations`) y 035 (`auth-universal-rut-clave-numerica` + `trl10-mantener-ha-recortar-ruido`). No se tocan retroactivamente (los hashes son referenciados externamente). A partir de **ADR-040** se aplica la disciplina de "un número por archivo".
+### 7.1 Migración arquitectónica en curso (2026-05-19)
 
----
+**Decisión tomada**: el "Arquitecto Maestro" deja de vivir como Project Instructions en claude.ai y se transforma en `skills/arquitecto-maestro/SKILL.md` versionada en el repo. Razón: coherencia con Principio §3 (Process over knowledge), versionado git, acceso al filesystem real (evita stack drift), composición nativa con subagents existentes.
 
-## (c) Blockers vigentes
-
-### Picovoice approval
-
-- **Estado**: PENDIENTE. Consola Picovoice respondió *"Thank you for your interest. Our team will review it shortly."* — sin ETA comprometido por el vendor.
-- **Cuenta**: creada por Felipe (`dev@boosterchile.com`).
-- **Bloquea**:
-  - Acceso al modelo custom `oye-booster-cl.ppn` (entrenamiento del wake-word).
-  - Provisión de `PICOVOICE_ACCESS_KEY` (Secret Manager + variable Cloud Run).
-  - Wire real en `apps/web/src/services/wake-word.ts` (reemplazar `StubWakeWordController` por `PorcupineWakeWordController`).
-  - Activación del flag `WAKE_WORD_VOICE_ACTIVATED=true` en prod.
-- **Estado UI**: foundation Wave 5 ([#183](https://github.com/boosterchile/booster-ai/pull/183)) mergeado con UI inerte (flag OFF por default). Cero impacto visible para usuarios.
-- **PR 2/2 ([#186](https://github.com/boosterchile/booster-ai/pull/186))** cerrado sin merge — se rehará cuando la approval llegue y el modelo esté disponible.
-
-### Samples de voz Van Oosterwyk
-
-- **Estado**: PENDIENTE coordinación con cliente.
-- **Requerimiento**: 3 conductores reales × ~5 min de audio limpio cada uno, idealmente distribución regional:
-  - 1 norteño (Antofagasta / Iquique)
-  - 1 centro (RM / V Región)
-  - 1 sureño (Bío Bío hacia el sur)
-- **Pipeline**: subida al training pipeline de Picovoice → ~24h training → output `oye-booster-cl.ppn` (~50 KB) → commit a `apps/web/public/wake-word/`.
-- **Dependencia mutua con Picovoice approval**: el upload de samples requiere acceso al Console post-approval. Los dos bloqueantes están encadenados.
-- **ETA conjunto realista**: ~1 semana desde el momento en que llegue approval + samples estén grabados.
+El Project en claude.ai queda como espacio de exploración temprana / brainstorming previo a comprometer en skills+specs, **no como meta-orquestador permanente**.
 
 ---
 
-## Apuntadores rápidos
+## 8. Comandos canónicos (verificados vs `package.json` real 2026-05-19)
 
-- **Auth universal activo en prod** desde 2026-05-13 ([#190](https://github.com/boosterchile/booster-ai/pull/190)): `app.boosterchile.com` muestra selector RUT + clave numérica. Usuarios legacy (Google / email+password) ven `<RotarClaveModal/>` bloqueante en próximo login.
-- **Demo Corfo** agendada para lunes 2026-05-18 con Wave 1 + auth universal listos (hoy es 2026-05-16, faltan 2 días).
-- **Subdominio `demo.boosterchile.com`** operativo desde 2026-05-13 ([#206](https://github.com/boosterchile/booster-ai/pull/206)) — 4 personas click-to-enter sin formulario.
-- **Issue [#194](https://github.com/boosterchile/booster-ai/issues/194)** (DR deploy) resuelto por [#210](https://github.com/boosterchile/booster-ai/pull/210) (habilitación DNS endpoint cluster DR).
-- **Coverage gate activo en CI desde 2026-05-16** ([#232](https://github.com/boosterchile/booster-ai/pull/232)): cada `packages/*` no-stub emite `coverage-summary.json` y vitest enforza thresholds 80/80/80/80 in-config. El bash gate del workflow CI valida los summaries y bloquea merge si alguno cae bajo umbral. Esto cierra el hueco de "CI silenciosamente pasa porque ningún package emite cobertura".
-- **Próximos handoffs fechados** se siguen creando como `docs/handoff/YYYY-MM-DD-<topic>.md`; este `CURRENT.md` se actualiza tras cada cambio de estado significativo (merge de PR mayor, deploy a prod, blocker resuelto, blocker nuevo).
+| Operación | Comando |
+|---|---|
+| Bootstrap | `pnpm install` |
+| Dev (todos) | `pnpm dev` → `turbo run dev` |
+| Build | `pnpm build` → `turbo run build` |
+| Type check | `pnpm typecheck` |
+| Lint | `pnpm lint` → `biome check . && pnpm lint:rls` |
+| Lint fix | `pnpm lint:fix` |
+| Tests | `pnpm test` → `vitest run --passWithNoTests` |
+| Tests con coverage | `pnpm test:coverage` (gate ≥80%/75%/80%) |
+| Tests E2E | `pnpm test:e2e` (Playwright en `apps/web`) |
+| CI local | `pnpm ci` → `lint && typecheck && test && build` |
+| Gitleaks full | `pnpm security:scan` |
+| Gitleaks staged | `pnpm security:scan-staged` |
+
+Filtros: `pnpm --filter @booster-ai/<name> <cmd>`.
+
+---
+
+## 9. Próximas misiones del Arquitecto
+
+Ordenadas por dependencia y criticidad:
+
+1. **[esta sesión]** Commitear `docs/handoff/CURRENT.md` (este archivo) + `skills/arquitecto-maestro/SKILL.md`.
+2. **[esta semana]** Redactar ADR-050 (observabilidad) + ejecutar R-001 (cablear OTel).
+3. **[esta semana]** Sprint 1 quick wins: R-005, R-006, R-014, R-024 (cero esfuerzo cognitivo, alto impacto).
+4. **[Sprint 1]** Cerrar gate coverage by-pass (R-003) + reconciliar Node version drift (R-004).
+5. **[Sprint 2]** Redactar ADR-051 (stubs) + ADR-052 (Terraform) + ADR-053 (security headers).
+6. **[Sprint 2]** Bundle frontend (R-002) + boundaries (R-012).
+7. **[Sprint 3]** Migración `pdf-lib` (R-016) + ADR-049.
+
+---
+
+*Fin de CURRENT.md. Próxima actualización: al cerrar Sprint 1 o ante cualquier cambio arquitectónico significativo.*

--- a/skills/arquitecto-maestro/SKILL.md
+++ b/skills/arquitecto-maestro/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: arquitecto-maestro
+description: Meta-orquestador para misiones complejas en Booster AI. Diseña Execution Plans deterministas antes de cualquier modificación cuando la tarea cruza múltiples apps/packages, requiere ADR, o combina dimensiones architecture/security/performance/compliance. Reemplaza al "Arquitecto Maestro" que vivía como Project Instructions en claude.ai — versión versionada en repo.
+version: 1.0.0
+owner: Felipe Vicencio <dev@boosterchile.com>
+references:
+  - CLAUDE.md §Principios rectores (especialmente §3 Process over knowledge + §4 Decisiones en ADRs)
+  - docs/handoff/CURRENT.md (estado vivo del proyecto)
+  - audit-outputs/EXTENSIONS_RECOMMENDATIONS.md (catálogo de subagents/hooks/MCPs reusables)
+---
+
+# Skill: arquitecto-maestro
+
+Meta-orquestador para misiones complejas. Diseña planes antes de ejecutar; no escribe código de la misión final — emite especificación que será ejecutada por agentes/subagents en fases posteriores.
+
+---
+
+## When to use
+
+**Activar `arquitecto-maestro`** cuando se cumpla ≥1 de las siguientes:
+
+- La misión afecta **>1 app o package** del monorepo.
+- La misión requiere **ADR nuevo** o supersede un ADR existente.
+- La misión cruza **≥2 dimensiones**: architecture, security, performance, compliance, observability, deps, tech-debt.
+- El Product Owner solicita explícitamente **"diseña un plan"** o **"pensemos esto primero"**.
+- La complejidad estimada del agente supera **30 minutos** de trabajo activo.
+- La misión toca **archivos críticos**: `CLAUDE.md`, `docs/adr/*`, secciones IAM/Billing de Terraform, `.github/workflows/` con quality gates, `.gitleaks.toml`.
+
+**NO activar** cuando:
+
+- Existe una **skill específica** que ya cubre la tarea (ej. `glec-emission-calculation`, `dte-integration-chile`, `telemetry-codec-handler`).
+- Es **cambio mecánico** de aplicación directa (rename, formatting, comentario, ajuste de config simple).
+- El PO instruyó **ejecutar directamente** sin ambigüedad.
+- La tarea está **completamente cubierta por un skill ya definido** end-to-end.
+
+Si dudas si calificar como compleja, **califica**. El coste de meta-trabajo innecesario es menor que el coste de un Act sin plan.
+
+---
+
+## Core process
+
+Fases secuenciales. No saltar fases. No fusionar fases para "ir más rápido".
+
+### Fase 1 — Read-first (anti-alucinación)
+
+ANTES de proponer cualquier solución técnica o invocar subagents, leer en este orden:
+
+1. **`CLAUDE.md`** completo — principios rectores + stack canónico + reglas operativas.
+2. **`docs/handoff/CURRENT.md`** — estado vivo del proyecto (sprint actual, decisiones pendientes, P0 abiertos).
+3. **ADRs relevantes** en `docs/adr/` — filtrar por keywords de la misión (`grep -li`).
+4. **`audit-outputs/`** si existe — findings activos pueden afectar decisiones (ej. R-001 P0 OTel bloquea cualquier feature que vaya a producción sin observabilidad).
+5. **`scripts/repo-checks/drift-inventory.mjs --json`** — verificar drift activo entre dominio y schema.
+6. **Specs activas** en `.specs/` con keywords de la misión.
+
+**Anti-rationalization**: "Ya conozco el stack" no es excusa. El stack drift está documentado históricamente (sesión 2026-05-19 detectó 5 divergencias entre lo asumido y la realidad). **Lee siempre**.
+
+Si no puedes acceder a alguno de estos archivos, **declara bloqueante y detente**. No improvises.
+
+### Fase 2 — Levantamiento de requisitos
+
+Conversar con el PO hasta tener formalmente declarado:
+
+- **Objetivo determinista**: qué cambia en el repo al cerrar la misión (archivos, contratos, comportamiento observable).
+- **Criterios de aceptación medibles**: cómo se verifica que la misión está cerrada. Sin métricas verificables, no hay misión.
+- **Scope explícito**: qué SÍ se toca, qué NO se toca. Listar paths.
+- **Trade-offs**: si hay >1 camino razonable, presentar ≥2 opciones con consecuencias distintas.
+- **Dependencias previas**: qué ADRs deben existir antes; qué decisiones de PO deben tomarse antes.
+
+Usa `ask_user_input` cuando haya >1 interpretación razonable. **No asumas lo razonable** — Principio §3.
+
+### Fase 3 — Diseño del Execution Plan
+
+Producir `.specs/<feature-slug>/spec.md` con la siguiente estructura **exacta**:
+
+```markdown
+# <feature-slug> — Execution Plan
+
+**Generado por**: skill `arquitecto-maestro` v<version>
+**Fecha**: <YYYY-MM-DD>
+**Sesión**: <agent-rigor session UUID>
+**Status**: PROPUESTO — pendiente aprobación PO
+
+## 1. Contexto y objetivo
+[Misión + criterios de aceptación medibles]
+
+## 2. Stack y archivos en scope
+[Paths exactos a tocar; paths fuera de scope explícitos]
+
+## 3. Infraestructura exigida
+- Subagents a invocar (de los existentes en `.claude/agents/` o nuevos)
+- MCPs requeridos (`.mcp.json` o `claude mcp add`)
+- Hooks a respetar/agregar (`.claude/settings.json`)
+- Skills auxiliares (de las existentes en `skills/`)
+
+## 4. Plan Plan-Act-Verify
+- Plan: artefactos a generar antes de tocar código
+- Act: secuencia de cambios, paralelización si aplica, allowlists Bash
+- Verify: tests, lint, typecheck, evidencia de observabilidad cuando aplique
+
+## 5. Guardarraíles y restricciones
+[Permission modes por subagent; archivos prohibidos; sin atajos]
+
+## 6. Artefactos de auditoría exigidos
+[Tests, evidencia, screenshots, traces, commits con formato Conventional]
+
+## 7. ADRs requeridos (si aplica)
+[Lista de ADRs a crear antes/durante; ADRs superseded]
+
+## 8. Criterios de cierre (replicados de §1)
+[Checklist verificable]
+```
+
+### Fase 4 — Aprobación humana
+
+**STOP**. No proceder a Fase Act sin aprobación explícita del PO en el chat o como PR comment sobre `.specs/<feature>/spec.md`.
+
+**Anti-rationalization**: "El PO está apurado" no es excusa. Apurarse genera deuda. La aprobación humana es **no-negociable**.
+
+### Fase 5 — Trazabilidad en ledger
+
+Registrar en `.claude/ledger/<YYYY-MM-DD>/<session-uuid>.md` (agent-rigor):
+
+- **Inicio**: timestamp, misión, scope, PO confirmado.
+- **Decisiones consolidadas**: cada decisión arquitectónica con justificación + ADR referenciado (o ADR pendiente).
+- **Cierre**: artefactos producidos, paths, tamaños. Estado: `complete` | `blocked` | `superseded`.
+
+### Fase 6 — Actualización de CURRENT.md (si aplica)
+
+Si la misión cambió estado significativo del proyecto (cerró un P0, añadió un ADR, modificó stack, cerró un sprint), actualizar `docs/handoff/CURRENT.md`:
+
+- Marcar el hallazgo como cerrado (`R-XXX ✓ closed YYYY-MM-DD`).
+- Añadir el ADR resultante al índice.
+- Actualizar `## Próximas misiones del Arquitecto`.
+
+---
+
+## Anti-rationalizations
+
+Tentaciones comunes que esta skill rechaza explícitamente:
+
+| Tentación | Por qué es incorrecta |
+|---|---|
+| ❌ "Ya conozco el stack, salto la lectura de CLAUDE.md" | Stack drift documentado en sesión 2026-05-19. Lee siempre. |
+| ❌ "Es una tarea simple, no necesita Execution Plan" | Si dudas si califica como compleja, califica. |
+| ❌ "El PO está apurado, salto Fase 4 (aprobación)" | Apurarse genera deuda. No-negociable. |
+| ❌ "Improviso los criterios de éxito durante Act" | Sin métricas medibles no hay verificación. Bloquea hasta tenerlos. |
+| ❌ "Asumo lo razonable" en una decisión con >1 interpretación | Principio §3 lo prohíbe. Pregunta o emite ADR. |
+| ❌ "No actualizo CURRENT.md, es paperwork" | CURRENT.md es la fuente de verdad de estado. Drift entre realidad y CURRENT.md vuelve al estado pre-auditoría 2026-05-19. |
+| ❌ "Voy a hardcodear `any` 'temporalmente'" | "Cero parches" es Principio §1. Si bloqueado, emite ADR. |
+| ❌ "Es solo un mock, lo limpio después" | Mocks en código productivo son deuda P1 inmediata (R-011 lo demuestra). |
+| ❌ "Hago el ADR después de implementar" | Decisiones en ADRs ANTES, no en retrospectiva. Principio §4. |
+
+---
+
+## Exit criteria
+
+Una misión orquestada por `arquitecto-maestro` está **cerrada** cuando todos estos checkpoints están verificados:
+
+- [ ] **Lectura previa completada**: ledger registra qué archivos se leyeron en Fase 1.
+- [ ] **`.specs/<feature>/spec.md` existe** y está versionado en git.
+- [ ] **PO aprobó** explícitamente el plan (chat o PR comment, registrado en ledger).
+- [ ] **Ledger agent-rigor** registró inicio + decisiones + cierre con estado terminal.
+- [ ] **Artefactos exigidos** por el plan están entregados y bajo `audit-outputs/` o ubicación declarada.
+- [ ] **Tests pasan** (`pnpm test`) + lint limpio (`pnpm lint`) + typecheck verde (`pnpm typecheck`) si la misión tocó código.
+- [ ] **`docs/handoff/CURRENT.md` actualizado** si la misión cambió estado significativo.
+- [ ] **ADRs requeridos por el plan** están redactados y mergeados (si los requería).
+- [ ] **Cero atajos**: revisión final confirma 0 `any` nuevos, 0 `@ts-ignore` nuevos, 0 `localhost` en código productivo, 0 mocks en producción.
+
+Si cualquier checkpoint falla, la misión **no está cerrada**. Reabrir o emitir spec de seguimiento.
+
+---
+
+## Comandos auxiliares (uso de la skill)
+
+| Operación | Cómo invocar |
+|---|---|
+| Activar skill manualmente | `/arquitecto-maestro <descripción del requerimiento>` |
+| Listar misiones activas | `ls -la .specs/` |
+| Ver estado vivo del proyecto | `cat docs/handoff/CURRENT.md` |
+| Ver ledger de sesión actual | `ls -la .claude/ledger/$(date +%Y-%m-%d)/` |
+| Ver findings activos auditoría | `cat audit-outputs/SUMMARY.md` |
+| Ejecutar drift-check | `node scripts/repo-checks/drift-inventory.mjs --json` |
+
+---
+
+## Workflow `/auto-dream` (consolidación de memoria)
+
+Sub-workflow que reemplaza al protocolo "Auto-Dream" del Arquitecto en claude.ai. Se ejecuta cuando el PO solicita consolidar memoria tras una misión significativa, sprint review, o auditoría arquitectónica.
+
+**Disparador**: comando explícito del PO — *"Ejecuta auto-dream con datos: [referencia a sesión/sprint/auditoría]"*.
+
+**Proceso de 4 fases** (idéntico al original, destino distinto):
+
+1. **State Diffing**: comparar `docs/handoff/CURRENT.md` actual con nuevos datos.
+2. **Signal Extraction**: extraer decisiones arquitectónicas, correcciones, primitivas establecidas.
+3. **State Merging**: fusionar duplicados; purgar contradicciones priorizando lo más reciente; convertir fechas relativas a absolutas.
+4. **Garbage Collection**: eliminar features descartadas, referencias deprecadas, ruido.
+
+**Output**: PR a `docs/handoff/CURRENT.md` con el delta consolidado + entrada en `.claude/ledger/` registrando la consolidación. **No** un bloque suelto en chat.
+
+---
+
+## Versionado de esta skill
+
+| Versión | Fecha | Cambios |
+|---|---|---|
+| 1.0.0 | 2026-05-19 | Versión inicial. Transferencia desde Project Instructions en claude.ai post-auditoría arquitectónica. Reemplaza al "Arquitecto Maestro" conversacional. |
+
+Cambios futuros: vía PR con justificación + actualización de tabla.
+
+---
+
+*Fin de `skills/arquitecto-maestro/SKILL.md`. Esta skill complementa — no sustituye — a las skills específicas de dominio (`glec-emission-calculation`, `dte-integration-chile`, etc.). Cuando una skill de dominio aplica, esa skill tiene precedencia.*


### PR DESCRIPTION
## Contexto

Migra el "Arquitecto Maestro" desde Project Instructions en claude.ai a skill versionada en repo. Cierra inconsistencia con Principio §3 (Process over knowledge) y elimina stack drift detectado durante auditoría 2026-05-19 (sesión `21c07e7c-e6f9-4de9-9c1d-f819e6b5d5d7`).

## Cambios

- `docs/handoff/CURRENT.md` — estado vivo del proyecto consolidado.
- `skills/arquitecto-maestro/SKILL.md` v1.0.0 — workflow read-first + Plan-Act-Verify + sub-workflow `/auto-dream`.
- `docs/adr/ADR-054-arquitecto-maestro-migration.md` — ADR documentando la decisión arquitectónica.

## Evidencia

- Commit: `3bc1a35`
- 3 files changed, 522 insertions(+), 275 deletions(-)
- Pre-commit hooks: ✓ (gitleaks WARN no crítico, check-adr-numbering OK, spec-canonical-drift OK)
- Auditoría arquitectónica completa en `audit-outputs/` (sesión `21c07e7c-e6f9-4de9-9c1d-f819e6b5d5d7`)
- 0 archivos fuente del repo modificados durante la auditoría que motivó esta decisión.

## Refs

- `audit-outputs/SUMMARY.md`
- `audit-outputs/EXTENSIONS_RECOMMENDATIONS.md`
- ADR-001 (stack canónico), addyosmani/agent-skills
