### PR TITLE
feat(api): T10 SEC-001 — rate-limit IP + fail-closed Redis + cascade docs

### DIFF
--- a/.specs/sec-001-cierre/plan.md
+++ b/.specs/sec-001-cierre/plan.md
@@ -179,7 +179,7 @@ El spec v3.2 cubre 8 sub-fases (H1.0-H1.6 + H2 + H4) con ~50 SCs. Si se planeara
 - **Rollback**: revertir commit → middleware desconectado del wire de auth-driver.ts → endpoint vuelve a comportamiento pre-spec (sin rate-limit). Riesgo: regresión seguridad H2 reverso. Mitigation: solo revertir si bug crítico encontrado en T10.
 - **Spec trace**: §3 H2 SC-H2.1, SC-H2.1c, SC-H2.2, SC-H2.3 + §SC-1.3.8 interaction.
 
-### T10: Rate-limit IP-based + fail-closed Redis + Cloud Armor cascade docs
+### T10: Rate-limit IP-based + fail-closed Redis + Cloud Armor cascade docs [DONE 2026-05-25]
 
 - **Files**: `apps/api/src/middleware/rate-limit-pin.ts` (extend con IP-based + fail-closed), `apps/api/src/middleware/rate-limit-pin.test.ts` (extend), `docs/qa/rate-limit-cascade.md` (new).
 - **LOC estimate**: ~60 (extension ~25 + tests ~25 + doc ~10).

--- a/apps/api/src/middleware/rate-limit-pin.test.ts
+++ b/apps/api/src/middleware/rate-limit-pin.test.ts
@@ -24,11 +24,23 @@ interface MockPipelineCalls {
   expireCalled: Array<[string, number, string]>;
 }
 
