### PR TITLE
docs(sec-001): T4 + T7b cierre — one-shot retire evidencia + ADR-053 Accepted

### DIFF
--- a/.specs/sec-001-cierre/sprint-2a-evidence/t4-one-shot-retire.md
+++ b/.specs/sec-001-cierre/sprint-2a-evidence/t4-one-shot-retire.md
@@ -1,0 +1,111 @@
+# T4 SEC-001 — One-shot retire evidencia (2026-05-25)
+
+- **Sprint**: 2a
+- **Spec**: `.specs/sec-001-cierre/spec.md` §3 H1.1 (SC-1.1.1..SC-1.1.5)
+- **Plan**: `.specs/sec-001-cierre/plan-sprint-2a.md` T4
+- **ADR**: `docs/adr/053-post-disclosure-account-replacement.md` (Status: Accepted)
+- **Runbook**: `docs/qa/demo-accounts.md`
+- **Servicio**: `apps/api/src/services/harden-demo-accounts.ts`
+- **CLI**: `apps/api/scripts/harden-demo-accounts.mjs`
+- **Ejecutado por**: dev@boosterchile.com desde Cloud Shell
+
+## Timeline operacional
+
+| Timestamp UTC | Step | Resultado |
+|---|---|---|
+| ~19:26 | PR #344 (tsup entry + apply evidencia) green CI, mergeado a `main` | `9956ded` |
+| ~19:30 | Cloud Shell clone + `pnpm install` + `pnpm --filter @booster-ai/api build` | `dist/services/harden-demo-accounts.js` generado |
+| ~19:32 | `cloud-sql-proxy --port=5432 --auto-iam-authn --private-ip &` | Aceptando conexiones localhost:5432 |
+| ~19:48 | `tsx apps/api/scripts/harden-demo-accounts.mjs --recreate` | `created: 4, skipped: 0`, durationMs=4537 |
+| 20:42:51 | Cloud SQL proxy accepted connection retire batch | OK |
+| 20:42:52..54 | 4× `event: audit.demo_uid_retired` emitted | OK |
+| 20:42:54 | `retire-old-batch done`: `retired: 4, skippedAlreadyDisabled: 0, failed: []`, durationMs=3435 | Window-of-overlap CERRADA |
+
+**Window-of-overlap duration**: ~50 minutos (19:48Z recreate → 20:42Z retire). Bien dentro del SLA 4h.
+
+## UIDs nuevas (post-recreate, activas)
+
+| Persona | Email | Firebase UID nuevo | TTL (expires_at) |
+|---|---|---|---|
+| `generador_carga` | `demo-2026-shipper@boosterchile.com` | `GtVtmajwdtU6UARYQDykP8AW1Vx2` | 2026-06-24 (30d default) |
+| `transportista` | `demo-2026-carrier@boosterchile.com` | `4DDODougqUXNkm7jTZJgkJKs5z2` | 2026-06-24 |
+| `stakeholder` | `demo-2026-stakeholder@boosterchile.com` | `1h10ASeyeUSP18B7IKLXveZCxt82` | 2026-06-24 |
+| `conductor` | `drivers+demo-2026-conductor@boosterchile.invalid` | `P4fuEB3HIzOAqr4m4X1vJjA7cam1` | 2026-06-24 |
+
+Passwords iniciales: Secret Manager `demo-account-password-{shipper,carrier,stakeholder,conductor-firebase}-2026` version 1 (creados por `init-demo-secrets-2026.sh` 2026-05-25 ~17:55Z).
+
+## UIDs viejas (post-retire, disabled — vector cerrado)
+
+| Persona original | Firebase UID viejo | Estado post-retire |
+|---|---|---|
+| demo-shipper | `nQSqGqVCHGUn8yrU21uFtnLvaCK2` | `disabled: true` + custom claim `audit_demo_uid_retired` |
+| demo-stakeholder | `Uxa37UZPAEPWPYEhjjG772ELOiI2` | `disabled: true` + custom claim `audit_demo_uid_retired` |
+| demo-carrier | `s1qSYAUJZcUtjGu4Pg2wjcjgd2o1` | `disabled: true` + custom claim `audit_demo_uid_retired` |
+| conductor (drivers+123456785) | `Gg9k3gIPa1cJZtgKC0RRkWQ0QHJ3` | `disabled: true` + custom claim `audit_demo_uid_retired` |
+
+`cuentas_demo.deshabilitado_en` synced para los 4. Reason: `post-disclosure replacement 2026-05-24 (ADR-053)`.
+
+## Audit log output (extraído de Cloud Shell)
+
+```
+[2026-05-25 20:42:52.205 +0000] INFO:
+    event: "audit.demo_uid_retired"
+    uid: "nQSqGqVCHGUn8yrU21uFtnLvaCK2"
+    reason: "post-disclosure replacement 2026-05-24 (ADR-053)"
+    message: "harden-demo-accounts.retire: UID disabled + audit log + cuentas_demo.deshabilitado_en synced"
+
+[2026-05-25 20:42:52.988 +0000] INFO:
+    event: "audit.demo_uid_retired"
+    uid: "Uxa37UZPAEPWPYEhjjG772ELOiI2"
+    ...
+
+[2026-05-25 20:42:53.530 +0000] INFO:
+    event: "audit.demo_uid_retired"
+    uid: "s1qSYAUJZcUtjGu4Pg2wjcjgd2o1"
+    ...
+
+[2026-05-25 20:42:54.257 +0000] INFO:
+    event: "audit.demo_uid_retired"
+    uid: "Gg9k3gIPa1cJZtgKC0RRkWQ0QHJ3"
+    ...
+
+[2026-05-25 20:42:54.257 +0000] INFO:
+    retired: 4
+    skipped: 0
+    failed: 0
+    dryRun: false
+    message: "harden-demo-accounts.retireOldBatch: batch complete"
+
+[2026-05-25 20:42:54.258 +0000] INFO:
+    result: { "retired": 4, "skippedAlreadyDisabled": 0, "failed": [] }
+    durationMs: 3435
+    message: "retire-old-batch done"
+```
+
+## Verificación success criteria (spec §3 H1.1)
+
+- **SC-1.1.1** (UIDs viejas disabled en Firebase): ✅ 4/4 retired, audit log emitted.
+- **SC-1.1.2** (UIDs nuevas operativas con custom claims `is_demo + persona + expires_at`): ✅ 4/4 created, claims set via `setCustomUserClaims`.
+- **SC-1.1.3** (cuentas_demo synced): ✅ `firebase_uid` actualizado en recreate, `deshabilitado_en` actualizado en retire.
+- **SC-1.1.4** (passwords nuevas en Secret Manager, no en código): ✅ 4 secrets version 1 creados via `init-demo-secrets-2026.sh`.
+- **SC-1.1.5** (audit log `event: audit.demo_uid_retired` emitido por cada retire): ✅ 4 eventos visibles arriba; log-based metric `sec001/demo_uid_retired` debería contar 4.
+
+## Follow-ups inmediatos
+
+1. **Cloud Logging metric verification** (Logs Explorer): query
+   `logName:"projects/booster-ai-494222/logs/run.googleapis.com%2Fstdout" jsonPayload.event="audit.demo_uid_retired"`
+   Debe mostrar 4 eventos del 2026-05-25T20:42Z.
+
+2. **`demo_uid_retired` log-based metric**: ver si el counter incrementó +4 en Cloud Monitoring → Metrics Explorer.
+
+3. **Silent-window guard alert para `demo_uid_retired`** (tracked en `docs/qa/demo-accounts.md` §"Log-based metric ready sin alert todavía"): ahora que hay baseline >0, evaluar crear alert `count(metric) < 4 sustained 4h post-deploy`. Tracked en `.specs/_followups/`.
+
+4. **Renovación TTL próxima**: 2026-06-17 (-7d antes de 2026-06-24) — cron T6a debería emitir `demo.ttl_low` y notificar.
+
+## Referencias
+
+- ADR-053: `docs/adr/053-post-disclosure-account-replacement.md`
+- Runbook: `docs/qa/demo-accounts.md`
+- Plan Sprint 2a: `.specs/sec-001-cierre/plan-sprint-2a.md` §T4
+- Apply terraform: `.specs/sec-001-cierre/sprint-2a-evidence/terraform-apply-2026-05-25.md`
+- PR #344 (tsup entry pre-Cloud-Shell): https://github.com/boosterchile/booster-ai/pull/344

