### PR TITLE
feat(sec-001-h1-2-google-blocking-a): T5 email normalize + R-2C-9 tests

### DIFF
--- a/apps/auth-blocking-functions/package.json
+++ b/apps/auth-blocking-functions/package.json
@@ -15,11 +15,13 @@
     "firebase-admin": "^13.7.0",
     "firebase-functions": "^6.6.0",
     "gcip-cloud-functions": "0.2.0",
-    "pg": "^8.13.1"
+    "pg": "^8.13.1",
+    "punycode": "^2.3.1"
   },
   "devDependencies": {
     "@types/node": "^22.14.0",
     "@types/pg": "^8.11.10",
+    "@types/punycode": "^2.1.4",
     "@vitest/coverage-v8": "^4.0.18",
     "tsup": "^8.5.1",
     "tsx": "^4.19.2",

--- a/apps/auth-blocking-functions/src/email-normalize.test.ts
+++ b/apps/auth-blocking-functions/src/email-normalize.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeEmail } from './email-normalize.js';
+
+/**
+ * Sprint 2c-A T5 — R-2C-9 (email normalization risk) coverage.
+ *
+ * 22 variants covering: casing, whitespace, NFC/NFD equivalence, IDN
+ * domains, punycode-encoded domains, mixed-case punycode, gmail-specific
+ * patterns explicitly NOT collapsed, multi-`@` parsing, empty input.
+ */
+
+describe('normalizeEmail — canonical forms', () => {
+  it('canonical lowercase input stays unchanged', () => {
+    expect(normalizeEmail('foo@bar.com')).toBe('foo@bar.com');
+  });
+
+  it('uppercase email is lowercased', () => {
+    expect(normalizeEmail('FOO@BAR.COM')).toBe('foo@bar.com');
+  });
+
+  it('mixed case email is lowercased', () => {
+    expect(normalizeEmail('Foo@BAR.com')).toBe('foo@bar.com');
+  });
+
+  it('local-part preserves dots (no gmail collapse)', () => {
+    expect(normalizeEmail('foo.bar@gmail.com')).toBe('foo.bar@gmail.com');
+  });
+
+  it('local-part preserves plus alias (no gmail strip)', () => {
+    expect(normalizeEmail('first+last@gmail.com')).toBe('first+last@gmail.com');
+  });
+
+  it('local-part preserves multi-dot + plus', () => {
+    expect(normalizeEmail('f.o.o+anything@gmail.com')).toBe('f.o.o+anything@gmail.com');
+  });
+});
+
+describe('normalizeEmail — whitespace', () => {
+  it('strips leading whitespace', () => {
+    expect(normalizeEmail('  foo@bar.com')).toBe('foo@bar.com');
+  });
+
+  it('strips trailing whitespace', () => {
+    expect(normalizeEmail('foo@bar.com  ')).toBe('foo@bar.com');
+  });
+
+  it('strips leading + trailing whitespace', () => {
+    expect(normalizeEmail('  foo@bar.com  ')).toBe('foo@bar.com');
+  });
+
+  it('strips trailing newline', () => {
+    expect(normalizeEmail('foo@bar.com\n')).toBe('foo@bar.com');
+  });
+
+  it('strips trailing tab', () => {
+    expect(normalizeEmail('foo@bar.com\t')).toBe('foo@bar.com');
+  });
+});
+
+describe('normalizeEmail — Unicode NFC vs NFD', () => {
+  it('NFD-decomposed local-part normalizes to NFC', () => {
+    // 'café' in NFD: 'c' + 'a' + 'f' + 'e' + combining-acute (U+0301)
+    const nfd = `cafe${String.fromCharCode(0x0301)}@bar.com`;
+    const nfc = 'café@bar.com';
+    expect(normalizeEmail(nfd)).toBe(nfc);
+    expect(normalizeEmail(nfd).normalize('NFC')).toBe(nfc);
+  });
+
+  it('NFC input remains in NFC form', () => {
+    expect(normalizeEmail('José@bar.com')).toBe('josé@bar.com');
+  });
+});
+
+describe('normalizeEmail — IDN domains', () => {
+  it('Unicode IDN domain preserved (and lowercased)', () => {
+    expect(normalizeEmail('foo@müller.de')).toBe('foo@müller.de');
+  });
+
+  it('punycode-encoded domain decoded to Unicode', () => {
+    expect(normalizeEmail('foo@xn--mller-kva.de')).toBe('foo@müller.de');
+  });
+
+  it('uppercase punycode (after lowercase + decode) returns Unicode', () => {
+    expect(normalizeEmail('foo@XN--MLLER-KVA.DE')).toBe('foo@müller.de');
+  });
+
+  it('punycode label in subdomain decodes correctly', () => {
+    expect(normalizeEmail('foo@xn--mller-kva.example.com')).toBe('foo@müller.example.com');
+  });
+
+  it('numeric IP-like domain preserved (no IDN decode)', () => {
+    expect(normalizeEmail('foo@192.168.1.1')).toBe('foo@192.168.1.1');
+  });
+});
+
+describe('normalizeEmail — edge cases', () => {
+  it('empty string returns empty string', () => {
+    expect(normalizeEmail('')).toBe('');
+  });
+
+  it('whitespace-only returns empty after trim', () => {
+    expect(normalizeEmail('   \t\n  ')).toBe('');
+  });
+
+  it('input without `@` returns lowercased + trimmed', () => {
+    expect(normalizeEmail('  Foo  ')).toBe('foo');
+  });
+
+  it('input with multiple `@` splits at the last one', () => {
+    // Quoted local-parts with `@` are valid per RFC 5321 §4.1.2.
+    expect(normalizeEmail('"a@b"@example.com')).toBe('"a@b"@example.com');
+  });
+});

