### PR TITLE
build(api): add harden-demo-accounts entry to tsup config

### DIFF
--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -13,7 +13,13 @@ import { defineConfig } from 'tsup';
  * autocontenido. Elegimos bundling por simplicidad del Dockerfile.
  */
 export default defineConfig({
-  entry: ['src/main.ts', 'src/jobs/merge-duplicate-users.ts'],
+  entry: [
+    'src/main.ts',
+    'src/jobs/merge-duplicate-users.ts',
+    // T4 SEC-001 Sprint 2a — service module consumido por
+    // apps/api/scripts/harden-demo-accounts.mjs CLI wrapper.
+    'src/services/harden-demo-accounts.ts',
+  ],
   format: ['esm'],
   clean: true,
   sourcemap: true,


### PR DESCRIPTION
Agrega entry point para harden-demo-accounts en tsup.config.ts, requerido para que el build produzca dist/services/harden-demo-accounts.js