### PR TITLE
feat(infra): T7.5 SEC-001 — init secret + CI gate WIF demo-seed-password

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -134,6 +134,58 @@ jobs:
           category: trivy-config
 
   # ---------------------------------------------------------------------------
+  # T7.5 SEC-001 — gate fail-closed: el secret demo-seed-password debe tener
+  # al menos 1 version antes de mergear cambios a apps/api/src/services/seed-demo*.ts.
+  # Previene P0-5 del round 1 devils-advocate: que T8 mergee con secret vacío
+  # y crashee cold-starts del api.
+  #
+  # Auth WIF mismo patrón que release.yml:77 (google-github-actions/auth@v2).
+  # SA: github-deployer (vars.WIF_SERVICE_ACCOUNT_DEPLOY) con
+  # roles/secretmanager.viewer sobre demo-seed-password — grant en
+  # infrastructure/security-hotfixes-2026-05-14.tf (T7.5.1).
+  # ---------------------------------------------------------------------------
+  check-secret-version-exists:
+    name: Demo seed password — version exists
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # paths filter via if + paths-filter action; aquí usamos paths via files
+    # context. El job solo es relevante en PRs que tocan seed-demo*.ts (P0-5).
+    # En push a main corre incondicionalmente para detectar regresiones.
+    permissions:
+      contents: read
+      id-token: write  # Para WIF
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect seed-demo changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            seed:
+              - 'apps/api/src/services/seed-demo*.ts'
+              - 'infrastructure/scripts/check-secret-version-exists.sh'
+              - 'infrastructure/scripts/init-demo-seed-password.sh'
+              - 'infrastructure/security-hotfixes-2026-05-14.tf'
+              - '.github/workflows/security.yml'
+      - name: Authenticate to Google Cloud
+        if: steps.changes.outputs.seed == 'true' || github.event_name == 'push'
+        uses: google-github-actions/auth@v2
+        with:
+          project_id: booster-ai-494222
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.WIF_SERVICE_ACCOUNT_DEPLOY }}
+      - name: Set up gcloud
+        if: steps.changes.outputs.seed == 'true' || github.event_name == 'push'
+        uses: google-github-actions/setup-gcloud@v3
+      - name: Check demo-seed-password has >= 1 version
+        if: steps.changes.outputs.seed == 'true' || github.event_name == 'push'
+        run: |
+          bash infrastructure/scripts/check-secret-version-exists.sh demo-seed-password
+      - name: Skipped (no seed-demo changes)
+        if: steps.changes.outputs.seed != 'true' && github.event_name != 'push'
+        run: echo "Skip — PR no toca seed-demo*.ts ni el plumbing del gate."
+
+  # ---------------------------------------------------------------------------
   # SBOM generation — Software Bill of Materials para auditoría
   # ---------------------------------------------------------------------------
   sbom:

--- a/.specs/sec-001-cierre/plan.md
+++ b/.specs/sec-001-cierre/plan.md
@@ -138,7 +138,7 @@ El spec v3.2 cubre 8 sub-fases (H1.0-H1.6 + H2 + H4) con ~50 SCs. Si se planeara
 - **Rollback**: revertir commit → secret destroyed por terraform. **Cuidado**: si algún Cloud Run revision sigue referenciado al env, fallará en restart. Mitigation: aplicar revert SOLO si T8 también revertido (orden coordinado).
 - **Spec trace**: §3 H1.4 SC-1.4.2.
 
-### T7.5: Set initial Secret Manager version + CI gate (nuevo en v2 per P0-5)
+### T7.5: Set initial Secret Manager version + CI gate (nuevo en v2 per P0-5) [DONE 2026-05-24]
 
 - **Files**: `infrastructure/scripts/init-demo-seed-password.sh` (new, ~10 LOC); `infrastructure/scripts/check-secret-version-exists.sh` (new, ~20 LOC); `infrastructure/main.tf` o `secrets.tf` (add `google_secret_manager_secret_iam_member` para `github-deployer` SA, ~5 LOC HCL); `docs/runbooks/secret-init-runbook.md` (new); `.github/workflows/security.yml` (modify, add `check-secret-version-exists` job ~25 LOC YAML).
 - **LOC estimate**: ~70 (scripts + IAM grant + runbook + workflow job).

