### PR TITLE
feat(web): T11 SEC-001 — maintenance page demo.boosterchile.com

### DIFF
--- a/.specs/sec-001-cierre/plan.md
+++ b/.specs/sec-001-cierre/plan.md
@@ -191,7 +191,7 @@ El spec v3.2 cubre 8 sub-fases (H1.0-H1.6 + H2 + H4) con ~50 SCs. Si se planeara
 - **Rollback**: revertir commit → solo per-RUT rate-limit queda (T9 funcional pero sin IP defense ni fail-closed). Degradación parcial aceptable.
 - **Spec trace**: §3 H2 SC-H2.1b, SC-H2.4 + SC-1.2.5 cascade docs.
 
-### T11: Maintenance page demo.boosterchile.com (SC-INT-1)
+### T11: Maintenance page demo.boosterchile.com (SC-INT-1) [DONE 2026-05-24]
 
 - **Files**: `apps/web/src/routes/maintenance.tsx` (new), `apps/web/src/router.tsx` (modificar para incluir route), `apps/web/src/routes/demo.tsx` (modificar para check flag `DEMO_MODE_ACTIVATED` desde `/feature-flags` y conditional render maintenance vs landing).
 - **LOC estimate**: ~50 (component ~30 + router wire ~5 + demo.tsx fetch+conditional ~15).

--- a/apps/web/src/hooks/use-feature-flags.test.tsx
+++ b/apps/web/src/hooks/use-feature-flags.test.tsx
@@ -28,6 +28,7 @@ describe('useFeatureFlags', () => {
       auth_universal_v1_activated: true,
       wake_word_voice_activated: false,
       matching_algorithm_v2_activated: true,
+      demo_mode_activated: true,
     });
     const Wrapper = makeWrapper();
     const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper });
@@ -36,6 +37,7 @@ describe('useFeatureFlags', () => {
     expect(result.current.flags.auth_universal_v1_activated).toBe(true);
     expect(result.current.flags.wake_word_voice_activated).toBe(false);
     expect(result.current.flags.matching_algorithm_v2_activated).toBe(true);
+    expect(result.current.flags.demo_mode_activated).toBe(true);
   });
 
   it('default conservador (todos false) si el endpoint falla', async () => {
@@ -50,6 +52,7 @@ describe('useFeatureFlags', () => {
     expect(result.current.flags.auth_universal_v1_activated).toBe(false);
     expect(result.current.flags.wake_word_voice_activated).toBe(false);
     expect(result.current.flags.matching_algorithm_v2_activated).toBe(false);
+    expect(result.current.flags.demo_mode_activated).toBe(false);
   });
 
   it('loading inicial → flags por defecto (false) sin crash', () => {
@@ -60,5 +63,20 @@ describe('useFeatureFlags', () => {
     expect(result.current.isLoading).toBe(true);
     // Aun en loading state, debe haber un valor defaultivo seguro.
     expect(result.current.flags.auth_universal_v1_activated).toBe(false);
+    expect(result.current.flags.demo_mode_activated).toBe(false);
+  });
+
+  it('surface demo_mode_activated cuando backend lo devuelve en false', async () => {
+    vi.spyOn(api, 'get').mockResolvedValue({
+      auth_universal_v1_activated: false,
+      wake_word_voice_activated: false,
+      matching_algorithm_v2_activated: false,
+      demo_mode_activated: false,
+    });
+    const Wrapper = makeWrapper();
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.flags.demo_mode_activated).toBe(false);
   });
 });

--- a/apps/web/src/hooks/use-feature-flags.ts
+++ b/apps/web/src/hooks/use-feature-flags.ts
@@ -12,6 +12,7 @@ export interface FeatureFlags {
   auth_universal_v1_activated: boolean;
   wake_word_voice_activated: boolean;
   matching_algorithm_v2_activated: boolean;
+  demo_mode_activated: boolean;
 }
 
 const FEATURE_FLAGS_QUERY_KEY = ['feature-flags'] as const;
@@ -50,6 +51,7 @@ export function useFeatureFlags(): {
     auth_universal_v1_activated: false,
     wake_word_voice_activated: false,
     matching_algorithm_v2_activated: false,
+    demo_mode_activated: false,
   };
 
   return {

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -24,6 +24,7 @@ import { LegalTerminosRoute } from './routes/legal-terminos.js';
 import { LiquidacionesRoute } from './routes/liquidaciones.js';
 import { LoginConductorRoute } from './routes/login-conductor.js';
 import { LoginRoute } from './routes/login.js';
+import { MaintenanceRoute } from './routes/maintenance.js';
 import { OfertasRoute } from './routes/ofertas.js';
 import { OnboardingRoute } from './routes/onboarding.js';
 import { PerfilRoute } from './routes/perfil.js';
@@ -76,6 +77,16 @@ const demoRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/demo',
   component: DemoRoute,
+});
+
+// SC-INT-1 (sec-001-cierre): página de mantenimiento renderizada por
+// DemoRoute cuando flag demo_mode_activated=false. Ruta directa
+// `/maintenance` expone también el componente para preview/QA sin
+// depender del flag.
+const maintenanceRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/maintenance',
+  component: MaintenanceRoute,
 });
 
 // D9 — Surface dedicada de login para conductores. Acepta RUT + PIN
