### PR TITLE
feat(sec-001): H1.2 PR2 — T7 Drizzle migration solicitudes_registro + domain

### DIFF
--- a/.specs/sec-001-cierre/plan-sprint-2b.md
+++ b/.specs/sec-001-cierre/plan-sprint-2b.md
@@ -156,7 +156,7 @@ PR3 discoveries deferred a Sprint 2c.
 - **Rollback**: revertir ambos archivos.
 - **Spec trace**: §3 SC-1.2.0.
 
-### T7: Drizzle migration `solicitudes_registro` + pgEnum + domain schema
+### T7: Drizzle migration `solicitudes_registro` + pgEnum + domain schema [DONE 2026-05-26]
 
 - **Files**: `apps/api/src/db/schema.ts` (modify — agregar `estadoSolicitudRegistroEnum` pgEnum + `solicitudesRegistro` pgTable), `apps/api/drizzle/0039_solicitudes_registro.sql` (nuevo via `drizzle-kit generate`), `packages/shared-schemas/src/domain/signup-request.ts` (nuevo domain canónico)
 - **LOC estimate**: ~80

--- a/apps/api/drizzle/0039_solicitudes_registro.sql
+++ b/apps/api/drizzle/0039_solicitudes_registro.sql
@@ -1,0 +1,64 @@
+-- Migration 0039 — solicitudes_registro: signup público gated por admin-approval
+-- (SEC-001 Sprint 2b H1.2, plan-sprint-2b T7).
+--
+-- Diseño (per spec sec-001-cierre §3 H1.2 SC-1.2.1 + ADR-052):
+--   - Sustituye el flow anterior `createUserWithEmailAndPassword` client-side
+--     (apps/web/src/hooks/use-auth.ts:137) por POST /api/v1/signup-request
+--     que inserta row con estado=pendiente_aprobacion.
+--   - Admin approve (T10) ejecuta Firebase Admin SDK auth.createUser +
+--     UPDATE estado=aprobado + aprobado_por + aprobado_en. Reject solo
+--     actualiza estado=rechazado.
+--   - Email enumeration defense (SC-1.2.5): el endpoint NO revela si email
+--     ya existe; el dedup lo decide service layer T8.
+--
+-- Naming bilingüe (CLAUDE.md §Reglas naming bilingüe):
+--   - Tabla y columnas: español snake_case sin tildes.
+--   - Enum name: snake_case Spanish; values en Spanish per CLAUDE.md.
+--
+-- ADR: docs/adr/052-signup-migration-admin-sdk-gate.md (Proposed 2026-05-26
+-- via PR #351; transiciona a Accepted en T13 post-canary success + 2h watch).
+
+-- 1. Enum estado_solicitud_registro.
+--
+-- Transiciones permitidas (service layer T10 enforced; no CHECK constraint
+-- DB-side porque la transición depende de columnas adicionales):
+--   pendiente_aprobacion → aprobado   (admin approve)
+--   pendiente_aprobacion → rechazado  (admin reject)
+CREATE TYPE "public"."estado_solicitud_registro" AS ENUM (
+  'pendiente_aprobacion',
+  'aprobado',
+  'rechazado'
+);
+--> statement-breakpoint
+-- 2. Tabla solicitudes_registro.
+--
+-- id es uuid (no email PK como cuentas_demo) porque:
+--   - El mismo email puede aparecer en múltiples rows (resubmit tras reject).
+--   - Admin UI necesita un identifier estable en URLs /admin/signup-requests/:id.
+--   - pgcrypto gen_random_uuid es la convención del repo para tablas mutables.
+--
+-- aprobado_por es text (no varchar) porque es columna de audit no consultada
+-- frecuentemente; sin restricción de longitud (Firebase admin emails pueden
+-- variar). aprobado_en es nullable y se setea cuando estado deja de ser
+-- pendiente_aprobacion (service layer mantiene la invariante).
+CREATE TABLE "solicitudes_registro" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "email" varchar(320) NOT NULL,
+  "nombre_completo" varchar(200) NOT NULL,
+  "estado" "estado_solicitud_registro" DEFAULT 'pendiente_aprobacion' NOT NULL,
+  "solicitado_en" timestamptz DEFAULT now() NOT NULL,
+  "aprobado_por" text,
+  "aprobado_en" timestamptz
+);
+--> statement-breakpoint
+COMMENT ON TABLE "solicitudes_registro" IS
+  'SEC-001 Sprint 2b H1.2: signup público gated por admin-approval. POST /api/v1/signup-request inserta row pendiente; admin approve (T10) ejecuta Admin SDK createUser. Ver docs/adr/052-signup-migration-admin-sdk-gate.md.';
+--> statement-breakpoint
+COMMENT ON COLUMN "solicitudes_registro"."email" IS
+  'Email del solicitante. Max 320 chars (RFC 5321). Service layer T8 lowercase y dedupea sin exponer enumeration vector.';
+--> statement-breakpoint
+COMMENT ON COLUMN "solicitudes_registro"."estado" IS
+  'Workflow state. Inicial pendiente_aprobacion; admin approve→aprobado o reject→rechazado. Estados terminales (no más transiciones).';
+--> statement-breakpoint
+COMMENT ON COLUMN "solicitudes_registro"."aprobado_por" IS
+  'Email del admin que tomó la decisión. NULL mientras pending. Audit trail (Ley 19.628 art. 5).';

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1780876800002,
       "tag": "0038_cuentas_demo",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1780876800003,