--- a/docs/runbooks/secret-init-runbook.md
+++ b/docs/runbooks/secret-init-runbook.md
@@ -1,0 +1,176 @@
+# Runbook — Inicialización de Secret Manager secrets (run-once setup)
+
+> Última actualización: 2026-05-24 · T7.5 SEC-001
+> Spec: [`.specs/sec-001-cierre/spec.md`](../../.specs/sec-001-cierre/spec.md) §3 H1.4 · [Plan T7.5](../../.specs/sec-001-cierre/plan.md)
+
+## Contexto
+
+Varios secrets en GCP Secret Manager se crean inicialmente con un placeholder (`REPLACE_ME_BEFORE_DEPLOY`) porque sus valores reales no pueden vivir en Terraform (credenciales rotadas, passwords compromise-replace, etc.). La rotación a valor real ocurre **una sola vez** post-`terraform apply`, ejecutada manualmente por el Product Owner desde su máquina.
+
+Este runbook aplica al secret `demo-seed-password` (T7.5). El mismo patrón se reutiliza para futuros secrets con placeholder (ver `infrastructure/security-hotfixes-2026-05-14.tf`).
+
+## Cuándo correr el script
+
+| Trigger | Acción |
+|---|---|
+| Tras mergear T7 (`feat(infra): T7 SEC-001 — mount DEMO_SEED_PASSWORD…`) | Correr una vez |
+| Tras un `terraform destroy` accidental del secret | Correr una vez |
+| Antes del primer merge de T8 (`feat(api): T8 SEC-001 — seed-demo lee DEMO_SEED_PASSWORD`) | Verificar primero con `check-secret-version-exists.sh`; si pasa, no correr |
+| Rotación programada (Sprint 3 H1.6 cutover, o post-incident) | NO — usar `gcloud secrets versions add` directo + revocar versions previas (no es flujo init) |
+
+## Prerequisitos
+
+- [ ] `gcloud auth login` con la cuenta del PO (`dev@boosterchile.com`).
+- [ ] `gcloud config set project booster-ai-494222`.
+- [ ] El secret `demo-seed-password` existe en Secret Manager (verificar con `gcloud secrets describe demo-seed-password`).
+- [ ] Rol IAM: `secretmanager.admin` sobre el secret (declarado en `security-hotfixes-2026-05-14.tf:138-145`).
+
+## Procedimiento
+
+### 1. Verificar estado previo
+
+```bash
+# ¿El secret existe?
+gcloud secrets describe demo-seed-password --project=booster-ai-494222
+
+# ¿Cuántas versions tiene? (debería tener al menos 1 placeholder)
+gcloud secrets versions list demo-seed-password --project=booster-ai-494222
+
+# ¿La latest es placeholder? (idempotency check del script)
+gcloud secrets versions access latest --secret=demo-seed-password --project=booster-ai-494222
+# Esperado pre-init: REPLACE_ME_BEFORE_DEPLOY
+```
+
+### 2. Ejecutar el script idempotente
+
+```bash
+cd <repo-root>
+bash infrastructure/scripts/init-demo-seed-password.sh
+```
+
+Comportamiento:
+
+- Si la latest version NO es `REPLACE_ME_BEFORE_DEPLOY`, el script skipea con `Skip (idempotente)` y exit 0.
+- Si lo es, genera `openssl rand -base64 32` (32 bytes, ~43 caracteres base64) y agrega una nueva version.
+
+Output esperado en éxito:
+
+```
+→ Checking current latest version of 'demo-seed-password' in project 'booster-ai-494222'...
+→ Generando password random 32 bytes base64...
+→ Agregando nueva version a 'demo-seed-password'...
+Created version [2] of the secret [demo-seed-password].
+✓ Nueva version del secret 'demo-seed-password' creada.
+
+Próximos pasos:
+  1. Restart Cloud Run revision del api para que mountee la nueva version: ...
+  2. T8 PR puede mergearse (CI gate validará version count >= 1).
+  3. Anotar en .specs/sec-001-cierre/sprint-1-evidence/t7-5-secret-init.md.
+```
+
+### 3. Verificar post-init
+
+```bash
+# Debe haber al menos 2 versions ahora (placeholder + real)
+gcloud secrets versions list demo-seed-password --project=booster-ai-494222
+
+# La latest debe ser != placeholder
+gcloud secrets versions access latest --secret=demo-seed-password --project=booster-ai-494222
+# Esperado: ~43 caracteres base64 (no `REPLACE_ME_BEFORE_DEPLOY`)
+```
+
+### 4. Restart Cloud Run api revision
+
+Cloud Run mountea la version `latest` al startup. Para tomar la nueva version sin esperar al próximo deploy:
+
+```bash
+gcloud run services update booster-ai-api \
+  --region=us-central1 \
+  --project=booster-ai-494222
+```
+
+(Un `update` sin args fuerza un revision rollout que vuelve a leer secrets.)
+
+### 5. Anotar evidencia
+
+Crear `.specs/sec-001-cierre/sprint-1-evidence/t7-5-secret-init.md` con:
+
+- Timestamp de ejecución del script.
+- Output del script.
+- Output de `gcloud secrets versions list demo-seed-password` post-init.
+- Confirmación de revision rollout (`gcloud run revisions list --service=booster-ai-api`).
+
+## Verificación del CI gate
+
+El gate `check-secret-version-exists` corre en GitHub Actions (`.github/workflows/security.yml`) en PRs que toquen:
+
+- `apps/api/src/services/seed-demo*.ts`
+- `infrastructure/scripts/check-secret-version-exists.sh`
+- `infrastructure/scripts/init-demo-seed-password.sh`
+- `infrastructure/security-hotfixes-2026-05-14.tf`
+- `.github/workflows/security.yml`
+
+Auth via Workload Identity Federation (mismo SA `github-deployer` que `release.yml`). Si el SA no tiene `roles/secretmanager.viewer` sobre `demo-seed-password`, el job falla con error explícito (apuntando a esta sección del runbook).
+
+## Rotación futura (NO usar este script para rotación)
+
+Para rotar el password (`secretAccessor` paths breach, sospecha de compromise, política periodica):
+
+```bash
+# 1. Agregar nueva version con valor nuevo
+openssl rand -base64 32 | gcloud secrets versions add demo-seed-password \
+  --project=booster-ai-494222 --data-file=-
+
+# 2. Restart Cloud Run para que tome la nueva latest
+gcloud run services update booster-ai-api --region=us-central1 --project=booster-ai-494222
+
+# 3. Verificar que el nuevo cold-start funciona, luego deshabilitar la version anterior
+gcloud secrets versions disable <previous-version-number> \
+  --secret=demo-seed-password --project=booster-ai-494222
+
+# 4. Documentar rotación en docs/security/rotations.md (template TBD).
+```
+
+## Troubleshooting
+
+### Error `Permission denied` al ejecutar el script
+
+```
+ERROR: (gcloud.secrets.versions.access) PERMISSION_DENIED: ...
+```
+
+Causa: cuenta `gcloud auth list` activa NO tiene `secretmanager.admin` sobre `demo-seed-password`.
+
+Fix:
+1. `gcloud auth list` — verifica la cuenta activa.
+2. `gcloud auth login dev@boosterchile.com` si es otra cuenta.
+3. Si la cuenta correcta no tiene el rol, ver `infrastructure/security-hotfixes-2026-05-14.tf:138-145` — el binding existe en HCL, así que un `terraform apply` reciente debe haberlo aplicado.
+
+### Error en CI gate `Failed to list versions of 'demo-seed-password'`
+
+```
+::error::Failed to list versions of 'demo-seed-password' in project 'booster-ai-494222'.
+ERROR: (gcloud.secrets.versions.list) PERMISSION_DENIED: ...
+```
+
+Causa: el SA `github-deployer` (impersonated via WIF) no tiene `roles/secretmanager.viewer`.
+
+Fix:
+1. Verifica el grant T7.5.1 en `security-hotfixes-2026-05-14.tf` (resource `demo_seed_password_github_deployer_viewer`).
+2. Confirma con `gcloud secrets get-iam-policy demo-seed-password --project=booster-ai-494222` — debe listar el SA.
+3. Si falta, corre `terraform apply` desde main (chequear strict gate per T0).
+
+### Error `Secret 'demo-seed-password' tiene 0 versions`
+
+Causa: el secret existe pero nunca recibió ni siquiera el placeholder.
+
+Fix: ejecuta el procedimiento desde el paso 2. El script generará la primera version real (no placeholder).
+
+## Referencias
+
+- Spec original: [`.specs/security-blocking-hotfixes-2026-05-14/spec.md`](../../.specs/security-blocking-hotfixes-2026-05-14/spec.md) §3 H1.4
+- Plan T7.5: [`.specs/sec-001-cierre/plan.md`](../../.specs/sec-001-cierre/plan.md) T7.5 acceptance
+- HCL del secret + IAM: [`infrastructure/security-hotfixes-2026-05-14.tf`](../../infrastructure/security-hotfixes-2026-05-14.tf)
+- Pattern WIF auth: [`.github/workflows/release.yml`](../../.github/workflows/release.yml) líneas 75-83
+- ADR-032 git history password compromise: [`docs/adr/032-git-history-password-compromise-opcion-c.md`](../adr/032-git-history-password-compromise-opcion-c.md)
+- Incidente histórico SEC-2026-04-01 (regresión silent fail-open a evitar): este runbook explícitamente prohíbe el patrón fail-open en el gate.