@@ -382,6 +393,7 @@ const routeTree = rootRoute.addChildren([
   legalCobraHoyRoute,
   liquidacionesRoute,
   adminCobraHoyRoute,
+  maintenanceRoute,
 ]);
 
 export const router = createRouter({

--- a/apps/web/src/routes/demo.test.tsx
+++ b/apps/web/src/routes/demo.test.tsx
@@ -1,0 +1,86 @@
+import { DEFAULT_SITE_CONFIG } from '@booster-ai/shared-schemas';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useFeatureFlagsMock = vi.fn();
+const useSiteSettingsMock = vi.fn();
+const useNavigateMock = vi.fn(() => () => undefined);
+
+vi.mock('../hooks/use-feature-flags.js', () => ({ useFeatureFlags: useFeatureFlagsMock }));
+vi.mock('../hooks/use-site-settings.js', () => ({ useSiteSettings: useSiteSettingsMock }));
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+  useNavigate: useNavigateMock,
+}));
+vi.mock('../hooks/use-auth.js', () => ({
+  signInDriverWithCustomToken: vi.fn(),
+}));
+
+const { DemoRoute } = await import('./demo.js');
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useSiteSettingsMock.mockReturnValue({ config: DEFAULT_SITE_CONFIG, isLoading: false });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('DemoRoute — conditional render basado en feature flag', () => {
+  it('demo_mode_activated=false → renderiza MaintenancePage (SC-INT-1)', () => {
+    useFeatureFlagsMock.mockReturnValue({
+      flags: {
+        auth_universal_v1_activated: false,
+        wake_word_voice_activated: false,
+        matching_algorithm_v2_activated: false,
+        demo_mode_activated: false,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    render(<DemoRoute />, { wrapper });
+    expect(screen.getByText(/Modo demo en mantenimiento/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Modo demo · datos sintéticos/i)).not.toBeInTheDocument();
+  });
+
+  it('demo_mode_activated=true → renderiza el selector de personas', () => {
+    useFeatureFlagsMock.mockReturnValue({
+      flags: {
+        auth_universal_v1_activated: false,
+        wake_word_voice_activated: false,
+        matching_algorithm_v2_activated: false,
+        demo_mode_activated: true,
+      },
+      isLoading: false,
+      isError: false,
+    });
+    render(<DemoRoute />, { wrapper });
+    expect(screen.getByText(/Modo demo · datos sintéticos/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Modo demo en mantenimiento/i)).not.toBeInTheDocument();
+  });
+
+  it('loading inicial (flag aún no resuelto) → fail-safe a MaintenancePage', () => {
+    useFeatureFlagsMock.mockReturnValue({
+      flags: {
+        auth_universal_v1_activated: false,
+        wake_word_voice_activated: false,
+        matching_algorithm_v2_activated: false,
+        demo_mode_activated: false,
+      },
+      isLoading: true,
+      isError: false,
+    });
+    render(<DemoRoute />, { wrapper });
+    expect(screen.getByText(/Modo demo en mantenimiento/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/demo.tsx
+++ b/apps/web/src/routes/demo.tsx
@@ -10,8 +10,10 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import { signInDriverWithCustomToken } from '../hooks/use-auth.js';
+import { useFeatureFlags } from '../hooks/use-feature-flags.js';
 import { useSiteSettings } from '../hooks/use-site-settings.js';
 import { getApiUrl } from '../lib/api-url.js';
+import { MaintenanceRoute } from './maintenance.js';
 
 type Persona = 'shipper' | 'carrier' | 'conductor' | 'stakeholder';
 
@@ -51,8 +53,20 @@ const PERSONA_ICONS: Record<Persona, LucideIcon> = {
 export function DemoRoute() {
   const navigate = useNavigate();
   const { config } = useSiteSettings();
+  const { flags } = useFeatureFlags();
   const [loadingPersona, setLoadingPersona] = useState<Persona | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // SC-INT-1 (sec-001-cierre): mientras el flag demo está OFF, mostrar
+  // copy explícita de mantenimiento en vez de la landing que fallaría
+  // al hacer POST /demo/login (endpoint inactivo cuando flag=false).
+  // Fail-safe: durante loading o error de /feature-flags el hook
+  // retorna defaults conservadores (todos false), por lo que la
+  // maintenance también se muestra — comportamiento alineado con el
+  // estado actual de prod.
+  if (!flags.demo_mode_activated) {
+    return <MaintenanceRoute />;
+  }
 
   async function handleEnter(persona: Persona) {
     setErrorMessage(null);

--- a/apps/web/src/routes/maintenance.test.tsx
+++ b/apps/web/src/routes/maintenance.test.tsx
@@ -1,0 +1,36 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, ...props }: { children: ReactNode }) => <a {...props}>{children}</a>,
+}));
+
+const { MaintenanceRoute } = await import('./maintenance.js');
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe('MaintenanceRoute', () => {
+  it('renderiza copy explícita SC-INT-1: "Modo demo en mantenimiento"', () => {
+    render(<MaintenanceRoute />, { wrapper });
+    expect(screen.getByText(/Modo demo en mantenimiento/i)).toBeInTheDocument();
+    expect(screen.getByText(/Volvemos pronto/i)).toBeInTheDocument();
+  });
+
+  it('expone CTA a producción app.boosterchile.com', () => {
+    render(<MaintenanceRoute />, { wrapper });
+    const cta = screen.getByRole('link', { name: /app\.boosterchile\.com/i });
+    expect(cta).toHaveAttribute('href', 'https://app.boosterchile.com');
+  });
+
+  it('NO renderiza el alert genérico "Hubo un problema entrando a la demo"', () => {
+    render(<MaintenanceRoute />, { wrapper });
+    expect(screen.queryByText(/Hubo un problema entrando a la demo/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/routes/maintenance.tsx
+++ b/apps/web/src/routes/maintenance.tsx
@@ -1,0 +1,64 @@
+import { ExternalLink, Wrench } from 'lucide-react';
+import { useSiteSettings } from '../hooks/use-site-settings.js';
+
+/**
+ * /maintenance — Página de mantenimiento del subdominio
+ * demo.boosterchile.com. Renderizada por `DemoRoute` cuando el flag
+ * `demo_mode_activated` está en false (período de construcción
+ * documentado en spec sec-001-cierre SC-INT-1).
+ *
+ * Sin fetches ni state — componente puramente presentacional. La
+ * decisión de mostrarla vive en el caller (demo.tsx) para que el flag
+ * gobierne el toggle, no dos llamadas independientes al backend.
+ */
+export function MaintenanceRoute() {
+  const { config } = useSiteSettings();
+
+  return (
+    <div className="flex min-h-screen flex-col bg-neutral-50">
+      <header className="border-neutral-200 border-b bg-white">
+        <div className="mx-auto flex max-w-3xl items-center gap-3 px-6 py-4">
+          <img
+            src={config.identity.logo_url ?? '/icons/icon.svg'}
+            alt={config.identity.logo_alt}
+            className="h-9 w-9"
+          />
+          <span className="font-semibold text-base text-neutral-900 tracking-tight">
+            {config.identity.logo_alt}
+          </span>
+        </div>
+      </header>
+
+      <main className="mx-auto flex w-full max-w-2xl flex-1 flex-col items-center justify-center px-6 py-16 text-center">
+        <div className="inline-flex h-12 w-12 items-center justify-center rounded-full border border-neutral-200 bg-white text-neutral-700">
+          <Wrench className="h-6 w-6" aria-hidden />
+        </div>
+        <h1 className="mt-6 font-bold text-3xl text-neutral-900 tracking-tight sm:text-4xl">
+          Modo demo en mantenimiento
+        </h1>
+        <p className="mt-4 text-lg text-neutral-700 leading-relaxed">Volvemos pronto.</p>
+        <p className="mt-2 max-w-md text-neutral-500 text-sm leading-relaxed">
+          Estamos reconstruyendo el entorno demo para que muestre la versión actual del producto. Si
+          necesitas usar Booster en producción, continúa abajo.
+        </p>
+
+        <a
+          href="https://app.boosterchile.com"
+          className="mt-8 inline-flex items-center gap-2 rounded-lg bg-primary-600 px-5 py-2.5 font-semibold text-sm text-white shadow-sm transition hover:bg-primary-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-400 focus-visible:ring-offset-2"
+        >
+          Ir a app.boosterchile.com
+          <ExternalLink className="h-4 w-4" aria-hidden />
+        </a>
+      </main>
+
+      <footer className="border-neutral-200 border-t py-6 text-center text-neutral-500 text-xs">
+        <p>
+          Booster AI ·{' '}
+          <a href="https://boosterchile.com" className="underline hover:text-neutral-700">
+            boosterchile.com
+          </a>
+        </p>
+      </footer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Cierra T11 de `.specs/sec-001-cierre/plan.md` (SC-INT-1).

Reemplaza el alert genérico _"Hubo un problema entrando a la demo"_ que veían los visitantes de `demo.boosterchile.com` cuando el flag `demo_mode_activated=false` por una página de mantenimiento explícita con CTA a producción.

### Cambios

- **`apps/web/src/routes/maintenance.tsx`** (new, presentational): copy _"Modo demo en mantenimiento. Volvemos pronto."_ + CTA a `https://app.boosterchile.com`. Sin fetches ni state; usa `useSiteSettings` para el logo de marca.
- **`apps/web/src/routes/demo.tsx`**: conditional render — si `flags.demo_mode_activated === false` (o loading/error), renderiza `<MaintenanceRoute />`. Fail-safe: defaults conservadores del hook hacen que se muestre la maintenance también durante loading o si `/feature-flags` falla — alineado con el estado actual de prod.
- **`apps/web/src/hooks/use-feature-flags.ts`**: extiende `FeatureFlags` con `demo_mode_activated: boolean`, default fallback `false`.
- **`apps/web/src/router.tsx`**: nueva ruta `/maintenance` expone el componente para preview/QA sin depender del flag.

## Comportamiento

| Estado | `flags.demo_mode_activated` | UI en `/demo` |
|---|---|---|
| Hoy (prod, flag OFF) | `false` | Maintenance copy + CTA a prod |
| Sprint 3 H1.6 cutover | `true` | Selector de personas (comportamiento previo) |
| `/feature-flags` loading | `false` (default) | Maintenance (no alert engañoso) |
| `/feature-flags` 5xx | `false` (default fail-safe) | Maintenance |

## Evidencia

- **Tests**: `pnpm --filter @booster-ai/web test` → 108 archivos · 1016/1016 pass. Tests nuevos T11: 10/10 (3 maintenance + 3 demo conditional + 4 hook).
- **Typecheck**: `pnpm --filter @booster-ai/web typecheck` → 0 errores.
- **Biome (root)**: 0 errores. 47 warnings preexistentes en el repo (no introducidos por T11; 1 warning sobre orden de clases en `demo.tsx` línea 255 es pre-existente).
- **Plan**: T11 marcado `[DONE 2026-05-24]` en `.specs/sec-001-cierre/plan.md`.

## SC traceability

- SC-INT-1 (sec-001-cierre §3): _"durante el período de construcción (mientras demo_mode_activated: false en /feature-flags), demo.boosterchile.com/ muestra explicit maintenance page con copy..."_  ✅

## Test plan

- [ ] CI verde (CI + Security workflows).
- [ ] Smoke manual post-deploy staging: `https://demo-staging.../demo` muestra maintenance (flag OFF en staging actual).
- [ ] Confirmar que `/maintenance` directo renderiza idéntico al render dentro de `/demo`.
- [ ] Cuando Sprint 3 H1.6 flippea el flag a `true`, validar que `/demo` vuelve al selector sin redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)