+      "tag": "0039_solicitudes_registro",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -446,6 +446,23 @@ export const personaDemoEnum = pgEnum('persona_demo', [
   'conductor',
 ]);
 
+/**
+ * SEC-001 Sprint 2b H1.2 — estado enum para solicitudes_registro
+ * (migration 0039). Signup público gated por admin-approval — ver
+ * docs/adr/052-signup-migration-admin-sdk-gate.md. Values Spanish per
+ * CLAUDE.md §Reglas naming bilingüe.
+ *
+ * Transiciones permitidas (service layer T10 enforced):
+ *   pendiente_aprobacion → aprobado   (admin approve)
+ *   pendiente_aprobacion → rechazado  (admin reject)
+ * Sin transiciones desde estados terminales.
+ */
+export const estadoSolicitudRegistroEnum = pgEnum('estado_solicitud_registro', [
+  'pendiente_aprobacion',
+  'aprobado',
+  'rechazado',
+]);
+
 // =============================================================================
 // BILLING / AUTH
 // =============================================================================
@@ -2180,6 +2197,35 @@ export const cuentasDemo = pgTable('cuentas_demo', {
 });
 
 // =============================================================================
+// SEC-001 Sprint 2b H1.2 — solicitudes_registro (migration 0039)
+// =============================================================================
+//
+// Tabla DB-driven que sustenta el flow signup-request → admin-approval gate
+// definido en docs/adr/052-signup-migration-admin-sdk-gate.md. POST
+// /api/v1/signup-request (T8) inserta row con estado=pendiente_aprobacion;
+// admin approve/reject (T10) actualiza estado + approver email + timestamp.
+//
+// Email enumeration defense (SC-1.2.5): la response del endpoint NO depende
+// de si el email ya existe en users o solicitudes_registro — el dedup vive
+// en service layer (T8) sin signal lateral.
+
+export const solicitudesRegistro = pgTable('solicitudes_registro', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  email: varchar('email', { length: 320 }).notNull(),
+  nombreCompleto: varchar('nombre_completo', { length: 200 }).notNull(),
+  estado: estadoSolicitudRegistroEnum('estado').notNull().default('pendiente_aprobacion'),
+  solicitadoEn: timestamp('solicitado_en', { withTimezone: true }).notNull().defaultNow(),
+  /**
+   * Email del admin que aprobó (o rechazó). NULL mientras pending. NOT NULL
+   * post-decision. La service layer (T10) garantiza la invariante; aquí no
+   * lo enforce-amos via CHECK porque la condición es bi-columnar
+   * (estado + aprobado_por NOT NULL) y service-layer es el único writer.
+   */
+  aprobadoPor: text('aprobado_por'),
+  aprobadoEn: timestamp('aprobado_en', { withTimezone: true }),
+});
+
+// =============================================================================
 // TYPE EXPORTS
 // =============================================================================
 