--- a/infrastructure/scripts/check-secret-version-exists.sh
+++ b/infrastructure/scripts/check-secret-version-exists.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# T7.5 SEC-001 — CI gate que valida que un Secret Manager secret tenga >= 1 version.
+#
+# Fail-closed loudly: exit 1 si
+#   - gcloud auth no responde,
+#   - el secret no existe,
+#   - el secret tiene 0 versions.
+# Nunca silent fail-open (regresión de SEC-2026-04-01 fue exactamente eso).
+#
+# Usage: check-secret-version-exists.sh <secret-id> [project-id]
+# Defaults: project = booster-ai-494222 (override con env PROJECT o $2).
+#
+# Permisos necesarios: `roles/secretmanager.viewer` sobre el secret para el SA
+# que ejecuta (en CI: github-deployer via WIF — grant en
+# security-hotfixes-2026-05-14.tf T7.5.1).
+#
+# Spec: .specs/sec-001-cierre/plan.md T7.5; ronda 2 P0-C.
+
+set -euo pipefail
+
+SECRET="${1:-}"
+if [ -z "${SECRET}" ]; then
+  echo "::error::Usage: $0 <secret-id> [project-id]" >&2
+  exit 1
+fi
+PROJECT="${2:-${PROJECT:-booster-ai-494222}}"
+
+# `gcloud secrets versions list` falla si auth misconfig OR si secret no
+# existe (ambas son fallas hard que queremos surfacing). `--limit=1
+# --format='value(name)'` retorna el nombre completo de la version más
+# reciente (e.g. `projects/.../secrets/X/versions/3`) o cadena vacía si 0.
+if ! versions=$(gcloud secrets versions list "${SECRET}" \
+  --project="${PROJECT}" \
+  --limit=1 \
+  --format='value(name)' 2>&1); then
+  echo "::error::Failed to list versions of '${SECRET}' in project '${PROJECT}'." >&2
+  echo "${versions}" >&2
+  echo "::notice::Si auth falla, revisa que el SA del runner tenga roles/secretmanager.viewer sobre el secret (security-hotfixes-2026-05-14.tf grant T7.5.1)." >&2
+  exit 1
+fi
+
+if [ -z "${versions}" ]; then
+  echo "::error::Secret '${SECRET}' tiene 0 versions." >&2
+  echo "::notice::Run-once setup pendiente: ejecuta infrastructure/scripts/init-demo-seed-password.sh desde la máquina del PO. Ver docs/runbooks/secret-init-runbook.md." >&2
+  exit 1
+fi
+
+echo "✓ Secret '${SECRET}' tiene al menos 1 version: ${versions}"

