### PR TITLE
feat(api): T8 SEC-001 — seed-demo lee DEMO_SEED_PASSWORD del env

### DIFF
--- a/.specs/sec-001-cierre/plan.md
+++ b/.specs/sec-001-cierre/plan.md
@@ -152,7 +152,7 @@ El spec v3.2 cubre 8 sub-fases (H1.0-H1.6 + H2 + H4) con ~50 SCs. Si se planeara
 - **Rollback**: revertir commit → CI gate desaparece. Secret version sigue existiendo (no se borra). T8 puede mergear sin verification — pero entonces P0-5 reaparece (seed crashea en cold-start si flag ON). Solo revertir si bug crítico en el CI gate mismo.
 - **Spec trace**: round 4 P0-5; spec §3 H1.4 SC-1.4.2 reforzado.
 
-### T8: seed-demo.ts + seed-demo-startup.ts leen DEMO_SEED_PASSWORD
+### T8: seed-demo.ts + seed-demo-startup.ts leen DEMO_SEED_PASSWORD [DONE 2026-05-24]
 
 - **Files**: `apps/api/src/services/seed-demo.ts` (modificar línea 86, eliminar literal `BoosterDemo2026!`), `apps/api/src/services/seed-demo-startup.ts` (modificar línea 142, mismo cambio), `apps/api/src/services/seed-demo.test.ts` (extend).
 - **LOC estimate**: ~50 (refactor ~20 + tests ~30).

--- a/apps/api/src/services/seed-demo-startup.ts
+++ b/apps/api/src/services/seed-demo-startup.ts
@@ -4,7 +4,7 @@ import type { Auth } from 'firebase-admin/auth';
 import type { ApiEnv } from '../config.js';
 import type { Db } from '../db/client.js';
 import { conductores, empresas, users } from '../db/schema.js';
