### PR TITLE
feat(sec-001): H1.2 PR2 — T11 Terraform IdP self-signup OFF (email/password) + doc

### DIFF
--- a/.specs/sec-001-cierre/plan-sprint-2b.md
+++ b/.specs/sec-001-cierre/plan-sprint-2b.md
@@ -255,7 +255,7 @@ PR3 discoveries deferred a Sprint 2c.
 - **Rollback**: feature flag flip; no code revert necesario.
 - **Spec trace**: §3 SC-1.2.1, §7.5 rollback feature flag.
 
-### T11: Terraform `google_identity_platform_config` email/password OFF + IdP config doc
+### T11: Terraform `google_identity_platform_config` email/password OFF + IdP config doc [DONE 2026-05-26]
 
 - **Files**: `infrastructure/identity-platform.tf` (nuevo o modify si existe), `docs/qa/identity-platform-config.md` (nuevo)
 - **LOC estimate**: ~40

--- a/docs/qa/identity-platform-config.md
+++ b/docs/qa/identity-platform-config.md
@@ -1,0 +1,140 @@
+# Identity Platform config — SEC-001 Sprint 2b H1.2 T11
+
+> SEC-001 Sprint 2b (`.specs/sec-001-cierre/plan-sprint-2b.md` T11) · 2026-05-26
+> SC-1.2.2 amendment A3 v3.4 (email/password leg MET, Google leg TRACKED_RESIDUAL).
+> Terraform: `infrastructure/identity-platform.tf`.
+> ADR: [`052-signup-migration-admin-sdk-gate.md`](../adr/052-signup-migration-admin-sdk-gate.md).
+
+## 1. Estado final tras T11
+
+| Propiedad | Valor | Efecto |
+|---|---|---|
+| `sign_in.email.enabled` | `true` | Sign-IN email/password sigue habilitado (users existing pueden hacer login). |
+| `sign_in.email.password_required` | `true` | No magic-link / no email-only signin. |
+| `sign_in.allow_duplicate_emails` | `false` | Un email no puede coexistir bajo 2 providers distintos. |
+| `client.permissions.disabled_user_signup` | **`true`** ★ | **Self-signup client-side OFF (la knob principal de T11).** Cualquier `createUserWithEmailAndPassword` desde Firebase SDK retorna `auth/operation-not-allowed`. |
+| `client.permissions.disabled_user_deletion` | `false` | Users pueden borrar sus propias cuentas (UX OK). |
+
+**Scope crítico**: `disabled_user_signup` aplica a **client SDKs solamente**. Admin SDK `auth.createUser` (invocado desde backend con service account auth) **NO se ve afectado**. Esto es deliberado — el flow `signup-request` post-T10 ejecuta `auth.createUser` desde el service, que sigue funcionando.
+
+## 2. Residual: Google sign-in (TRACKED_RESIDUAL Sprint 2c)
+
+Aunque `disabled_user_signup=true` técnicamente aplica a **todos los providers** (email, Google, Anonymous, Phone), Identity Platform tiene una limitación documentada con federated identity providers (Google OAuth, Apple, etc.):
+
+- Cuando un user hace `signInWithPopup(googleProvider)` por primera vez con cuenta Google nueva, Firebase **crea implícitamente** un user de Identity Platform como parte del flow OAuth, **antes** de que `disabled_user_signup` pueda intervenir.
+- El comportamiento es inherente al diseño de federated identity: el provider Google es la "fuente de verdad" del identity proofing; Identity Platform actúa como un mirror.
+
+**Resultado**: a 2026-05-26 (post-T11 apply), Google self-signup **queda OPEN** entre Sprint 2b ship y Sprint 2c ship. Mitigación documentada:
+
+- **Risk surface acotado**: una cuenta Google nueva crea un Firebase User SIN role en `users` table de Booster. Sin role, el user no consume endpoints útiles (todos requieren membership downstream).
+- **Tracked en spec §3 SC-1.2.2 amendment A3** + `R-DA-GOOGLE-OPEN` riesgo residual en ADR-052.
+- **Sprint 2c spec** (`.specs/_followups/sprint-2c-google-blocking-function.md`): Firebase Auth Blocking Function `beforeCreate` que rechaza first sign-in Google si no hay `solicitudes_registro.estado=aprobado` matching email.
+- **Monitoring**: alerta Cloud Monitoring sobre Identity Platform audit log con `signup.create` provider=`google.com` sin matching `solicitudes_registro.estado=aprobado` (configurable post-Sprint-2b).
+
+## 3. Apply del cambio Terraform
+
+### 3.1. Pre-flight check — config existe?
+
+Identity Platform crea un config implícito al habilitar `identitytoolkit.googleapis.com` (ver `infrastructure/project.tf:120`). El primer `terraform plan` post-T11 puede mostrar:
+
+- **Create** del recurso `google_identity_platform_config.default` (si Terraform no encuentra el config en state).
+- **Update** del recurso (si ya fue importado).
+
+Si plan dice **create** y el config implícito YA existe, hay que importar primero:
+
+```bash
+cd infrastructure
+terraform import google_identity_platform_config.default booster-ai-494222
+```
+
+### 3.2. Plan + apply
+
+```bash
+cd infrastructure
+terraform plan -out=tfplan-t11
+# Revisar el diff. Esperado:
+#   - sign_in.email.enabled: (no-op, ya era true)
+#   - sign_in.email.password_required: (no-op si ya era true)
+#   - sign_in.allow_duplicate_emails: (puede ser true → false)
+#   - client.permissions.disabled_user_signup: (false → true) ★ el cambio clave
+terraform apply tfplan-t11
+```
+
+**Pre-apply checklist** (per spec §7.4 categórica):
+- [ ] `terraform plan` muestra 0 diffs inesperados en `google_iam_*`, `google_secret_manager_*`, `google_storage_bucket*`, `google_cloud_run_v2_service*`.
+- [ ] Cambio focused solo en `google_identity_platform_config.default`.
+- [ ] Branch protection OK + reviewer humano en PR (CLAUDE.md "infrastructure/* requiere PR revisado").
+
+### 3.3. Verificación post-apply
+
+Comando oficial spec SC-1.2.2 (idéntico al spec):
+
+```bash
+curl -s -H "Authorization: Bearer $(gcloud auth application-default print-access-token)" \
+     -H "x-goog-user-project: booster-ai-494222" \
+     "https://identitytoolkit.googleapis.com/admin/v2/projects/booster-ai-494222/config" \
+     | jq '.signIn.email, .client.permissions'
+```
+
+**Esperado**:
+
+```json
+{
+  "enabled": true,
+  "passwordRequired": true
+}
+{
+  "disabledUserSignup": true,
+  "disabledUserDeletion": false
+}
+```
+
+### 3.4. Smoke E2E manual
+
+Después del apply, probar **manual** con la web app (en staging primero):
+
+1. Abrir `https://app.boosterchile.com/login` (staging) en modo incognito.
+2. Hacer click "Crear cuenta" → ingresar email nuevo + password.
+3. **Expected**: error `auth/operation-not-allowed` (o equivalente) → UI muestra "No pudimos completar la operación".
+4. Probar también con email YA existente en `users` table → mismo error (anti-enumeration por design en T8 `submitSignupRequest`).
+5. **Negative**: el endpoint `POST /api/v1/signup-request` debe seguir aceptando solicitudes (202) — verificar con `curl`:
+   ```bash
+   curl -s -X POST https://api-staging.boosterchile.com/api/v1/signup-request \
+        -H "content-type: application/json" \
+        -d '{"email":"test@example.cl","nombreCompleto":"Test"}'
+   # Expected: HTTP 202 + {"ok":true}
+   ```
+6. Confirmar row insertado en `solicitudes_registro` (staging DB).
+
+## 4. Rollback path
+
+Si T11 apply provoca regresión inesperada (e.g., Admin SDK `auth.createUser` empezó a fallar — contraintuitivo pero plan §7.5 lo contempla):
+
+```bash
+cd infrastructure
+# Revertir el commit que introdujo T11:
+git revert <T11-commit-sha>
+terraform plan -out=tfplan-rollback
+# Verificar que el diff revierte client.permissions.disabled_user_signup a false.
+terraform apply tfplan-rollback
+```
+
+**Rollback impact**: vuelve a abrir self-signup email/password. Los users existing siguen igual. **NO** abre el Google leg (Google ya está OPEN como residual — el rollback no afecta el estado Google).
+
+Per spec §7.5, rollback de T11 NO requiere flip del feature flag `SIGNUP_REQUEST_FLOW_ACTIVATED` (admin UI sigue funcional via Admin SDK).
+
+## 5. Tracking de drift
+
+`security-hotfixes-2026-05-14.tf:45` ya menciona `identity_platform_config drift` como una de las alertas SRE configuradas. Post-T11, configurar Cloud Monitoring log-based alert sobre cambios manuales al config (audit log `SetProjectConfig` operations sin matching `terraform apply` event). Tracked como follow-up T13+ una vez Cloud Build canary success.
+
+## 6. Referencias
+
+- Spec: `.specs/sec-001-cierre/spec.md` §3 H1.2 SC-1.2.2.
+- Plan: `.specs/sec-001-cierre/plan-sprint-2b.md` T11.
+- ADR: `docs/adr/052-signup-migration-admin-sdk-gate.md` (Proposed).
+- Audit inventory: `docs/qa/signup-paths-audit.md` (T6).
+- Cascade doc: `docs/qa/rate-limit-cascade.md` §signup-request layer.
+- Followup: `.specs/_followups/sprint-2c-google-blocking-function.md` (Google leg).
+- Terraform: `infrastructure/identity-platform.tf`.
+- Identity Platform API: <https://cloud.google.com/identity-platform/docs/reference/rest/v2/Config>
+- Terraform provider resource: <https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/identity_platform_config>

