### PR TITLE
fix(sec-001): T13 signup_probe_failure alert aggregation reducer

### DIFF
--- a/infrastructure/signup-probe.tf
+++ b/infrastructure/signup-probe.tf
@@ -89,11 +89,15 @@ resource "google_monitoring_alert_policy" "signup_probe_failure" {
       # con LT detecta any failure dentro de la window.
       threshold_value = 1
 
+      # `check_passed` se reporta como DOUBLE (1.0 ok / 0.0 fail). ALIGN_
+      # FRACTION_TRUE convierte a fracción true por período (1.0 = todos
+      # los samples pass, 0.0 = todos fail). Sin cross_series_reducer
+      # explícito el monitor opera por serie individual (uno por uptime
+      # check_id), que es lo que queremos para alertar sobre este check
+      # específico.
       aggregations {
-        alignment_period     = "60s"
-        per_series_aligner   = "ALIGN_FRACTION_TRUE"
-        cross_series_reducer = "REDUCE_COUNT_FALSE"
-        group_by_fields      = ["resource.label.project_id"]
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_FRACTION_TRUE"
       }
     }
   }


### PR DESCRIPTION
## Summary

Hot-patch del alert policy `signup_probe_failure` para reconciliar el .tf con el state real en GCP post-apply de T13.

### Problema

Identity Platform Admin API rechazó el `cross_series_reducer = "REDUCE_COUNT_FALSE"` con:

> Error 400: Field aggregation.crossSeriesReducer had an invalid value of "REDUCE_COUNT_FALSE": The reducer cannot be applied to metrics with value type DOUBLE.

La métrica `monitoring.googleapis.com/uptime_check/check_passed` es `DOUBLE` (1.0/0.0), no `INT64`/`BOOL`. Mi PR #359 inicial asumió la última.

### Fix

Remover `cross_series_reducer` + `group_by_fields`. Con `per_series_aligner = "ALIGN_FRACTION_TRUE"` el monitor opera por serie individual (1 serie por uptime `check_id`), que es lo deseado para alertar sobre este check específico.

### Evidencia post-fix (aplicado live)

Aplicado 2026-05-26 19:55Z via `terraform apply -target=google_monitoring_alert_policy.signup_probe_failure` post-merge. Verificado via Monitoring REST API:

```json
{
  "displayName": "Signup probe — /health/signup-flow failures (2 consecutive)",
  "enabled": true
}
```

Este PR reconcilia el `.tf` con el state ya aplicado.

### Tests

- `terraform validate` Success.
- `terraform plan` post-fix: 0 to add, 0 to change, 0 to destroy (state matches .tf).

🤖 Generated with [Claude Code](https://claude.com/claude-code)