### PR TITLE
feat(logger): T4 SEC-001 — PII redaction core (value-based regex + wire)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -24,7 +24,14 @@
 useDefault = true
 
 [allowlist]
-description = "Firebase + Google Maps web keys — públicas por diseño"
+description = "Firebase + Google Maps web keys + JWT test fixtures (PII redaction T4 SEC-001)"
 paths = [
   '''cloudbuild\.production\.yaml''',
+  # Test fixtures con JWTs sintéticos para verificar PII redaction (T4 SEC-001).
+  # NO son JWTs reales — payload `{"sub":"user1"}` con signature placeholder
+  # (no firma real, no expira, no autoriza nada). Documentado en commit messages
+  # + PR #319. Sin esta allowlist gitleaks dispara la regla `jwt` sobre cualquier
+  # string `eyJ...\..*\..*` que estructuralmente es JWT shape.
+  '''packages/logger/src/value-redaction\.test\.ts''',
+  '''packages/logger/src/createLogger\.test\.ts''',
 ]

--- a/.specs/sec-001-cierre/plan.md
+++ b/.specs/sec-001-cierre/plan.md
@@ -85,7 +85,7 @@ El spec v3.2 cubre 8 sub-fases (H1.0-H1.6 + H2 + H4) con ~50 SCs. Si se planeara
 - **Rollback**: revertir commit. Si `STRICT_MIGRATION_ORDERING` set true en alguna revision, env var vuelve a default false en revert → behavior previo restaurado en < 1 minuto.
 - **Spec trace**: round 4 P1-R4-4 + P0-2 + P0-4. Sprint 2 SCs dependientes: SC-1.1.8 (demo_accounts), SC-1.2.1 (signup_requests).
 
-### T4: PII redaction core (email/RUT/JWT/password) en `@booster-ai/logger`
+### T4: PII redaction core (email/RUT/JWT/password) en `@booster-ai/logger` [DONE 2026-05-24]
 
 - **Files**: `packages/logger/src/redaction.ts` (new), `packages/logger/src/createLogger.ts` (wire redaction), `packages/logger/src/redaction.test.ts` (new).
 - **LOC estimate**: ~80 (impl ~40 + tests ~40).
@@ -282,6 +282,8 @@ Anything que emergió durante planning y debe resolverse antes de /build:
 - 2026-05-24 — **T0b merged** PR #316 (commit `172e345`). Post-merge `terraform plan` desde main: `Plan: 0 to add, 2 to change, 0 to destroy` — strict gate verified (29 destroys eliminated).
 - 2026-05-24 — **🚨 SMS fallback gateway incident RESOLVED**: bug `WEBHOOK_PUBLIC_URL=''` (17 días activo desde commit 4c7ccc2 Wave 2/3) descubierto durante T0b investigation. Fix vía `terraform apply -target=module.service_sms_fallback_gateway... -var-file=terraform.tfvars.local`. Cloud Run revision `00217-4ds` rolled; curl 403 (sig check active, era 503); 0 CRITICAL logs post 21:26. Incident report PR #317 merged (commit `aa1cf4b`). 5 follow-ups identificados.
 - 2026-05-24 — **T2 DONE** (PR pending). `normalizePhone(raw: string): string | null` agregado a `packages/shared-schemas/src/primitives/chile.ts`. TDD discipline: tests primero (16 tests fail con TypeError), implementación mínima (29 LOC), GREEN (16/16 pass). Coverage chile.ts: 98% stmts / 93.33% branches / 100% funcs (líneas uncovered son pre-existentes en validateRutCheckDigit, no mi código). Package full: 206 tests passing (was 190). typecheck clean; biome clean; zero `any`.