--- a/apps/auth-blocking-functions/src/email-normalize.ts
+++ b/apps/auth-blocking-functions/src/email-normalize.ts
@@ -1,0 +1,51 @@
+// `punycode` (without `node:` prefix and without trailing slash) resolves to
+// the npm userland package, not the deprecated Node builtin. `node:punycode`
+// is deprecated since Node 7 and slated for removal; the userland fork
+// (maintained by `mathias`) is the stable choice.
+// biome-ignore lint/style/useNodejsImportProtocol: userland npm package, not Node builtin
+import { toUnicode } from 'punycode';
+
+/**
+ * Sprint 2c-A T5 — email canonicalization for admin-approval gate
+ * lookup (per spec §9 R-2C-9).
+ *
+ * Applied transformations (in order):
+ *   1. `trim()` — leading/trailing whitespace (incl. tab, newline).
+ *   2. `normalize('NFC')` — Unicode canonical composition. Defends
+ *      against NFD-vs-NFC equivalence (e.g., decomposed `é`
+ *      → precomposed `é`).
+ *   3. `toLowerCase()` — case-insensitive comparison. RFC 5321 §2.4
+ *      says local-part is technically case-sensitive but virtually
+ *      every email provider treats it as case-insensitive; matching
+ *      that pragmatic behavior matches admin-approval UX.
+ *   4. `punycode.toUnicode(domain)` — IDN decode. Defends against
+ *      `josé@xn--mller-kva.de` vs `josé@müller.de` divergence (same
+ *      domain, two encodings). DB store form is what admin enters
+ *      during approval; gate canonicalizes incoming email to the
+ *      same canonical form for lookup.
+ *
+ * **Explicitly NOT applied** (per plan v4 acceptance):
+ *   - Gmail dot collapsing (`foo.bar@gmail.com` ≠ `foobar@gmail.com`):
+ *     would be Gmail-provider-specific; admin may approve users that
+ *     register from any provider. Local-part dots preserved as-is.
+ *   - Gmail plus-aliasing strip (`foo+anything@gmail.com`): same
+ *     reasoning. Preserved.
+ *   - Sub-addressing (RFC 5233): preserved.
+ *
+ * Edge cases:
+ *   - Empty input → empty string.
+ *   - No `@` → input returned unchanged after transforms 1-3
+ *     (no domain to decode).
+ *   - Multiple `@` → `lastIndexOf('@')` splits at the last `@`,
+ *     consistent with most email parsers; conforms to RFC 5321 §4.1.2.
+ */
+export function normalizeEmail(input: string): string {
+  const cleaned = input.trim().normalize('NFC').toLowerCase();
+  const atIdx = cleaned.lastIndexOf('@');
+  if (atIdx < 0) {
+    return cleaned;
+  }
+  const local = cleaned.slice(0, atIdx);
+  const domain = cleaned.slice(atIdx + 1);
+  return `${local}@${toUnicode(domain)}`;
+}

--- a/apps/auth-blocking-functions/src/handler.test.ts
+++ b/apps/auth-blocking-functions/src/handler.test.ts
@@ -83,6 +83,34 @@ describe('beforeCreateCallback (T4 active branches)', () => {
   });
 });
 
