### PR TITLE
feat(sec-001-h1-2-google-blocking-b): T2 translateAuthError extract + T-LITERALS

### DIFF
--- a/.specs/_followups/translate-auth-error-unify.md
+++ b/.specs/_followups/translate-auth-error-unify.md
@@ -1,0 +1,76 @@
+# Followup: translate-auth-error-unify
+
+**Status**: Draft (stub; not urgent)
+**Created**: 2026-05-27 by Sprint 2c-B T2 PR (per plan v4 F-B1 acceptance — option (a) login-domain-only extraction; AuthProvidersSection.tsx untouched).
+**Estimated effort**: 60-90 min (reconcile + tests + UX review).
+
+---
+
+## Objetivo
+
+Unificar las DOS implementaciones de `translateAuthError` que viven en distintos dominios apps/web:
+
+1. **Login/signup domain** — `apps/web/src/lib/translate-auth-error.ts` (extraído en Sprint 2c-B T2 desde `apps/web/src/routes/login.tsx`). 10 cases canonical + 1 case `auth/internal-error` con `BLOCKED_SIGNUP_PENDING_APPROVAL` substring detection.
+2. **Provider-linking domain** — `apps/web/src/components/profile/AuthProvidersSection.tsx:598-621` (inline function NO extraída). 10 cases para flujos linkWithCredential / unlink / re-link de providers OAuth.
+
+Las DOS funciones overlap en **5 códigos** pero producen **distinto copy en español** para al menos `auth/email-already-in-use`:
+- Login domain → "Ya existe una cuenta con ese email. Inicia sesión."
+- Linking domain → "Esa cuenta ya pertenece a otro usuario de Booster. Cerrá sesión y entrá con esa cuenta directamente."
+
+## Por qué no se unificó en Sprint 2c-B T2
+
+Per plan v4 F-B1 fix:
+> "different domains (login vs provider-linking) with different Spanish copy for overlapping codes. Forcing unification requires UX-copy reconciliation that is out-of-scope for 2c-B."
+
+Sprint 2c-B T2 narrowed scope a login-domain-only extraction. AuthProvidersSection.tsx no se tocó.
+
+## Opciones de unificación
+
+### Option A — Single function con context discriminant
+
+```typescript
+export function translateAuthError(
+  code: string | undefined,
+  context: 'login' | 'provider-linking',
+  message?: string,
+): string | null { ... }
+```
+
+Pro: una sola tabla; less drift risk.
+Con: cada call site debe pasar `context`; switch interno crece.
+
+### Option B — Dos funciones exportadas del mismo módulo
+
+```typescript
+export function translateLoginAuthError(code, message?): string | null { ... }
+export function translateProviderAuthError(code, message?): string | null { ... }
+```
+
+Pro: clear domain separation; cada uno tiene su propia tabla.
+Con: duplica codes que pueden coincidir; pero permite copy diferenciado por dominio (probablemente el correcto trade-off para UX).
+
+### Option C — Status quo
+
+Mantener separados; agregar tests de no-regression en cada función; documentar en este followup que es deliberado.
+
+## Recomendación
+
+**Option B** preferida. Razón: las copies divergentes existen por motivo de UX (provider-linking errors necesitan messaging que apunte a "cerrá sesión y entrá con esa cuenta directamente"; signup errors apuntan a "inicia sesión"). Forzar single-context loses this affordance.
+
+## Acceptance criteria si se ejecuta
+
+- `apps/web/src/lib/translate-auth-error.ts` exporta `translateLoginAuthError` (rename del current) + `translateProviderAuthError` (extraído desde AuthProvidersSection.tsx).
+- `apps/web/src/components/profile/AuthProvidersSection.tsx` modificado: remove inline function + import desde new module.
+- Tests: 20+ casos cross-domain (10 login + 10 linking + overlap verification).
+- UX copy review: PO valida que ambas variantes preservan intent del dominio.
+- Cross-source-literals.test.ts (creado en Sprint 2c-B T2) sigue passing.
+
+## Trigger (cuándo ejecutar)
+
+- Post-Sprint-2c-B CERRADO (gate-friendly: no production impact).
+- O cuando una de las dos funciones gane un caso new que también merece la otra (drift signal).
+
+## Notas
+
+- Bajo prioridad. Las dos funciones funcionan correctamente en sus dominios.
+- Si pasa >180 días sin ejecutar, PO debe re-evaluar si la duplicación se acepta de facto.