@@ -2256,3 +2302,7 @@ export type NewZonaStakeholderRow = typeof zonasStakeholder.$inferInsert;
 // SEC-001 Sprint 2a H1.1 — cuentas_demo (migration 0038)
 export type CuentaDemoRow = typeof cuentasDemo.$inferSelect;
 export type NewCuentaDemoRow = typeof cuentasDemo.$inferInsert;
+
+// SEC-001 Sprint 2b H1.2 — solicitudes_registro (migration 0039)
+export type SolicitudRegistroRow = typeof solicitudesRegistro.$inferSelect;
+export type NewSolicitudRegistroRow = typeof solicitudesRegistro.$inferInsert;

--- a/apps/api/test/integration/solicitudes-registro-roundtrip.integration.test.ts
+++ b/apps/api/test/integration/solicitudes-registro-roundtrip.integration.test.ts
@@ -1,0 +1,176 @@
+import { signupRequestSchema } from '@booster-ai/shared-schemas';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest';
+import { type TestDbHandle, createTestDb } from '../helpers/test-db.js';
+
+/**
+ * T7 SEC-001 Sprint 2b — Integration test mínimo de roundtrip insert+select
+ * sobre `solicitudes_registro` (migration 0039, spec sec-001-cierre §3 H1.2
+ * SC-1.2.1 foundation). Verifica:
+ *
+ *   1. Migration aplicó el schema correctamente (CREATE TABLE + CREATE TYPE
+ *      enum + defaults).
+ *   2. INSERT con campos mínimos toma defaults (estado, solicitado_en, id).
+ *   3. SELECT round-trip retorna shape que valida contra el domain canónico
+ *      `signupRequestSchema` (packages/shared-schemas/src/domain/signup-request.ts).
+ *   4. Pueden coexistir múltiples rows con mismo email en estados distintos
+ *      (resubmit tras reject scenario).
+ *   5. Las 3 transiciones permitidas del enum (pendiente_aprobacion / aprobado /
+ *      rechazado) son aceptadas como values válidos.
+ *
+ * El test usa raw SQL pool query (pattern seed-demo-cuentas-idempotency) para
+ * no depender de Drizzle ORM API surface — verifica la migración tal como
+ * será aplicada en prod. La validación domain se hace post-fetch sobre los
+ * datos crudos.
+ */
+describe('integration: solicitudes_registro roundtrip + domain validation (SC-1.2.1)', () => {
+  let handle: TestDbHandle;
+
+  beforeAll(() => {
+    handle = createTestDb();
+  });
+
+  afterAll(async () => {
+    await handle.pool.end();
+  });
+
+  beforeEach(async () => {
+    await handle.pool.query('DELETE FROM solicitudes_registro');
+    const after = await handle.pool.query<{ c: number }>(
+      'SELECT count(*)::int as c FROM solicitudes_registro',
+    );
+    expect(after.rows[0].c).toBe(0);
+  });
+
+  test('INSERT con email + nombre_completo toma defaults id/estado/solicitado_en', async () => {
+    const insert = await handle.pool.query<{ id: string }>(
+      `INSERT INTO solicitudes_registro (email, nombre_completo)
+       VALUES ($1, $2)
+       RETURNING id`,
+      ['nuevo@empresa.cl', 'Felipe Vicencio'],
+    );
+    expect(insert.rows[0].id).toMatch(/^[0-9a-f-]{36}$/);
+
+    const select = await handle.pool.query<{
+      id: string;
+      email: string;
+      nombre_completo: string;
+      estado: string;
+      solicitado_en: Date;
+      aprobado_por: string | null;
+      aprobado_en: Date | null;
+    }>(
+      `SELECT id, email, nombre_completo, estado, solicitado_en, aprobado_por, aprobado_en
+       FROM solicitudes_registro WHERE id = $1`,
+      [insert.rows[0].id],
+    );
+
+    expect(select.rows).toHaveLength(1);
+    const row = select.rows[0];
+    expect(row.email).toBe('nuevo@empresa.cl');
+    expect(row.nombre_completo).toBe('Felipe Vicencio');
+    expect(row.estado).toBe('pendiente_aprobacion');
+    expect(row.solicitado_en).toBeInstanceOf(Date);
+    expect(row.aprobado_por).toBeNull();
+    expect(row.aprobado_en).toBeNull();
+
+    // Domain validation: el row crudo de pg + transformación timestamps a ISO
+    // debe parsear contra signupRequestSchema sin throw.
+    const parsed = signupRequestSchema.parse({
+      id: row.id,
+      email: row.email,
+      nombreCompleto: row.nombre_completo,
+      estado: row.estado,
+      requestedAt: row.solicitado_en.toISOString(),
+      approvedBy: row.aprobado_por,
+      approvedAt: row.aprobado_en,
+    });
+    expect(parsed.estado).toBe('pendiente_aprobacion');
+  });
+
+  test('UPDATE a estado=aprobado + aprobado_por + aprobado_en persiste y valida', async () => {
+    const insert = await handle.pool.query<{ id: string }>(
+      `INSERT INTO solicitudes_registro (email, nombre_completo)
+       VALUES ($1, $2) RETURNING id`,
+      ['cliente@logistica.cl', 'Cliente Real'],
+    );
+    const id = insert.rows[0].id;
+
+    await handle.pool.query(
+      `UPDATE solicitudes_registro
+       SET estado = 'aprobado', aprobado_por = $1, aprobado_en = now()
+       WHERE id = $2`,
+      ['dev@boosterchile.com', id],
+    );
+
+    const select = await handle.pool.query<{
+      estado: string;
+      aprobado_por: string | null;
+      aprobado_en: Date | null;
+    }>('SELECT estado, aprobado_por, aprobado_en FROM solicitudes_registro WHERE id = $1', [id]);
+    expect(select.rows[0].estado).toBe('aprobado');
+    expect(select.rows[0].aprobado_por).toBe('dev@boosterchile.com');
+    expect(select.rows[0].aprobado_en).toBeInstanceOf(Date);
+  });
+
+  test('UPDATE a estado=rechazado persiste sin aprobado_por requerido', async () => {
+    const insert = await handle.pool.query<{ id: string }>(
+      `INSERT INTO solicitudes_registro (email, nombre_completo)
+       VALUES ($1, $2) RETURNING id`,
+      ['spam@throwaway.test', 'No Real'],
+    );
+    const id = insert.rows[0].id;
+
+    await handle.pool.query(
+      `UPDATE solicitudes_registro
+       SET estado = 'rechazado', aprobado_por = $1, aprobado_en = now()
+       WHERE id = $2`,
+      ['dev@boosterchile.com', id],
+    );
+
+    const select = await handle.pool.query<{ estado: string }>(
+      'SELECT estado FROM solicitudes_registro WHERE id = $1',
+      [id],
+    );
+    expect(select.rows[0].estado).toBe('rechazado');
+  });
+
+  test('coexisten múltiples rows con mismo email en estados distintos (resubmit tras reject)', async () => {
+    // Primera solicitud rejected.
+    await handle.pool.query(
+      `INSERT INTO solicitudes_registro (email, nombre_completo, estado, aprobado_por, aprobado_en)
+       VALUES ($1, $2, 'rechazado', $3, now() - interval '7 days')`,
+      ['reaplicante@empresa.cl', 'Re Aplicante', 'dev@boosterchile.com'],
+    );
+    // Segunda solicitud (resubmit) — pendiente.
+    await handle.pool.query(
+      `INSERT INTO solicitudes_registro (email, nombre_completo)
+       VALUES ($1, $2)`,
+      ['reaplicante@empresa.cl', 'Re Aplicante'],
+    );
+
+    const count = await handle.pool.query<{ c: number }>(
+      "SELECT count(*)::int as c FROM solicitudes_registro WHERE email = 'reaplicante@empresa.cl'",
+    );
+    expect(count.rows[0].c).toBe(2);
+
+    const distribution = await handle.pool.query<{ pending: number; rejected: number }>(`
+      SELECT
+        count(*) FILTER (WHERE estado = 'pendiente_aprobacion')::int as pending,
+        count(*) FILTER (WHERE estado = 'rechazado')::int as rejected
+      FROM solicitudes_registro
+      WHERE email = 'reaplicante@empresa.cl'
+    `);
+    expect(distribution.rows[0].pending).toBe(1);
+    expect(distribution.rows[0].rejected).toBe(1);
+  });
+
+  test('enum estado_solicitud_registro rechaza values no enumerados', async () => {
+    await expect(
+      handle.pool.query(
+        `INSERT INTO solicitudes_registro (email, nombre_completo, estado)
+         VALUES ($1, $2, $3)`,
+        ['x@y.cl', 'X Y', 'aprovado_typo'],
+      ),
+    ).rejects.toThrow(/invalid input value for enum/i);
+  });
+});

