### PR TITLE
feat(sec-001-h1-2-google-blocking-a): T6 DB pool + logger instance

### DIFF
--- a/apps/auth-blocking-functions/src/db.test.ts
+++ b/apps/auth-blocking-functions/src/db.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { __resetDbPoolForTests, getDbPool } from './db.js';
+
+/**
+ * Sprint 2c-A T6 — DB pool tests.
+ *
+ * Verifies the singleton contract:
+ *   - Lazy initialization (no Pool constructed at module import).
+ *   - Reuse across calls (same instance returned).
+ *   - Config snapshot matches the planned timeouts (3 s).
+ *
+ * Real DB connectivity NOT exercised here; `pg.Pool` is lazy — `new
+ * pg.Pool({...})` does not open sockets until `.query()`. T9a/T9b
+ * (Firebase emulator integration) and T10a/T10b (race + Admin SDK)
+ * exercise the live path.
+ */
+
+describe('getDbPool', () => {
+  afterEach(() => {
+    __resetDbPoolForTests();
+  });
+
+  it('returns a singleton: two calls produce the same instance', () => {
+    const a = getDbPool();
+    const b = getDbPool();
+    expect(a).toBe(b);
+  });
+
+  it('uses configured timeouts (statement, query, connection: 3000ms)', () => {
+    const pool = getDbPool();
+    // pg.Pool exposes options on `.options`. We assert against the
+    // public config object that pg builds at construction.
+    const options = (pool as unknown as { options: Record<string, unknown> }).options;
+    expect(options.statement_timeout).toBe(3000);
+    expect(options.query_timeout).toBe(3000);
+    expect(options.connectionTimeoutMillis).toBe(3000);
+    expect(options.max).toBe(5);
+  });
+
+  it('reads DATABASE_URL env at construction (lazy until first call)', () => {
+    const originalUrl = process.env.DATABASE_URL;
+    process.env.DATABASE_URL = 'postgresql://test:test@localhost/test?ssl=false';
+    try {
+      const pool = getDbPool();
+      const options = (pool as unknown as { options: Record<string, unknown> }).options;
+      expect(options.connectionString).toBe('postgresql://test:test@localhost/test?ssl=false');
+    } finally {
+      if (originalUrl === undefined) {
+        process.env.DATABASE_URL = undefined;
+      } else {
+        process.env.DATABASE_URL = originalUrl;
+      }
+    }
+  });
+});

--- a/apps/auth-blocking-functions/src/db.ts
+++ b/apps/auth-blocking-functions/src/db.ts
@@ -1,0 +1,48 @@
+import pg from 'pg';
+
+/**
+ * Sprint 2c-A T6 — lazy-initialized `pg.Pool` singleton.
+ *
+ * The Cloud Function Gen 1 runtime instantiates one Node.js process per
+ * container; module-level singletons survive across invocations within
+ * that container. Lazy initialization (vs eager) means:
+ *
+ *   - Cold-start cost: no DB connection attempt at module load. First
+ *     invocation pays the connect overhead; subsequent invocations on
+ *     the same container reuse the pool.
+ *   - Test ergonomics: importing `db.ts` does not require
+ *     `DATABASE_URL` to be set. Tests can `vi.mock('./db.js')` cleanly.
+ *
+ * Connection target (Sprint 2c-B wires the unix-socket form via
+ * Terraform):
+ *   `DATABASE_URL=postgresql://user:pass@/dbname?host=/cloudsql/<conn-name>`
+ *
+ * Per Cloud Run + Cloud SQL Auth Proxy unix-socket pattern (no TCP).
+ *
+ * Timeouts: 3 s aligned with umbrella spec §6 C6 (handler total
+ * budget ≤ 5 s including JWT validation overhead).
+ */
+
+let pool: pg.Pool | undefined;
+
+export function getDbPool(): pg.Pool {
+  if (!pool) {
+    pool = new pg.Pool({
+      connectionString: process.env.DATABASE_URL,
+      statement_timeout: 3000,
+      query_timeout: 3000,
+      connectionTimeoutMillis: 3000,
+      max: 5,
+    });
+  }
+  return pool;
+}
+
+/**
+ * Test-only escape hatch. Resets the singleton so subsequent
+ * `getDbPool()` calls re-evaluate `DATABASE_URL`. Production code MUST
+ * NOT call this.
+ */
+export function __resetDbPoolForTests(): void {
+  pool = undefined;
+}

--- a/apps/auth-blocking-functions/src/handler.test.ts
+++ b/apps/auth-blocking-functions/src/handler.test.ts
@@ -100,13 +100,15 @@ describe('beforeCreateCallback (T5 — email validation in Google branch)', () =
     });
   });
 