+- 2026-05-24 — **T2 merged** PR #318 (commit `c0bfd6e`).
+- 2026-05-24 — **T4 DONE** (PR pending). PII redaction core en `@booster-ai/logger`. Hallazgo importante: `redaction.ts` ya existía path-based (Pino redact paths) — EXTIENDO con value-based regex (complementario). Funciones nuevas: `redactValue(input: string): string` (regex sobre strings: email/JWT/RUT con módulo-11 check) + `redactObjectValues(obj, visited)` (recursive walk + sensitive key /pass|secret|token|key|auth/i match). Wire en createLogger: `hooks.logMethod` para string args (message) + `formatters.log` para object payload — Pino docs confirmaron formatters.log NO recibe message. Workspace dep add: `@booster-ai/shared-schemas` para reusar `rutSchema + ensureRutHasDash` (módulo-11). TDD: RED (19 tests fail), GREEN (39 tests pass = 11 path + 19 value + 9 createLogger). Coverage 97.72% / 96.87% / 100% / 97.56%. Edge case found: logger tsconfig tenía rootDir (único package con esa restricción + workspace dep) → removed para alinear con apps pattern.
 - 2026-05-24 — Plan v3 producido via 5 surgical Edits:
   - T0 acceptance: gate strict — exactly 1 line diff, otros drifts bloquean apply until T7+T7.5+T8 ready.
   - T3 acceptance: STRICT_MIGRATION_ORDERING=true en STAGING desde Sprint 1 merge (real cold-start coverage); prod queda false hasta Sprint 2.

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -14,6 +14,7 @@
     "test:coverage": "vitest run --coverage --passWithNoTests"
   },
   "dependencies": {
+    "@booster-ai/shared-schemas": "workspace:*",
     "pino": "^9.5.0"
   },
   "devDependencies": {

--- a/packages/logger/src/createLogger.test.ts
+++ b/packages/logger/src/createLogger.test.ts
@@ -126,4 +126,33 @@ describe('createLogger', () => {
     expect(typeof logger.info).toBe('function');
     expect(typeof logger.error).toBe('function');
   });
+
+  // --- T4 SC-H4.1: value-based redaction (regex sobre strings) ---
+
+  it('value-redaction: redacta email inline en message string', () => {
+    const logger = createLogger({ service: 's' });
+    logger.info('signin from user@example.com');
+    expect(lastLog().message).toBe('signin from [REDACTED:email]');
+  });
+
+  it('value-redaction: redacta RUT válido en field arbitrario (no en paths)', () => {
+    const logger = createLogger({ service: 's' });
+    logger.info({ note: 'cliente 11111111-1 consultó' }, 'lookup');
+    expect(lastLog().note).toBe('cliente [REDACTED:rut] consultó');
+  });
+
+  it('value-redaction: redacta JWT inline en message', () => {
+    const logger = createLogger({ service: 's' });
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMSJ9.abc-signature';
+    logger.info(`auth header: Bearer ${jwt}`);
+    expect(lastLog().message).toBe('auth header: Bearer [REDACTED:jwt]');
+  });
+
+  it('value-redaction: key custom no-allowlisted con "secret" → [REDACTED:password]', () => {
+    const logger = createLogger({ service: 's' });
+    logger.info({ customApiSecret: 'abc123' }, 'evt');
+    // path-based (Pino redact) no cubre `customApiSecret` literal,
+    // pero value-redaction matchea la key con /secret/i.
+    expect(lastLog().customApiSecret).toBe('[REDACTED:password]');
+  });
 });

--- a/packages/logger/src/createLogger.ts
+++ b/packages/logger/src/createLogger.ts
@@ -1,5 +1,5 @@
 import { type Logger as PinoLogger, type LoggerOptions as PinoOptions, pino } from 'pino';
-import { redactionPaths } from './redaction.js';
+import { redactObjectValues, redactValue, redactionPaths } from './redaction.js';
 
 export type Logger = PinoLogger;
 
@@ -44,10 +44,23 @@ export function createLogger(options: LoggerOptions): Logger {
         severity: pinoLevelToGcpSeverity(label),
         level: number,
       }),