--- a/packages/shared-schemas/src/domain/signup-request.ts
+++ b/packages/shared-schemas/src/domain/signup-request.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+/**
+ * Solicitudes de registro — signup público gated por admin-approval (SEC-001
+ * Sprint 2b H1.2, plan-sprint-2b T7 + T8 + T10). Reemplaza el flow anterior
+ * de `createUserWithEmailAndPassword` client-side por:
+ *
+ *   1. Visitante envía form → POST /api/v1/signup-request → row INSERT con
+ *      `estado=pendiente_aprobacion`.
+ *   2. Email a admin allowlist; admin aprueba en UI → backend ejecuta Admin
+ *      SDK `auth.createUser` + UPDATE `estado=aprobado` + `aprobado_por` +
+ *      `aprobado_en`.
+ *   3. Admin reject → UPDATE `estado=rechazado` (cuenta nunca creada).
+ *
+ * Ver ADR-052 (`docs/adr/052-signup-migration-admin-sdk-gate.md`) Status
+ * `Proposed` (T6) → `Accepted` (T13 post-canary success).
+ *
+ * Naming: español snake_case en SQL/enum DDL, camelCase en TS identifiers
+ * (CLAUDE.md §Reglas naming bilingüe). Spec O-1 + amendment A3 v3.4.
+ */
+export const signupRequestEstadoSchema = z.enum(['pendiente_aprobacion', 'aprobado', 'rechazado']);
+export type SignupRequestEstado = z.infer<typeof signupRequestEstadoSchema>;
+
+export const signupRequestSchema = z.object({
+  /**
+   * UUID v4 generado por la BD (defaultRandom via pgcrypto gen_random_uuid).
+   * Identifica la solicitud en la UI admin + en URLs de approve/reject.
+   */
+  id: z.string().uuid(),
+  /**
+   * Email del solicitante. Max 320 chars (RFC 5321 § 4.5.3.1.3 local-part
+   * 64 + @ + domain 255 = 320). Validación lowercase a cargo del service
+   * layer (T8) para evitar duplicates `Foo@x.cl` vs `foo@x.cl`.
+   */
+  email: z.string().email().max(320),
+  /**
+   * Nombre del solicitante tal como lo escribió en el form. Plain text;
+   * se usa como `displayName` en Firebase `auth.createUser` post-approve
+   * (T10). Max 200 chars para permitir nombres compuestos chilenos sin
+   * truncate prematuro.
+   */
+  nombreCompleto: z.string().min(1).max(200),
+  estado: signupRequestEstadoSchema,
+  /**
+   * Timestamp de la solicitud (INSERT). Default `now()` en BD.
+   */
+  requestedAt: z.string().datetime(),
+  /**
+   * Email del admin que aprobó la solicitud. NULL hasta que un admin
+   * ejecuta approve. Persiste audit trail aún si el admin pierde acceso
+   * (Ley 19.628 art. 5: responsabilidad del responsable del registro).
+   */
+  approvedBy: z.string().email().max(320).nullable(),
+  /**
+   * Timestamp del approve / reject. NULL mientras `estado=pendiente_aprobacion`.
+   * NOT NULL si `estado IN ('aprobado','rechazado')`. Service layer (T10) es
+   * responsable de mantener la invariante al UPDATE.
+   */
+  approvedAt: z.string().datetime().nullable(),
+});
+export type SignupRequest = z.infer<typeof signupRequestSchema>;

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -65,3 +65,6 @@ export * from './aggregations/k-anonymity.js';
 
 // SEC-001 Sprint 2a H1.1 — cuentas demo DB-driven registry (ADR-053)
 export * from './domain/cuentas-demo.js';