--- a/infrastructure/scripts/init-demo-seed-password.sh
+++ b/infrastructure/scripts/init-demo-seed-password.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# T7.5 SEC-001 — run-once init de demo-seed-password
+#
+# Genera un password random (32 bytes base64) y lo agrega como nueva version
+# del secret `demo-seed-password`. Idempotente: si la version más reciente NO
+# es el placeholder `REPLACE_ME_BEFORE_DEPLOY`, asume que ya fue inicializado
+# y skipea.
+#
+# Requiere autenticación gcloud con rol `secretmanager.admin` (PO). Esto NO
+# debe correr desde GitHub Actions — solo desde la máquina del PO post-T7
+# merge. La CI gate (`check-secret-version-exists.sh`) verifica que el script
+# fue corrido, pero NO lo corre por sí misma.
+#
+# Spec: .specs/sec-001-cierre/plan.md T7.5; SC-1.4.2.
+
+set -euo pipefail
+
+PROJECT="${PROJECT:-booster-ai-494222}"
+SECRET="${SECRET:-demo-seed-password}"
+PLACEHOLDER_SENTINEL="REPLACE_ME_BEFORE_DEPLOY"
+
+echo "→ Checking current latest version of '${SECRET}' in project '${PROJECT}'..."
+
+# `gcloud secrets versions access latest` retorna el payload de la version
+# más reciente. Requiere `secretmanager.secretAccessor` (PO/admin lo tiene).
+# Si no podemos leer, fallamos loudly — silent fail-open es exactamente lo
+# que el plan prohíbe.
+if ! latest=$(gcloud secrets versions access latest \
+  --secret="${SECRET}" \
+  --project="${PROJECT}" 2>&1); then
+  echo "✗ No se pudo leer '${SECRET}'. gcloud output:" >&2
+  echo "${latest}" >&2
+  echo "  Verifica: 1) gcloud auth login con cuenta PO/admin," >&2
+  echo "           2) el secret existe (terraform apply de T7 completado)," >&2
+  echo "           3) tienes rol secretmanager.secretAccessor o admin." >&2
+  exit 1
+fi
+
+if [ "${latest}" != "${PLACEHOLDER_SENTINEL}" ]; then
+  echo "✓ '${SECRET}' ya tiene valor no-placeholder. Skip (idempotente)."
+  exit 0
+fi
+
+echo "→ Generando password random 32 bytes base64..."
+new_password="$(openssl rand -base64 32)"
+
+echo "→ Agregando nueva version a '${SECRET}'..."
+printf '%s' "${new_password}" | gcloud secrets versions add "${SECRET}" \
+  --project="${PROJECT}" \
+  --data-file=-
+
+echo "✓ Nueva version del secret '${SECRET}' creada."
+echo
+echo "Próximos pasos:"
+echo "  1. Restart Cloud Run revision del api para que mountee la nueva version:"
+echo "     gcloud run services update booster-ai-api --region=us-central1 --project=${PROJECT}"
+echo "  2. T8 PR puede mergearse (CI gate validará version count >= 1)."
+echo "  3. Anotar en .specs/sec-001-cierre/sprint-1-evidence/t7-5-secret-init.md."

