### PR TITLE
feat(sec-001-h1-2-google-blocking-a): T4 handler skeleton + provider check

### DIFF
--- a/apps/auth-blocking-functions/src/handler.test.ts
+++ b/apps/auth-blocking-functions/src/handler.test.ts
@@ -1,0 +1,91 @@
+import type gcipCloudFunctions from 'gcip-cloud-functions';
+import { describe, expect, it } from 'vitest';
+import { beforeCreateCallback } from './handler.js';
+
+/**
+ * Sprint 2c-A T4 tests — provider passthrough only.
+ *
+ * Per plan v4 acceptance: "NO T1/T2 yet (per F-02 v1 fix from umbrella)
+ * — those require DB code, moved to T7." Tests covering Google provider
+ * + approved row / no-row / DB throw land in T7.
+ *
+ * T4 active branches:
+ *   - providerData absent → return {} (passthrough)
+ *   - providerData empty → return {} (passthrough)
+ *   - providerData non-Google → return {} (passthrough)
+ *
+ * T5-T7 placeholder branch is istanbul-ignored; not tested here.
+ */
+
+function buildUser(
+  providerData: Array<Partial<gcipCloudFunctions.UserInfo>> | undefined,
+): gcipCloudFunctions.UserRecord {
+  return {
+    uid: 'test-uid',
+    email: 'test@example.com',
+    emailVerified: false,
+    displayName: 'Test',
+    phoneNumber: '',
+    photoURL: '',
+    disabled: false,
+    metadata: {
+      lastSignInTime: '',
+      creationTime: '',
+      toJSON: () => ({}),
+    },
+    providerData: providerData as gcipCloudFunctions.UserInfo[],
+    toJSON: () => ({}),
+  };
+}
+
+const STUB_CONTEXT = {
+  eventId: 'test-event',
+  timestamp: new Date().toISOString(),
+  eventType: 'providers/cloud.auth/eventTypes/user.beforeCreate',
+  resource: 'projects/test-project',
+  params: {},
+  ipAddress: '127.0.0.1',
+  userAgent: 'test-ua',
+} as unknown as gcipCloudFunctions.AuthEventContext;
+
+describe('beforeCreateCallback (T4 active branches)', () => {
+  it('returns {} when providerData is undefined (passthrough)', async () => {
+    const user = buildUser(undefined);
+    const result = await beforeCreateCallback(user, STUB_CONTEXT);
+    expect(result).toEqual({});
+  });
+
+  it('returns {} when providerData is empty array (passthrough)', async () => {
+    const user = buildUser([]);
+    const result = await beforeCreateCallback(user, STUB_CONTEXT);
+    expect(result).toEqual({});
+  });
+
+  it('returns {} for password provider (non-Google passthrough)', async () => {
+    const user = buildUser([{ providerId: 'password', uid: 'pw-uid', email: 'test@example.com' }]);
+    const result = await beforeCreateCallback(user, STUB_CONTEXT);
+    expect(result).toEqual({});
+  });
+
+  it('returns {} for SAML provider (non-Google passthrough)', async () => {
+    const user = buildUser([{ providerId: 'saml.example', uid: 'saml-uid' }]);
+    const result = await beforeCreateCallback(user, STUB_CONTEXT);
+    expect(result).toEqual({});
+  });
+
+  it('returns {} when no provider matches google.com (multiple non-Google providers)', async () => {
+    const user = buildUser([
+      { providerId: 'password', uid: 'pw-uid' },
+      { providerId: 'phone', uid: 'phone-uid' },
+    ]);
+    const result = await beforeCreateCallback(user, STUB_CONTEXT);
+    expect(result).toEqual({});
+  });
+});
+
+describe('beforeCreateCallback (structure smoke)', () => {
+  it('is an async function', () => {
+    expect(typeof beforeCreateCallback).toBe('function');
+    expect(beforeCreateCallback.constructor.name).toBe('AsyncFunction');
+  });
+});

--- a/apps/auth-blocking-functions/src/handler.ts
+++ b/apps/auth-blocking-functions/src/handler.ts
@@ -1,0 +1,49 @@
+import type gcipCloudFunctions from 'gcip-cloud-functions';
+
+/**
+ * Sprint 2c-A T4 — handler skeleton with provider check (active) +
+ * istanbul-ignored placeholder for T5-T7 logic.
+ *
+ * **Istanbul-ignore strategy** (per plan v4 H-A2 fix):
+ *
+ * T4 ships a minimal skeleton where the only active branch is the
+ * provider check (return `{}` if signup is not Google federated). The
+ * un-implemented T5-T7 logic (email normalize + DB lookup + fail-closed
+ * + structured log) is replaced by a single istanbul-ignored throw line.
+ *
+ * Each subsequent PR removes the istanbul-ignore comment + adds the
+ * covering test:
+ *
+ *   - T5: removes istanbul-ignore + adds email normalize call + R-2C-9 test.
+ *   - T6: extends with DB pool reference (still istanbul-ignored at query).
+ *   - T7: removes final istanbul-ignore + adds DB lookup + fail-closed +
+ *         structured log + 5 new tests (T1+T2+T3+T6+T7 per spec §10).
+ *
+ * This pattern keeps `Test + Coverage (≥80%)` CI gate **green on every
+ * PR** instead of relying on transient waivers (plan v4 H-A2 rejected
+ * "reviewer approves with explicit waiver in PR description" as the
+ * rebranded honor-system anti-pattern).
+ *
+ * Plan deviation: original plan v4 §T4 code block envisioned the full
+ * skeleton with dynamic imports of `./email-normalize` and `./db` modules
+ * that don't yet exist (T5/T6 create them as NEW per plan). Those
+ * imports would fail typecheck in T4. The simpler single-throw
+ * placeholder satisfies the H-A2 spirit (coverage gate green per PR)
+ * without requiring stub files outside T4 scope.
+ */
+export const beforeCreateCallback: gcipCloudFunctions.BeforeCreateHandlerCallback = async (
+  user,
+) => {
+  const isGoogle = user.providerData?.some((p) => p.providerId === 'google.com') ?? false;
+  if (!isGoogle) {
+    return {};
+  }
+
+  // T5-T7 logic ships in subsequent PRs (email normalize → DB lookup →
+  // fail-closed). The throw below is a sentinel: if it ever fires en
+  // prod it means T4 was deployed without the rest of the chain. T2b
+  // path-gate + T11 handler-completeness smoke catch this at PR time.
+  // vitest v8 provider respects `c8 ignore` (not `istanbul ignore`).
+  /* c8 ignore next */
+  throw new Error('handler T5-T7 logic not yet implemented (Sprint 2c-A T4 ships skeleton only)');
+};