+
+// SEC-001 Sprint 2b H1.2 — solicitudes de registro signup gate (ADR-052)
+export * from './domain/signup-request.js';


### PR DESCRIPTION
## Summary

Sprint 2b H1.2 PR2 task **T7** — schema foundation para el flow signup-request → admin-approval definido en [ADR-052](https://github.com/boosterchile/booster-ai/blob/main/docs/adr/052-signup-migration-admin-sdk-gate.md) (Status `Proposed` post-T6 merge).

- **Domain canónico** (`packages/shared-schemas/src/domain/signup-request.ts`, 61 LOC): `signupRequestSchema` + `signupRequestEstadoSchema` Zod. Campos `id` (uuid), `email`, `nombreCompleto`, `estado` enum (`pendiente_aprobacion | aprobado | rechazado`), `requestedAt`, `approvedBy` nullable, `approvedAt` nullable. Re-export desde `index.ts` barrel.
- **Drizzle schema** (`apps/api/src/db/schema.ts`, +50 LOC): `estadoSolicitudRegistroEnum` pgEnum + `solicitudesRegistro` pgTable con columnas Spanish snake_case (`email`, `nombre_completo`, `estado`, `solicitado_en`, `aprobado_por`, `aprobado_en`). Type exports `SolicitudRegistroRow` + `NewSolicitudRegistroRow`.
- **Migration 0039** (`apps/api/drizzle/0039_solicitudes_registro.sql`, 64 LOC): incremental `CREATE TYPE estado_solicitud_registro` + `CREATE TABLE solicitudes_registro` + `COMMENT ON` sobre tabla y columnas críticas (audit trail Ley 19.628). Journal entry con `when=1780876800003` (monotónico per [ADR-044](https://github.com/boosterchile/booster-ai/blob/main/docs/adr/044-migration-journal-integrity-guard.md) ordering contract).
- **Integration tests** (`apps/api/test/integration/solicitudes-registro-roundtrip.integration.test.ts`, 176 LOC): 5 tests via raw pg pool query (pattern `seed-demo-cuentas-idempotency`) — INSERT defaults, UPDATE approve flow, UPDATE reject, coexistencia múltiples rows mismo email distintos estados (resubmit), enum rechaza values no enumerados.

## Evidencia

### Tests

- `pnpm typecheck` → **31 tasks successful, 0 errors** (turbo cache + cache-miss api/sms-fallback/whatsapp).
- `pnpm --filter @booster-ai/api test` → **Test Files 106 passed (106), Tests 1272 passed (2 skipped) (1274)** — sin regression vs baseline T6.
- `pnpm --filter @booster-ai/shared-schemas test` → **Test Files 8 passed (8), Tests 213 passed (213)**.
- Integration test corre en CI gate `Integration tests (DB + Redis)` — no `TEST_DATABASE_URL` local, pero CI aplica migration 0039 vía `runMigrations(pool, logger)` en `test/integration/setup-global.ts` y ejecuta los 5 cases. CI verde requiere los 5 passing.

### Lint

- `pnpm exec biome check` sobre los 4 archivos modificados → 0 errors post-auto-fix.

### Pre-commit gates

- gitleaks: WARN no instalado (no-op).
- biome check: PASS sobre 6 staged files.
- check-adr-numbering: PASS — `OK — no collisions`.
- spec-canonical-drift: PASS.

### Naming bilingüe (CLAUDE.md §Reglas naming bilingüe)

- SQL DDL: `solicitudes_registro`, `estado_solicitud_registro`, columnas `nombre_completo / solicitado_en / aprobado_por / aprobado_en` — todas español snake_case sin tildes.
- TS identifiers: `solicitudesRegistro`, `estadoSolicitudRegistroEnum`, `nombreCompleto`, `solicitadoEn`, `aprobadoPor`, `aprobadoEn` — camelCase EN naming styles, ES content.
- Enum values: español snake_case (`pendiente_aprobacion`, `aprobado`, `rechazado`) per CLAUDE.md + ADR-052 §Decision.
- UI labels: out-of-scope T7 (cubierto T10 admin UI).

### Notas sobre la migration

Drizzle-kit no tiene snapshots intermedios committed (`0001..0038_snapshot.json` no están en git por convención del repo — solo `_journal.json` + `.sql` files se versionan). Esto hace que `drizzle-kit generate` localmente sin snapshots produzca un dump full-schema (~57KB) en lugar de incremental. **Resolución**: la migration 0039 fue editada manualmente al patrón incremental clásico (precedent `0038_cuentas_demo.sql` 78 LOC). Verificado que el migrator runtime (`apps/api/src/db/migrator.ts`) usa solo `_journal.json` + `.sql`, no requiere snapshots — el flujo runtime es correcto. Tracked como follow-up no-bloqueante: regenerar el chain de snapshots `0001..0038` para que future `drizzle-kit generate` produzca incremental output by-default; sin urgencia operativa.

### Migration ordering (ADR-044 + plan §11)

- Journal entry idx=39 con `when=1780876800003`, monotonically increasing vs idx=38 (`1780876800002`). Cumple ordering contract.
- CI gate `migration-journal-integrity-guard` (parte del set de checks security/CI) valida esto post-push.

## ADR compliance checklist

- [x] **ADR-049 (plugin system)**: ledger `.claude/ledger/2026-05-26_3796e944-c02a-4ba0-8de4-316149db2ddd.jsonl` con `phase_enter (build/T7)` + `pre_build_articulation (T7 + 3 alternatives + 5 failure modes)`.
- [x] **ADR-052 (signup migration)**: ADR cubre la decisión arquitectural; T7 implementa el schema foundation (SC-1.2.1 foundation), ADR sigue en Status `Proposed` hasta T13.
- [x] **ADR-044 (migration journal integrity)**: journal entry monotonically increasing; ordering contract preserved.
- [x] **CLAUDE.md "ADR before code"**: ADR-052 mergeó en PR #351 (commit `dcfb588`) ANTES de este PR. ✅
- [x] **CLAUDE.md naming bilingüe**: SQL Spanish snake_case + TS camelCase EN identifiers + enum values Spanish, sin tildes. ✅
- [x] **CLAUDE.md booster-stack-conventions**: zero `any`, Zod en boundaries (`signupRequestSchema`), structured types via `$inferSelect / $inferInsert`. ✅
- [x] **CLAUDE.md Conventional Commits con scope**: `feat(sec-001):` summary imperativo en español. ✅
- [x] **PR sección Evidencia**: presente arriba.

## Spec trace

- SC-1.2.1 foundation (schema DB + domain): cubierto por domain + Drizzle + migration.
- Spec §11 migración DB: cubierto por journal entry monotónico + migration applies on startup.

## Test plan (post-merge)

- [ ] **Merge a `main`** via squash merge.
- [ ] **Next task T8** (endpoint `POST /api/v1/signup-request` + service + rate-limit + liveness `/health/signup-flow` + wire `server.ts`) puede iniciar inmediatamente post-merge — depende de T7 merged.
- [ ] **No deploy implicado en T7**: schema-only change. Migration aplicará automáticamente al próximo deploy api (sea T7 standalone deploy o T8 bundle). Per spec §11, ordering contract garantiza no silent-skip.

## Próximos pasos (Sprint 2b PR2 progress)

| Task | Status | Depende de |
|---|---|---|
| T6 | ✅ shipped (#351, sha `dcfb588`) | PR1 H1.3 shipped ✅ |
| **T7** | ✅ este PR | T6 merged ✅ |
| T8 | pendiente | T7 merged |
| T9a, T9b | pendiente | T8 merged |
| T9c | pendiente | T11 merged |
| T10 | pendiente | T9a merged |
| T11 | pendiente | T10 merged |
| T13 | pendiente | T11 + T9a/b/c |

🤖 Generated with [Claude Code](https://claude.com/claude-code)