### PR TITLE
feat(sec-001-h1-2-google-blocking-b): T1 pre-flight verification evidence

### DIFF
--- a/.specs/sec-001-h1-2-google-blocking-b/sprint-2c-b-evidence/ghost-users-dry-run.csv
+++ b/.specs/sec-001-h1-2-google-blocking-b/sprint-2c-b-evidence/ghost-users-dry-run.csv
@@ -1,0 +1,6 @@
+firebaseUid,email,displayName,createdAt,matchingApprovedRequest
+"1F33HE4oisVIGlGtYopQYWOHa4r2","gobe00@gmail.com","Gabriel Barros","Fri, 08 May 2026 10:56:52 GMT","unknown (dry-run; DB cross-ref skipped)"
+"SlEjGxefAXMXcz7pgn98yTBXtB52","edio.pinilla@gmail.com","Edio Pinilla Castillo","Fri, 08 May 2026 11:48:20 GMT","unknown (dry-run; DB cross-ref skipped)"
+"eMSaQTM7TbMWpOpTCOwfV7vnvzp1","dev@boosterchile.com","Felipe Vicencio","Mon, 11 May 2026 04:47:57 GMT","unknown (dry-run; DB cross-ref skipped)"
+"rCY9ZKFbfPWCh6XOJQxkIaUhwxZ2","pensando@fueradelacaja.co","Felipe Vicencio","Sat, 02 May 2026 15:49:17 GMT","unknown (dry-run; DB cross-ref skipped)"
+"tBZtLbhurnWyCdTObdMiUKkhllE3","fvicencio@gmail.com","Fe Vicencio","Sat, 02 May 2026 04:12:50 GMT","unknown (dry-run; DB cross-ref skipped)"

--- a/.specs/sec-001-h1-2-google-blocking-b/sprint-2c-b-evidence/sa-email-verification.txt
+++ b/.specs/sec-001-h1-2-google-blocking-b/sprint-2c-b-evidence/sa-email-verification.txt
@@ -1,0 +1,39 @@
+# Verified by Felipe Vicencio @ 2026-05-27T19:35:00Z for use in T4 var.identity_platform_sa_email
+# Plan T1 deviation declared (see below).
+service-469283083998@gcp-sa-identitytoolkit.iam.gserviceaccount.com
+
+# ─────────────────────────────────────────────────────────────────────
+# Plan T1 deviation — verification command corrected
+# ─────────────────────────────────────────────────────────────────────
+#
+# Plan v4 T1 acceptance prescribed:
+#   gcloud iam service-accounts list --project=booster-ai-494222 \
+#     --format='value(email)' | grep -E 'identitytoolkit\.iam\.gserviceaccount\.com$'
+#
+# This command returns ZERO matches because:
+#   - Identity Platform's invoker is a Google-managed *service agent*
+#     (auto-created on first API enablement), NOT a user-created SA.
+#   - Google service agents follow pattern
+#     `service-<PROJECT_NUMBER>@gcp-sa-<service>.iam.gserviceaccount.com`,
+#     NOT `<service>.iam.gserviceaccount.com`.
+#   - `gcloud iam service-accounts list` only enumerates user-created
+#     SAs; service agents are not returned.
+#
+# Canonical verification command (idempotent):
+#   gcloud beta services identity create \
+#     --service=identitytoolkit.googleapis.com \
+#     --project=booster-ai-494222
+#
+# Output verbatim 2026-05-27 19:34 UTC:
+#   Service identity created: service-469283083998@gcp-sa-identitytoolkit.iam.gserviceaccount.com
+#
+# Project number (lookup `gcloud projects describe booster-ai-494222
+# --format='value(projectNumber)'`): 469283083998
+#
+# Notes for T4 + T7b consumers:
+#   - This SA is the invoker that GCP grants `roles/cloudfunctions.invoker`
+#     on the deployed `beforeCreate` function (T4 IAM binding).
+#   - T4 `var.identity_platform_sa_email` MUST equal the email above
+#     verbatim (no quoting issues, no trailing whitespace).
+#   - T4 .tf reference: `google_cloudfunctions_function_iam_member.idp_invoker`
+#     with `member = "serviceAccount:${var.identity_platform_sa_email}"`.


### PR DESCRIPTION
## Summary

Sprint 2c-B T1 — pre-flight verification operational task. Evidence committed: SA email + ghost users dry-run.

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `.specs/sec-001-h1-2-google-blocking-b/sprint-2c-b-evidence/sa-email-verification.txt` | 33 | NEW (SA email + plan deviation note) |
| `.specs/sec-001-h1-2-google-blocking-b/sprint-2c-b-evidence/ghost-users-dry-run.csv` | 6 | NEW (header + 5 Google-federated users) |

## SA email — canonical Identity Platform service agent

```
service-469283083998@gcp-sa-identitytoolkit.iam.gserviceaccount.com
```

**Plan T1 deviation declared**: the plan v4 literal regex `identitytoolkit\.iam\.gserviceaccount\.com$` against `gcloud iam service-accounts list` returns **ZERO matches**. Identity Platform's invoker is a **Google-managed service agent** (auto-created on first API enablement; pattern `service-<num>@gcp-sa-<service>.iam.*`), NOT a user-created SA. `gcloud iam service-accounts list` enumerates user SAs only.

**Correct canonical command** (idempotent; documented in evidence file):
```bash
gcloud beta services identity create \
  --service=identitytoolkit.googleapis.com \
  --project=booster-ai-494222
```

Plan v4 should be amended in T4 to reference this SA + the corrected verification command. Out-of-band followup recommended.

## Ghost users dry-run

5 Google-federated users found in prod Firebase Auth tenant pre-launch. `matchingApprovedRequest=unknown` for all rows (**dry-run partial**: DB cross-ref skipped to avoid exposing prod DB credentials in this session; full DB cross-reference execution lands in T11 post-wire).

Used `firebase-admin/auth.listUsers` paginated via ADC (`gcloud auth application-default login` refreshed by PO at start of session).

## Test plan

- [x] gcloud auth refreshed (user + ADC).
- [x] SA email canonical command run successfully.
- [x] Firebase Admin listUsers via ADC succeeded.
- [x] CSV format matches T1 acceptance template.
- [x] Helper script `/tmp/list-google-users.mjs` removed (no test pollution).
- [x] Pre-commit hooks pass.
- [x] Commitlint pass.
- [ ] CI green.

## Dependencies

- ✅ Plan v4 Approved (PR #381).
- T1 is read-only / no ADR-052 dep per plan.
- Next: T2 (apps/web extract translateAuthError + T-LITERALS test + ADR-054 path correction). T3 onwards gated on ADR-052 Accepted (Sprint-2b T13 canary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)