### PR TITLE
feat(sec-001-h1-2-google-blocking-b): T3 tsup config + cloudbuild deploy

### DIFF
--- a/apps/auth-blocking-functions/tsup.config.ts
+++ b/apps/auth-blocking-functions/tsup.config.ts
@@ -1,0 +1,71 @@
+import { writeFileSync } from 'node:fs';
+import { defineConfig } from 'tsup';
+import sourcePkg from './package.json' with { type: 'json' };
+
+/**
+ * Sprint 2c-B T3 — tsup build config for Cloud Function Gen 1 runtime.
+ *
+ * Gen 1 runtime (`gcloud functions deploy --gen2=false`) expects a
+ * CommonJS entrypoint at `index.js` (or `main` in deployed package.json)
+ * inside the `--source` directory. Workspace source is ESM (`"type":
+ * "module"` in apps/auth-blocking-functions/package.json); this tsup
+ * pipeline bridges:
+ *   1. Compiles ESM → CJS bundle at `dist/index.js`.
+ *   2. Writes a synthetic `dist/package.json` declaring `"type":
+ *      "commonjs"` (so Node interprets `.js` as CJS at runtime
+ *      regardless of the source workspace's ESM declaration) +
+ *      `dependencies` listing only the EXTERNAL production deps
+ *      (workspace deps are bundled via `noExternal` so they don't
+ *      appear here).
+ *
+ * Per ADR-054: source format ESM (workspace convention) + deploy
+ * artifact CommonJS (Gen 1 requirement) — bridged here.
+ */
+
+const EXTERNAL_RUNTIME_DEPS = [
+  'gcip-cloud-functions',
+  'firebase-admin',
+  'firebase-functions',
+  'pg',
+  'punycode',
+] as const;
+
+function pickVersion(name: string): string {
+  const v = (sourcePkg.dependencies as Record<string, string>)[name];
+  if (!v) {
+    throw new Error(
+      `tsup post-build: missing version for runtime dep ${name} in source package.json`,
+    );
+  }
+  return v;
+}
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs'],
+  target: 'node20',
+  outDir: 'dist',
+  clean: true,
+  sourcemap: true,
+  outExtension: () => ({ js: '.js' }),
+  noExternal: ['@booster-ai/logger', '@booster-ai/shared-schemas'],
+  external: [...EXTERNAL_RUNTIME_DEPS],
+  async onSuccess() {
+    const distPkg = {
+      name: '@booster-ai/auth-blocking-functions-deployed',
+      version: sourcePkg.version,
+      private: true,
+      type: 'commonjs',
+      main: 'index.js',
+      engines: { node: '20' },
+      dependencies: Object.fromEntries(
+        EXTERNAL_RUNTIME_DEPS.map((name) => [name, pickVersion(name)]),
+      ),
+    };
+    writeFileSync('dist/package.json', `${JSON.stringify(distPkg, null, 2)}\n`);
+    // Build-time signal only (no runtime console at all in shipped code).
+    process.stdout.write(
+      '[tsup post-build] wrote dist/package.json (CJS + runtime deps for Gen 1)\n',
+    );
+  },
+});

--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -427,6 +427,70 @@ steps:
         exit 1
     waitFor: [deploy-api, deploy-whatsapp-bot]
 
+  # =========================================================================
+  # Sprint 2c-B T3 — Auth Blocking Function (Cloud Function Gen 1)
+  # =========================================================================
+  # Build the auth-blocking-functions workspace artifact via tsup (ESM
+  # workspace source → CommonJS dist/index.js + synthetic dist/package.json
+  # with runtime deps). Deploys via gcloud functions deploy --gen2=false
+  # targeting Identity Platform `beforeCreate` trigger. Per ADR-054 +
+  # Sprint 2c-B plan v4 T3 + DA G-03 atomic-deploy contract.
+  - id: build-auth-blocking
+    name: node:20-bookworm
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        corepack enable
+        corepack prepare pnpm@9.15.4 --activate
+        pnpm install --frozen-lockfile --filter='@booster-ai/auth-blocking-functions...'
+        pnpm --filter @booster-ai/auth-blocking-functions build
+        ls -la apps/auth-blocking-functions/dist
+    waitFor: ['-']
+
+  - id: deploy-auth-blocking
+    name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        gcloud functions deploy beforeCreate \
+          --gen2=false \
+          --runtime=nodejs20 \
+          --source=apps/auth-blocking-functions/dist \
+          --entry-point=beforeCreate \
+          --region=us-east1 \
+          --no-allow-unauthenticated \
+          --max-instances=5 \
+          --min-instances=0 \
+          --trigger-http \
+          --project=booster-ai-494222
+    waitFor: [build-auth-blocking]
+
+  # DA v2 G-03 atomic-deploy fix: post-deploy verification — gcloud
+  # functions describe MUST return non-empty sourceArchiveUrl + status
+  # ACTIVE. Failure here blocks downstream IdP wire (T5 terraform apply
+  # checks this via T7b CI workflow before merging the wire PR).
+  - id: verify-auth-blocking-deployed
+    name: gcr.io/cloud-builders/gcloud
+    entrypoint: bash
+    args:
+      - -c
+      - |
+        set -e
+        DESC=$$(gcloud functions describe beforeCreate \
+          --region=us-east1 \
+          --project=booster-ai-494222 \
+          --format=json)
+        SRC=$$(echo "$$DESC" | python3 -c "import sys,json; print(json.load(sys.stdin).get('sourceArchiveUrl',''))")
+        ST=$$(echo "$$DESC" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))")
+        if [ -z "$$SRC" ]; then echo "FAIL: empty sourceArchiveUrl"; exit 1; fi
+        if [ "$$ST" != "ACTIVE" ]; then echo "FAIL: status=$$ST (expected ACTIVE)"; exit 1; fi
+        echo "OK: function ACTIVE with sourceArchiveUrl=$$SRC"
+    waitFor: [deploy-auth-blocking]
+
 substitutions:
   _REGION: southamerica-west1
   _REGISTRY: southamerica-west1-docker.pkg.dev/booster-ai-494222/containers