-  it('T5: Google + valid email reaches normalize call (placeholder throws pending T6-T7)', async () => {
+  it('T5+T6: Google + valid email reaches normalize + getDbPool (placeholder throws pending T7)', async () => {
     const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
     user.email = 'foo@example.com';
-    // Placeholder throw (c8-ignored) is the sentinel for un-shipped T6-T7
-    // chain. Test verifies the normalize call line is reached.
+    // Placeholder throw (c8-ignored) is the sentinel for un-shipped T7
+    // chain. Test verifies the normalize + getDbPool call lines are
+    // reached (and getDbPool returns a pg.Pool without trying to
+    // connect — lazy until .query()).
     await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toThrow(
-      /handler T6-T7 logic not yet implemented/,
+      /handler T7 logic not yet implemented/,
     );
   });
 });

--- a/apps/auth-blocking-functions/src/handler.ts
+++ b/apps/auth-blocking-functions/src/handler.ts
@@ -1,26 +1,23 @@
 import gcipCloudFunctions from 'gcip-cloud-functions';
+import { getDbPool } from './db.js';
 import { normalizeEmail } from './email-normalize.js';
 
 /**
- * Sprint 2c-A T4-T5 — handler with provider check + email normalize
- * (active) + c8-ignored placeholder for T6-T7 DB lookup + fail-closed.
+ * Sprint 2c-A T4-T6 — handler with provider check + email normalize +
+ * DB pool init (active) + c8-ignored placeholder for T7 query +
+ * fail-closed + structured log.
  *
- * **C8-ignore strategy** (per plan v4 H-A2 fix):
- *
- * Each PR T4..T7 keeps the `Test + Coverage (≥80%)` CI gate green by
- * marking un-implemented branches with `/* c8 ignore next *​/`. Each
- * subsequent PR removes the ignore comment + adds covering tests:
+ * **C8-ignore strategy** (per plan v4 H-A2 fix): each PR T4..T7 keeps
+ * the `Test + Coverage (≥80%)` CI gate green by marking un-implemented
+ * branches with `/* c8 ignore next *​/`. Each subsequent PR removes the
+ * ignore comment + adds covering tests:
  *
  *   - T4 (shipped): provider check (return `{}` if non-Google).
- *   - T5 (this PR): email check + normalize → covered by tests T5+T6;
- *     remaining DB lookup + fail-closed marked c8-ignored.
- *   - T6: DB pool initialization (still c8-ignored at query).
+ *   - T5 (shipped): email check + normalize.
+ *   - T6 (this PR): `getDbPool()` reachable line added; query +
+ *     rowCount check + fail-closed + structured log still c8-ignored.
  *   - T7: removes final c8-ignore + adds DB lookup + fail-closed +
  *     structured log + 4 new tests (T1+T2+T3+T7 per spec §10).
- *
- * Plan deviation: original plan v4 §T4 code block envisioned dynamic
- * imports of `./email-normalize` and `./db`. Static imports adopted as
- * each module ships (T5 here adds the email-normalize static import).
  */
 export const beforeCreateCallback: gcipCloudFunctions.BeforeCreateHandlerCallback = async (
   user,
@@ -38,12 +35,15 @@ export const beforeCreateCallback: gcipCloudFunctions.BeforeCreateHandlerCallbac
   }
 
   const normalized = normalizeEmail(user.email);
+  const pool = getDbPool();
 
-  // T6-T7 logic ships in subsequent PRs (DB pool → query →
-  // fail-closed → structured log). The throw below is a sentinel:
-  // if it ever fires en prod it means handler was deployed without the
-  // rest of the chain. T2b path-gate + T11 handler-completeness smoke
-  // catch this at PR time.
+  // T7 logic ships in the next PR (query solicitudes_registro WHERE
+  // estado='aprobado' + permission-denied throw + structured log).
+  // The throw below is a sentinel: if it ever fires en prod it means
+  // handler was deployed without the rest of the chain. T2b path-gate
+  // + T11 handler-completeness smoke catch this at PR time.
   /* c8 ignore next */
-  throw new Error(`handler T6-T7 logic not yet implemented (email=${normalized.length} chars)`);
+  throw new Error(
+    `handler T7 logic not yet implemented (email=${normalized.length} chars, pool=${typeof pool})`,
+  );
 };