+      // T4 SC-H4.1: value-based PII redaction sobre el log record entero.
+      // Complementa path-based redact (arriba): cubre PII en strings libres
+      // y en keys no allowlisted (e.g. `customApiSecret`, mensaje con email).
+      log: (obj) => redactObjectValues(obj) as Record<string, unknown>,
     },
     redact: {
       paths: [...redactionPaths, ...additionalRedactionPaths],
       censor: '[REDACTED]',
+    },
+    // T4 SC-H4.1: intercepta string args (message + format args) ANTES del
+    // serialize de Pino para aplicar value-based regex redaction. Complementa
+    // formatters.log que cubre el object payload.
+    hooks: {
+      logMethod(inputArgs, method) {
+        const out = inputArgs.map((a) => (typeof a === 'string' ? redactValue(a) : a));
+        return method.apply(this, out as Parameters<typeof method>);
+      },
     },
     timestamp: pino.stdTimeFunctions.isoTime,
     messageKey: 'message',

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -9,4 +9,4 @@
  */
 
 export { createLogger, type Logger, type LoggerOptions } from './createLogger.js';
-export { redactionPaths } from './redaction.js';
+export { redactionPaths, redactObjectValues, redactValue } from './redaction.js';

--- a/packages/logger/src/redaction.ts
+++ b/packages/logger/src/redaction.ts
@@ -69,10 +69,10 @@ export const redactionPaths: string[] = [
 // aparece dentro de strings (mensajes libres) o en fields con nombres no
 // allowlisted. Aplicado vía `formatters.log` en createLogger.
 
-// Domain split en segmentos `.label` para evitar polynomial ReDoS
-// (CodeQL js/polynomial-redos): regex con char classes overlapping alrededor
-// del literal `.` causa backtracking polinomial en strings sin `@`.
-const EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
+// Username + domain ambos splittean en segmentos `.label` para evitar polynomial
+// ReDoS (CodeQL js/polynomial-redos). Sin split, `[\w.+-]+@` causa backtracking
+// polinomial en strings sin `@` (engine intenta múltiples divisiones).
+const EMAIL_RE = /[\w+-]+(?:\.[\w+-]+)*@[\w-]+(?:\.[\w-]+)+/g;
 const JWT_RE = /eyJ[\w-]+\.[\w-]+\.[\w-]+/g;
 const RUT_RE = /\b\d{7,8}-?[\dkK]\b/g;
 const SENSITIVE_KEY_RE = /pass|secret|token|key|auth/i;

--- a/packages/logger/src/redaction.ts
+++ b/packages/logger/src/redaction.ts
@@ -69,10 +69,11 @@ export const redactionPaths: string[] = [
 // aparece dentro de strings (mensajes libres) o en fields con nombres no
 // allowlisted. Aplicado vía `formatters.log` en createLogger.
 
-// Username + domain ambos splittean en segmentos `.label` para evitar polynomial
-// ReDoS (CodeQL js/polynomial-redos). Sin split, `[\w.+-]+@` causa backtracking
-// polinomial en strings sin `@` (engine intenta múltiples divisiones).
-const EMAIL_RE = /[\w+-]+(?:\.[\w+-]+)*@[\w-]+(?:\.[\w-]+)+/g;
+// Username/domain split en segmentos `\w+` con separadores single-char
+// (`[.+\-]` y `[.\-]`). Sin char class overlap entre segmentos y separadores
+// → CodeQL js/polynomial-redos safe (cada `\w+` es greedy single-class
+// unambiguous; separadores son single chars sin quantifier).
+const EMAIL_RE = /\w+(?:[.+\-]\w+)*@\w+(?:[.-]\w+)+/g;
 const JWT_RE = /eyJ[\w-]+\.[\w-]+\.[\w-]+/g;
 const RUT_RE = /\b\d{7,8}-?[\dkK]\b/g;
 const SENSITIVE_KEY_RE = /pass|secret|token|key|auth/i;

--- a/packages/logger/src/redaction.ts
+++ b/packages/logger/src/redaction.ts
@@ -1,3 +1,5 @@
+import { ensureRutHasDash, rutSchema } from '@booster-ai/shared-schemas';
+
 /**
  * Paths que Pino debe redactar automáticamente en cada log.
  *
@@ -58,3 +60,63 @@ export const redactionPaths: string[] = [
   '*.privateNotes',
   '*.private_notes',
 ];
+
+// ----------------------------------------------------------------------------
+// Value-based redaction (T4 SC-H4.1) — regex sobre VALORES de strings
+// ----------------------------------------------------------------------------
+//
+// Complementa la path-based redaction (Pino redact paths) para catch PII que
+// aparece dentro de strings (mensajes libres) o en fields con nombres no
+// allowlisted. Aplicado vía `formatters.log` en createLogger.
+
+const EMAIL_RE = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+const JWT_RE = /eyJ[\w-]+\.[\w-]+\.[\w-]+/g;
+const RUT_RE = /\b\d{7,8}-?[\dkK]\b/g;
+const SENSITIVE_KEY_RE = /pass|secret|token|key|auth/i;
+
+function isValidRut(candidate: string): boolean {
+  return rutSchema.safeParse(ensureRutHasDash(candidate)).success;
+}
+
+/**
+ * Redacta PII patterns en una string: emails, JWTs, RUTs (con módulo-11
+ * check para evitar false positives sobre números aleatorios).
+ */
+export function redactValue(input: string): string {
+  let out = input.replace(EMAIL_RE, '[REDACTED:email]').replace(JWT_RE, '[REDACTED:jwt]');
+  out = out.replace(RUT_RE, (match) => (isValidRut(match) ? '[REDACTED:rut]' : match));
+  return out;
+}
+
+/**
+ * Walks recursive un object/array; redacta strings via `redactValue` + reemplaza
+ * values donde la KEY matchea sensitive pattern (/pass|secret|token|key|auth/i).
+ * Protege contra circular refs via WeakSet.
+ */
+export function redactObjectValues(
+  obj: unknown,
+  visited: WeakSet<object> = new WeakSet(),
+): unknown {
+  if (typeof obj === 'string') {
+    return redactValue(obj);
+  }
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+  if (visited.has(obj as object)) {
+    return obj;
+  }
+  visited.add(obj as object);
+  if (Array.isArray(obj)) {
+    return obj.map((v) => redactObjectValues(v, visited));
+  }
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (typeof v === 'string' && SENSITIVE_KEY_RE.test(k)) {
+      out[k] = '[REDACTED:password]';
+    } else {
+      out[k] = redactObjectValues(v, visited);
+    }
+  }
+  return out;
+}

--- a/packages/logger/src/redaction.ts
+++ b/packages/logger/src/redaction.ts
@@ -69,7 +69,10 @@ export const redactionPaths: string[] = [
 // aparece dentro de strings (mensajes libres) o en fields con nombres no
 // allowlisted. Aplicado vía `formatters.log` en createLogger.
 
-const EMAIL_RE = /[\w.+-]+@[\w-]+\.[\w.-]+/g;
+// Domain split en segmentos `.label` para evitar polynomial ReDoS
+// (CodeQL js/polynomial-redos): regex con char classes overlapping alrededor
+// del literal `.` causa backtracking polinomial en strings sin `@`.
+const EMAIL_RE = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
 const JWT_RE = /eyJ[\w-]+\.[\w-]+\.[\w-]+/g;
 const RUT_RE = /\b\d{7,8}-?[\dkK]\b/g;
 const SENSITIVE_KEY_RE = /pass|secret|token|key|auth/i;

--- a/packages/logger/src/value-redaction.test.ts
+++ b/packages/logger/src/value-redaction.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { redactObjectValues, redactValue } from './redaction.js';
+
+describe('redactValue — email patterns (T4 SC-H4.1)', () => {
+  it('email simple → [REDACTED:email]', () => {
+    expect(redactValue('contacto: user@example.com')).toBe('contacto: [REDACTED:email]');
+  });
+
+  it('email con + tag → [REDACTED:email]', () => {
+    expect(redactValue('user+tag@booster-ai.com')).toBe('[REDACTED:email]');
+  });
+
+  it('múltiples emails en mismo string → todos redactados', () => {
+    expect(redactValue('A: a@x.com, B: b@y.com')).toBe('A: [REDACTED:email], B: [REDACTED:email]');
+  });
+
+  it('no email → passthrough', () => {
+    expect(redactValue('plain text without PII')).toBe('plain text without PII');
+  });
+});
+
+describe('redactValue — JWT patterns', () => {
+  it('JWT 3 segments base64 → [REDACTED:jwt]', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMSJ9.signaturepart';
+    expect(redactValue(`Bearer ${jwt}`)).toBe('Bearer [REDACTED:jwt]');
+  });
+
+  it('NO redacta strings con dots pero no JWT shape', () => {
+    expect(redactValue('version: 1.2.3 minor.patch.release')).toBe(
+      'version: 1.2.3 minor.patch.release',
+    );
+  });
+});
+
+describe('redactValue — RUT patterns (con módulo-11 validation)', () => {
+  it('RUT válido formato canónico → [REDACTED:rut]', () => {
+    expect(redactValue('cliente: 11111111-1')).toBe('cliente: [REDACTED:rut]');
+  });
+
+  it('RUT válido sin guión → [REDACTED:rut]', () => {
+    expect(redactValue('rut 111111111')).toBe('rut [REDACTED:rut]');
+  });
+
+  it('RUT con DV K minúscula → [REDACTED:rut] (módulo-11 reconoce K)', () => {
+    // 5000001-K es válido (módulo-11 verified: body=5000001, sum=12, rem=1 → DV=K)
+    expect(redactValue('rut 5000001-k')).toBe('rut [REDACTED:rut]');
+  });
+
+  it('número que parece RUT pero módulo-11 inválido → NO redacta (false positive avoidance)', () => {
+    // 12345678-9 tiene DV inválido (real DV is 5)
+    expect(redactValue('código 12345678-9')).toBe('código 12345678-9');
+  });
+
+  it('números cortos no-RUT → passthrough', () => {
+    expect(redactValue('123 456')).toBe('123 456');
+  });
+});
+
+describe('redactObjectValues — recursive walk', () => {
+  it('flat object con sensitive key (matchea /pass|secret|token|key/i) → value redacted', () => {
+    const input = { username: 'alice', password: 'p4ssw0rd' };
+    const out = redactObjectValues(input) as Record<string, unknown>;
+    expect(out.username).toBe('alice');
+    expect(out.password).toBe('[REDACTED:password]');
+  });
+
+  it('keys con secret/token/key/auth case-insensitive → redacted', () => {
+    const input = {
+      apiSecret: 'abc',
+      access_token: 'xyz',
+      MY_KEY: 'def',
+      authHeader: 'ghi',
+    };
+    const out = redactObjectValues(input) as Record<string, unknown>;
+    expect(out.apiSecret).toBe('[REDACTED:password]');
+    expect(out.access_token).toBe('[REDACTED:password]');
+    expect(out.MY_KEY).toBe('[REDACTED:password]');
+    expect(out.authHeader).toBe('[REDACTED:password]');
+  });
+
+  it('nested objects → recursion redacta deep', () => {
+    const input = {
+      user: { name: 'alice', email: 'alice@x.com' },
+      meta: { trace: 'plain text' },
+    };
+    const out = redactObjectValues(input) as {
+      user: { name: string; email: string };
+      meta: { trace: string };
+    };
+    expect(out.user.name).toBe('alice');
+    expect(out.user.email).toBe('[REDACTED:email]');
+    expect(out.meta.trace).toBe('plain text');
+  });
+
+  it('arrays → walks element por element', () => {
+    const input = {
+      messages: ['hello', 'contact me at bob@x.com', 'plain'],
+    };
+    const out = redactObjectValues(input) as { messages: string[] };
+    expect(out.messages).toEqual(['hello', 'contact me at [REDACTED:email]', 'plain']);
+  });
+
+  it('circular reference → no infinite loop', () => {
+    const circular: { self?: unknown; msg: string } = { msg: 'safe' };
+    circular.self = circular;
+    expect(() => redactObjectValues(circular)).not.toThrow();
+  });
+
+  it('null y undefined values → passthrough', () => {
+    const input = { a: null, b: undefined, c: 'plain' };
+    const out = redactObjectValues(input) as Record<string, unknown>;
+    expect(out.a).toBeNull();
+    expect(out.b).toBeUndefined();
+    expect(out.c).toBe('plain');
+  });
+
+  it('numbers y booleans → passthrough', () => {
+    const input = { count: 42, active: true, name: 'plain' };
+    const out = redactObjectValues(input) as Record<string, unknown>;
+    expect(out.count).toBe(42);
+    expect(out.active).toBe(true);
+    expect(out.name).toBe('plain');
+  });
+
+  it('email dentro de field name no-sensitive → redactado por value match', () => {
+    // Field name 'note' no es sensitive (no matchea /pass|secret|token|key|auth/i),
+    // pero el value contiene email → value-based regex lo detecta.
+    const input = { note: 'Contact: user@example.com for support' };
+    const out = redactObjectValues(input) as { note: string };
+    expect(out.note).toBe('Contact: [REDACTED:email] for support');
+  });
+});

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "./dist",
-    "rootDir": "./src"
+    "outDir": "./dist"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "test"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -794,6 +794,9 @@ importers:
 
   packages/logger:
     dependencies:
+      '@booster-ai/shared-schemas':
+        specifier: workspace:*
+        version: link:../shared-schemas
       pino:
         specifier: ^9.5.0
         version: 9.14.0


### PR DESCRIPTION
## Summary

T4 del plan Sprint 1 SEC-001 cierre. Extiende `@booster-ai/logger` con **value-based PII redaction** (regex sobre VALORES de strings) que complementa la existing path-based redaction (Pino `redact.paths`).

**Hallazgo durante implementación**: `packages/logger/src/redaction.ts` ya existía con `redactionPaths` array (path-based para defense-in-depth con field names conocidos). T4 requiere regex sobre VALUES — approach complementario, no replacement. EXTIENDO el archivo en lugar de reemplazar.

## Cambios

| Archivo | Tipo | LOC | Propósito |
|---|---|---|---|
| `packages/logger/src/redaction.ts` | M | +62 | Regex constants + `redactValue` + `redactObjectValues` (preserva `redactionPaths`) |
| `packages/logger/src/createLogger.ts` | M | +15 | Wire `hooks.logMethod` + `formatters.log` |
| `packages/logger/src/value-redaction.test.ts` | A | +132 | 19 tests TDD para nuevas funciones |
| `packages/logger/src/createLogger.test.ts` | M | +29 | 4 integration tests para wire |
| `packages/logger/package.json` | M | +1 | dep `@booster-ai/shared-schemas` workspace |
| `packages/logger/tsconfig.json` | M | -1 | remove `rootDir` (TS6059 fix con workspace deps) |
| `packages/logger/src/index.ts` | M | ±1 | export `redactValue` + `redactObjectValues` |
| `.specs/sec-001-cierre/plan.md` | M | +3/-1 | T4 marker `[DONE 2026-05-24]` + decision log |

Net **+246/-5 LOC** (≥100 LOC + por ser foundational + 19+4 tests TDD-driven).

## Patterns cubiertos

| Pattern | Regex | Action |
|---|---|---|
| Emails | `[\w.+-]+@[\w-]+\.[\w.-]+` | → `[REDACTED:email]` |
| JWTs | `eyJ[\w-]+\.[\w-]+\.[\w-]+` (3 segments base64) | → `[REDACTED:jwt]` |
| RUTs | `\b\d{7,8}-?[\dkK]\b` + módulo-11 check via `rutSchema` | → `[REDACTED:rut]` |
| Sensitive keys | `/pass\|secret\|token\|key\|auth/i` en object keys | value → `[REDACTED:password]` |

**RUT false-positive avoidance**: regex matchea cualquier 7-9 dígitos con guión, PERO `rutSchema.safeParse(ensureRutHasDash(match)).success` valida módulo-11 ANTES de redactar. Números aleatorios (e.g. `12345678-9` cuyo DV correcto es `5`) NO se redactan.

## Wire en createLogger

Pino docs explícito: `formatters.log` NO recibe el `message` string (solo el mergingObject). Por eso wire en DOS hooks complementarios:

```typescript
hooks: {
  logMethod(inputArgs, method) {
    // Intercepta string args ANTES del serialize: message + format args
    const out = inputArgs.map((a) => (typeof a === 'string' ? redactValue(a) : a));
    return method.apply(this, out);
  },
},
formatters: {
  log: (obj) => redactObjectValues(obj),  // Cubre object payload + sensitive keys
},
```

## TDD discipline

| Fase | Tests | Estado |
|---|---|---|
| RED (value-redaction.test.ts) | 19 | All fail con `TypeError: redactObjectValues is not a function` |
| GREEN (impl + wire) | 19+4 | Todos pass |
| Full package post-T4 | **39/39** | ✓ |

## Edge case encontrado: TS6059 rootDir

Logger era el **único package con `rootDir`+workspace dep** (apps no tienen rootDir, otros packages no dependen de shared-schemas con rootDir). Al agregar dep `@booster-ai/shared-schemas`, TS6059 fired:

```
error TS6059: File '...shared-schemas/src/site-settings.ts' is not under
'rootDir' '/.../packages/logger/src'.
```

**Fix**: remove `rootDir` del logger/tsconfig.json, alinea con apps/* pattern.

## Evidencia

### Coverage post-T4

```
File             | % Stmts | % Branch | % Funcs | % Lines
-----------------|---------|----------|---------|---------
All files        |   97.72 |    96.87 |     100 |   97.56
 createLogger.ts |   94.44 |    93.33 |     100 |   94.11  (line 101 = pretty=true transport)
 redaction.ts    |  100    |  100     |  100    |  100
```

Todos los thresholds CLAUDE.md ≥80%.

### Pre-commit hooks

- ✅ biome check --write (formatting auto-fix)
- ✅ check-adr-numbering — sin colisiones
- ✅ spec-canonical-drift — OK

### Tests

```
pnpm --filter @booster-ai/logger test
 Test Files  3 passed (3)
      Tests  39 passed (39)
```

### TypeScript + lint

- ✅ `pnpm --filter @booster-ai/logger typecheck` — clean
- ✅ `pnpm exec biome check packages/logger/src/` — clean
- ✅ Zero `any`

## Compliance Ley 19.628 Chile (parcial)

T4 cierra el **HALF-1** del SC-H4.1 (regex patterns + wire). Pendiente para cierre completo:
- **T5**: PII redaction phone (usa `normalizePhone` de T2; ya merged). Bloquea hasta T4 merge para crear infra base.
- **T6**: thresholds verification + ADR (fixtures legit/adversarial). Bloquea hasta T4+T5 merge.

## Trazabilidad

- Spec: `.specs/sec-001-cierre/spec.md` §3 H4 SC-H4.1
- Plan: `.specs/sec-001-cierre/plan.md` §Tasks T4
- Round 1 P0-3 / Round 2 O-12 (in-scope H4 PII redaction per Ley 19.628 compliance)
- Sin deps en T0/T1/T2/T3; T5 depends on T4 (este PR) + T2 (merged #318)

## Test plan

- [ ] PR merge
- [ ] Verify `redactValue` + `redactObjectValues` disponibles vía `@booster-ai/logger` import (probado en T5)
- [ ] T5 (PII redaction phone) usa estas funciones + `normalizePhone` de T2