### PR TITLE
feat(sec-001-h1-2-google-blocking-a): T7 handler complete + 2c-B spec edit

### DIFF
--- a/.specs/sec-001-h1-2-google-blocking-b/spec.md
+++ b/.specs/sec-001-h1-2-google-blocking-b/spec.md
@@ -104,6 +104,7 @@ Subset of umbrella §10 reachable in 2c-B:
 - **SA email verification**: empirical gcloud call per SC-2C.B.9.
 - **Atomic deploy verification**: `gcloud functions describe` post-terraform-apply + pre-IdP-wire.
 - **CI gate path-filter test**: PR fixture toca solo 2c-B paths → check-adr-status-accepted fires + fails con Status: Proposed; flip Status: Accepted → passes. PR fixture toca solo 2c-A paths → gate NOT fires.
+- **T-LITERALS** _(cross-source-of-truth obligation added 2026-05-27 by Sprint 2c-A T7 PR per G-A2 plan v4 fix)_: integration test que asegura que el literal `BLOCKED_CODE` definido inline en `apps/auth-blocking-functions/src/handler.ts` (handler shipped en Sprint 2c-A T7) **MUST equal** el string mapeado en `apps/web/src/utils/translate-auth-error.ts` (path **estimated**; 2c-B plan-b draft debe verificar antes de lockear — si el file está ausente, T-LITERALS se convierte en "crear file + agregar mapping" en lugar de "extender existing"). Ambos literales deben igualar `BLOCKED_SIGNUP_PENDING_APPROVAL`. El test asserts equality leyendo ambos files vía test harness (grep + comparación) **O** importando ambas constantes + `expect(a).toBe(b)`. Rationale: handler.ts inlined per F-A4 option (a) trade-off; este test cierra la fuga de "drift if literals diverge" sin requerir `shared-schemas` export.
 
 ## 11. Rollout (sub-sprint scope)
 

--- a/apps/auth-blocking-functions/src/handler.test.ts
+++ b/apps/auth-blocking-functions/src/handler.test.ts
@@ -1,20 +1,44 @@
 import type gcipCloudFunctions from 'gcip-cloud-functions';
-import { describe, expect, it } from 'vitest';
-import { beforeCreateCallback } from './handler.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the DB pool module BEFORE the handler imports it. vitest hoists
+// `vi.mock` to the top of the file, so the handler sees the mocked
+// `getDbPool` at import time.
+const mockQuery = vi.fn();
+vi.mock('./db.js', () => ({
+  getDbPool: vi.fn(() => ({ query: mockQuery })),
+  __resetDbPoolForTests: vi.fn(),
+}));
+
+// Mock the logger so we can both keep tests silent and assert log
+// payloads do not contain plaintext email.
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+vi.mock('./logger.js', () => ({
+  logger: mockLogger,
+}));
+
+const { beforeCreateCallback } = await import('./handler.js');
 
 /**
- * Sprint 2c-A T4 tests — provider passthrough only.
+ * Sprint 2c-A T7 — handler full-flow tests (T1+T2+T3+T7 per spec §10).
  *
- * Per plan v4 acceptance: "NO T1/T2 yet (per F-02 v1 fix from umbrella)
- * — those require DB code, moved to T7." Tests covering Google provider
- * + approved row / no-row / DB throw land in T7.
+ * T4 active branches (providers passthrough) and T5/T6 (email check +
+ * normalize + getDbPool reach) covered in earlier describe blocks.
  *
- * T4 active branches:
- *   - providerData absent → return {} (passthrough)
- *   - providerData empty → return {} (passthrough)
- *   - providerData non-Google → return {} (passthrough)
+ * New tests in this PR:
+ *   - T1: DB rowCount=0 (no approval row) → permission-denied.
+ *   - T2: DB rowCount=1 (approved row) → returns {} (allow signup).
+ *   - T3: DB throws → internal HttpsError (fail-closed via internal status).
+ *   - T7: DB rowCount=0 because estado != aprobado (query WHERE filter)
+ *     → permission-denied. Documents the invariant that non-approved
+ *     estado cannot reach rowCount >= 1.
  *
- * T5-T7 placeholder branch is istanbul-ignored; not tested here.
+ * PII assertions: log payloads never contain `email` plaintext (only
+ * `emailHashed` SHA-256 truncated).
  */
 
 function buildUser(
@@ -47,6 +71,13 @@ const STUB_CONTEXT = {
   ipAddress: '127.0.0.1',
   userAgent: 'test-ua',
 } as unknown as gcipCloudFunctions.AuthEventContext;
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockLogger.info.mockReset();
+  mockLogger.warn.mockReset();
+  mockLogger.error.mockReset();
+});
 
 describe('beforeCreateCallback (T4 active branches)', () => {
   it('returns {} when providerData is undefined (passthrough)', async () => {
@@ -99,17 +130,101 @@ describe('beforeCreateCallback (T5 — email validation in Google branch)', () =
       status: 'INVALID_ARGUMENT',
     });
   });
+});
 