--- a/apps/auth-blocking-functions/src/index.ts
+++ b/apps/auth-blocking-functions/src/index.ts
@@ -1,12 +1,18 @@
+import gcipCloudFunctions from 'gcip-cloud-functions';
+import { beforeCreateCallback } from './handler.js';
+
 /**
- * Sprint 2c-A T3 — bootstrap placeholder.
+ * Sprint 2c-A T4 — entrypoint deploy wrapper.
  *
- * Real handler wiring lands in T4 (per plan v4). This stub exists only
- * to satisfy tsc TS18003 ("No inputs were found in config file") so
- * `pnpm --filter @booster-ai/auth-blocking-functions typecheck` passes
- * on an otherwise-empty workspace.
+ * Replaces the T3 BOOTSTRAP_T3 placeholder with the actual gcip-cloud-
+ * functions `beforeCreate` Cloud Function Gen 1 export. `gcloud
+ * functions deploy beforeCreate` (Sprint 2c-B) picks up this export.
  *
- * T4 will replace this content with the
- * `gcipCloudFunctions.AuthFunction.beforeCreateHandler` import scaffold.
+ * The handler logic lives in `./handler.ts` (testable in isolation
+ * without the deploy machinery). This wrapper is excluded from
+ * coverage per `vitest.config.ts` (`exclude: ['src/**\/index.ts']`)
+ * because the gcip Auth instantiation has no testable surface.
  */
-export const BOOTSTRAP_T3 = 'placeholder; replaced in T4' as const;
+const auth = new gcipCloudFunctions.Auth();
+
+export const beforeCreate = auth.functions().beforeCreateHandler(beforeCreateCallback);


### PR DESCRIPTION
## Summary

Sprint 2c-A T4 — handler skeleton with provider passthrough (active branch) + c8-ignored throw placeholder for T5-T7 logic + 6 unit tests. Coverage gate green per H-A2 plan v4 fix.

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `apps/auth-blocking-functions/src/handler.ts` | 51 | NEW |
| `apps/auth-blocking-functions/src/index.ts` | 19 | MODIFY (replaces T3 BOOTSTRAP_T3 placeholder) |
| `apps/auth-blocking-functions/src/handler.test.ts` | 84 | NEW (6 tests) |

## Coverage local

```
File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered
------------|---------|----------|---------|---------|----------
handler.ts  |   83.33 |     75   |   100   |   80    |    48
```

All thresholds met (≥80/75/80/80). EXIT=0.

## Plan deviation declared

T4 ships **minimal skeleton with single c8-ignored throw** vs plan v4 §T4 "full skeleton with dynamic imports of `./email-normalize` and `./db`". Rationale: dynamic imports of files that T5/T6 create as NEW (per plan) would fail TypeScript compilation in T4. Stub files in T4 conflict with T5/T6 NEW scope. Single placeholder throw satisfies H-A2 spirit (coverage gate green every PR through T7).

T5 replaces the placeholder with normalize call + R-2C-9 tests. T6 adds DB pool reference. T7 adds query + fail-closed + structured log + 5 new tests.

## Architecture

- `src/index.ts`: thin deploy wrapper. Instantiates `gcipCloudFunctions.Auth()` and wraps the callback via `auth.functions().beforeCreateHandler(callback)`. Exports `beforeCreate` for Sprint 2c-B `gcloud functions deploy`. Excluded from coverage (`src/**/index.ts`).
- `src/handler.ts`: pure callback. Testable in isolation without deploy machinery.
- `src/handler.test.ts`: 5 active-branch tests + 1 structure smoke.

## Tests

| Test | What it verifies |
|---|---|
| `providerData undefined → {}` | Edge case: signup with no provider info |
| `providerData empty array → {}` | Edge case |
| `password provider → {}` | Non-Google passthrough (email/pw signup unaffected) |
| `saml.example provider → {}` | Non-Google passthrough (custom SAML providers unaffected) |
| `multiple non-Google providers → {}` | Multi-provider edge case |
| `beforeCreateCallback is AsyncFunction` | Structure smoke |

## Dependencies

- ✅ T3 merged (workspace bootstrapped).
- Next: T5 email normalization + remove placeholder + R-2C-9 tests.

## Test plan

- [x] Local typecheck pass
- [x] Local test:coverage 6/6 pass + thresholds met
- [x] Local biome lint pass
- [x] Local root `pnpm typecheck` pass (32/32 workspaces)
- [x] Pre-commit hooks pass
- [x] Commitlint pass
- [ ] CI green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)