### PR TITLE
feat(infra): T7 SEC-001 — mount DEMO_SEED_PASSWORD en api Cloud Run

### DIFF
--- a/.specs/sec-001-cierre/plan.md
+++ b/.specs/sec-001-cierre/plan.md
@@ -124,7 +124,7 @@ El spec v3.2 cubre 8 sub-fases (H1.0-H1.6 + H2 + H4) con ~50 SCs. Si se planeara
 - **Rollback**: revertir commit. Tests y ADR son documentación; runtime no afectado.
 - **Spec trace**: §3 H4 SC-H4.1, SC-H4.4.
 
-### T7: Secret Manager `demo-seed-password` (Terraform + IAM)
+### T7: Secret Manager `demo-seed-password` (Terraform + IAM) [DONE 2026-05-24]
 
 - **Files**: `infrastructure/main.tf` o `infrastructure/secrets.tf` (resource `google_secret_manager_secret` + version + `google_secret_manager_secret_iam_member`), `infrastructure/compute.tf` (env var mount al service api).
 - **LOC estimate**: ~35 (HCL: 1 secret + 1 version + 2 IAM bindings + env var mount).

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -27,10 +27,15 @@ locals {
   # Lista de IDs de todas las secret versions que deben existir antes de crear
   # cualquier Cloud Run service que monte secrets. Se pasa a cada módulo via
   # `secret_versions_ready` para que Terraform propague el orden automáticamente.
-  # Incluye los 14 placeholders + database_url (que es generado dinámicamente).
+  # Incluye los 14 placeholders originales + database_url (generado dinámicamente)
+  # + las versions del set hotfix-2026-05-14 (6 placeholders + pepper aleatorio)
+  # que ya están mounteadas por al menos un service (T7 SEC-001 monta
+  # DEMO_SEED_PASSWORD en el api).
   all_secret_versions_ready = concat(
     [for v in values(google_secret_manager_secret_version.placeholder) : v.id],
     [google_secret_manager_secret_version.database_url.id],
+    [for v in values(google_secret_manager_secret_version.hotfix_2026_05_14_placeholder) : v.id],
+    [google_secret_manager_secret_version.pin_rate_limit_hmac_pepper.id],
   )
 
   # URLs *.run.app de los Cloud Run services — audience canónica para tráfico
@@ -235,6 +240,19 @@ module "service_api" {
     # ADR-037: GEMINI_API_KEY eliminada con el mismo patrón (Vertex AI +
     # ADC con roles/aiplatform.user). API key Booster Gemini ya eliminada
     # post-apply de PR #196.
+
+    # T7 SEC-001 (spec sec-001-cierre §3 H1.4 SC-1.4.2) — password leído
+    # por seed-demo.ts y seed-demo-startup.ts cuando DEMO_MODE_ACTIVATED
+    # está ON. Reemplaza el literal `BoosterDemo2026!` hardcoded en
+    # `apps/api/src/services/seed-demo.ts:86` + `seed-demo-startup.ts:142`.
+    # El secret + IAM bindings + placeholder version `REPLACE_ME_BEFORE_DEPLOY`
+    # están declarados en `security-hotfixes-2026-05-14.tf` (importado en
+    # T0b PR #316); aquí solo se mountea como env var. La rotación a
+    # password real ocurre via `gcloud secrets versions add demo-seed-password`
+    # (T7.5 run-once) ANTES de que T8 active el lookup en el código —
+    # T7.5 gate de CI bloquea PRs que toquen seed-demo*.ts si version
+    # count == 0.
+    DEMO_SEED_PASSWORD = google_secret_manager_secret.hotfix_2026_05_14["demo-seed-password"].secret_id
   })
 
   vpc_connector = google_vpc_access_connector.serverless.id


### PR DESCRIPTION
## Summary

Cierra T7 de `.specs/sec-001-cierre/plan.md` (SC-1.4.2 — env var mount).

### Hallazgo de investigación

El secret `demo-seed-password` + IAM bindings (SA `cloud_run_runtime` con `secretAccessor` + `dev@boosterchile.com` con `admin`) + placeholder version `REPLACE_ME_BEFORE_DEPLOY` ya estaban completamente declarados en `infrastructure/security-hotfixes-2026-05-14.tf` (importado en T0b PR #316). El único faltante para SC-1.4.2 era el env var mount en el Cloud Run del api.

### Cambios

- **`compute.tf`** (`module "service_api"` secrets block): agrega `DEMO_SEED_PASSWORD` apuntando a `google_secret_manager_secret.hotfix_2026_05_14["demo-seed-password"].secret_id`.
- **`compute.tf`** (`local.all_secret_versions_ready`): extiende con las 7 versions del set hotfix-2026-05-14 (6 placeholders + pepper aleatorio) para dependencia explícita Terraform → cualquier service que las monte espera a que estén readonly antes del rollout.

### Acceptance T7

- ✅ Secret existe (T0b apply context).
- ✅ IAM solo SA api + PO admin (declarado en hotfix file líneas 127-144).
- ✅ Env var mount declarado (este PR).
- ⏳ `gcloud secrets describe demo-seed-password` (post-apply verify por PO).
- ⏳ `gcloud run services describe booster-ai-api ... | grep DEMO_SEED_PASSWORD` (post-apply verify por PO).

## Plan diff esperado (PO strict gate post-merge)

- 1 modify en `module.service_api.google_cloud_run_v2_service.service` (env var añadida).
- Drift residual cosmético previo: 2 changes esperados (`monitoring dashboard JSON` + `SMS gateway env var`) per decision log T0b PR #316.

Total esperado: ~3 changes, 0 destroys.

## Evidencia

- **terraform validate**: ✅ Success.
- **terraform fmt -check**: drift único en `telemetry-monitoring.tf` (pre-existente, no T7 — confirmado con `git diff`).
- **Plan**: T7 marcado `[DONE 2026-05-24]` en `.specs/sec-001-cierre/plan.md`.

## Cadena T7 → T7.5 → T8

- **T7** (este PR): mount HCL del env var. Apply queda para PO.
- **T7.5** (siguiente PR): script run-once `init-demo-seed-password.sh` (`openssl rand -base64 32 | gcloud secrets versions add ...`) + CI gate WIF que bloquea PRs a `seed-demo*.ts` si version count == 0.
- **T8** (siguiente PR): refactor `seed-demo.ts:86` y `seed-demo-startup.ts:142` para leer `process.env.DEMO_SEED_PASSWORD` (elimina literal `BoosterDemo2026!`).

## Test plan

- [ ] CI verde (CI + Security workflows).
- [ ] Code review: verificar que `DEMO_SEED_PASSWORD` aparece solo una vez (no duplicado en común con el de `database-url` u otros mecanismos).
- [ ] PO: `terraform plan` desde main muestra ~3 changes, 0 destroys (T0 strict gate spirit).
- [ ] PO: `terraform apply` + verificación gcloud post-apply.
- [ ] Confirmar que el cold-start del api **no** crashea con la versión placeholder `REPLACE_ME_BEFORE_DEPLOY` (T8 aún no activa el lookup — env var simplemente está mounteado pero no leído).

🤖 Generated with [Claude Code](https://claude.com/claude-code)