--- a/infrastructure/security-hotfixes-2026-05-14.tf
+++ b/infrastructure/security-hotfixes-2026-05-14.tf
@@ -143,3 +143,16 @@ resource "google_secret_manager_secret_iam_member" "hotfix_2026_05_14_felipe_adm
   role      = "roles/secretmanager.admin"
   member    = "user:dev@boosterchile.com"
 }
+
+# T7.5.1 SEC-001 (sec-001-cierre ronda 2 P0-C) — grant viewer al SA
+# `github-deployer` (impersonated por GitHub Actions via WIF; ver
+# release.yml:77 patrón canónico) sobre `demo-seed-password` para que el
+# CI gate `check-secret-version-exists` pueda listar versions. Viewer NO
+# permite acceder al payload (eso requiere secretAccessor); solo metadata
+# count que es lo que el gate necesita.
+resource "google_secret_manager_secret_iam_member" "demo_seed_password_github_deployer_viewer" {
+  project   = google_secret_manager_secret.hotfix_2026_05_14["demo-seed-password"].project
+  secret_id = google_secret_manager_secret.hotfix_2026_05_14["demo-seed-password"].secret_id
+  role      = "roles/secretmanager.viewer"
+  member    = "serviceAccount:${google_service_account.github_deployer.email}"
+}


### PR DESCRIPTION
## Summary

Cierra T7.5 de `.specs/sec-001-cierre/plan.md` (P0-5 round 1 + P0-C round 2 devils-advocate).

### 5 artefactos