--- a/infrastructure/identity-platform.tf
+++ b/infrastructure/identity-platform.tf
@@ -1,0 +1,74 @@
+# SEC-001 Sprint 2b H1.2 — Identity Platform email/password self-signup OFF (T11).
+#
+# Spec: .specs/sec-001-cierre/spec.md §3 H1.2 SC-1.2.2 (amendment A3 v3.4):
+#   - Email/password leg (Sprint 2b): "Allow new accounts to sign up" = OFF.
+#   - Google leg (TRACKED_RESIDUAL Sprint 2c): requires Firebase Auth
+#     Blocking Function `beforeCreate`. NO managed aquí.
+#
+# ADR: docs/adr/052-signup-migration-admin-sdk-gate.md (Proposed; Status flip
+# Accepted en T13 post-canary success).
+#
+# Doc operacional: docs/qa/identity-platform-config.md (verification curl +
+# manual import steps + Google leg residual tracking).
+#
+# Project: booster-ai-494222 (via var.project_id).
+
+resource "google_identity_platform_config" "default" {
+  project = google_project.booster_ai.project_id
+
+  # Email/password sign-IN (login de users existing) permanece ENABLED. Lo
+  # único que cambia es el "Allow new accounts to sign up" toggle via
+  # client.permissions.disabled_user_signup abajo.
+  sign_in {
+    email {
+      enabled           = true
+      password_required = true
+    }
+    # Defensa adicional: prevenir cuentas con email duplicado entre providers
+    # (e.g., dos users con misma direccion pero diferente provider).
+    allow_duplicate_emails = false
+  }
+
+  # ★ T11 SC-1.2.2 (email/password leg) ★ — disable client-side new-user
+  # signup project-wide.
+  #
+  # Per Identity Platform API (cloud.google.com/identity-platform/docs/
+  # reference/rest/v2/Config#ClientPermissionConfig):
+  #
+  #   "When true, end users cannot sign up for a new account on the
+  #   associated project through any of the means supported by the project
+  #   (Email/Password, IdPs, Anonymous, Phone)."
+  #
+  # **Important scope**: this disables CLIENT-SIDE signup (Firebase Auth
+  # SDK via web/mobile). Admin SDK `auth.createUser({email, displayName})`
+  # invoked from server-side (apps/api/src/services/signup-request.ts T10
+  # approveSignupRequest) is NOT affected — service account auth bypasses
+  # `clientPermissionConfig`. Verified via API docs + Sprint 2a precedent
+  # `harden-demo-accounts.ts` which uses `auth.createUser` from Admin SDK.
+  #
+  # **Google residual**: while this flag covers email/password client signup,
+  # Google `signInWithPopup` still creates new Firebase users on first sign-in
+  # because Google OAuth is a federated provider where account creation is
+  # implicit. The fix is Firebase Auth Blocking Function `beforeCreate`,
+  # deferred to Sprint 2c (.specs/_followups/sprint-2c-google-blocking-
+  # function.md). Documented as TRACKED_RESIDUAL in spec amendment A3.
+  client {
+    permissions {
+      disabled_user_signup   = true
+      disabled_user_deletion = false # users can still self-delete (UX OK)
+    }
+  }
+
+  lifecycle {
+    # No managed aquí:
+    #   - authorized_domains: gestionado manualmente (incluye boosterchile.com
+    #     y demo.boosterchile.com via console + DNS).
+    #   - blocking_functions: pre-empty para Sprint 2c BlockingFunction
+    #     `beforeCreate` (Google leg residual). Cuando ese spec se merge,
+    #     se removerá del ignore_changes.
+    ignore_changes = [
+      authorized_domains,
+      blocking_functions,
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Sprint 2b H1.2 PR2 task **T11** — Terraform IaC para cerrar SC-1.2.2 email/password leg. Google leg permanece `TRACKED_RESIDUAL` (Sprint 2c BlockingFunction).

**⚠ INFRA PR — NO MERGE WITHOUT REVIEW**: este PR toca Identity Platform en producción. Per CLAUDE.md, `infrastructure/*.tf` requiere PR revisado. **Sin apply automático**: la secuencia post-merge es `terraform plan` → human verifica diff → `terraform apply` manual (ver §3.2 del doc).

### Files (215 LOC)

- **`infrastructure/identity-platform.tf`** (74 LOC): resource `google_identity_platform_config.default` con `client.permissions.disabled_user_signup=true` (la knob clave). `sign_in.email.enabled=true` keeps sign-IN para users existing. `lifecycle.ignore_changes` para `authorized_domains` + `blocking_functions` (Sprint 2c pre-empty).
- **`docs/qa/identity-platform-config.md`** (140 LOC): estado final, scope `disabled_user_signup` (client SDKs only, NO Admin SDK), Google residual rationale, apply steps con `terraform import` si config implícito existe, verification curl + smoke E2E manual, rollback path, drift tracking.

## Evidencia

- `terraform fmt -check identity-platform.tf` → idempotent (0 diff).
- `terraform validate` → **Success! The configuration is valid.**
- `terraform plan` no ejecutado en CI: requiere gcloud re-auth interactivo (`invalid_rapt`); el plan + apply los corre el reviewer humano post-PR review en su workstation con ADC válidas.
- Pre-commit gates: biome PASS (md files); check-adr-numbering OK; spec-canonical-drift OK.

## Scope del knob `disabled_user_signup`

**Aplica a**: Firebase Auth SDK calls (client-side) → `createUserWithEmailAndPassword`, `signInWithEmailLink` (creation path), `applyActionCode` for first-time enrollment, etc. Todos retornarán `auth/operation-not-allowed`.

**NO aplica a**: Firebase Admin SDK `auth.createUser({email, displayName})` invocado desde backend service account. El service `approveSignupRequest` (T10 shipped en sha `4854703`) sigue funcionando.

**Google leg gap**: federated providers (Google OAuth, etc.) crean el Firebase User implícitamente en el OAuth callback ANTES de que `disabled_user_signup` aplique. Sprint 2c BlockingFunction `beforeCreate` cierra este residual. Documentado en spec amendment A3 + ADR-052 §Riesgo residual + `.specs/_followups/sprint-2c-google-blocking-function.md`.

## Pre-apply checklist (per spec §7.4 categórica)

- [ ] **Reviewer humano** revisa el diff.
- [ ] `terraform plan` muestra:
  - [ ] Cambio focused en `google_identity_platform_config.default` (no diffs inesperados en otros recursos).
  - [ ] 0 diffs en `google_iam_*`, `google_secret_manager_*`, `google_storage_bucket*`, `google_cloud_run_v2_service*`.
- [ ] Si plan muestra **create** del recurso pero el config implícito ya existe → ejecutar `terraform import google_identity_platform_config.default booster-ai-494222` ANTES de apply.
- [ ] **Staging primero** (si proyecto staging tiene Identity Platform habilitado).
- [ ] Smoke E2E manual post-apply per §3.4 del doc.

## SC trace

- **SC-1.2.2 email/password leg** = MET (pendiente apply del user).
- **SC-1.2.2 Google leg** = TRACKED_RESIDUAL (Sprint 2c).

## ADR compliance

- [x] ADR-049 ledger eventos `phase_enter / pre_build_articulation (3 alternatives + 5 failure modes) / phase_exit`.
- [x] CLAUDE.md "infrastructure requiere PR revisado" — este PR pide explicit human review.
- [x] CLAUDE.md "NUNCA tocar infrastructure/main.tf en secciones IAM humana o Billing" — este PR crea nuevo archivo `identity-platform.tf`, no toca IAM ni Billing.
- [x] Conventional Commits scope `sec-001`.

## Test plan post-merge

- [ ] **NO merge automático**: human review obligatorio.
- [ ] Post-merge: ejecutar `terraform plan` → revisar diff → `terraform import` si necesario → `terraform apply`.
- [ ] Verificar via curl + smoke E2E manual (web app signup form debe retornar `auth/operation-not-allowed`).
- [ ] T9c (integration matrix per-method) **desbloqueado**: depende T11 apply para que el `auth/operation-not-allowed` sea real en staging.
- [ ] T13 desbloqueado: depende T11 merged + T9a + T9b + T9c.

## Próximos pasos (PR2 progress)

| Task | Status |
|---|---|
| T6 / T7 / T8 / T9a / T9b / T10 | ✅ shipped |
| **T11** | ✅ este PR (apply manual post-review) |
| T9c (integration matrix per-method) | pendiente (depende T11 apply) |
| T13 (canary + Status flip Accepted) | pendiente |

🤖 Generated with [Claude Code](https://claude.com/claude-code)