### PR TITLE
fix(arquitecto-maestro): skill activation + Fase 1 disambiguation

### DIFF
--- a/.claude/skills/arquitecto-maestro/SKILL.md
+++ b/.claude/skills/arquitecto-maestro/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/arquitecto-maestro/SKILL.md

--- a/.gitignore
+++ b/.gitignore
@@ -128,9 +128,17 @@ __pycache__/
 * 3.*
 
 # Claude Code local settings
-.claude/
+.claude/*
 
 # Playwright screenshots (UI verification debug artifacts)
 *.png
 !apps/**/*.png
 !packages/**/*.png
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Excepciones a .claude/: skills compartidas versionadas como parte de la
+# arquitectura del repo (no son settings personales). Ver ADR-054.
+# ─────────────────────────────────────────────────────────────────────────────
+!.claude/skills/
+!.claude/skills/arquitecto-maestro/
+!.claude/skills/arquitecto-maestro/SKILL.md

--- a/skills/arquitecto-maestro/SKILL.md
+++ b/skills/arquitecto-maestro/SKILL.md
@@ -45,7 +45,7 @@ Fases secuenciales. No saltar fases. No fusionar fases para "ir más rápido".
 
 ANTES de proponer cualquier solución técnica o invocar subagents, leer en este orden:
 
-1. **`CLAUDE.md`** completo — principios rectores + stack canónico + reglas operativas.
+1. **`CLAUDE.md`** (raíz del repo, NO `audit-outputs/CLAUDE.md` que es propuesta no promovida) — principios rectores + stack canónico + reglas operativas.
 2. **`docs/handoff/CURRENT.md`** — estado vivo del proyecto (sprint actual, decisiones pendientes, P0 abiertos).
 3. **ADRs relevantes** en `docs/adr/` — filtrar por keywords de la misión (`grep -li`).
 4. **`audit-outputs/`** si existe — findings activos pueden afectar decisiones (ej. R-001 P0 OTel bloquea cualquier feature que vaya a producción sin observabilidad).


### PR DESCRIPTION
## Contexto

PR de seguimiento al PR #303 (ADR-054). Corrige dos issues detectados en el test de humo de la skill `arquitecto-maestro` durante la sesión 2026-05-19.

## B.4 — Slash command activation

**Problema**: el slash command `/arquitecto-maestro` no funcionaba porque Claude Code busca skills en `.claude/skills/`, no en `skills/` (top-level).

**Solución**: symlink relativo desde `.claude/skills/arquitecto-maestro/SKILL.md` apuntando a la skill canónica en `skills/arquitecto-maestro/SKILL.md`.

**Diseño**:
- Una sola fuente de verdad: la skill canónica en `skills/`.
- `.gitignore` declarativo: `.claude/` → `.claude/*` + excepciones explícitas para skills compartidas como parte de la arquitectura del repo (no settings personales).

## B.5 — Fase 1 disambiguation

**Problema observado en test de humo**: la skill cargó `audit-outputs/CLAUDE.md` (propuesta no promovida) en vez de `CLAUDE.md` (raíz del repo, vigente).

**Solución**: Fase 1 línea 48 ahora especifica:
- La ruta de raíz del repo explícitamente.
- Qué archivo NO debe leerse.

Coherente con el principio "anti-alucinación" que la propia Fase 1 declara.

## Files changed

- `skills/arquitecto-maestro/SKILL.md` — disambiguation en Fase 1, línea 48.
- `.claude/skills/arquitecto-maestro/SKILL.md` (new, symlink mode 120000) — activación del slash command.
- `.gitignore` — `.claude/` → `.claude/*` + excepciones declarativas para skills compartidas.

## Refs

- ADR-054 (migración Arquitecto Maestro, PR #303)
- Test de humo 2026-05-19 (sesión 21c07e7c-e6f9-4de9-9c1d-f819e6b5d5d7)
