### PR TITLE
feat(sec-001-h1-2-google-blocking-a): T2b sprint-2c-build-gate workflow

### DIFF
--- a/.github/workflows/sprint-2c-build-gate.yml
+++ b/.github/workflows/sprint-2c-build-gate.yml
@@ -1,0 +1,101 @@
+# ---------------------------------------------------------------------------
+# Sprint 2c-A T2b — Mechanical CI build gate for Sprint 2c-B deploy paths.
+#
+# Spec: .specs/sec-001-h1-2-google-blocking-a/plan.md v4 §T2b acceptance.
+# Wired script: apps/api/scripts/check-adr-status-accepted.ts (T2a).
+#
+# Purpose: prevent Sprint 2c-B Cloud Function deploy paths from merging
+# antes de que ADR-052 (admin-approval gate vía Admin SDK) tenga Status
+# Accepted. ADR-052 flip Proposed → Accepted ocurre post-Sprint-2b T13
+# canary success + 2h watch en un separate post-merge commit.
+#
+# Path filter scope (file-level; GitHub Actions paths no soporta sub-file
+# filtering, así que cualquier modify a estos files dispara el gate —
+# false-positive risk para changes no-deploy aceptado per plan v4):
+#
+#   - infrastructure/auth-blocking-functions.tf
+#         New file en Sprint 2c-B; no false-positives posible.
+#   - infrastructure/identity-platform.tf
+#         Existing (Sprint 2b T11). False-positive si futuras edits para
+#         otros auth providers. Mitigation: workflow_dispatch escape-hatch
+#         post-Sprint-2c-B CERRADO.
+#   - cloudbuild.production.yaml
+#         Actively maintained. False-positive si edits no-blocking-function.
+#         Mitigation: workflow_dispatch escape-hatch.
+#
+# Escape-hatch:
+#   Si el gate tiene un bug requiriendo fix que toca Sprint 2c-B paths,
+#   o si una edición legítima a uno de estos files NO está relacionada
+#   con blocking-function deploy, override:
+#
+#     gh workflow run sprint-2c-build-gate.yml -f force=true
+#
+#   El job entonces marca success sin invocar el script. Trace queda en
+#   Actions tab.
+#
+# Required branch protection: post-merge T2b, agregar como required check
+#   con (PO command documented en T2b PR description):
+#
+#     gh api -X PATCH repos/boosterchile/booster-ai/branches/main/protection \
+#       --field "required_status_checks[contexts][]=Sprint 2c-B build gate (ADR-052 Accepted)"
+#
+# Post-Sprint-2c-B CERRADO: remove the required check (gate no longer
+# needed; ADR-054 Accepted + 2c-B post-launch + 7d watch successful).
+# ---------------------------------------------------------------------------
+
+name: Sprint 2c-B build gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'infrastructure/auth-blocking-functions.tf'
+      - 'infrastructure/identity-platform.tf'
+      - 'cloudbuild.production.yaml'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Bypass gate (escape-hatch). Use only if gate has a bug or change unrelated to blocking-function deploy.'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+concurrency:
+  group: sprint-2c-build-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check-adr-052-accepted:
+    name: Sprint 2c-B build gate (ADR-052 Accepted)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Bypass gate (escape-hatch)
+        if: github.event_name == 'workflow_dispatch' && inputs.force == 'true'
+        run: |
+          echo "::warning::Sprint 2c-B build gate bypassed via workflow_dispatch force=true"
+          echo "Reason must be documented in the PR / commit that triggered this run."
+          exit 0
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.force != 'true')
+      - uses: pnpm/action-setup@v6
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.force != 'true')
+        with:
+          version: '9.15.4'
+      - uses: actions/setup-node@v6
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.force != 'true')
+        with:
+          node-version: '24'
+          cache: pnpm
+      - name: Install dependencies
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.force != 'true')
+        run: pnpm install --frozen-lockfile
+      - name: Verify ADR-052 Status Accepted
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.force != 'true')
+        run: pnpm --filter @booster-ai/api exec tsx scripts/check-adr-status-accepted.ts


### PR DESCRIPTION
## Summary

Sprint 2c-A T2b — mechanical CI gate **workflow** wiring T2a script (`apps/api/scripts/check-adr-status-accepted.ts`) con path-filter Sprint 2c-B deploy paths + `workflow_dispatch` escape-hatch.

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `.github/workflows/sprint-2c-build-gate.yml` | 101 | NEW |

LOC ~101 vs plan estimate ~35: comments/escape-hatch logic + `workflow_dispatch` machinery account for the delta. Acceptance criteria unaffected.

## Path-filter scope (file-level)

GitHub Actions `paths:` no soporta sub-file filtering. Aceptado false-positive risk para changes no-deploy a estos files; mitigado via escape-hatch.

| File | Existing en `main`? | False-positive risk |
|---|---|---|
| `infrastructure/auth-blocking-functions.tf` | NO (new en 2c-B) | ninguno |
| `infrastructure/identity-platform.tf` | YES (Sprint 2b T11) | medio (otros auth providers) |
| `cloudbuild.production.yaml` | YES | medio (deploy steps no-blocking-function) |

## Escape-hatch (per F-A13 plan v4 fix)

YAML comment + `workflow_dispatch` input documented:

```bash
gh workflow run sprint-2c-build-gate.yml -f force=true
```

Si el gate tiene un bug requiriendo fix que toca 2c-B paths, o si edición legítima no-blocking-function-deploy a estos files, override sin re-correr el script (job marca success directly). Trace queda en Actions tab.

## Branch protection wiring (post-merge T2b, PO command)

```bash
gh api -X PATCH repos/boosterchile/booster-ai/branches/main/protection \
  --field "required_status_checks[contexts][]=Sprint 2c-B build gate (ADR-052 Accepted)"
```

Verificación post-aplicación:

```bash
gh api repos/boosterchile/booster-ai/branches/main/protection \
  --jq '.required_status_checks.contexts'
```

Post-Sprint-2c-B CERRADO: remove the required check (`required_status_checks[contexts][]` minus this entry); ADR-054 Accepted + 2c-B post-launch + 7d watch successful = gate no longer needed.

## Verification this PR

- [x] Path filter NOT firing on this PR (no 2c-B paths in diff). Workflow registers + becomes available para futuras 2c-B PRs.
- [x] Pre-commit hooks pass.
- [x] Commitlint pass.
- [x] YAML structural sanity (name + on + concurrency + permissions + jobs at top-level; no tabs).

## Future verification (when first 2c-B PR opens)

- [ ] On a PR modifying any 2c-B path → workflow auto-triggers.
- [ ] Job invokes `pnpm --filter @booster-ai/api exec tsx scripts/check-adr-status-accepted.ts`.
- [ ] Script exit 1 vs ADR-052 Proposed → job fails → PR blocked.
- [ ] Post-ADR-052-Accepted: script exit 0 → job passes → PR unblocked.

## Dependencies

- ✅ T2a merged (`dc54d57`): script + tests in `main`.
- Next: T3 apps/auth-blocking-functions bootstrap.

## Test plan

- [x] Local YAML structural validation
- [x] Path-filter confirmed not firing on T2b's own PR
- [ ] CI green (this PR; workflow itself not triggered, only registered)
- [ ] PO runs `gh api` branch-protection command post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)