+describe('beforeCreateCallback (T5 — email validation in Google branch)', () => {
+  it('T6: throws HttpsError invalid-argument when Google user has no email', async () => {
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = '' as unknown as string;
+    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toMatchObject({
+      status: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('T6: throws HttpsError invalid-argument when email is undefined-coerced', async () => {
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    Reflect.deleteProperty(user, 'email');
+    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toMatchObject({
+      status: 'INVALID_ARGUMENT',
+    });
+  });
+
+  it('T5: Google + valid email reaches normalize call (placeholder throws pending T6-T7)', async () => {
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = 'foo@example.com';
+    // Placeholder throw (c8-ignored) is the sentinel for un-shipped T6-T7
+    // chain. Test verifies the normalize call line is reached.
+    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toThrow(
+      /handler T6-T7 logic not yet implemented/,
+    );
+  });
+});
+
 describe('beforeCreateCallback (structure smoke)', () => {
   it('is an async function', () => {
     expect(typeof beforeCreateCallback).toBe('function');

--- a/apps/auth-blocking-functions/src/handler.ts
+++ b/apps/auth-blocking-functions/src/handler.ts
@@ -1,35 +1,26 @@
-import type gcipCloudFunctions from 'gcip-cloud-functions';
+import gcipCloudFunctions from 'gcip-cloud-functions';
+import { normalizeEmail } from './email-normalize.js';
 
 /**
- * Sprint 2c-A T4 — handler skeleton with provider check (active) +
- * istanbul-ignored placeholder for T5-T7 logic.
+ * Sprint 2c-A T4-T5 — handler with provider check + email normalize
+ * (active) + c8-ignored placeholder for T6-T7 DB lookup + fail-closed.
  *
- * **Istanbul-ignore strategy** (per plan v4 H-A2 fix):
+ * **C8-ignore strategy** (per plan v4 H-A2 fix):
  *
- * T4 ships a minimal skeleton where the only active branch is the
- * provider check (return `{}` if signup is not Google federated). The
- * un-implemented T5-T7 logic (email normalize + DB lookup + fail-closed
- * + structured log) is replaced by a single istanbul-ignored throw line.
+ * Each PR T4..T7 keeps the `Test + Coverage (≥80%)` CI gate green by
+ * marking un-implemented branches with `/* c8 ignore next *​/`. Each
+ * subsequent PR removes the ignore comment + adds covering tests:
  *
- * Each subsequent PR removes the istanbul-ignore comment + adds the
- * covering test:
+ *   - T4 (shipped): provider check (return `{}` if non-Google).
+ *   - T5 (this PR): email check + normalize → covered by tests T5+T6;
+ *     remaining DB lookup + fail-closed marked c8-ignored.
+ *   - T6: DB pool initialization (still c8-ignored at query).
+ *   - T7: removes final c8-ignore + adds DB lookup + fail-closed +
+ *     structured log + 4 new tests (T1+T2+T3+T7 per spec §10).
  *
- *   - T5: removes istanbul-ignore + adds email normalize call + R-2C-9 test.
- *   - T6: extends with DB pool reference (still istanbul-ignored at query).
- *   - T7: removes final istanbul-ignore + adds DB lookup + fail-closed +
- *         structured log + 5 new tests (T1+T2+T3+T6+T7 per spec §10).
- *
- * This pattern keeps `Test + Coverage (≥80%)` CI gate **green on every
- * PR** instead of relying on transient waivers (plan v4 H-A2 rejected
- * "reviewer approves with explicit waiver in PR description" as the
- * rebranded honor-system anti-pattern).
- *
- * Plan deviation: original plan v4 §T4 code block envisioned the full
- * skeleton with dynamic imports of `./email-normalize` and `./db` modules
- * that don't yet exist (T5/T6 create them as NEW per plan). Those
- * imports would fail typecheck in T4. The simpler single-throw
- * placeholder satisfies the H-A2 spirit (coverage gate green per PR)
- * without requiring stub files outside T4 scope.
+ * Plan deviation: original plan v4 §T4 code block envisioned dynamic
+ * imports of `./email-normalize` and `./db`. Static imports adopted as
+ * each module ships (T5 here adds the email-normalize static import).
  */
 export const beforeCreateCallback: gcipCloudFunctions.BeforeCreateHandlerCallback = async (
   user,
@@ -39,11 +30,20 @@ export const beforeCreateCallback: gcipCloudFunctions.BeforeCreateHandlerCallbac
     return {};
   }
 
-  // T5-T7 logic ships in subsequent PRs (email normalize → DB lookup →
-  // fail-closed). The throw below is a sentinel: if it ever fires en
-  // prod it means T4 was deployed without the rest of the chain. T2b
-  // path-gate + T11 handler-completeness smoke catch this at PR time.
-  // vitest v8 provider respects `c8 ignore` (not `istanbul ignore`).
+  if (!user.email) {
+    throw new gcipCloudFunctions.https.HttpsError(
+      'invalid-argument',
+      'email required for Google federated signup',
+    );
+  }
+
+  const normalized = normalizeEmail(user.email);
+
+  // T6-T7 logic ships in subsequent PRs (DB pool → query →
+  // fail-closed → structured log). The throw below is a sentinel:
+  // if it ever fires en prod it means handler was deployed without the
+  // rest of the chain. T2b path-gate + T11 handler-completeness smoke
+  // catch this at PR time.
   /* c8 ignore next */
-  throw new Error('handler T5-T7 logic not yet implemented (Sprint 2c-A T4 ships skeleton only)');
+  throw new Error(`handler T6-T7 logic not yet implemented (email=${normalized.length} chars)`);
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       pg:
         specifier: ^8.13.1
         version: 8.20.0
+      punycode:
+        specifier: ^2.3.1
+        version: 2.3.1
     devDependencies:
       '@types/node':
         specifier: ^22.14.0
@@ -220,6 +223,9 @@ importers:
       '@types/pg':
         specifier: ^8.11.10
         version: 8.20.0
+      '@types/punycode':
+        specifier: ^2.1.4
+        version: 2.1.4
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.1.5(vitest@4.1.5)
@@ -3723,6 +3729,9 @@ packages:
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/punycode@2.1.4':
+    resolution: {integrity: sha512-trzh6NzBnq8yw5e35f8xe8VTYjqM3NE7bohBtvDVf/dtUer3zYTLK1Ka3DG3p7bdtoaOHZucma6FfVKlQ134pQ==}
 
   '@types/qs@6.15.1':
     resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
@@ -10730,6 +10739,8 @@ snapshots:
       pg-types: 2.2.0
 
   '@types/prop-types@15.7.15': {}
+
+  '@types/punycode@2.1.4': {}
 
   '@types/qs@6.15.1': {}
 


### PR DESCRIPTION
## Summary

Sprint 2c-A T5 — email canonicalization module + 22 R-2C-9 variants + handler email check (T6 test) + normalize call wiring. **Coverage 100%** across all 4 axes.

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `apps/auth-blocking-functions/src/email-normalize.ts` | 53 | NEW |
| `apps/auth-blocking-functions/src/email-normalize.test.ts` | 116 | NEW (22 tests) |
| `apps/auth-blocking-functions/src/handler.ts` | 56 | MODIFY (placeholder → email check + normalize call) |
| `apps/auth-blocking-functions/src/handler.test.ts` | 113 | MODIFY (+3 tests: T6 email-empty / T6 email-undefined / T5 normalize-call) |
| `apps/auth-blocking-functions/package.json` | 31 | MODIFY (+punycode + @types/punycode) |
| `pnpm-lock.yaml` | +20 | MODIFY (purely additive — 2 new packages) |

## Coverage local

```
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered
-------------------|---------|----------|---------|---------|----------
All files          |   100   |   100    |   100   |   100   |          
```

**31/31 tests pass**. handler.ts + email-normalize.ts both fully covered.

## R-2C-9 variants (22)

| Category | Tests |
|---|---|
| Canonical / casing | 6 |
| Whitespace | 5 |
| NFC vs NFD equivalence | 2 |
| IDN / punycode | 5 |
| Edge cases (empty / no@ / multi-@) | 4 |

## Handler T5 changes

Before (T4):
```
provider check → if non-Google return {} → /* c8 ignore next */ throw placeholder
```

After (T5):
```
provider check → if non-Google return {} →
  if !email → throw HttpsError invalid-argument →
  normalized = normalizeEmail(email) →
  /* c8 ignore next */ throw placeholder (T6-T7 chain pending)
```

## Deps

| Dep | Version | Reason |
|---|---|---|
| `punycode` | `^2.3.1` | IDN domain decode (xn-- → Unicode); npm userland fork (NOT deprecated `node:punycode` builtin) |
| `@types/punycode` | `^2.1.4` | TypeScript types for above |

Biome `useNodejsImportProtocol` rule false-positive on `punycode` (treats as builtin); explicit `biome-ignore` comment with rationale.

## Test plan

- [x] Local typecheck pass
- [x] Local test:coverage 31/31 pass + 100% coverage all 4 axes
- [x] Local biome lint pass
- [x] Local pnpm install --frozen-lockfile succeeds
- [x] Local root `pnpm typecheck` pass (32/32 workspaces)
- [x] Pre-commit hooks pass
- [x] Commitlint pass
- [ ] CI green (this PR)

## Dependencies

- ✅ T4 merged.
- Next: T6 DB pool + logger instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)