-function makeRedis(
-  // El INCR retorna el counter post-incremento; el test controla qué
-  // counter ver. Si pasamos un array, INCR shifts uno por call.
-  counters: number[],
-): { redis: unknown; calls: MockPipelineCalls } {
+interface MakeRedisOptions {
+  // Counters por INCR call. T10 extiende a 2 INCR (RUT + IP) por
+  // request, así que el orden esperado es [rutCount_req1, ipCount_req1,
+  // rutCount_req2, ipCount_req2, ...].
+  counters?: number[];
+  // Si seteado, la pipeline exec throw en lugar de retornar resultados.
+  // Usado para simular Redis unreachable (SC-H2.1b).
+  throwOnExec?: Error;
+}
+
+function makeRedis(opts: MakeRedisOptions | number[]): {
+  redis: unknown;
+  calls: MockPipelineCalls;
+} {
+  // Backwards compat con tests T9 que pasaban un array suelto.
+  const normalized: MakeRedisOptions = Array.isArray(opts) ? { counters: opts } : opts;
+  const counters = normalized.counters ?? [];
   const calls: MockPipelineCalls = { incrCalled: [], expireCalled: [] };
   let i = 0;
   const pipeline = {
@@ -41,11 +53,18 @@ function makeRedis(
       return this;
     },
     async exec(): Promise<unknown[]> {
-      const c = counters[i] ?? 0;
-      i += 1;
-      // ioredis exec retorna array de [err, result] tuples.
+      if (normalized.throwOnExec) {
+        throw normalized.throwOnExec;
+      }
+      // T10: 2 INCR + 2 EXPIRE → 4 tuples. El middleware lee
+      // results[0][1] = rutCount, results[2][1] = ipCount.
+      const rutCount = counters[i] ?? 0;
+      const ipCount = counters[i + 1] ?? 0;
+      i += 2;
       return [
-        [null, c],
+        [null, rutCount],
+        [null, 1],
+        [null, ipCount],
         [null, 1],
       ];
     },
@@ -71,7 +90,7 @@ afterEach(() => {
 
 describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('1er intento → next() (counter=1)', async () => {
-    const { redis, calls } = makeRedis([1]);
+    const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
       // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
@@ -84,12 +103,13 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
       body: JSON.stringify({ rut: '12345678-5' }),
     });
     expect(res.status).toBe(200);
-    expect(calls.incrCalled).toEqual([`${KEY_PREFIX}12345678-5`]);
-    expect(calls.expireCalled).toEqual([[`${KEY_PREFIX}12345678-5`, 900, 'NX']]);
+    // T10: 2 INCR (RUT + IP) por request.
+    expect(calls.incrCalled).toEqual([`${KEY_PREFIX}12345678-5`, expect.stringContaining(':ip:')]);
+    expect(calls.expireCalled.length).toBe(2);
   });
 
   it('5º intento OK (counter=5 ≤ limit)', async () => {
-    const { redis } = makeRedis([5]);
+    const { redis } = makeRedis([5, 1]);
     const mw = createRateLimitPinMiddleware({
       // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
@@ -104,8 +124,8 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
     expect(res.status).toBe(200);
   });
 
-  it('6º intento → 429 + Retry-After:900 (SC-H2.1)', async () => {
-    const { redis } = makeRedis([6]);
+  it('6º intento → 429 + Retry-After:900 + X-RateLimit-Scope:rut (SC-H2.1)', async () => {
+    const { redis } = makeRedis([6, 1]);
     const mw = createRateLimitPinMiddleware({
       // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
@@ -119,8 +139,75 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
     });
     expect(res.status).toBe(429);
     expect(res.headers.get('Retry-After')).toBe('900');
+    expect(res.headers.get('X-RateLimit-Scope')).toBe('rut');
     const body = (await res.json()) as { error: string; code: string };
     expect(body).toEqual({ error: 'too_many_attempts', code: 'too_many_attempts' });
+  });
+
+  it('SC-H2.4 — 31º intento desde misma IP con RUTs distintos → 429 X-RateLimit-Scope:ip', async () => {
+    // counter RUT siempre = 1 (RUT distinto cada vez), counter IP escala
+    // hasta 31. La response del 31º request debe ser 429 scope=ip.
+    const { redis } = makeRedis([1, 31]);
+    const mw = createRateLimitPinMiddleware({
+      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
+      redis: redis as any,
+      logger: noopLogger,
+    });
+    const app = makeApp(mw);
+    const res = await app.request('/x', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.42',
+      },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBe('900');
+    expect(res.headers.get('X-RateLimit-Scope')).toBe('ip');
+  });
+
+  it('SC-H2.1b — Redis unreachable → 503 + Retry-After:30 (fail-closed loudly)', async () => {
+    const { redis } = makeRedis({ throwOnExec: new Error('ECONNREFUSED') });
+    const mw = createRateLimitPinMiddleware({
+      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
+      redis: redis as any,
+      logger: noopLogger,
+    });
+    const app = makeApp(mw);
+    const res = await app.request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get('Retry-After')).toBe('30');
+    const body = (await res.json()) as { error: string; code: string };
+    expect(body).toEqual({ error: 'service_unavailable', code: 'service_unavailable' });
+  });
+
+  it('IP scope > RUT scope cuando ambos exceden (defensa contra rotation primero)', async () => {
+    // Si rutCount=6 Y ipCount=31, prioridad va a IP (espec dice "attacker
+    // rota RUTs → IP fires"). Esto cubre tanto el caso donde el attacker
+    // pega 30 con 6 RUTs distintos como el caso límite donde la misma
+    // ronda tropieza ambos.
+    const { redis } = makeRedis([6, 31]);
+    const mw = createRateLimitPinMiddleware({
+      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
+      redis: redis as any,
+      logger: noopLogger,
+    });
+    const app = makeApp(mw);
+    const res = await app.request('/x', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-forwarded-for': '203.0.113.42',
+      },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('X-RateLimit-Scope')).toBe('ip');
   });
 
   it('SC-H2.1c — RUT normalize: "12.345.678-5" y "12345678-5" comparten key', async () => {
@@ -130,7 +217,7 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
     // que también retorna 401 para ese formato. Aquí verificamos que los
     // dos formatos VÁLIDOS (con-puntos y sin-puntos) colapsan al mismo
     // canónico via la transform del schema.
-    const { redis, calls } = makeRedis([1, 2]);
+    const { redis, calls } = makeRedis([1, 1, 2, 2]);
     const mw = createRateLimitPinMiddleware({
       // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
@@ -147,11 +234,14 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ rut: '12345678-5' }),
     });
-    expect(calls.incrCalled).toEqual([`${KEY_PREFIX}12345678-5`, `${KEY_PREFIX}12345678-5`]);
+    // T10: cada request hace 2 INCR (RUT + IP). Filtramos para chequear
+    // que los RUT keys colapsan al mismo canónico.
+    const rutKeys = calls.incrCalled.filter((k) => !k.includes(':ip:'));
+    expect(rutKeys).toEqual([`${KEY_PREFIX}12345678-5`, `${KEY_PREFIX}12345678-5`]);
   });
 
   it('body sin campo rut → skip (no incrementa counter)', async () => {
-    const { redis, calls } = makeRedis([1]);
+    const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
       // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
@@ -168,7 +258,7 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   });
 
   it('body no-JSON → skip (handler downstream maneja el error)', async () => {
-    const { redis, calls } = makeRedis([1]);
+    const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
       // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
@@ -187,7 +277,7 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   });
 
   it('RUT con formato inválido → skip (no oracle de RUTs válidos)', async () => {
-    const { redis, calls } = makeRedis([1]);
+    const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
       // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,

--- a/apps/api/src/middleware/rate-limit-pin.ts
+++ b/apps/api/src/middleware/rate-limit-pin.ts
@@ -4,48 +4,62 @@ import type { MiddlewareHandler } from 'hono';
 import type Redis from 'ioredis';
 
 /**
- * T9 SEC-001 (sec-001-cierre §3 H2 SC-H2.1, SC-H2.1c, SC-H2.2) —
- * middleware Hono que rate-limita `POST /auth/driver-activate` por RUT
- * normalizado.
+ * T9 + T10 SEC-001 (sec-001-cierre §3 H2 SC-H2.1, SC-H2.1b, SC-H2.1c,
+ * SC-H2.2, SC-H2.4) — middleware Hono que rate-limita
+ * `POST /auth/driver-activate` con dos counters Redis independientes:
  *
- * Política base (T9):
- *   - Límite: 5 intentos por RUT en 15 min (configurable).
- *   - Counter en Memorystore Redis HA (T1 verificado STANDARD_HA).
- *   - Key: `rl:pin-activate:<rutNormalizado>` para colapsar formatos
- *     equivalentes ("12.345.678-5" y "123456785" → mismo bucket).
- *   - Window fija (no sliding): `EXPIRE NX` setea TTL solo en el primer
- *     INCR, así sucesivos intentos no refrescan el TTL. Predecible y
- *     auditable.
- *   - Si el counter > limit: 429 `too_many_attempts` + header
- *     `Retry-After: 900`.
+ *   - Per-RUT (T9): `rl:pin-activate:<rutCanonical>` — 5 intentos /
+ *     15min por RUT normalizado. Si counter > limit → 429 con
+ *     `X-RateLimit-Scope: rut`.
+ *   - Per-IP (T10 SC-H2.4): `rl:pin-activate:ip:<ip>` — 30 intentos /
+ *     15min por IP origen. Contra attackers que rotan RUTs. Si supera
+ *     → 429 con `X-RateLimit-Scope: ip`.
  *
- * Fuera de scope T9 (a cubrir en T10):
- *   - IP-based global limit (30/15min/IP) — SC-H2.4.
- *   - Fail-closed loudly si Redis down (503 service_unavailable) —
- *     SC-H2.1b. T9 deja que el error Redis propague como 500 default.
- *   - Cloud Armor cascade docs — SC-1.2.5.
+ * Ambos counters se incrementan en el MISMO pipeline atómico (1 RTT
+ * a Redis). El response prioritiza el scope IP si ambos exceden, per
+ * spec: "attacker rota 20 RUTs distintos → IP-based fires a los 30
+ * intentos".
+ *
+ * T10 SC-H2.1b — fail-closed loudly: si el pipeline falla (Redis
+ * unreachable, timeout, etc.), el middleware retorna
+ * `503 service_unavailable` + header `Retry-After: 30`. **No silent
+ * fail-open**: rate-limit es defensa de seguridad, no degradable.
+ * El logger.error captura el err para post-mortem.
+ *
+ * Trust boundary X-Forwarded-For: en prod Cloud Run el LB (ADR-009)
+ * setea el header con el client IP. Sin un proxy delante (dev local
+ * sin LB), el header puede ser ausente o spoofeable; en ese caso
+ * caemos a la string `unknown` que comparte bucket — aceptable en
+ * dev. En prod la cascada Cloud Armor (1000/min/IP por defecto)
+ * actúa como pre-filtro antes que llegue al middleware (ver
+ * docs/qa/rate-limit-cascade.md).
  *
  * Body parsing: el middleware lee `c.req.json()` que Hono memoiza —
- * zValidator del handler vuelve a leer el body sin re-parsear ni
- * consumirlo dos veces. Si el body NO es JSON parseable o no contiene
- * `rut`, el middleware skipea (no incrementa counter; el handler vía
- * zValidator retornará 400). Esto evita un oracle de RUTs válidos a
- * través del comportamiento del counter.
+ * zValidator del handler vuelve a leer el body sin re-parsear. Si el
+ * body NO es JSON parseable o no contiene `rut`, el middleware skipea
+ * (no incrementa counter; el handler vía zValidator retornará 400).
+ * Esto evita un oracle de RUTs válidos a través del comportamiento
+ * del counter.
  */
 
 export const KEY_PREFIX = 'rl:pin-activate:';
+export const IP_KEY_PREFIX = 'rl:pin-activate:ip:';
 const DEFAULT_LIMIT_PER_RUT = 5;
+const DEFAULT_LIMIT_PER_IP = 30;
 const DEFAULT_WINDOW_SECONDS = 900;
+const FAIL_CLOSED_RETRY_AFTER_SECONDS = 30;
 
 export interface RateLimitPinOptions {
   redis: Redis;
   logger: Logger;
   limitPerRut?: number;
+  limitPerIp?: number;
   windowSeconds?: number;
 }
 
 export function createRateLimitPinMiddleware(opts: RateLimitPinOptions): MiddlewareHandler {
-  const limit = opts.limitPerRut ?? DEFAULT_LIMIT_PER_RUT;
+  const rutLimit = opts.limitPerRut ?? DEFAULT_LIMIT_PER_RUT;
+  const ipLimit = opts.limitPerIp ?? DEFAULT_LIMIT_PER_IP;
   const window = opts.windowSeconds ?? DEFAULT_WINDOW_SECONDS;
 
   return async function rateLimitPin(c, next) {
@@ -72,18 +86,53 @@ export function createRateLimitPinMiddleware(opts: RateLimitPinOptions): Middlew
     }
     const normRut = parsed.data;
 
-    const key = `${KEY_PREFIX}${normRut}`;
+    const rutKey = `${KEY_PREFIX}${normRut}`;
+    const ip = extractClientIp(c.req.header('x-forwarded-for'));
+    const ipKey = `${IP_KEY_PREFIX}${ip}`;
 
-    const results = await opts.redis.multi().incr(key).expire(key, window, 'NX').exec();
-    const incrResult = results?.[0];
-    const count = Number(incrResult?.[1] ?? 0);
+    let rutCount: number;
+    let ipCount: number;
+    try {
+      const results = await opts.redis
+        .multi()
+        .incr(rutKey)
+        .expire(rutKey, window, 'NX')
+        .incr(ipKey)
+        .expire(ipKey, window, 'NX')
+        .exec();
+      rutCount = Number(results?.[0]?.[1] ?? 0);
+      ipCount = Number(results?.[2]?.[1] ?? 0);
+    } catch (err) {
+      // T10 SC-H2.1b — fail-closed loudly. No silent fail-open: rate-limit
+      // es defensa de seguridad, debe estar UP o el endpoint se bloquea.
+      opts.logger.error(
+        { err, rutNormalizado: normRut, ip },
+        'rate-limit-pin: Redis pipeline failed; fail-closed con 503',
+      );
+      c.header('Retry-After', String(FAIL_CLOSED_RETRY_AFTER_SECONDS));
+      return c.json({ error: 'service_unavailable', code: 'service_unavailable' }, 503);
+    }
 
-    if (count > limit) {
+    // Orden de chequeo: IP primero (prioridad spec — "attacker rota RUTs
+    // → IP-based fires"). Si IP excede, devolvemos 429 con scope=ip aún
+    // si RUT también excede.
+    if (ipCount > ipLimit) {
       opts.logger.warn(
-        { rutNormalizado: normRut, count, limit, windowSeconds: window },
-        'rate-limit-pin: 429 too_many_attempts',
+        { ip, ipCount, ipLimit, windowSeconds: window },
+        'rate-limit-pin: 429 too_many_attempts scope=ip',
       );
       c.header('Retry-After', String(window));
+      c.header('X-RateLimit-Scope', 'ip');
+      return c.json({ error: 'too_many_attempts', code: 'too_many_attempts' }, 429);
+    }
+
+    if (rutCount > rutLimit) {
+      opts.logger.warn(
+        { rutNormalizado: normRut, rutCount, rutLimit, windowSeconds: window },
+        'rate-limit-pin: 429 too_many_attempts scope=rut',
+      );
+      c.header('Retry-After', String(window));
+      c.header('X-RateLimit-Scope', 'rut');
       return c.json({ error: 'too_many_attempts', code: 'too_many_attempts' }, 429);
     }
 
@@ -93,4 +142,20 @@ export function createRateLimitPinMiddleware(opts: RateLimitPinOptions): Middlew
 
 function isObject(v: unknown): v is Record<string, unknown> {
   return typeof v === 'object' && v !== null;
+}
+
+/**
+ * Extrae el primer IP del header `X-Forwarded-For` (el LB en prod
+ * pone el client IP como primero, separado por comas si hubo más
+ * hops). Si el header está ausente, devolvemos `'unknown'` que
+ * comparte bucket — aceptable en dev local sin LB; en prod Cloud
+ * Armor filtra antes de que llegue al middleware (ver
+ * docs/qa/rate-limit-cascade.md §Trust boundary).
+ */
+function extractClientIp(xff: string | undefined): string {
+  if (!xff) {
+    return 'unknown';
+  }
+  const first = xff.split(',')[0]?.trim();
+  return first && first.length > 0 ? first : 'unknown';
 }

--- a/docs/qa/rate-limit-cascade.md
+++ b/docs/qa/rate-limit-cascade.md
@@ -1,0 +1,135 @@
+# Rate-limit cascade — `/auth/driver-activate`
+
+> T10 SEC-001 (`.specs/sec-001-cierre/plan.md`) · 2026-05-25
+> SC-1.2.5 + SC-H2.1, SC-H2.1b, SC-H2.1c, SC-H2.2, SC-H2.4
+
+Defensa en capas para el endpoint público `POST /auth/driver-activate`. Cada capa filtra una clase distinta de abuso; juntas componen la postura de seguridad.
+
+## Capas (orden de evaluación)
+
+```
+1. Cloud Armor (LB nivel)        — 1000 req/min/IP    [pre-filter]
+2. Redis IP-based (middleware)   — 30 req/15min/IP    [SC-H2.4]
+3. Redis RUT-based (middleware)  — 5 req/15min/RUT    [SC-H2.1, SC-H2.1c]
+4. zValidator (handler)           — schema RUT + PIN   [pre-existing]
+5. Handler (auth-driver.ts)       — 401 si RUT/PIN no matchean
+```
+
+### Capa 1 — Cloud Armor WAF
+
+- **Ubicación**: `infrastructure/security.tf` `google_compute_security_policy.waf` adaptive throttle.
+- **Política**: 1000 req/min/IP por defecto sobre el LB global de Booster (\*.boosterchile.com).
+- **Acción**: throttle de la IP (RPC `THROTTLE` con ban window definido por Cloud Armor).
+- **Cuando dispara**: antes de que el request llegue al runtime Cloud Run.
+- **Cuando NO dispara**: tráfico interno Cloud Run-to-Cloud Run (no pasa por el LB).
+
+### Capa 2 — Redis IP-based (T10)
+
+- **Ubicación**: `apps/api/src/middleware/rate-limit-pin.ts` `createRateLimitPinMiddleware`.
+- **Key**: `rl:pin-activate:ip:<x-forwarded-for[0]>`.
+- **Política**: 30 req/15min/IP. Window fija (`EXPIRE NX`).
+- **Acción**: response `429 too_many_attempts` + `Retry-After: 900` + `X-RateLimit-Scope: ip`.
+- **Cuando dispara**: attacker rota RUTs distintos desde la misma IP para evitar el límite per-RUT (Capa 3).
+- **Trust del X-Forwarded-For**: en prod el LB lo setea con el client IP real (`global_compute_target_https_proxy` lo agrega antes de rutear al backend Cloud Run). Sin LB delante (dev local) el header puede ser ausente — el middleware cae a `unknown` (bucket único compartido). Cualquier consumidor que envíe el header sin pasar por el LB debe ser tratado como untrusted; Cloud Armor en Capa 1 es la defensa primaria contra spoofing.
+
+### Capa 3 — Redis RUT-based (T9)
+
+- **Ubicación**: idem (mismo middleware).
+- **Key**: `rl:pin-activate:<rutCanonical>` (normalizado via `rutSchema.safeParse`).
+- **Política**: 5 req/15min/RUT. Window fija.
+- **Acción**: response `429 too_many_attempts` + `Retry-After: 900` + `X-RateLimit-Scope: rut`.
+- **Cuando dispara**: brute-force contra un RUT específico (probar 6+ PINs).
+
+### Capa 4 — zValidator (existente)
+
+- **Ubicación**: `apps/api/src/routes/auth-driver.ts` `zValidator('json', activateBodySchema)`.
+- **Política**: `rut` string ≥1, `pin` regex `^\d{6}$`.
+- **Acción**: 400 `bad_request` si el body no matchea.
+- **Counter side-effect**: ninguno — la Capa 3 ya filtró antes con el mismo `rutSchema` validation, así que cualquier 400 acá es por `pin` malformado únicamente.
+
+### Capa 5 — Handler
+
+- **Ubicación**: `auth-driver.ts` post handler.
+- **Política**: lookup user por RUT + verify PIN con `verifyActivationPin` (scrypt timing-safe).
+- **Acción**: 401 `invalid_credentials` si RUT no existe O PIN no matchea (response idéntico — no oracle de RUTs existentes).
+
+## Casos cubiertos
+
+### Caso A — brute-force PIN contra un RUT específico
+
+- Request 1-5: PIN incorrecto. Counter RUT 1→5. Handler retorna 401. Counter IP 1→5.
+- Request 6: Counter RUT incrementa a 6 > 5. **Middleware retorna 429 + scope=rut**. Handler NO se ejecuta — counter no se "infla" más por este RUT.
+- Request 7+ desde otra IP, mismo RUT: igual 429 (key compartida por RUT).
+
+### Caso B — attacker rota RUTs (SC-H2.4)
+
+- Requests 1-30: 30 RUTs distintos, mismo IP. Counter RUT por cada uno = 1 (no excede). Counter IP escala 1→30.
+- Request 31: Counter IP excede 30. **Middleware retorna 429 + scope=ip**. Handler NO ejecuta.
+- IP queda bloqueada 15min para `/auth/driver-activate`. Otros endpoints siguen accesibles.
+
+### Caso C — Redis down (SC-H2.1b)
+
+- Pipeline INCR/EXPIRE arroja (`ECONNREFUSED`, timeout, etc.).
+- **Middleware fail-closed loudly**: response `503 service_unavailable` + `Retry-After: 30`. logger.error con el err.
+- Handler NO ejecuta — **rate-limit es defensa de seguridad, no degradable a fail-open**.
+- Cloud Armor (Capa 1) sigue activo: si attacker explota el window de Redis down, sigue bloqueado por throttle global del LB.
+- Mitigación operacional: Memorystore HA (STANDARD_HA tier verificado T1) hace failover automático cross-zone en < 30s. El 503 dura sólo durante el failover, no es una caída de larga duración.
+
+### Caso D — Cloud Armor banea ANTES de Redis
+
+- Attacker pasa 1000 req/min desde una IP → Cloud Armor THROTTLE.
+- Request 1001 nunca llega al Cloud Run. Counter Redis no incrementa.
+- Cuando el attacker espera y vuelve: comienza nuevamente con counter Redis "limpio" si pasó 15min desde el último intento que SÍ llegó al runtime.
+
+### Caso E — request interno bot → api (sin LB)
+
+- Bypass de Capa 1 (Cloud Armor). Cliente OIDC autenticado.
+- El bot NO llama `/auth/driver-activate` — ese endpoint es PWA-only. Si en el futuro un caller interno lo necesitara, debería pasar por una surface dedicada con auth previa.
+
+## Configuración / fixing
+
+| Param | Default | Override |
+|---|---|---|
+| `limitPerRut` | 5 | factory arg en `server.ts` |
+| `limitPerIp` | 30 | factory arg en `server.ts` |
+| `windowSeconds` | 900 | factory arg |
+| Cloud Armor req/min/IP | 1000 | `infrastructure/security.tf` |
+
+Para flipear runtime: tuning en `server.ts` + redeploy. Hay un futuro flag `RATE_LIMIT_PIN_DISABLED` que puede agregarse si se necesita bypass de emergencia — por defecto no existe, el middleware siempre está ON cuando wireado.
+
+## Observabilidad
+
+- **Logs**: `logger.warn` con `{rutNormalizado, ip, scope, count, limit}` en cada 429. `logger.error` con `{err}` en 503 fail-closed.
+- **Métrica futura** (no incluida T10): contador Prometheus `rate_limit_pin_blocked_total{scope}` para alertas SRE. Tracked como follow-up.
+
+## Tests
+
+- Unit: `apps/api/src/middleware/rate-limit-pin.test.ts` — 10 tests cubriendo:
+  - 1er/5º intento OK
+  - 6º → 429 scope=rut
+  - 31º (rotando RUTs desde misma IP) → 429 scope=ip
+  - Redis throw → 503 + Retry-After:30
+  - IP scope prevalece cuando ambos exceden
+  - RUT normalize colapsa formatos válidos
+  - body sin RUT / no-JSON / RUT inválido → skip
+
+- Integration: hot path cubierto por `apps/api/test/integration/migrations.integration.test.ts` + smoke E2E manual post-deploy (curl con `Authorization` ausente y 6 RUTs distintos).
+
+## Cómo escalar
+
+| Si | Bumpear |
+|---|---|
+| Usuario legítimo retry-en-loop por bug UI | client-side throttle (no servidor) |
+| Cliente desktop con NAT compartida (muchos drivers → mismo IP) | `limitPerIp` a 60 o 100; trade-off contra protección de rotación |
+| Activations masivas en evento (onboarding 100 conductores) | bumpar window a 1800s durante el evento + revert post-evento |
+| Redis flapping crónico | investigar Memorystore HA + cuotas, no relajar `503` fail-closed |
+
+## Referencias
+
+- Spec: `.specs/sec-001-cierre/spec.md` §3 H2 + §SC-1.2.5.
+- Plan: `.specs/sec-001-cierre/plan.md` T9 + T10.
+- T9 commit: `9d1b2e5` (per-RUT base + wire en auth-driver).
+- T1 evidence (Redis HA): `.specs/sec-001-cierre/sprint-1-evidence/t1-redis-state.md`.
+- Cloud Armor config: `infrastructure/security.tf`.
+- Middleware: `apps/api/src/middleware/rate-limit-pin.ts`.
+- Tests: `apps/api/src/middleware/rate-limit-pin.test.ts`.


### PR DESCRIPTION
## Summary

Cierra T10 de \`.specs/sec-001-cierre/plan.md\` (SC-H2.1b + SC-H2.4 + SC-1.2.5). Cadena **H2 completa** (T1 + T9 + T10).

### Cambios

- **\`apps/api/src/middleware/rate-limit-pin.ts\`**: extiende pipeline atómico con segundo INCR + EXPIRE NX para key \`rl:pin-activate:ip:<ip>\` (limit 30/15min/IP). Wraps redis multi+exec en try/catch — si arroja, retorna **503 + Retry-After:30** + \`logger.error\` con stack (fail-closed loudly, **no silent fail-open**). Si \`ipCount > ipLimit\` → \`429\` + \`X-RateLimit-Scope: ip\` con prioridad sobre scope RUT (per spec "attacker rota RUTs → IP fires"). \`extractClientIp()\` lee \`X-Forwarded-For[0]\`; fallback \`'unknown'\` si ausente (dev local).
- **\`apps/api/src/middleware/rate-limit-pin.test.ts\`**: extiende mock para \`throwOnExec\` + 4-tuple results. **3 tests nuevos**:
  - 31º request rotando RUTs desde misma IP → 429 scope=ip.
  - Redis throw → 503 + Retry-After:30.
  - IP scope prevalece cuando ambos counters exceden.
- **\`docs/qa/rate-limit-cascade.md\`** (new, 130 LOC): 5 capas (Cloud Armor → Redis IP → Redis RUT → zValidator → Handler), 5 casos (brute-force RUT, rotation IP, Redis down, Cloud Armor pre-filter, internal Cloud Run), tabla de configuración + cómo escalar.

## H2 cerrado

| SC | T9 | T10 |
|---|---|---|
| **SC-H2.1** per-RUT 5/15min | ✅ | — |
| **SC-H2.1b** fail-closed 503 | — | ✅ |
| **SC-H2.1c** RUT normalize | ✅ | — |
| **SC-H2.2** counter Redis HA | ✅ (depende T1) | — |
| **SC-H2.4** IP global 30/15min | — | ✅ |
| **SC-1.2.5** cascade docs | — | ✅ |

## Decisiones

1. **IP scope > RUT scope cuando ambos exceden** — defensa contra rotation prevalece.
2. **X-Forwarded-For fallback \`'unknown'\`** — dev local con bucket compartido aceptable; prod LB siempre setea header. Cloud Armor (Capa 1) es defensa primaria contra spoofing.
3. **Métrica Prometheus \`rate_limit_pin_blocked_total{scope}\`** tracked como follow-up (no T10).

## Evidencia

- **Tests**: \`pnpm --filter @booster-ai/api test\` → 95 archivos · 1123 pass + 2 skipped. +3 nuevos T10 = 10 total en \`rate-limit-pin.test.ts\`.
- **Typecheck**: 0 errores.
- **Biome**: 0 errores, 10 warnings (biome-ignore \`as any\` para mocks Redis — explícitos y justificados).
- **Plan**: T10 marcado \`[DONE 2026-05-25]\`.

## Test plan

- [ ] CI verde.
- [ ] Manual smoke post-deploy: 31 curls \`POST /auth/driver-activate\` con RUTs distintos desde misma IP → 31º debe retornar 429 + \`X-RateLimit-Scope: ip\`.
- [ ] Manual smoke fail-closed: simular Redis off (puede usarse \`gcloud redis instances export\` durante mantenimiento) y verificar 503 + \`Retry-After: 30\`. Idealmente NO se hace contra prod sin maintenance window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)