-  it('T5+T6: Google + valid email reaches normalize + getDbPool (placeholder throws pending T7)', async () => {
+describe('beforeCreateCallback (T7 — DB lookup full flow)', () => {
+  it('T1: rowCount=0 (no approval row) → throws permission-denied with BLOCKED_CODE', async () => {
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = 'unknown@example.com';
+    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toMatchObject({
+      status: 'PERMISSION_DENIED',
+      message: 'BLOCKED_SIGNUP_PENDING_APPROVAL',
+    });
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    const warnCall = mockLogger.warn.mock.calls[0]?.[0] ?? {};
+    expect(warnCall.event).toBe('signup.blocked.google');
+    expect(JSON.stringify(warnCall)).not.toContain('unknown@example.com');
+  });
+
+  it('T2: rowCount=1 (approved row) → returns {} (allow signup)', async () => {
+    mockQuery.mockResolvedValue({ rowCount: 1, rows: [{ '?column?': 1 }] });
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = 'approved@example.com';
+    const result = await beforeCreateCallback(user, STUB_CONTEXT);
+    expect(result).toEqual({});
+    expect(mockLogger.info).toHaveBeenCalledTimes(1);
+    const infoCall = mockLogger.info.mock.calls[0]?.[0] ?? {};
+    expect(infoCall.event).toBe('signup.allowed.google');
+    expect(JSON.stringify(infoCall)).not.toContain('approved@example.com');
+  });
+
+  it('T3: DB pool.query rejects → throws HttpsError internal with BLOCKED_CODE', async () => {
+    mockQuery.mockRejectedValue(new Error('connection refused'));
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = 'transient@example.com';
+    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toMatchObject({
+      status: 'INTERNAL',
+      message: 'BLOCKED_SIGNUP_PENDING_APPROVAL',
+    });
+    expect(mockLogger.error).toHaveBeenCalledTimes(1);
+    const errCall = mockLogger.error.mock.calls[0]?.[0] ?? {};
+    expect(errCall.event).toBe('signup.gate.db_error');
+    expect(errCall.err).toBe('connection refused');
+    expect(JSON.stringify(errCall)).not.toContain('transient@example.com');
+  });
+
+  it('T7: non-aprobado estado → rowCount=0 → permission-denied (query filters estado=aprobado)', async () => {
+    // DB has the row but estado='pendiente'; the query `WHERE estado='aprobado'`
+    // filter means rowCount=0, indistinguishable at handler level from T1.
+    // Test documents the invariant: gate cannot allow non-approved estado.
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = 'pending@example.com';
+    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toMatchObject({
+      status: 'PERMISSION_DENIED',
+      message: 'BLOCKED_SIGNUP_PENDING_APPROVAL',
+    });
+  });
+
+  it('T7: query receives normalized lowercase email (not original casing)', async () => {
+    mockQuery.mockResolvedValue({ rowCount: 1, rows: [{ '?column?': 1 }] });
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = 'MixedCase@Example.COM';
+    await beforeCreateCallback(user, STUB_CONTEXT);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const queryCall = mockQuery.mock.calls[0];
+    expect(queryCall?.[1]).toEqual(['mixedcase@example.com']);
+  });
+
+  it('T7: query receives IDN-decoded punycode domain in normalized email', async () => {
+    mockQuery.mockResolvedValue({ rowCount: 1, rows: [{ '?column?': 1 }] });
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = 'foo@xn--mller-kva.de';
+    await beforeCreateCallback(user, STUB_CONTEXT);
+    const queryCall = mockQuery.mock.calls[0];
+    expect(queryCall?.[1]).toEqual(['foo@müller.de']);
+  });
+
+  it('T3 variant: non-Error rejection (e.g., string) logs `unknown` err message', async () => {
+    mockQuery.mockRejectedValue('connection refused');
     const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
     user.email = 'foo@example.com';
-    // Placeholder throw (c8-ignored) is the sentinel for un-shipped T7
-    // chain. Test verifies the normalize + getDbPool call lines are
-    // reached (and getDbPool returns a pg.Pool without trying to
-    // connect — lazy until .query()).
-    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toThrow(
-      /handler T7 logic not yet implemented/,
-    );
+    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toMatchObject({
+      status: 'INTERNAL',
+    });
+    const errCall = mockLogger.error.mock.calls[0]?.[0] ?? {};
+    expect(errCall.err).toBe('unknown');
+  });
+
+  it('T7 variant: pg returns null rowCount → coalesces to 0 → permission-denied', async () => {
+    mockQuery.mockResolvedValue({ rowCount: null, rows: [] });
+    const user = buildUser([{ providerId: 'google.com', uid: 'g-uid' }]);
+    user.email = 'foo@example.com';
+    await expect(beforeCreateCallback(user, STUB_CONTEXT)).rejects.toMatchObject({
+      status: 'PERMISSION_DENIED',
+      message: 'BLOCKED_SIGNUP_PENDING_APPROVAL',
+    });
   });
 });
 

--- a/apps/auth-blocking-functions/src/handler.ts
+++ b/apps/auth-blocking-functions/src/handler.ts
@@ -1,26 +1,56 @@
+import { createHash } from 'node:crypto';
 import gcipCloudFunctions from 'gcip-cloud-functions';
 import { getDbPool } from './db.js';
 import { normalizeEmail } from './email-normalize.js';
+import { logger } from './logger.js';
 
 /**
- * Sprint 2c-A T4-T6 — handler with provider check + email normalize +
- * DB pool init (active) + c8-ignored placeholder for T7 query +
- * fail-closed + structured log.
+ * Sprint 2c-A T7 — admin-approval gate for Google federated signup
+ * (full flow active).
  *
- * **C8-ignore strategy** (per plan v4 H-A2 fix): each PR T4..T7 keeps
- * the `Test + Coverage (≥80%)` CI gate green by marking un-implemented
- * branches with `/* c8 ignore next *​/`. Each subsequent PR removes the
- * ignore comment + adds covering tests:
+ * Flow:
+ *   1. Provider check (T4). Non-Google → return `{}` (passthrough).
+ *   2. Email presence check (T5). Missing → throw HttpsError
+ *      `invalid-argument`.
+ *   3. Email normalize (T5). Canonical form for DB lookup
+ *      (lowercase + NFC + IDN punycode decode).
+ *   4. DB query (T7). `SELECT 1 FROM solicitudes_registro WHERE
+ *      LOWER(email) = $1 AND estado = 'aprobado' LIMIT 1`. Try/catch
+ *      isolates DB errors from the gate decision.
+ *   5. Decision (T7):
+ *      - DB error → log `signup.gate.db_error` (error) + throw
+ *        HttpsError `internal` with code `BLOCKED_CODE`. The IdP
+ *        propagates this to the client as an internal failure; the
+ *        signup is rejected (fail-closed).
+ *      - `rowCount === 0` → log `signup.blocked.google` (warn) + throw
+ *        HttpsError `permission-denied` with code `BLOCKED_CODE`.
+ *        Common cases: no admin approval row + non-aprobado estado
+ *        (query filters `estado = 'aprobado'` so rowCount is 0).
+ *      - `rowCount >= 1` → log `signup.allowed.google` (info) + return
+ *        `{}` (allow signup without modifications).
  *
- *   - T4 (shipped): provider check (return `{}` if non-Google).
- *   - T5 (shipped): email check + normalize.
- *   - T6 (this PR): `getDbPool()` reachable line added; query +
- *     rowCount check + fail-closed + structured log still c8-ignored.
- *   - T7: removes final c8-ignore + adds DB lookup + fail-closed +
- *     structured log + 4 new tests (T1+T2+T3+T7 per spec §10).
+ * **BLOCKED_CODE** is inlined per F-A4 option (a). Cross-source-of-
+ * truth obligation enforced via 2c-B spec §10 T-LITERALS integration
+ * test (added in this PR per G-A2 fix). 2c-B `apps/web/src/utils/
+ * translate-auth-error.ts` duplicates the literal with a code comment
+ * cross-referencing this file.
+ *
+ * **PII redaction** (Ley 19.628 + booster-stack-conventions): email
+ * appears only as `emailHashed` (SHA-256, first 16 hex chars) in logs.
+ * Plaintext email never logged. correlationId derives from
+ * `event.eventId` for trace correlation; `ipAddress` is from the event
+ * context, not PII per Booster IDOR audits scope.
  */
+
+const BLOCKED_CODE = 'BLOCKED_SIGNUP_PENDING_APPROVAL' as const;
+
+function hashEmail(email: string): string {
+  return createHash('sha256').update(email).digest('hex').slice(0, 16);
+}
+
 export const beforeCreateCallback: gcipCloudFunctions.BeforeCreateHandlerCallback = async (
   user,
+  context,
 ) => {
   const isGoogle = user.providerData?.some((p) => p.providerId === 'google.com') ?? false;
   if (!isGoogle) {
@@ -35,15 +65,44 @@ export const beforeCreateCallback: gcipCloudFunctions.BeforeCreateHandlerCallbac
   }
 
   const normalized = normalizeEmail(user.email);
-  const pool = getDbPool();
+  const emailHashed = hashEmail(normalized);
+  const correlationId = context.eventId;
+  const ipAddress = context.ipAddress;
 
-  // T7 logic ships in the next PR (query solicitudes_registro WHERE
-  // estado='aprobado' + permission-denied throw + structured log).
-  // The throw below is a sentinel: if it ever fires en prod it means
-  // handler was deployed without the rest of the chain. T2b path-gate
-  // + T11 handler-completeness smoke catch this at PR time.
-  /* c8 ignore next */
-  throw new Error(
-    `handler T7 logic not yet implemented (email=${normalized.length} chars, pool=${typeof pool})`,
-  );
+  let rowCount: number;
+  try {
+    const pool = getDbPool();
+    const result = await pool.query(
+      "SELECT 1 FROM solicitudes_registro WHERE LOWER(email) = $1 AND estado = 'aprobado' LIMIT 1",
+      [normalized],
+    );
+    rowCount = result.rowCount ?? 0;
+  } catch (err) {
+    logger.error({
+      event: 'signup.gate.db_error',
+      correlationId,
+      ipAddress,
+      emailHashed,
+      err: err instanceof Error ? err.message : 'unknown',
+    });
+    throw new gcipCloudFunctions.https.HttpsError('internal', BLOCKED_CODE);
+  }
+
+  if (rowCount === 0) {
+    logger.warn({
+      event: 'signup.blocked.google',
+      correlationId,
+      ipAddress,
+      emailHashed,
+    });
+    throw new gcipCloudFunctions.https.HttpsError('permission-denied', BLOCKED_CODE);
+  }
+
+  logger.info({
+    event: 'signup.allowed.google',
+    correlationId,
+    ipAddress,
+    emailHashed,
+  });
+  return {};
 };


### PR DESCRIPTION
## Summary

Sprint 2c-A T7 — **finalizes handler.ts** (removes final c8-ignored placeholder, adds full DB query flow + structured logs + BLOCKED constant + email hashing) + adds **T-LITERALS** test bullet to 2c-B spec §10 per G-A2 fix. **Coverage 100% all 4 axes**. **38 tests pass.**

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `apps/auth-blocking-functions/src/handler.ts` | 102 (was 60) | MODIFY — full flow + BLOCKED_CODE + hashEmail + 3 structured logs |
| `apps/auth-blocking-functions/src/handler.test.ts` | 207 (was 113) | MODIFY — vi.mock + 8 new tests |
| `.specs/sec-001-h1-2-google-blocking-b/spec.md` | +1 bullet | MODIFY — T-LITERALS test added per G-A2 |

## Coverage local (final, no c8-ignored lines)

```
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered
All files     |   100   |    100   |   100   |   100   |
```

**38/38 tests pass.** Closes transient T4-T6 coverage handling (H-A2 fix verified: every PR T4..T7 stayed ≥80% via istanbul-ignore-next strategy; T7 ships with 100% real coverage, no c8-ignore comments remaining).

## Handler T7 final flow

```typescript
const BLOCKED_CODE = 'BLOCKED_SIGNUP_PENDING_APPROVAL' as const;

beforeCreateCallback(user, context):
  if !isGoogle → return {}                          // T4 passthrough
  if !email → throw HttpsError invalid-argument     // T5 validation
  normalized = normalizeEmail(email)                // T5 canonicalize
  emailHashed = sha256(normalized).slice(0, 16)     // PII redaction
  try {
    pool = getDbPool()                              // T6
    result = await pool.query(
      "SELECT 1 FROM solicitudes_registro WHERE LOWER(email)=$1 AND estado='aprobado' LIMIT 1",
      [normalized],
    )
    rowCount = result.rowCount ?? 0
  } catch (err) {
    logger.error({ event: 'signup.gate.db_error', correlationId, ipAddress, emailHashed, err })
    throw HttpsError 'internal' + BLOCKED_CODE      // observability distinction
  }
  if rowCount === 0:
    logger.warn({ event: 'signup.blocked.google', correlationId, ipAddress, emailHashed })
    throw HttpsError 'permission-denied' + BLOCKED_CODE
  logger.info({ event: 'signup.allowed.google', correlationId, ipAddress, emailHashed })
  return {}
```

## Tests added (8 new, per plan v4 T7 acceptance)

| Test | Path |
|---|---|
| **T1** | rowCount=0 → `permission-denied` + warn log + NO email plaintext |
| **T2** | rowCount=1 → `{}` + info log + NO email plaintext |
| **T3** | query rejects (Error) → `internal` + error log + NO email plaintext |
| **T7** | non-aprobado estado → same path as T1 (documents invariant) |
| **T7 normalize-casing** | query receives lowercased `mixedcase@example.com` |
| **T7 punycode-IDN** | query receives Unicode-decoded `foo@müller.de` |
| **T3 variant** | non-Error reject → `err: 'unknown'` branch |
| **T7 variant** | `rowCount: null` → coalesce 0 → `permission-denied` |

## PII redaction (Ley 19.628 + booster-stack-conventions)

- Plaintext email never logged. Tests assert `JSON.stringify(log)` does NOT contain plaintext email substrings.
- `emailHashed` is SHA-256 first 16 hex chars — opaque but stable for cross-log correlation.
- `correlationId` from `event.eventId` (gcip context); not PII.
- `ipAddress` from event context; per Booster IDOR audit scope.

## G-A2 fix: T-LITERALS obligation lands with T7

`.specs/sec-001-h1-2-google-blocking-b/spec.md` §10 gains the cross-source-of-truth test bullet **in the same PR** as the handler.ts BLOCKED_CODE inline literal. Sprint 2c-B plan-b draft will see this obligation file-visible before locking — closes the "vapor mitigation" concern (DA v2 G-A2). Path `apps/web/src/utils/translate-auth-error.ts` annotated estimated per G-A9.

## Test plan

- [x] Local typecheck pass
- [x] Local test:coverage 38/38 pass + 100% all axes (closes transient T4-T6 H-A2 handling)
- [x] Local biome lint pass
- [x] Local root `pnpm typecheck` pass (32/32 workspaces)
- [x] Pre-commit hooks pass
- [x] Commitlint pass
- [ ] CI green (this PR)

## Dependencies

- ✅ T6 merged (db.ts + logger.ts shipped).
- Next: T8 ghost user inventory script (read-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)