### PR DESCRIPTION
## Summary

Sprint 2c-B T3 — tsup build pipeline + 3 atomic Cloud Build steps (build-auth-blocking + deploy-auth-blocking + verify-auth-blocking-deployed) per plan v4 + DA G-03 atomic-deploy contract.

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `apps/auth-blocking-functions/tsup.config.ts` | 78 | NEW (ESM→CJS bundle + synthetic dist/package.json) |
| `cloudbuild.production.yaml` | +63 | MODIFY (3 new steps before `substitutions:`) |

## tsup pipeline

- ESM workspace source → CommonJS `dist/index.js` + sourcemap.
- `outExtension` forces `.js` (NOT `.cjs` default; Gen 1 runtime).
- `noExternal` bundles workspace deps (logger + shared-schemas).
- `external` keeps 5 runtime deps (gcip-cloud-functions, firebase-admin, firebase-functions, pg, punycode).
- **`onSuccess` hook writes synthetic `dist/package.json`** with `"type":"commonjs"` + `main:"index.js"` + dependencies. Without this, Node interprets `dist/index.js` as ESM (because workspace `package.json` says `"type":"module"`) → CJS `module.exports` ignored → `beforeCreate` export missing at runtime.

## Local build verification

```
$ pnpm --filter @booster-ai/auth-blocking-functions build
CJS dist/index.js     319.38 KB
CJS dist/index.js.map 622.65 KB
[tsup post-build] wrote dist/package.json (CJS + runtime deps for Gen 1)

$ ls apps/auth-blocking-functions/dist/
index.js  index.js.map  package.json

$ node -e "const m = require('./apps/auth-blocking-functions/dist/index.js'); console.log(typeof m.beforeCreate)"
function
```

## Cloud Build steps (3 new, atomic)

1. **`build-auth-blocking`** (`node:20-bookworm` + `corepack pnpm@9.15.4`): install + tsup compile → `apps/auth-blocking-functions/dist/`.
2. **`deploy-auth-blocking`** (`gcr.io/cloud-builders/gcloud`): `gcloud functions deploy beforeCreate --gen2=false --runtime=nodejs20 --source=apps/auth-blocking-functions/dist --entry-point=beforeCreate --region=us-east1 --no-allow-unauthenticated --max-instances=5 --min-instances=0 --trigger-http`.
3. **`verify-auth-blocking-deployed`** (`gcr.io/cloud-builders/gcloud`): `gcloud functions describe` + inline python assert `sourceArchiveUrl` non-empty + `status === 'ACTIVE'`. **DA G-03 atomic-deploy gate** — failure here blocks downstream IdP wire (T5).

## ADR-052 gate behavior on this PR

Plan v4 contingency clause notes: **ADR-052 is still Proposed** → `sprint-2c-build-gate.yml` (from Sprint 2c-A T2b) WILL fire on this PR (path-filter covers `cloudbuild.production.yaml`) and **WILL fail**.

**Branch protection state verified**: only `"CI Success"` is in `required_status_checks`. The Sprint 2c-B gate workflow is NOT a required check (PO has not yet wired it per Sprint 2c-A T2b PR description). Therefore:

- Gate runs + reports failure (informational only).
- Other required checks pass.
- PR merges via `gh pr merge` (no admin needed; no `workflow_dispatch force=true` required).

Per plan v4 contingency, this gate fail is documented in the PR description (here) for transparency. When PO eventually flips ADR-052 Status post-Sprint-2b T13 canary, future 2c-B PRs touching gated paths will pass the check cleanly.

## Dependencies

- ✅ Plan v4 Approved (#381).
- ✅ T1 + T2 SHIPPED.
- T7 (`check-cloud-function-deployed.ts` standalone script) NOT yet shipped; T3 inline verification step covers the same contract for the Cloud Build flow.
- Next: T4 (`infrastructure/auth-blocking-functions.tf`).

## Test plan

- [x] Local tsup build → dist/index.js + dist/package.json valid
- [x] Local require resolves `beforeCreate` as function
- [x] Local root `pnpm typecheck` pass (32/32 workspaces)
- [x] Pre-commit hooks pass (after biome auto-fix `noConsole` → `process.stdout.write`)
- [x] Commitlint pass
- [ ] CI green (with sprint-2c-build-gate expected to fail; "CI Success" expected to pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)