--- a/apps/auth-blocking-functions/src/logger.test.ts
+++ b/apps/auth-blocking-functions/src/logger.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { logger } from './logger.js';
+
+/**
+ * Sprint 2c-A T6 — structure smoke for logger module.
+ *
+ * Verifies that `createLogger` was called with valid options at module
+ * load and the exported `logger` has the standard Pino API surface.
+ * Behavioral tests of redaction etc. live in `@booster-ai/logger`'s
+ * own suite.
+ */
+describe('logger', () => {
+  it('exports a configured pino-like logger', () => {
+    expect(typeof logger.info).toBe('function');
+    expect(typeof logger.warn).toBe('function');
+    expect(typeof logger.error).toBe('function');
+  });
+
+  it('is bound to the auth-blocking-functions service', () => {
+    const bindings = logger.bindings();
+    expect(bindings.service).toBe('@booster-ai/auth-blocking-functions');
+  });
+});

--- a/apps/auth-blocking-functions/src/logger.ts
+++ b/apps/auth-blocking-functions/src/logger.ts
@@ -1,0 +1,19 @@
+import { createLogger } from '@booster-ai/logger';
+
+/**
+ * Sprint 2c-A T6 — structured logger for auth-blocking-functions.
+ *
+ * Service name `@booster-ai/auth-blocking-functions` matches the
+ * workspace package name and shows up in every log entry's `service`
+ * field. Cloud Run + Cloud Logging map the JSON output to structured
+ * log fields (severity, trace, etc.) automatically per @booster-ai/
+ * logger conventions.
+ *
+ * Used by T7 onwards for `event: 'signup.blocked.google'` structured
+ * log entries with PII-redacted email (hashed) + correlationId +
+ * ipAddress.
+ */
+export const logger = createLogger({
+  service: '@booster-ai/auth-blocking-functions',
+  level: 'info',
+});


### PR DESCRIPTION
## Summary

Sprint 2c-A T6 — pg.Pool lazy singleton + `@booster-ai/logger` instance + handler wire (getDbPool call active; query line still c8-ignored until T7). **Coverage 100%** all 4 axes.

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `apps/auth-blocking-functions/src/db.ts` | 47 | NEW (lazy pg.Pool singleton + test reset) |
| `apps/auth-blocking-functions/src/db.test.ts` | 50 | NEW (3 tests) |
| `apps/auth-blocking-functions/src/logger.ts` | 17 | NEW (createLogger wrapper) |
| `apps/auth-blocking-functions/src/logger.test.ts` | 24 | NEW (2 tests) |
| `apps/auth-blocking-functions/src/handler.ts` | 60 | MODIFY (+getDbPool import + call) |
| `apps/auth-blocking-functions/src/handler.test.ts` | 113 | MODIFY (placeholder regex T6-T7 → T7) |

## Coverage local

```
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered
All files     |   100   |    100   |   100   |   100   |
```

**34/34 tests pass**. All files fully covered.

## Pool config

| Setting | Value | Rationale |
|---|---|---|
| `connectionString` | `process.env.DATABASE_URL` | Sprint 2c-B wires unix-socket form via Terraform |
| `statement_timeout` | 3000 ms | Umbrella §6 C6 budget ≤ 5s |
| `query_timeout` | 3000 ms | Same |
| `connectionTimeoutMillis` | 3000 ms | Cold-start defensive |
| `max` | 5 | Cloud Function single-process; Cloud SQL Auth Proxy unix socket |

## Logger config

| Field | Value |
|---|---|
| `service` | `@booster-ai/auth-blocking-functions` |
| `level` | `info` |
| Output | JSON → Cloud Logging structured log mapping (via @booster-ai/logger pino conventions) |

## Handler T6 flow

```
provider check → if non-Google return {}
if !email → throw HttpsError INVALID_ARGUMENT
normalized = normalizeEmail(email)
pool = getDbPool()                ← NEW (T6 active)
/* c8 ignore next */
throw 'T7 not yet implemented'    ← shifted; covers T7 territory only
```

T7 removes the c8-ignore + adds: `pool.query("SELECT estado FROM solicitudes_registro WHERE LOWER(email)=$1 AND estado='aprobado' LIMIT 1", [normalized])` + `if rowCount === 0 throw permission-denied BLOCKED_SIGNUP_PENDING_APPROVAL` + `logger.warn({ event: 'signup.blocked.google', ... })`.

## Test plan

- [x] Local typecheck pass
- [x] Local test:coverage 34/34 pass + 100% all axes
- [x] Local biome lint pass (after auto-fix useLiteralKeys / noDelete)
- [x] Local root `pnpm typecheck` pass (32/32 workspaces)
- [x] Pre-commit hooks pass
- [x] Commitlint pass
- [ ] CI green (this PR)

## Dependencies

- ✅ T5 merged (email normalize landed).
- Next: T7 handler DB lookup complete + BLOCKED constant + 2c-B spec edit + 4 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)