### PR TITLE
docs(sec-001): T1 evidence — Redis state ya STANDARD_HA (no-op)

### DIFF
--- a/.specs/sec-001-cierre/plan.md
+++ b/.specs/sec-001-cierre/plan.md
@@ -45,7 +45,7 @@ El spec v3.2 cubre 8 sub-fases (H1.0-H1.6 + H2 + H4) con ~50 SCs. Si se planeara
 - **Rollback**: revertir commit → variables.tf vuelve a `default = true`. Pero importante: el state remoto sigue `false` (drift cierra in main, pero apply revertido en cualquier momento podría flipear estado a `true` activando demo con literal y UIDs viejos). **Mitigation**: T0 es prerequisito de cualquier otra task que toque infra (T1, T7) — durante el resto de Sprint 1, `terraform apply` desde main NO flipea el demo flag involuntariamente. Si T0 se revierte, el riesgo de auto-revert vuelve.
 - **Spec trace**: §3 H1.0 SC-1.0.1, SC-1.0.2; §7.4 drift categórico; round 4 P0-3.
 
-### T1: Memorystore HA — verify state vs config (modificado en v2 per P0-1)
+### T1: Memorystore HA — verify state vs config (modificado en v2 per P0-1) [DONE 2026-05-25 — no-op, state ya STANDARD_HA]
 
 - **Files**: `infrastructure/data.tf:312` (existing `resource "google_redis_instance" "main"` — verificar tier setting); `infrastructure/variables.tf:redis_tier` (default ya es `"STANDARD_HA"` per evidence devils-advocate); evidence en `.specs/sec-001-cierre/sprint-1-evidence/t1-redis-state.md`.
 - **LOC estimate**: ~0-30 LOC (rango porque puede ser no-op).

--- a/.specs/sec-001-cierre/sprint-1-evidence/t1-redis-state.md
+++ b/.specs/sec-001-cierre/sprint-1-evidence/t1-redis-state.md
@@ -1,0 +1,64 @@
+# T1 evidence — Memorystore Redis state verification
+
+**Fecha**: 2026-05-25 00:35-00:45 UTC
+**Operador**: Claude Opus 4.7 (headless via ADC token de `dev@boosterchile.com`)
+**Spec**: `.specs/sec-001-cierre/plan.md` T1 (modificado v2 per P0-1)
+**Resolución**: **NO-OP** — state ya cumple R-DA-REDIS-SPOF mitigation. Sin cambios HCL.
+
+---
+
+## 1. OQ-PLAN-1 — recurso Terraform
+
+```bash
+$ terraform state list | grep -i redis
+google_project_service.apis["redis.googleapis.com"]
+google_redis_instance.main
+```
+
+Nombre canónico: `google_redis_instance.main` (1 instancia única, declarada en `infrastructure/data.tf:312`).
+
+## 2. OQ-PLAN-8 — tier actual en state
+
+```bash
+$ terraform state show google_redis_instance.main | grep -E "tier|location|replica|auth|encryption|connect"
+    alternative_location_id     = "southamerica-west1-a"
+    auth_enabled                = true
+    connect_mode                = "PRIVATE_SERVICE_ACCESS"
+    location_id                 = "southamerica-west1-b"
+    name                        = "booster-ai-redis"
+    read_replicas_mode          = "READ_REPLICAS_DISABLED"
+    redis_version               = "REDIS_7_2"
+    replica_count               = 1
+    tier                        = "STANDARD_HA"  ◀── MITIGACIÓN R-DA-REDIS-SPOF
+    transit_encryption_mode     = "SERVER_AUTHENTICATION"
+```
+
+## 3. Drift config ↔ state
+
+- `variables.tf:161 redis_tier { default = "STANDARD_HA" }` ✅ alineado con state.
+- `data.tf:315 tier = var.redis_tier` ✅ usa la variable, no literal.
+- `terraform.tfvars.local` — sin override de `redis_tier` (grep retorna vacío).
+
+Targeted plan confirma cero drift:
+
+```bash
+$ terraform plan -target=google_redis_instance.main
+No changes. Your infrastructure matches the configuration.
+```
+
+## 4. SC traceability
+
+- ✅ **R-DA-REDIS-SPOF** (spec §9): mitigado por STANDARD_HA tier + cross-zone (`southamerica-west1-b` primary + `southamerica-west1-a` alternative). Failover automático en caso de falla del nodo primario.
+- ✅ **Round 4 P1-R4-2**: cerrado (estado real ya cumple, no requería cambio).
+- ✅ **AUTH + TLS**: `auth_enabled = true` + `transit_encryption_mode = SERVER_AUTHENTICATION` (TLS server-side cert validation).
+- ✅ **Network isolation**: `connect_mode = PRIVATE_SERVICE_ACCESS` (Cloud Run accede via VPC peering, sin egress público).
+
+## 5. Decisión
+
+**T1 = no-op**. Sin commit de código. Solo este archivo de evidence + tick `[DONE 2026-05-25]` en `plan.md`.
+
+No requiere maintenance window. Sin riesgo de downtime. Sin rollback necesario.
+
+## 6. Habilita T9 + T10
+
+T1 era prerequisito de T9 (rate-limit-pin middleware usa Redis HA fail-closed). Con T1 cerrado, T9/T10 pueden arrancar — el middleware tendrá garantía de que el counter persiste tras failover de zona.


### PR DESCRIPTION
## Summary

Cierra T1 de \`.specs/sec-001-cierre/plan.md\` (R-DA-REDIS-SPOF mitigation + round 4 P1-R4-2).

T1 era una **verificación pura** introducida en plan v2 per devils-advocate P0-1 (\`variables.tf\` ya tenía default STANDARD_HA — sospecha de que el state real también lo cumpliera). Verificado headless via ADC token: state real **ya es STANDARD_HA**. No hay cambios HCL necesarios.

### Estado real (2026-05-25 00:35 UTC)

| Campo | Valor | Razón |
|---|---|---|
| \`tier\` | **STANDARD_HA** | Mitigación R-DA-REDIS-SPOF ✅ |
| \`location_id\` / \`alternative_location_id\` | \`southamerica-west1-b\` / \`-a\` | Cross-zone failover automático |
| \`replica_count\` | 1 | Failover replica |
| \`auth_enabled\` | true | Password auth requerida |
| \`transit_encryption_mode\` | SERVER_AUTHENTICATION | TLS con server cert |
| \`connect_mode\` | PRIVATE_SERVICE_ACCESS | VPC peering, sin egress público |
| \`redis_version\` | REDIS_7_2 | Vigente |

### Drift check

\`\`\`
$ terraform plan -target=google_redis_instance.main
No changes. Your infrastructure matches the configuration.
\`\`\`

## Evidencia

- **Archivo nuevo**: \`.specs/sec-001-cierre/sprint-1-evidence/t1-redis-state.md\` (62 líneas).
- **Plan**: T1 marcado \`[DONE 2026-05-25 — no-op, state ya STANDARD_HA]\`.
- **Open questions cerradas**: OQ-PLAN-1 (recurso = \`google_redis_instance.main\`) + OQ-PLAN-8 (state = STANDARD_HA).

## Sin riesgo de downtime

T1.1 sub-step (recreate desde BASIC) **NO** se ejecuta. Sin maintenance window. Sin rollback. Sin cambio de comportamiento runtime.

## Habilita T9 + T10

T9 (rate-limit-pin middleware, fail-closed si Redis down) depende de T1. Con T1 cerrado, T9 puede arrancar — el middleware tendrá garantía de que el counter persiste tras failover de zona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)