### PR TITLE
feat(sec-001-h1-2-google-blocking-b): T4 Cloud Function Gen 1 terraform

### DIFF
--- a/infrastructure/auth-blocking-functions.tf
+++ b/infrastructure/auth-blocking-functions.tf
@@ -1,0 +1,160 @@
+# SEC-001 Sprint 2c-B H1.2 — Cloud Function Gen 1 `beforeCreate` for
+# Identity Platform Blocking Function.
+#
+# Spec: .specs/sec-001-h1-2-google-blocking-b/spec.md §7 component 3.
+# Plan: .specs/sec-001-h1-2-google-blocking-b/plan.md v4 §T4 acceptance.
+# ADR: docs/adr/054-google-blocking-function-signup-gate.md (Proposed;
+#      Status flip Accepted en T13 post-7d-watch success).
+#
+# NOTE — Source artifact lifecycle (F-B9 plan v4 fix):
+# Function source is managed by Cloud Build deploy step
+# `deploy-auth-blocking` in cloudbuild.production.yaml (T3). The first
+# `terraform apply` creates the function shell with a placeholder
+# source (the `archive_file` data source below produces a tiny zip
+# with a stub index.js); immediately after, run the Cloud Build
+# trigger to populate `apps/auth-blocking-functions/dist/index.js` as
+# the real source. Without Cloud Build deploy, the function exists in
+# API/console but executes the placeholder no-op. Verification via
+# the cloudbuild step `verify-auth-blocking-deployed` (T3) + the
+# T7b CI workflow (`sprint-2c-b-deploy-gate.yml`).
+#
+# Atomic deploy contract (DA v2 G-03 fix):
+#   1. terraform apply -target=google_cloudfunctions_function.before_create
+#      → creates function shell with placeholder source.
+#   2. Cloud Build trigger → gcloud functions deploy replaces source.
+#   3. verify-auth-blocking-deployed step asserts sourceArchiveUrl
+#      non-empty + status ACTIVE.
+#   4. terraform apply -target=google_identity_platform_config.default
+#      → wires blocking_functions (T5).
+#
+# Step 4 cannot proceed until step 3 verifies (T7b workflow gate).
+
+# ---------------------------------------------------------------------------
+# Placeholder source archive
+# ---------------------------------------------------------------------------
+# The Cloud Function resource REQUIRES source_archive_bucket +
+# source_archive_object at creation. The actual source ships via
+# Cloud Build deploy (T3). We initialize with a tiny placeholder zip
+# that gcloud functions deploy replaces on first prod deploy.
+
+data "archive_file" "auth_blocking_placeholder" {
+  type        = "zip"
+  output_path = "${path.module}/.terraform/tmp/auth-blocking-placeholder.zip"
+
+  source {
+    content  = "// Sprint 2c-B T4 placeholder. Real source ships via Cloud Build deploy step `deploy-auth-blocking` in cloudbuild.production.yaml. If you see this in prod logs, the Cloud Build deploy did NOT run — escalate per runbook §Rollback.\nexports.beforeCreate = (_user, _ctx) => ({});\n"
+    filename = "index.js"
+  }
+
+  source {
+    content = jsonencode({
+      name    = "@booster-ai/auth-blocking-functions-placeholder"
+      version = "0.0.0"
+      private = true
+      type    = "commonjs"
+      main    = "index.js"
+      engines = { node = "20" }
+    })
+    filename = "package.json"
+  }
+}
+
+resource "google_storage_bucket" "auth_blocking_source" {
+  name          = "${var.project_id}-auth-blocking-functions-source"
+  project       = google_project.booster_ai.project_id
+  location      = var.region
+  storage_class = "STANDARD"
+
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+
+  versioning {
+    enabled = false
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_storage_bucket_object" "auth_blocking_placeholder" {
+  name   = "auth-blocking-functions-placeholder-${data.archive_file.auth_blocking_placeholder.output_md5}.zip"
+  bucket = google_storage_bucket.auth_blocking_source.name
+  source = data.archive_file.auth_blocking_placeholder.output_path
+}
+
+# ---------------------------------------------------------------------------
+# Cloud Function Gen 1 — `beforeCreate`
+# ---------------------------------------------------------------------------
+# Identity Platform Blocking Functions only support Gen 1 as of 2026-05
+# (verified empirically in `docs/lessons-learned/2026-05-sprint-2c-gen1-
+# vs-gen2.md`). Therefore `google_cloudfunctions_function` (NOT
+# `google_cloudfunctions2_function`).
+
+resource "google_cloudfunctions_function" "before_create" {
+  project = google_project.booster_ai.project_id
+  region  = "us-east1" # Identity Platform Blocking Functions require us-east1 per docs.cloud.google.com/identity-platform/docs/blocking-functions
+  name    = "beforeCreate"
+
+  runtime             = "nodejs20"
+  entry_point         = "beforeCreate"
+  available_memory_mb = 256
+  timeout             = 60
+  min_instances       = 0
+  max_instances       = 5
+  ingress_settings    = "ALLOW_ALL"
+
+  source_archive_bucket = google_storage_bucket.auth_blocking_source.name
+  source_archive_object = google_storage_bucket_object.auth_blocking_placeholder.name
+
+  trigger_http = true
+
+  # ENV vars (DATABASE_URL via Secret Manager mount + project context).
+  # SECRET_MANAGER_SECRET_NAME pattern matches existing Booster apps.
+  environment_variables = {
+    GCP_PROJECT_ID = google_project.booster_ai.project_id
+    LOG_LEVEL      = "info"
+  }
+
+  secret_environment_variables {
+    key     = "DATABASE_URL"
+    secret  = "database-url"
+    version = "latest"
+  }
+
+  lifecycle {
+    # Cloud Build deploy step manages the actual source artifact
+    # (gcloud functions deploy uploads to a gcloud-internal bucket).
+    # Terraform should ignore source drift to avoid re-deploying the
+    # placeholder on every apply.
+    ignore_changes = [
+      source_archive_object,
+      source_archive_bucket,
+      build_environment_variables,
+    ]
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# ---------------------------------------------------------------------------
+# IAM binding — Identity Platform service agent as invoker
+# ---------------------------------------------------------------------------
+# Per Sprint 2c-B T1 empirical verification (sprint-2c-b-evidence/
+# sa-email-verification.txt): the IdP invoker is
+# `service-<project_number>@gcp-sa-identitytoolkit.iam.gserviceaccount.com`
+# (Google-managed service agent, auto-provisioned via `gcloud beta
+# services identity create --service=identitytoolkit.googleapis.com`).
+# Computed from `google_project.booster_ai.number` (NOT hardcoded — this
+# makes the resource portable to any project that wires Identity
+# Platform Blocking Functions).
+
+locals {
+  identitytoolkit_service_agent = "service-${google_project.booster_ai.number}@gcp-sa-identitytoolkit.iam.gserviceaccount.com"
+}
+
+resource "google_cloudfunctions_function_iam_member" "idp_invoker" {
+  project        = google_project.booster_ai.project_id
+  region         = google_cloudfunctions_function.before_create.region
+  cloud_function = google_cloudfunctions_function.before_create.name
+  role           = "roles/cloudfunctions.invoker"
+  member         = "serviceAccount:${local.identitytoolkit_service_agent}"
+}

--- a/infrastructure/project.tf
+++ b/infrastructure/project.tf
@@ -71,25 +71,26 @@ resource "google_project_iam_audit_config" "all_services" {
 locals {
   required_apis = [
     # Core compute
-    "run.googleapis.com",                 # Cloud Run
-    "cloudbuild.googleapis.com",          # Cloud Build
-    "artifactregistry.googleapis.com",    # Docker images
-    "container.googleapis.com",           # GKE (telemetry-tcp-gateway)
+    "run.googleapis.com",              # Cloud Run
+    "cloudbuild.googleapis.com",       # Cloud Build
+    "artifactregistry.googleapis.com", # Docker images
+    "container.googleapis.com",        # GKE (telemetry-tcp-gateway)
+    "cloudfunctions.googleapis.com",   # Cloud Functions Gen 1 (Sprint 2c-B `beforeCreate`)
 
     # Data
-    "sqladmin.googleapis.com",            # Cloud SQL
-    "redis.googleapis.com",               # Memorystore
-    "firestore.googleapis.com",           # Firestore
-    "bigquery.googleapis.com",            # BigQuery
-    "pubsub.googleapis.com",              # Pub/Sub
-    "storage.googleapis.com",             # Cloud Storage
+    "sqladmin.googleapis.com",  # Cloud SQL
+    "redis.googleapis.com",     # Memorystore
+    "firestore.googleapis.com", # Firestore
+    "bigquery.googleapis.com",  # BigQuery
+    "pubsub.googleapis.com",    # Pub/Sub
+    "storage.googleapis.com",   # Cloud Storage
 
     # Security
-    "secretmanager.googleapis.com",       # Secret Manager
-    "cloudkms.googleapis.com",            # KMS
-    "iam.googleapis.com",                 # IAM
-    "iamcredentials.googleapis.com",      # WIF
-    "sts.googleapis.com",                 # WIF Security Token Service
+    "secretmanager.googleapis.com",  # Secret Manager
+    "cloudkms.googleapis.com",       # KMS
+    "iam.googleapis.com",            # IAM
+    "iamcredentials.googleapis.com", # WIF
+    "sts.googleapis.com",            # WIF Security Token Service
 
     # Observability
     "logging.googleapis.com",             # Cloud Logging
@@ -111,23 +112,23 @@ locals {
     "places.googleapis.com",
 
     # AI
-    "generativelanguage.googleapis.com",  # Gemini
-    "aiplatform.googleapis.com",          # Vertex AI
-    "documentai.googleapis.com",          # Document AI (OCR, ADR-007)
+    "generativelanguage.googleapis.com", # Gemini
+    "aiplatform.googleapis.com",         # Vertex AI
+    "documentai.googleapis.com",         # Document AI (OCR, ADR-007)
 
     # Firebase (para auth end-user)
     "firebase.googleapis.com",
-    "identitytoolkit.googleapis.com",     # Firebase Auth
-    "fcm.googleapis.com",                 # FCM push notifications
+    "identitytoolkit.googleapis.com", # Firebase Auth
+    "fcm.googleapis.com",             # FCM push notifications
 
     # Networking
-    "compute.googleapis.com",             # VPC, Load Balancer
-    "servicenetworking.googleapis.com",   # VPC peering Cloud SQL
-    "vpcaccess.googleapis.com",           # Serverless VPC Access
-    "dns.googleapis.com",                 # Cloud DNS
-    "iap.googleapis.com",                 # IAP TCP forwarding (ADR-013 bastion)
-    "oslogin.googleapis.com",             # OS Login (auth SSH del bastion via IAM)
-    "cloudscheduler.googleapis.com",      # Cloud Scheduler (P3.d chat-whatsapp-fallback cron)
+    "compute.googleapis.com",           # VPC, Load Balancer
+    "servicenetworking.googleapis.com", # VPC peering Cloud SQL
+    "vpcaccess.googleapis.com",         # Serverless VPC Access
+    "dns.googleapis.com",               # Cloud DNS
+    "iap.googleapis.com",               # IAP TCP forwarding (ADR-013 bastion)
+    "oslogin.googleapis.com",           # OS Login (auth SSH del bastion via IAM)
+    "cloudscheduler.googleapis.com",    # Cloud Scheduler (P3.d chat-whatsapp-fallback cron)
 
     # Billing
     "cloudbilling.googleapis.com",

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -14,6 +14,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.6"
     }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.7"
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Sprint 2c-B T4 — `google_cloudfunctions_function.before_create` (Gen 1) + IAM binding + `cloudfunctions.googleapis.com` API + `hashicorp/archive` provider. Per ADR-054 + plan v4 + DA F-B9 + F-B3 fixes. **Terraform apply is T8 (operational); T4 ships the .tf file only.**

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `infrastructure/auth-blocking-functions.tf` | 160 | NEW |
| `infrastructure/project.tf` | +1 LOC | MODIFY (add `cloudfunctions.googleapis.com`) |
| `infrastructure/versions.tf` | +4 LOC | MODIFY (add `hashicorp/archive` ~> 2.7) |

## Resources defined

- **`google_storage_bucket.auth_blocking_source`**: placeholder source bucket (Cloud Build deploy from T3 replaces real source via gcloud functions deploy; this bucket holds only the initial placeholder zip).
- **`data.archive_file.auth_blocking_placeholder`**: inline placeholder index.js + package.json (`"type":"commonjs"` matching Gen 1 runtime contract).
- **`google_cloudfunctions_function.before_create`**:
  - runtime `nodejs20`, available_memory_mb 256, timeout 60.
  - region `us-east1` (IdP Blocking Functions require us-east1).
  - entry_point `beforeCreate`, trigger_http true, ingress ALLOW_ALL.
  - min_instances 0, max_instances 5 (per plan T3 + F-B11 contingent rule).
  - `lifecycle.ignore_changes = [source_archive_object, source_archive_bucket, build_environment_variables]` per F-B9 fix — Cloud Build owns the source.
  - `secret_environment_variables` binds `DATABASE_URL` from Secret Manager.
- **`google_cloudfunctions_function_iam_member.idp_invoker`**: grants `roles/cloudfunctions.invoker` to `local.identitytoolkit_service_agent` computed as `service-${google_project.booster_ai.number}@gcp-sa-identitytoolkit.iam.gserviceaccount.com`. Per T1 empirical discovery: the SA is a Google-managed service agent (NOT a user SA visible via `iam service-accounts list`). Computed from project number → portable to any project.

## Atomic deploy contract (DA v2 G-03)

File header documents the 4-step sequence enforced by T7b CI workflow + T6 runbook §Deploy procedure:
1. `terraform apply -target=...before_create` → creates function shell with placeholder source.
2. Cloud Build trigger → gcloud functions deploy replaces source (T3 step).
3. `verify-auth-blocking-deployed` (T3 cloudbuild step) asserts `sourceArchiveUrl` non-empty + `status=ACTIVE`.
4. `terraform apply -target=google_identity_platform_config.default` → T5 wire.

Step 4 cannot proceed until step 3 verifies (T7b workflow gate, next PR).

## Local verification

- `terraform fmt -recursive` clean (T4 files only; 5 pre-existing fmt drift in unrelated files NOT staged).
- `terraform validate` (run in temp dir without backend; ADC has reauth issue in this session): **Success! The configuration is valid.**
- `archive` provider registers cleanly.

## ADR-052 gate behavior

Plan v4 contingency clause: ADR-052 still Proposed → `sprint-2c-build-gate.yml` path-filter covers `infrastructure/auth-blocking-functions.tf` per T2b workflow YAML... actually let me verify the path-filter:

Per sprint-2c-build-gate.yml line 47 (from T2b PR):
```yaml
paths:
  - 'infrastructure/auth-blocking-functions.tf'
  - 'infrastructure/identity-platform.tf'
  - 'cloudbuild.production.yaml'
```

This PR touches `infrastructure/auth-blocking-functions.tf` (NEW) + `infrastructure/project.tf` (cloudfunctions API addition) + `infrastructure/versions.tf` (archive provider). The path-filter WILL match `infrastructure/auth-blocking-functions.tf` → gate fires + fails (ADR-052 Proposed).

Gate is NOT in branch protection `required_status_checks` (only `"CI Success"` is). PR merges via `gh pr merge` despite gate failing. Documented per plan v4 contingency.

## Dependencies

- ✅ Plan v4 Approved (#381).
- ✅ T1 (SA email discovered) + T2 + T3 SHIPPED.
- T7b (`sprint-2c-b-deploy-gate.yml` enforcing atomic-deploy contract) NOT yet shipped; T7b is a downstream task per plan dep chain.
- Next: T5 (`infrastructure/identity-platform.tf` wire blocking_functions — also removes `blocking_functions` from existing `lifecycle.ignore_changes`).

## Test plan

- [x] Local terraform fmt + validate pass
- [x] Local archive provider registers
- [x] Pre-commit hooks pass (no biome match — no TS files in this PR)
- [x] Commitlint pass
- [ ] CI green (with sprint-2c-build-gate expected to fail; "CI Success" expected to pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)