--- a/apps/auth-blocking-functions/test/integration/cross-source-literals.test.ts
+++ b/apps/auth-blocking-functions/test/integration/cross-source-literals.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Sprint 2c-B T2 — cross-source-of-truth literal contract.
+ *
+ * The `BLOCKED_SIGNUP_PENDING_APPROVAL` literal exists in TWO files
+ * by design (per ADR-054 F-A4 option (a) decision: handler.ts inlines
+ * the literal; apps/web/translateAuthError duplicates it because the
+ * Firebase web SDK wraps the handler's HttpsError as `auth/internal-
+ * error` with a custom message containing the literal substring).
+ *
+ * This test enforces the contract: both files MUST contain the
+ * literal. Drift triggers test failure → reviewer must reconcile.
+ *
+ * **Plan v4 G-A2 fix obligation** added by Sprint 2c-A T7 PR. This
+ * test lands as part of Sprint 2c-B T2 (extracts + extends the
+ * apps/web translator) per plan v4 §"What changed v1 → v2" + spec
+ * §10 T-LITERALS bullet.
+ *
+ * Reads files via `fs.readFileSync` (NOT `import`) to avoid pulling
+ * apps/web React deps into apps/auth-blocking-functions test env.
+ */
+
+const HANDLER_PATH = new URL('../../src/handler.ts', import.meta.url).pathname;
+
+const TRANSLATE_PATH = new URL('../../../web/src/lib/translate-auth-error.ts', import.meta.url)
+  .pathname;
+
+const REQUIRED_LITERAL = 'BLOCKED_SIGNUP_PENDING_APPROVAL';
+
+describe('cross-source literals contract (Sprint 2c-A handler ↔ Sprint 2c-B apps/web translator)', () => {
+  it('handler.ts contains BLOCKED_SIGNUP_PENDING_APPROVAL', () => {
+    const source = readFileSync(HANDLER_PATH, 'utf-8');
+    expect(source).toContain(REQUIRED_LITERAL);
+  });
+
+  it('apps/web translate-auth-error.ts contains BLOCKED_SIGNUP_PENDING_APPROVAL', () => {
+    const source = readFileSync(TRANSLATE_PATH, 'utf-8');
+    expect(source).toContain(REQUIRED_LITERAL);
+  });
+
+  it('both files reference each other in code comments (audit traceability)', () => {
+    const handlerSource = readFileSync(HANDLER_PATH, 'utf-8');
+    const translateSource = readFileSync(TRANSLATE_PATH, 'utf-8');
+    expect(handlerSource).toMatch(/2c-B|apps\/web|translate-auth-error|BLOCKED_CODE/);
+    expect(translateSource).toMatch(/handler\.ts|apps\/auth-blocking-functions|ADR-054/);
+  });
+});

--- a/apps/web/src/lib/translate-auth-error.test.ts
+++ b/apps/web/src/lib/translate-auth-error.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { translateAuthError } from './translate-auth-error';
+
+/**
+ * Sprint 2c-B T2 tests — `translateAuthError` extraction + extension.
+ *
+ * Preserves all 10 existing cases from the inline function previously
+ * in `apps/web/src/routes/login.tsx:382-406`. Adds new
+ * `auth/internal-error` branch with `BLOCKED_SIGNUP_PENDING_APPROVAL`
+ * substring detection (Sprint 2c-A T7 handler returns this code; Firebase
+ * web SDK wraps as `auth/internal-error` with custom message per ADR-054).
+ */
+
+describe('translateAuthError — existing codes preserved verbatim', () => {
+  it('auth/invalid-credential → password incorrect message', () => {
+    expect(translateAuthError('auth/invalid-credential')).toBe('Email o contraseña incorrectos.');
+  });
+
+  it('auth/invalid-login-credentials → same fallthrough message', () => {
+    expect(translateAuthError('auth/invalid-login-credentials')).toBe(
+      'Email o contraseña incorrectos.',
+    );
+  });
+
+  it('auth/user-not-found', () => {
+    expect(translateAuthError('auth/user-not-found')).toBe('No existe una cuenta con ese email.');
+  });
+
+  it('auth/wrong-password', () => {
+    expect(translateAuthError('auth/wrong-password')).toBe('Contraseña incorrecta.');
+  });
+
+  it('auth/user-disabled — references support email', () => {
+    expect(translateAuthError('auth/user-disabled')).toBe(
+      'Esta cuenta está deshabilitada. Contacta a soporte@boosterchile.com.',
+    );
+  });
+
+  it('auth/email-already-in-use → signup-existing-account copy (login domain)', () => {
+    expect(translateAuthError('auth/email-already-in-use')).toBe(
+      'Ya existe una cuenta con ese email. Inicia sesión.',
+    );
+  });
+
+  it('auth/weak-password', () => {
+    expect(translateAuthError('auth/weak-password')).toBe(
+      'La contraseña es muy débil. Usa al menos 6 caracteres.',
+    );
+  });
+
+  it('auth/invalid-email', () => {
+    expect(translateAuthError('auth/invalid-email')).toBe('El email no es válido.');
+  });
+
+  it('auth/too-many-requests', () => {
+    expect(translateAuthError('auth/too-many-requests')).toBe(
+      'Demasiados intentos fallidos. Espera unos minutos e intenta de nuevo.',
+    );
+  });
+
+  it('auth/network-request-failed', () => {
+    expect(translateAuthError('auth/network-request-failed')).toBe(
+      'Sin conexión a internet. Intenta de nuevo.',
+    );
+  });
+});
+
+describe('translateAuthError — auth/internal-error new branch (Sprint 2c-B)', () => {
+  it('auth/internal-error with BLOCKED_SIGNUP_PENDING_APPROVAL substring → blocked-signup message', () => {
+    expect(
+      translateAuthError(
+        'auth/internal-error',
+        'Cloud Function returned an error: BLOCKED_SIGNUP_PENDING_APPROVAL',
+      ),
+    ).toBe(
+      'Tu solicitud de registro debe ser aprobada por un administrador antes de poder iniciar sesión. Si ya solicitaste registro, espera la confirmación por email.',
+    );
+  });
+
+  it('auth/internal-error with BLOCKED literal embedded in JSON-ish wrap → still matches', () => {
+    expect(
+      translateAuthError(
+        'auth/internal-error',
+        '{"error":{"message":"HTTP Cloud Function returned a custom error... BLOCKED_SIGNUP_PENDING_APPROVAL"}}',
+      ),
+    ).toMatch(/aprobada por un administrador/);
+  });
+
+  it('auth/internal-error WITHOUT BLOCKED literal → fallback null', () => {
+    expect(
+      translateAuthError('auth/internal-error', 'Some other generic internal error'),
+    ).toBeNull();
+  });
+
+  it('auth/internal-error with no message argument → fallback null', () => {
+    expect(translateAuthError('auth/internal-error')).toBeNull();
+  });
+});
+
+describe('translateAuthError — fallback null for unmapped codes', () => {
+  it('unknown code → null', () => {
+    expect(translateAuthError('auth/something-unmapped')).toBeNull();
+  });
+
+  it('undefined code → null', () => {
+    expect(translateAuthError(undefined)).toBeNull();
+  });
+
+  it('empty string → null', () => {
+    expect(translateAuthError('')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/translate-auth-error.ts
+++ b/apps/web/src/lib/translate-auth-error.ts
@@ -1,0 +1,51 @@
+/**
+ * Mensajes en español para los códigos de error más comunes de Firebase
+ * Auth. Si el código no está mapeado, devuelve null y el caller usa un
+ * fallback genérico.
+ *
+ * **Sprint 2c-B T2 extension**: handles `auth/internal-error` whose
+ * message contains the `BLOCKED_SIGNUP_PENDING_APPROVAL` literal —
+ * Firebase web SDK's wrapping for the Identity Platform Blocking
+ * Function rejection (per ADR-054). The literal MUST equal the
+ * `BLOCKED_CODE` constant inlined at
+ * `apps/auth-blocking-functions/src/handler.ts:45`. Cross-source-of-
+ * truth contract enforced by
+ * `apps/auth-blocking-functions/test/integration/cross-source-literals.test.ts`.
+ *
+ * Scope: signup/login domain (provider sign-in + email/pw form errors).
+ * Provider-linking errors are translated separately in
+ * `apps/web/src/components/profile/AuthProvidersSection.tsx` because the
+ * Spanish copy differs (e.g., `auth/email-already-in-use` for linking
+ * vs signup-existing-account). Unification tracked in
+ * `.specs/_followups/translate-auth-error-unify.md`.
+ */
+export function translateAuthError(code: string | undefined, message?: string): string | null {
+  switch (code) {
+    case 'auth/invalid-credential':
+    case 'auth/invalid-login-credentials':
+      return 'Email o contraseña incorrectos.';
+    case 'auth/user-not-found':
+      return 'No existe una cuenta con ese email.';
+    case 'auth/wrong-password':
+      return 'Contraseña incorrecta.';
+    case 'auth/user-disabled':
+      return 'Esta cuenta está deshabilitada. Contacta a soporte@boosterchile.com.';
+    case 'auth/email-already-in-use':
+      return 'Ya existe una cuenta con ese email. Inicia sesión.';
+    case 'auth/weak-password':
+      return 'La contraseña es muy débil. Usa al menos 6 caracteres.';
+    case 'auth/invalid-email':
+      return 'El email no es válido.';
+    case 'auth/too-many-requests':
+      return 'Demasiados intentos fallidos. Espera unos minutos e intenta de nuevo.';
+    case 'auth/network-request-failed':
+      return 'Sin conexión a internet. Intenta de nuevo.';
+    case 'auth/internal-error':
+      if (message?.includes('BLOCKED_SIGNUP_PENDING_APPROVAL')) {
+        return 'Tu solicitud de registro debe ser aprobada por un administrador antes de poder iniciar sesión. Si ya solicitaste registro, espera la confirmación por email.';
+      }
+      return null;
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -13,6 +13,7 @@ import {
   useAuth,
 } from '../hooks/use-auth.js';
 import { useFeatureFlags } from '../hooks/use-feature-flags.js';
+import { translateAuthError } from '../lib/translate-auth-error.js';
 
 type Mode = 'sign-in' | 'sign-up' | 'reset';
 
@@ -98,11 +99,12 @@ export function LoginRoute() {
       void navigate({ to: '/app' });
     } catch (err) {
       const code = (err as FirebaseError).code;
+      const message = (err as FirebaseError).message;
       if (code === 'auth/popup-closed-by-user' || code === 'auth/cancelled-popup-request') {
         return;
       }
       setError('root', {
-        message: translateAuthError(code) ?? 'No pudimos iniciar sesión con Google.',
+        message: translateAuthError(code, message) ?? 'No pudimos iniciar sesión con Google.',
       });
     }
   }
@@ -149,8 +151,9 @@ export function LoginRoute() {
       }
     } catch (err) {
       const code = (err as FirebaseError).code;
+      const message = (err as FirebaseError).message;
       setError('root', {
-        message: translateAuthError(code) ?? 'No pudimos completar la operación.',
+        message: translateAuthError(code, message) ?? 'No pudimos completar la operación.',
       });
     }
   }
@@ -372,35 +375,4 @@ export function LoginRoute() {
       </main>
     </div>
   );
-}
-
-/**
- * Mensajes en español para los códigos de error más comunes de Firebase
- * Auth. Si el código no está mapeado, devuelve null y el caller usa un
- * fallback genérico.
- */
-function translateAuthError(code: string | undefined): string | null {
-  switch (code) {
-    case 'auth/invalid-credential':
-    case 'auth/invalid-login-credentials':
-      return 'Email o contraseña incorrectos.';
-    case 'auth/user-not-found':
-      return 'No existe una cuenta con ese email.';
-    case 'auth/wrong-password':
-      return 'Contraseña incorrecta.';
-    case 'auth/user-disabled':
-      return 'Esta cuenta está deshabilitada. Contacta a soporte@boosterchile.com.';
-    case 'auth/email-already-in-use':
-      return 'Ya existe una cuenta con ese email. Inicia sesión.';
-    case 'auth/weak-password':
-      return 'La contraseña es muy débil. Usa al menos 6 caracteres.';
-    case 'auth/invalid-email':
-      return 'El email no es válido.';
-    case 'auth/too-many-requests':
-      return 'Demasiados intentos fallidos. Espera unos minutos e intenta de nuevo.';
-    case 'auth/network-request-failed':
-      return 'Sin conexión a internet. Intenta de nuevo.';
-    default:
-      return null;
-  }
 }

--- a/docs/adr/054-google-blocking-function-signup-gate.md
+++ b/docs/adr/054-google-blocking-function-signup-gate.md
@@ -79,7 +79,7 @@ Umbrella plan v2 alcanzó 5 P0 + 6 P1 + 5 P2 findings en DA. Plan threshold G-14
 
 **Rationale** (per plan v4 Alt-2c-A-Plan-III rejection + G-A2 mitigation):
 - Avoids adding package work to Sprint 2c-A scope (handler-only).
-- 2c-B `apps/web/src/utils/translate-auth-error.ts` duplicates the literal with cross-reference code comment.
+- 2c-B `apps/web/src/lib/translate-auth-error.ts` duplicates the literal with cross-reference code comment.
 - Sprint 2c-B T-LITERALS integration test (file-visible obligation added to 2c-B spec by Sprint 2c-A T7) ensures both copies match.
 
 Trade-off accepted: 2 source-of-truth locations, mitigated by test + file-visible cross-plan obligation.


### PR DESCRIPTION
## Summary

Sprint 2c-B T2 — apps/web `translateAuthError` extraction + extension + T-LITERALS cross-source test + ADR-054 path correction + unify followup stub. 4 atomic deliverables per plan v4 §T2 acceptance.

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `apps/web/src/lib/translate-auth-error.ts` | 54 | NEW (extracted + extended with `auth/internal-error` branch) |
| `apps/web/src/lib/translate-auth-error.test.ts` | 116 | NEW (17 tests) |
| `apps/web/src/routes/login.tsx` | -29/+4 | MODIFY (inline removed + imports module + call sites pass `err.message`) |
| `apps/auth-blocking-functions/test/integration/cross-source-literals.test.ts` | 47 | NEW (3 tests) |
| `docs/adr/054-google-blocking-function-signup-gate.md` | +1/-1 | MODIFY (path correction `utils/` → `lib/`) |
| `.specs/_followups/translate-auth-error-unify.md` | 75 | NEW (unify scope tracked) |

## Reviewer acceptance checklist (per plan v4 N-B5 fix)

- [x] **(1) apps/web extraction**: 10 existing cases preserved verbatim; new `auth/internal-error` branch with `BLOCKED_SIGNUP_PENDING_APPROVAL` substring detection
- [x] **(2) ADR-054 path correction**: `apps/web/src/utils/translate-auth-error.ts` → `apps/web/src/lib/translate-auth-error.ts` (line 82, Decision §BLOCKED_CODE)
- [x] **(3) T-LITERALS test**: `fs.readFileSync` over both `handler.ts` + `translate-auth-error.ts` asserts both contain `BLOCKED_SIGNUP_PENDING_APPROVAL` literal — fails on drift
- [x] **(4) Followup stub**: `translate-auth-error-unify.md` documents login vs provider-linking domain split + recommended Option B (two exported functions)

## Plan v4 F-B1 decision applied

`apps/web/src/components/profile/AuthProvidersSection.tsx` **UNTOUCHED**. Its provider-linking translator is a different domain with different Spanish copy for overlapping codes (e.g., `auth/email-already-in-use` → linking-domain message vs signup-domain message). Unification deferred to followup.

## Local verification

```
$ pnpm --filter @booster-ai/web typecheck    # 0 errors
$ pnpm --filter @booster-ai/web test         # 1033/1033 pass (+17 new)
$ pnpm --filter @booster-ai/auth-blocking-functions test
                                              # 55 pass + 6 skipped (+3 cross-source new)
$ pnpm typecheck                              # 32/32 workspaces
```

## Dependencies

- ✅ Plan v4 Approved (PR #381).
- ✅ T1 SHIPPED (#382; SA email + dry-run evidence).
- T2 has no ADR-052 dependency (apps/web + docs only; mechanical CI gate path-filter does NOT include `apps/web/src/lib/` or `docs/adr/` or `.specs/_followups/`).
- Next: T3 (tsup config + cloudbuild deploy step) — gated on ADR-052 Accepted via mechanical gate.

## Test plan

- [x] Local typecheck pass (apps/web + apps/auth-blocking-functions + root)
- [x] Local apps/web tests 1033/1033
- [x] Local apps/auth-blocking-functions tests 55+6 skipped
- [x] Pre-commit hooks pass
- [x] Commitlint pass
- [ ] CI green (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)