| # | Artefacto | Rol |
|---|---|---|
| 1 | `infrastructure/scripts/init-demo-seed-password.sh` | Run-once idempotente para PO. `openssl rand -base64 32 \| gcloud secrets versions add`. Skip si latest ≠ placeholder. |
| 2 | `infrastructure/scripts/check-secret-version-exists.sh` | CI gate fail-closed **loudly** (no silent fail-open, regresión SEC-2026-04-01 explícitamente prohibida). Exit 1 si 0 versions OR auth falla. |
| 3 | `security-hotfixes-2026-05-14.tf` (T7.5.1) | Grant `roles/secretmanager.viewer` sobre `demo-seed-password` al SA existente `github-deployer` (reusa pattern WIF de `release.yml:77`). |
| 4 | `.github/workflows/security.yml` job `check-secret-version-exists` | Auth WIF + setup-gcloud + paths filter (`dorny/paths-filter@v3`) sobre `seed-demo*.ts` + plumbing del gate. Corre on PR filtered + push main incondicional. |
| 5 | `docs/runbooks/secret-init-runbook.md` | Cuándo correr, prerequisitos, procedimiento, verificación, rotación futura, troubleshooting. |

### Por qué viewer y no secretAccessor

El gate solo necesita **metadata** (count de versions), no el payload. `viewer` es mínimo privilegio. La consecuencia: el gate **no puede** distinguir placeholder vs valor real — solo cuenta versions. Después de T0b apply ya hay 1 placeholder version, así que el gate ya pasa hoy. Defensa real contra "T8 mergea con secret vacío" se materializa en proyectos nuevos (sin T0b apply previo) o tras `terraform destroy` accidental.

## Acceptance T7.5

- ✅ Script `init-demo-seed-password.sh` idempotente: skip si latest ≠ `REPLACE_ME_BEFORE_DEPLOY`.
- ✅ T7.5.1: `roles/secretmanager.viewer` grant al SA existente `github-deployer` (no SA nuevo).
- ✅ CI gate fail-closed loudly: exit 1 + `::error::` + `::notice::` con next steps + runbook reference.
- ✅ Workflow corre on PRs touching seed-demo*.ts (paths filter) + push main (incondicional).
- ✅ Runbook documenta init + verification + rotación futura + 3 troubleshooting cases.
- ⏳ PO ejecuta `bash infrastructure/scripts/init-demo-seed-password.sh` post-merge; evidence en `.specs/sec-001-cierre/sprint-1-evidence/t7-5-secret-init.md`.

## Plan diff esperado (PO strict gate post-merge)

- 1 add: `google_secret_manager_secret_iam_member.demo_seed_password_github_deployer_viewer`.
- Drift residual cosmético previo (telemetry dashboard + SMS env var; ver log T0b).
- 0 changes adicionales.

## Evidencia

- **terraform validate**: ✅ Success.
- **bash -n** ambos scripts: ✅ syntax OK.
- **check-secret-version-exists.sh sin args**: exits 1 con `::error::Usage: ...` ✅.
- **terraform fmt -check**: drift solo en `telemetry-monitoring.tf` (pre-existente, no T7.5).
- **shellcheck / actionlint**: no instalados local; CI puede ejecutarlos. Scripts conservadores (`set -euo pipefail`, quoted vars, fail-closed paths).
- **Plan**: T7.5 marcado `[DONE 2026-05-24]`.

## Test plan

- [ ] CI verde (CI + Security workflows). El nuevo job `check-secret-version-exists` debe correr en este PR (toca el plumbing) y debe pasar — `vars.WIF_PROVIDER` y `vars.WIF_SERVICE_ACCOUNT_DEPLOY` ya están configuradas (release.yml las usa).
- [ ] Si el job CI falla por permission denied, el PO ejecuta el apply terraform PRIMERO para crear el viewer grant; luego re-run el workflow.
- [ ] PO: `terraform plan` desde main muestra 1 add + drift residual.
- [ ] PO: `terraform apply` + `bash infrastructure/scripts/init-demo-seed-password.sh`.
- [ ] Verificar runbook §4-5 (gcloud secrets versions list >= 2 versions + restart Cloud Run + evidence).

## Cadena T7 → T7.5 → T8

- **T7** (#324, mergeado): mount HCL del env var en api Cloud Run.
- **T7.5** (este PR): script init + CI gate WIF + viewer grant + runbook.
- **T8** (siguiente PR): refactor `seed-demo.ts:86` + `seed-demo-startup.ts:142` para leer `process.env.DEMO_SEED_PASSWORD`. CI gate de T7.5 protege que T8 no mergee si secret está vacío.

🤖 Generated with [Claude Code](https://claude.com/claude-code)