--- a/docs/adr/053-post-disclosure-account-replacement.md
+++ b/docs/adr/053-post-disclosure-account-replacement.md
@@ -1,6 +1,6 @@
 # ADR-053: Post-disclosure account replacement (SEC-001 H1.1)
 
-- **Status**: Proposed (2026-05-25; transitions to Accepted at PR #1 Sprint 2a H1.1 merge per plan T7b).
+- **Status**: Accepted (2026-05-25; T4 one-shot retire ejecutado exitosamente en prod — ver `.specs/sec-001-cierre/sprint-2a-evidence/t4-one-shot-retire.md`)
 - **Date**: 2026-05-25
 - **Deciders**: Felipe Vicencio (PO)
 - **Linked**:

--- a/docs/qa/demo-accounts.md
+++ b/docs/qa/demo-accounts.md
@@ -125,18 +125,20 @@ node apps/api/scripts/harden-demo-accounts.mjs --retire-old-batch
 Las UIDs ya disabled serán contadas como `skippedAlreadyDisabled`. Las
 restantes se retirarán.
 
-## Per-UID metadata (post T4 one-shot)
+## Per-UID metadata (post T4 one-shot — 2026-05-25)
 
-Hasta que T4 `--recreate` corra en prod, los `firebase_uid` no existen
-todavía. Post-recreate, completar esta tabla con los UIDs reales
-extraídos del Firebase console o `gcloud identity-platform accounts:lookup`:
+T4 `--recreate` ejecutado 2026-05-25T~19:48Z en prod desde Cloud Shell.
+T4 `--retire-old-batch` ejecutado 2026-05-25T20:42Z (window-of-overlap ~50min).
+Evidencia: [`t4-one-shot-retire.md`](../../.specs/sec-001-cierre/sprint-2a-evidence/t4-one-shot-retire.md).
 
 | Persona | Email | Firebase UID | Secret name | Owner |
 |---|---|---|---|---|
-| `generador_carga` | `demo-2026-shipper@boosterchile.com` | `<TBD>` | `demo-account-password-shipper-2026` | dev@boosterchile.com |
-| `transportista` | `demo-2026-carrier@boosterchile.com` | `<TBD>` | `demo-account-password-carrier-2026` | dev@boosterchile.com |
-| `stakeholder` | `demo-2026-stakeholder@boosterchile.com` | `<TBD>` | `demo-account-password-stakeholder-2026` | dev@boosterchile.com |
-| `conductor` | `drivers+demo-2026-conductor@boosterchile.invalid` | `<TBD>` | `demo-account-password-conductor-2026-firebase` | dev@boosterchile.com |
+| `generador_carga` | `demo-2026-shipper@boosterchile.com` | `GtVtmajwdtU6UARYQDykP8AW1Vx2` | `demo-account-password-shipper-2026` | dev@boosterchile.com |
+| `transportista` | `demo-2026-carrier@boosterchile.com` | `4DDODougqUXNkm7jTZJgkJKs5z2` | `demo-account-password-carrier-2026` | dev@boosterchile.com |
+| `stakeholder` | `demo-2026-stakeholder@boosterchile.com` | `1h10ASeyeUSP18B7IKLXveZCxt82` | `demo-account-password-stakeholder-2026` | dev@boosterchile.com |
+| `conductor` | `drivers+demo-2026-conductor@boosterchile.invalid` | `P4fuEB3HIzOAqr4m4X1vJjA7cam1` | `demo-account-password-conductor-2026-firebase` | dev@boosterchile.com |
+
+**Próxima renovación TTL**: 2026-06-17 (cron T6a `demo-account-ttl-alert` emitirá `demo.ttl_low`).
 
 **Propósito común**: 4 cuentas demo del subdominio `demo.boosterchile.com`.
 Custom claim `{ is_demo: true, persona: <enum>, expires_at: <ISO+30d> }`.


### PR DESCRIPTION
## Summary

Cierre operacional T4 SEC-001 Sprint 2a + T7b ADR-053 lifecycle transition.

- **ADR-053** Status: `Proposed` → **`Accepted`** (T7b).
- **Nueva evidencia**: `.specs/sec-001-cierre/sprint-2a-evidence/t4-one-shot-retire.md` con timeline + UIDs nuevas/viejas + audit log Cloud Shell + verificación SC-1.1.1..SC-1.1.5.
- **`docs/qa/demo-accounts.md`**: per-UID table completada con UIDs reales post-recreate.

## Resultado operacional (2026-05-25)

| Etapa | Hora UTC | Resultado |
|---|---|---|
| `--recreate` REAL ejecutado | ~19:48 | `created: 4, skipped: 0`, durationMs=4537 |
| `--retire-old-batch` ejecutado | 20:42 | `retired: 4, failed: []`, durationMs=3435 |
| **Window-of-overlap** | ~50 min | Bien dentro SLA 4h |
| `event: audit.demo_uid_retired` emitidos | 4× | log-based metric `sec001/demo_uid_retired` activa |

**Vector compromised passwords (PR #206 disclosure 2026-05-10 → 2026-05-14 audit) CERRADO**.

## UIDs (referencia operativa)

| Persona | UID nuevo (active) | UID viejo (disabled) |
|---|---|---|
| generador_carga | `GtVtmajwdtU6UARYQDykP8AW1Vx2` | `nQSqGqVCHGUn8yrU21uFtnLvaCK2` |
| transportista | `4DDODougqUXNkm7jTZJgkJKs5z2` | `s1qSYAUJZcUtjGu4Pg2wjcjgd2o1` |
| stakeholder | `1h10ASeyeUSP18B7IKLXveZCxt82` | `Uxa37UZPAEPWPYEhjjG772ELOiI2` |
| conductor | `P4fuEB3HIzOAqr4m4X1vJjA7cam1` | `Gg9k3gIPa1cJZtgKC0RRkWQ0QHJ3` |

## Evidencia

### Cambios
- `docs/adr/053-post-disclosure-account-replacement.md` — 1 LOC Status (Proposed → Accepted + evidencia link)
- `.specs/sec-001-cierre/sprint-2a-evidence/t4-one-shot-retire.md` — +110 LOC (nuevo, evidencia operacional canónica)
- `docs/qa/demo-accounts.md` — per-UID table: 4× `<TBD>` → UIDs reales + nota T4 timing

### Solo docs — sin código de producción tocado en este PR

CI debería pasar trivialmente (Biome format only).

## Test plan

- [ ] CI green (lint + typecheck pasarán; tests no aplican para docs)
- [ ] Verificar visualmente Cloud Logging: `jsonPayload.event="audit.demo_uid_retired"` debería mostrar 4 eventos del 2026-05-25T20:42Z
- [ ] Verificar Cloud Monitoring metric `sec001/demo_uid_retired` counter +4

🤖 Generated with [Claude Code](https://claude.com/claude-code)