### PR TITLE
docs(specs): stubs-decision sec 7.1 y 7.2 marcadas como superseded parcial por ADR-051

### DIFF
--- a/.specs/stubs-decision/spec.md
+++ b/.specs/stubs-decision/spec.md
@@ -52,6 +52,19 @@ Ninguno directo. Esta es una decisión interna de housekeeping. Indirectamente:
 | `apps/matching-engine` | **PROMOVER** | Idem. Capacidad declarada en README + ADR-023/033 (matching V1/V2). Hoy en `apps/api/src/services/matching*.ts` + `packages/matching-algorithm`. | **S3** (cubre SC-10). |
 | `apps/document-service` | **PROMOVER** | Idem. Capacidad declarada en README + ADR-007 (Chile docs) + ADR-024 (Sovos). Hoy en `apps/api/src/routes/documentos.ts` + `packages/dte-provider` + `packages/carta-porte-generator`. | **S4** (cubre SC-11). |
 
+
+---
+
+> **SUPERSEDED PARCIALMENTE**: ADR-051 (2026-05-19) supersedea puntos
+> específicos de esta sección bajo el principio operativo "tiempo a producción"
+> declarado por PO 2026-05-19. La sección mantiene status `Approved` pero los
+> puntos enumerados en `docs/adr/ADR-051-resolucion-8-stubs.md` §"Supersedes
+> explícitos sobre stubs-decision" quedan inaplicables a partir de esa fecha.
+>
+> Mapping exacto: 6 de 8 stubs superseded (matching-engine, notification-service,
+> document-service, ai-provider, carta-porte-generator, document-indexer).
+> Coinciden y mantienen vigencia: trip-state-machine y ui-components.
+
 ### 7.2 Packages stub
 
 | Stub | Decisión | Razón | Acción |
@@ -61,6 +74,19 @@ Ninguno directo. Esta es una decisión interna de housekeeping. Indirectamente:
 | `packages/document-indexer` | **ELIMINAR** | El plan original era CRUD docs. La realidad es que la indexación está hecha via `apps/api/src/routes/documentos.ts` con Drizzle directo. No hay caso de uso fuera de `document-service` que requiera abstracción. Mantenerlo es duplicación implícita. | Eliminar + ADR de supersede parcial ADR-001. **Ejecuta en S2.** |
 | `packages/trip-state-machine` | **PROMOVER** | Capacidad declarada explícita en README + comentarios en código original ("XState machines"). Hoy la state transition lógica está implícita en services (`liquidar-trip.ts`, `confirmar-entrega-viaje.ts`, etc.) y es la fuente del drift schema↔domain que ADR-043 resuelve. Una state machine declarativa elimina la fuente del drift estructuralmente. | **Implementar en S1** como parte del fix de drift (ADR-043). LOC estimado ~250 (definición XState + tests). |
 | `packages/ui-components` | **PROMOVER** parcial | Capacidad declarada en README (shadcn/ui + componentes Booster). Hoy `apps/web/src/components/` tiene ~42 componentes; algunos son obviamente reutilizables (`ChileanPlate`, `CompanySwitcher`, `EmptyState`, `FormField`, `Layout`, `ProtectedRoute`, `RelativeTime`, `DemoBanner`, `ConsentTermsBanner`, `DocumentosSection`). | **Extraer 5-8 componentes reutilizables** a `packages/ui-components` en S2 + tests por componente. NO mover todo (los componentes específicos de una página quedan en `apps/web`). LOC estimado ~600 (moves + tests). |
+
+
+---
+
+> **SUPERSEDED PARCIALMENTE**: ADR-051 (2026-05-19) supersedea puntos
+> específicos de esta sección bajo el principio operativo "tiempo a producción"
+> declarado por PO 2026-05-19. La sección mantiene status `Approved` pero los
+> puntos enumerados en `docs/adr/ADR-051-resolucion-8-stubs.md` §"Supersedes
+> explícitos sobre stubs-decision" quedan inaplicables a partir de esa fecha.
+>
+> Mapping exacto: 6 de 8 stubs superseded (matching-engine, notification-service,
+> document-service, ai-provider, carta-porte-generator, document-indexer).
+> Coinciden y mantienen vigencia: trip-state-machine y ui-components.
 
 ### 7.3 Resumen
 


### PR DESCRIPTION
## Contexto

Housekeeping documental de seguimiento al merge de ADR-051 (PR #310).

ADR-051 supersedea formalmente 6 de 8 puntos de `.specs/stubs-decision/spec.md` sec 7.1 y 7.2 bajo el principio operativo "tiempo a produccion" declarado por PO 2026-05-19. La spec previa mantiene status Approved pero los puntos enumerados quedan inaplicables.

Este PR agrega la nota explicita en ambas secciones para que cualquier futuro consumer de la spec (humano o agente Claude) vea el supersede sin tener que consultar ADR-051 directamente.

## Cambio

Inserta bloque identico al final de sec 7.1 (justo antes de sec 7.2) y al final de sec 7.2 (justo antes de sec 7.3 Resumen):

> SUPERSEDED PARCIALMENTE: ADR-051 (2026-05-19) supersedea puntos especificos de esta seccion bajo el principio operativo "tiempo a produccion" declarado por PO 2026-05-19.
> Mapping exacto: 6 de 8 stubs superseded; coinciden y mantienen vigencia trip-state-machine y ui-components.

## Mapping de supersede

**Superseded (6 stubs)**:
- matching-engine (spec PROMOVER S3 -> ADR-051 D)
- notification-service (spec PROMOVER S3 -> ADR-051 D)
- document-service (spec PROMOVER S4 -> ADR-051 D)
- ai-provider (spec ELIMINAR S2 -> ADR-051 A post-S1b)
- carta-porte-generator (spec PROMOVER S4 -> ADR-051 D)
- document-indexer (spec ELIMINAR S2 -> ADR-051 D)

**Vigentes (2 stubs)**:
- trip-state-machine (spec PROMOVER S1, ADR-051 A en S1b: coincide)
- ui-components (spec PROMOVER parcial S2, ADR-051 A condicional segunda app: coincide en direccion)

## Refs

- ADR-051 (PR #310 mergeado) - docs/adr/ADR-051-resolucion-8-stubs.md
- .specs/stubs-decision/spec.md (PO-aprobada 2026-05-17, ahora con supersede parcial documentado)
- Principio operativo PO consolidado 2026-05-19: "tiempo a produccion, no desarrollo eterno"