-import { DEMO_CONDUCTOR_RUT, DEMO_SHIPPER_RUT, seedDemo } from './seed-demo.js';
+import { DEMO_CONDUCTOR_RUT, DEMO_SHIPPER_RUT, getDemoPassword, seedDemo } from './seed-demo.js';
 
 /**
  * Hook que corre en startup del api server cuando `DEMO_MODE_ACTIVATED=true`.
@@ -100,11 +100,11 @@ export async function ensureDemoSeeded(opts: {
  *
  * Idempotente: si el conductor ya tiene firebase_uid real, no-op.
  *
- * El password sintético `BoosterDemo2026!` es el mismo que usan los
- * otros owners demo (ver `DEMO_PASSWORD` en seed-demo.ts). El conductor
- * normalmente usaría su PIN como password tras activación; acá lo
- * sobreescribimos porque el flujo demo entra via custom token, no via
- * signInWithEmailAndPassword.
+ * El password sintético es leído del env `DEMO_SEED_PASSWORD` (T8) —
+ * el mismo que usan los otros owners demo (ver `getDemoPassword` en
+ * seed-demo.ts). El conductor normalmente usaría su PIN como password
+ * tras activación; acá lo sobreescribimos porque el flujo demo entra
+ * via custom token, no via signInWithEmailAndPassword.
  */
 async function ensureConductorDemoActivated(opts: {
   db: Db;
@@ -137,9 +137,10 @@ async function ensureConductorDemoActivated(opts: {
 
   // 2. Crear (o reusar) el Firebase user. Email sintético determinístico
   //    en `.invalid` (RFC2606) para no rutear emails reales. Password
-  //    fijo `BoosterDemo2026!` consistente con los owners demo.
+  //    leído del env DEMO_SEED_PASSWORD (T8 SEC-001) — mismo helper que
+  //    los owners demo en seedDemo, garantiza un solo lugar de verdad.
   const syntheticEmail = `drivers+${DEMO_CONDUCTOR_RUT.replace(/[.\-]/g, '')}@boosterchile.invalid`;
-  const password = 'BoosterDemo2026!';
+  const password = getDemoPassword();
   let firebaseUid: string;
   try {
     const existingFb = await firebaseAuth.getUserByEmail(syntheticEmail).catch(() => null);

--- a/apps/api/src/services/seed-demo.test.ts
+++ b/apps/api/src/services/seed-demo.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getDemoPassword } from './seed-demo.js';
+
+// SC-1.4.3 (sec-001-cierre): si DEMO_MODE_ACTIVATED=true y env ausente,
+// seed CRASHEA al startup con error claro. Si flag OFF, seed skip sin
+// crash. La helper getDemoPassword es el chokepoint del env lookup —
+// los call sites (seedDemo, ensureConductorDemoActivated) la invocan
+// dentro del path "flag ON".
+//
+// Aislamiento de env: usamos vi.stubEnv en vez de mutar process.env
+// directamente — restore explícito en afterEach. Esto evita leak entre
+// tests aunque otro suite haya seteado DEMO_SEED_PASSWORD vía
+// test/setup.ts (default 'test-only-not-a-real-secret').
+
+beforeEach(() => {
+  // Force "ausente" — anula el default del setup global.
+  vi.stubEnv('DEMO_SEED_PASSWORD', '');
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('getDemoPassword (T8 SEC-001)', () => {
+  it('throw con mensaje accionable si DEMO_SEED_PASSWORD ausente', () => {
+    expect(() => getDemoPassword()).toThrowError(/DEMO_SEED_PASSWORD/);
+    expect(() => getDemoPassword()).toThrowError(/Secret Manager/);
+    expect(() => getDemoPassword()).toThrowError(/init-demo-seed-password\.sh/);
+  });
+
+  it('throw si DEMO_SEED_PASSWORD es string vacío', () => {
+    vi.stubEnv('DEMO_SEED_PASSWORD', '');
+    expect(() => getDemoPassword()).toThrowError(/ausente o vacía/);
+  });
+
+  it('throw si DEMO_SEED_PASSWORD es solo whitespace', () => {
+    vi.stubEnv('DEMO_SEED_PASSWORD', '   \t  ');
+    expect(() => getDemoPassword()).toThrowError(/ausente o vacía/);
+  });
+
+  it('retorna el valor cuando DEMO_SEED_PASSWORD está seteado', () => {
+    vi.stubEnv('DEMO_SEED_PASSWORD', 'real-random-secret-from-secret-manager');
+    expect(getDemoPassword()).toBe('real-random-secret-from-secret-manager');
+  });
+
+  it('NO retorna el sentinel placeholder REPLACE_ME_BEFORE_DEPLOY sin error', () => {
+    // El sentinel es un valor "no-real" pero técnicamente non-empty.
+    // Decisión: dejarlo pasar (el helper solo valida non-empty). El gate
+    // semántico (placeholder vs real) vive en el script init + en la
+    // verificación operacional post-init, no acá. Documentado en
+    // docs/runbooks/secret-init-runbook.md §"Por qué viewer y no
+    // secretAccessor".
+    vi.stubEnv('DEMO_SEED_PASSWORD', 'REPLACE_ME_BEFORE_DEPLOY');
+    expect(getDemoPassword()).toBe('REPLACE_ME_BEFORE_DEPLOY');
+  });
+});

--- a/apps/api/src/services/seed-demo.ts
+++ b/apps/api/src/services/seed-demo.ts
@@ -83,7 +83,38 @@ const SHIPPER_OWNER_EMAIL = 'demo-shipper@boosterchile.com';
 const CARRIER_OWNER_EMAIL = 'demo-carrier@boosterchile.com';
 const STAKEHOLDER_EMAIL = 'demo-stakeholder@boosterchile.com';
 const DEMO_STAKEHOLDER_ORG_NOMBRE = 'Observatorio Logístico Demo (Mesa pública sostenibilidad)';
-const DEMO_PASSWORD = 'BoosterDemo2026!';
+
+/**
+ * T8 SEC-001 (sec-001-cierre §3 H1.4 SC-1.4.1/SC-1.4.3/SC-1.4.4) —
+ * lee el password de demo desde `process.env.DEMO_SEED_PASSWORD`.
+ *
+ * El env var es mountado por Cloud Run desde el secret
+ * `demo-seed-password` (HCL en `infrastructure/compute.tf` service_api +
+ * `infrastructure/security-hotfixes-2026-05-14.tf`). El secret se
+ * inicializa con un valor real (no placeholder) corriendo el run-once
+ * `infrastructure/scripts/init-demo-seed-password.sh` por el PO post-T7
+ * apply.
+ *
+ * Fail-closed loudly: si el env está ausente o vacío, lanza un Error
+ * con mensaje accionable (referencia al runbook). Se llama desde
+ * `seedDemo` y `ensureConductorDemoActivated`, ambos en el path
+ * `DEMO_MODE_ACTIVATED=true` — cuando el flag está OFF, ninguno se
+ * invoca, así que la falta de env var no causa crash.
+ */
+export function getDemoPassword(): string {
+  const pw = process.env.DEMO_SEED_PASSWORD;
+  if (!pw || pw.trim() === '') {
+    throw new Error(
+      'DEMO_SEED_PASSWORD env var ausente o vacía. Es requerida cuando ' +
+        'DEMO_MODE_ACTIVATED=true. Verifica que el Secret Manager secret ' +
+        '`demo-seed-password` esté mountado en Cloud Run ' +
+        '(infrastructure/compute.tf service_api) y que tenga al menos 1 version ' +
+        'no-placeholder — corre infrastructure/scripts/init-demo-seed-password.sh ' +
+        'desde la máquina del PO. Ver docs/runbooks/secret-init-runbook.md.',
+    );
+  }
+  return pw;
+}
 
 /**
  * Crea (o reusa) el set demo completo. Idempotente: corridas sucesivas
@@ -95,6 +126,9 @@ export async function seedDemo(opts: {
   logger: Logger;
 }): Promise<DemoCredentials> {
   const { db, firebaseAuth, logger } = opts;
+  // Fail-closed: si el env no está mountado el seed crashea acá (early
+  // exit) en lugar de avanzar y crear users Firebase sin password.
+  const demoPassword = getDemoPassword();
 
   // 1. Resolver plan (estándar). Buscamos el plan_id ya existente.
   const planRows = await db
@@ -136,7 +170,7 @@ export async function seedDemo(opts: {
     firebaseAuth,
     logger,
     email: SHIPPER_OWNER_EMAIL,
-    password: DEMO_PASSWORD,
+    password: demoPassword,
     fullName: 'Dueño Andina Demo',
     rut: DEMO_SHIPPER_OWNER_RUT,
     isPlatformAdmin: false,
@@ -146,7 +180,7 @@ export async function seedDemo(opts: {
     firebaseAuth,
     logger,
     email: CARRIER_OWNER_EMAIL,
-    password: DEMO_PASSWORD,
+    password: demoPassword,
     fullName: 'Dueño Transportes Demo Sur',
     rut: DEMO_CARRIER_OWNER_RUT,
     isPlatformAdmin: false,
@@ -159,7 +193,7 @@ export async function seedDemo(opts: {
     firebaseAuth,
     logger,
     email: STAKEHOLDER_EMAIL,
-    password: DEMO_PASSWORD,
+    password: demoPassword,
     fullName: 'Stakeholder Demo (Mesa pública sostenibilidad)',
     rut: DEMO_STAKEHOLDER_USER_RUT,
     isPlatformAdmin: false,
@@ -288,9 +322,9 @@ export async function seedDemo(opts: {
   });
 
   return {
-    shipper_owner: { email: SHIPPER_OWNER_EMAIL, password: DEMO_PASSWORD },
-    carrier_owner: { email: CARRIER_OWNER_EMAIL, password: DEMO_PASSWORD },
-    stakeholder: { email: STAKEHOLDER_EMAIL, password: DEMO_PASSWORD },
+    shipper_owner: { email: SHIPPER_OWNER_EMAIL, password: demoPassword },
+    carrier_owner: { email: CARRIER_OWNER_EMAIL, password: demoPassword },
+    stakeholder: { email: STAKEHOLDER_EMAIL, password: demoPassword },
     conductor: { rut: DEMO_CONDUCTOR_RUT, activation_pin: driverResult.activationPin },
     carrier_empresa_id: carrierEmpresaId,
     shipper_empresa_id: shipperEmpresaId,

--- a/apps/api/test/setup.ts
+++ b/apps/api/test/setup.ts
@@ -41,3 +41,10 @@ process.env.JWT_ISSUER ??= 'booster-ai';
 process.env.API_AUDIENCE ??= 'https://api.test.boosterchile.com';
 process.env.ALLOWED_CALLER_SA ??= 'test-caller@booster-ai-test.iam.gserviceaccount.com';
 process.env.BOOSTER_PLATFORM_ADMIN_EMAILS ??= 'dev@boosterchile.com';
+// T8 SEC-001 — seedDemo / ensureConductorDemoActivated llaman
+// getDemoPassword() que throw si DEMO_SEED_PASSWORD ausente. En tests
+// unitarios sin el secret real, default a una cadena reconocible.
+// Tests que validan el throw path explícitamente hacen
+// `delete process.env.DEMO_SEED_PASSWORD` en su propio beforeEach
+// (ver src/services/seed-demo.test.ts).
+process.env.DEMO_SEED_PASSWORD ??= 'test-only-not-a-real-secret';

--- a/docs/demo/guia-uso-demo.md
+++ b/docs/demo/guia-uso-demo.md
@@ -78,15 +78,15 @@ Respuesta (guarda esto — el PIN no se vuelve a mostrar):
   "credentials": {
     "shipper_owner": {
       "email": "demo-shipper@boosterchile.com",
-      "password": "BoosterDemo2026!"
+      "password": "<DEMO_SEED_PASSWORD>"
     },
     "carrier_owner": {
       "email": "demo-carrier@boosterchile.com",
-      "password": "BoosterDemo2026!"
+      "password": "<DEMO_SEED_PASSWORD>"
     },
     "stakeholder": {
       "email": "demo-stakeholder@boosterchile.com",
-      "password": "BoosterDemo2026!"
+      "password": "<DEMO_SEED_PASSWORD>"
     },
     "conductor": {
       "rut": "12345678-5",
@@ -110,9 +110,9 @@ El seed es **idempotente** — corriéndolo de nuevo no duplica entidades, sólo
 
 | Usuario | Identificador | Credencial | Empresa | Rol |
 |---|---|---|---|---|
-| Dueño Andina Demo | demo-shipper@boosterchile.com | password `BoosterDemo2026!` | Andina Demo S.A. (RUT 76999111-1) | dueno (shipper) |
-| Dueño Transportes Demo Sur | demo-carrier@boosterchile.com | password `BoosterDemo2026!` | Transportes Demo Sur S.A. (RUT 77888222-K) | dueno (carrier) |
-| Stakeholder Demo | demo-stakeholder@boosterchile.com | password `BoosterDemo2026!` | Transportes Demo Sur (auditoría externa) | stakeholder_sostenibilidad |
+| Dueño Andina Demo | demo-shipper@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Andina Demo S.A. (RUT 76999111-1) | dueno (shipper) |
+| Dueño Transportes Demo Sur | demo-carrier@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Transportes Demo Sur S.A. (RUT 77888222-K) | dueno (carrier) |
+| Stakeholder Demo | demo-stakeholder@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Transportes Demo Sur (auditoría externa) | stakeholder_sostenibilidad |
 | Pedro González | RUT `12345678-5` | PIN 6 dígitos (del seed response) | Transportes Demo Sur | conductor |
 
 **Nota sobre RUT**: el sistema acepta RUT con o sin puntos al tipear, pero siempre persiste en formato canónico **sin puntos** (`12345678-5`). Los inputs de la UI muestran placeholder y hint indicando "Sin puntos, con guión".
@@ -213,7 +213,7 @@ El seed es **idempotente** — corriéndolo de nuevo no duplica entidades, sólo
 
 ### E. Como stakeholder — `demo-stakeholder@boosterchile.com`
 
-1. **Login**: `https://app.boosterchile.com/login` → email + password `BoosterDemo2026!`.
+1. **Login**: `https://app.boosterchile.com/login` → email + password leído de Secret Manager (`demo-seed-password`).
 2. **Surface guard**: si entra a `/app` se redirige automáticamente a `/app/stakeholder/zonas` (su único hub útil).
 3. **En `/app/stakeholder/zonas`** ve el dashboard de zonas de impacto logístico:
    - 5 zonas predefinidas (Puerto Valparaíso, Puerto San Antonio, Mercado Lo Valledor, Polo Quilicura, ZOFRI Iquique).

--- a/docs/handoff/2026-05-11-demo-features-night-sprint.md
+++ b/docs/handoff/2026-05-11-demo-features-night-sprint.md
@@ -104,8 +104,8 @@ Todos verdes. Typecheck, lint y build limpios en todos los packages.
 3. `POST /admin/seed/demo` con Firebase token de un admin → returns credenciales:
    ```json
    {
-     "shipper_owner": { "email": "demo-shipper@boosterchile.com", "password": "BoosterDemo2026!" },
-     "carrier_owner": { "email": "demo-carrier@boosterchile.com", "password": "BoosterDemo2026!" },
+     "shipper_owner": { "email": "demo-shipper@boosterchile.com", "password": "<DEMO_SEED_PASSWORD>" },
+     "carrier_owner": { "email": "demo-carrier@boosterchile.com", "password": "<DEMO_SEED_PASSWORD>" },
      "conductor": { "rut": "12.345.678-5", "activation_pin": "<6 dígitos>" }
    }
    ```

--- a/docs/handoff/CURRENT.md
+++ b/docs/handoff/CURRENT.md
@@ -8,7 +8,7 @@
 
 ## SEC-001 cierre — spec Approved (2026-05-24)
 
-Sesión de smoke E2E sobre `demo.boosterchile.com` reveló regresión backend: `POST /demo/login` → 404 silencioso porque `DEMO_MODE_ACTIVATED=false` en Cloud Run prod. Investigación trazó la causa a la rama abandonada `feat/security-blocking-hotfixes-2026-05-14` (22 commits sin PR; literal `BoosterDemo2026!` sigue en main HEAD en `apps/api/src/services/seed-demo.ts:86` + `seed-demo-startup.ts:142`; sin middleware enforcement; sin docs/qa; H2 `/auth/driver-activate` sin rate-limit; H3 bucket DTE `is_locked=false`). El `terraform apply` que apagó el flag se ejecutó desde esa rama → **drift IaC**: state Cloud Run diverge de main.
+Sesión de smoke E2E sobre `demo.boosterchile.com` reveló regresión backend: `POST /demo/login` → 404 silencioso porque `DEMO_MODE_ACTIVATED=false` en Cloud Run prod. Investigación trazó la causa a la rama abandonada `feat/security-blocking-hotfixes-2026-05-14` (22 commits sin PR; literal `<DEMO_SEED_PASSWORD literal eliminado en T8>` seguía en main HEAD en `apps/api/src/services/seed-demo.ts:86` + `seed-demo-startup.ts:142`; sin middleware enforcement; sin docs/qa; H2 `/auth/driver-activate` sin rate-limit; H3 bucket DTE `is_locked=false`). El `terraform apply` que apagó el flag se ejecutó desde esa rama → **drift IaC**: state Cloud Run diverge de main.
 
 ### Artefactos producidos en sesión 2026-05-24
 

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -243,7 +243,7 @@ module "service_api" {
 
     # T7 SEC-001 (spec sec-001-cierre §3 H1.4 SC-1.4.2) — password leído
     # por seed-demo.ts y seed-demo-startup.ts cuando DEMO_MODE_ACTIVATED
-    # está ON. Reemplaza el literal `BoosterDemo2026!` hardcoded en
+    # está ON. Reemplaza el literal hardcoded que vivía en
     # `apps/api/src/services/seed-demo.ts:86` + `seed-demo-startup.ts:142`.
     # El secret + IAM bindings + placeholder version `REPLACE_ME_BEFORE_DEPLOY`
     # están declarados en `security-hotfixes-2026-05-14.tf` (importado en

--- a/infrastructure/security-hotfixes-2026-05-14.tf
+++ b/infrastructure/security-hotfixes-2026-05-14.tf
@@ -34,7 +34,7 @@ locals {
       placeholder = true
     }
     "demo-seed-password" = {
-      purpose     = "Password leído por seed-demo*.ts cuando DEMO_MODE_ACTIVATED=true. Reemplaza literal hardcoded BoosterDemo2026! en seed-demo.ts:86 y seed-demo-startup.ts:142. Spec §3 H1.4, T6, ADR-032."
+      purpose     = "Password leído por seed-demo*.ts cuando DEMO_MODE_ACTIVATED=true via env var DEMO_SEED_PASSWORD (T7+T8 sec-001-cierre). Reemplaza literal hardcoded eliminado de seed-demo.ts:86 y seed-demo-startup.ts:142 en T8. Spec §3 H1.4, T6, ADR-032."
       placeholder = true
     }
     "pin-rate-limit-hmac-pepper" = {


### PR DESCRIPTION
## Summary

Cierra T8 de \`.specs/sec-001-cierre/plan.md\` (SC-1.4.1 + SC-1.4.3 + SC-1.4.4). Cierra la cadena T7 → T7.5 → T8 = H1.4 PR #2 del §14 minimum-viable-merge.

### Cambios principales

- **\`apps/api/src/services/seed-demo.ts\`**: nuevo helper exportado \`getDemoPassword()\` — lee \`process.env.DEMO_SEED_PASSWORD\`, throw con mensaje accionable (referencia a Secret Manager + runbook + script init) si ausente o vacío. \`seedDemo()\` lo invoca al inicio: fail-closed loudly antes de crear Firebase users sin password.
- **\`apps/api/src/services/seed-demo-startup.ts:142\`**: \`ensureConductorDemoActivated\` reemplaza literal local con \`getDemoPassword()\`. Docstring + comentario actualizados.
- **\`apps/api/src/services/seed-demo.test.ts\`** (new): 5 tests via \`vi.stubEnv\` — throw paths (ausente / vacío / whitespace), retorno valor real, retorno placeholder sentinel sin error.
- **\`apps/api/test/setup.ts\`**: default global \`DEMO_SEED_PASSWORD='test-only-not-a-real-secret'\` para que suites pre-existentes (\`test/unit/seed-demo.test.ts\`, \`test/unit/seed-demo-startup.test.ts\`) no crasheen; tests del throw path lo invalidan explícitamente con \`vi.stubEnv\`.
- **Docs + handoffs + infra**: literal reemplazado por \`<DEMO_SEED_PASSWORD>\` sentinel o referencia a Secret Manager (\`docs/demo/guia-uso-demo.md\`, \`docs/handoff/2026-05-11-…\`, \`docs/handoff/CURRENT.md\`, \`infrastructure/compute.tf\` comment, \`infrastructure/security-hotfixes-2026-05-14.tf\` annotation).

## Acceptance

- ✅ **SC-1.4.1**: \`seed-demo.ts:86\` + \`seed-demo-startup.ts:142\` leen \`process.env.DEMO_SEED_PASSWORD\` en vez del literal.
- ✅ **SC-1.4.3**: ausente + flag ON → throw (cubierto por 3 tests); ausente + flag OFF → \`ensureDemoSeeded\` early-return ANTES de invocar seedDemo, así que helper nunca se llama (path preservado); presente + flag ON → seed runs (cubierto por suites pre-existentes \`test/unit/seed-demo.test.ts\`).
- ✅ **SC-1.4.4**: \`git grep -F 'BoosterDemo2026' -- docs/ apps/ infrastructure/ packages/\` retorna **0 matches**. Residual aceptado:
  - \`.specs/sec-001-cierre/{plan,spec}.md\`: meta-references del spec describiendo el literal removido (la propia SC-1.4.4 dice "scope: código + docs + handoffs + infra"; \`.specs/\` es categoría separada).
  - \`.specs/sec-001-cierre/sprint-1-evidence/t0-…-FAILED.txt\`: frozen evidence del terraform plan original (rewriting falsifica evidencia).

## Evidencia

- **Tests**: \`pnpm --filter @booster-ai/api test\` → 93 archivos · 1109/1109 pass + 2 skipped. Nuevos T8: 5/5.
- **Typecheck**: \`pnpm --filter @booster-ai/api typecheck\` → 0 errores.
- **Biome**: \`pnpm lint\` → 0 errores (47 warnings pre-existentes, ninguno de los 10 archivos modificados).
- **Terraform validate**: ✅ Success.
- **git grep SC-1.4.4**: 0 matches en scope estricto.
- **Plan**: T8 marcado \`[DONE 2026-05-24]\`.

## Notas operacionales — gate T7.5 también va a fallar en este PR

El gate \`Demo seed password — version exists\` (introducido en #325, mergeado con admin override) corre en este PR porque toca \`seed-demo*.ts\`. Va a fallar con \`PERMISSION_DENIED secretmanager.versions.list\` hasta que se aplique el viewer grant terraform de T7.5 (1 IAM resource pendiente).

Mismo plan que T7.5: PO aplica terraform (1 add IAM viewer + drift cosmético) y luego re-dispara el workflow.

## Post-merge — PO checklist

1. \`terraform apply\` desde main (1 add IAM viewer de T7.5 + 2 cosmetic drifts pre-existentes).
2. \`bash infrastructure/scripts/init-demo-seed-password.sh\` (genera version real reemplazando \`REPLACE_ME_BEFORE_DEPLOY\`).
3. \`gcloud run services update booster-ai-api --region=us-central1\` para que tome la nueva latest version del secret.
4. Anotar evidence en \`.specs/sec-001-cierre/sprint-1-evidence/t7-5-secret-init.md\`.

## Cadena H1.4 cerrada

| Task | PR | Estado |
|---|---|---|
| T7 mount env var en Cloud Run | #324 | ✅ merged \`396edf0\` |
| T7.5 init script + CI gate + viewer grant + runbook | #325 | ✅ merged \`f3b21e6\` (admin override, gate auto-falla hasta apply) |
| T8 código lee env (este PR) | — | 🟡 abierto |

🤖 Generated with [Claude Code](https://claude.com/claude-code)