### PR TITLE
feat(sec-001-h1-2-google-blocking-b): T5 wire blocking_functions in IdP

### DIFF
--- a/infrastructure/identity-platform.tf
+++ b/infrastructure/identity-platform.tf
@@ -59,16 +59,34 @@ resource "google_identity_platform_config" "default" {
     }
   }
 
+  # Sprint 2c-B T5 — wire `beforeCreate` blocking function (Google leg
+  # admin-approval gate). Per ADR-054 + plan v4 §T5 acceptance +
+  # F-B3 critical fix (removed `blocking_functions` from
+  # ignore_changes BEFORE adding this block — without that removal,
+  # terraform would silently no-op the new block).
+  #
+  # `function_uri` references the Cloud Function created in T4
+  # (auth-blocking-functions.tf). The function is deployed via Cloud
+  # Build (T3 cloudbuild step) AFTER the resource shell is created
+  # by terraform apply -target=google_cloudfunctions_function.before_create.
+  # T7b CI workflow enforces deploy-before-wire ordering.
+  blocking_functions {
+    triggers {
+      event_type   = "beforeCreate"
+      function_uri = google_cloudfunctions_function.before_create.https_trigger_url
+    }
+  }
+
   lifecycle {
     # No managed aquí:
     #   - authorized_domains: gestionado manualmente (incluye boosterchile.com
     #     y demo.boosterchile.com via console + DNS).
-    #   - blocking_functions: pre-empty para Sprint 2c BlockingFunction
-    #     `beforeCreate` (Google leg residual). Cuando ese spec se merge,
-    #     se removerá del ignore_changes.
+    # NOTE: `blocking_functions` REMOVED from ignore_changes per Sprint
+    # 2c-B T5 F-B3 fix — terraform now manages the trigger declaration
+    # above; gcloud functions deploy only manages the function source
+    # artifact (T4 lifecycle.ignore_changes covers that).
     ignore_changes = [
       authorized_domains,
-      blocking_functions,
     ]
   }
 }


### PR DESCRIPTION
## Summary

Sprint 2c-B T5 — Identity Platform Admin API config wires the `beforeCreate` Cloud Function trigger to the admin-approval gate. **Critical F-B3 hidden-bug fix included** (removes `blocking_functions` from existing `lifecycle.ignore_changes` BEFORE adding the new block).

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `infrastructure/identity-platform.tf` | +22/-4 | MODIFY |

## What changes

**(1) CRITICAL F-B3 fix** — REMOVE `blocking_functions` from `lifecycle.ignore_changes`:

```diff
   lifecycle {
     ignore_changes = [
       authorized_domains,
-      blocking_functions,
     ]
   }
```

Without this removal, terraform would **silently no-op the new block**. This was a DA hidden bug surfaced in plan-b v3 DA pass — the existing lifecycle.ignore_changes was set as a placeholder for Sprint 2c future use; T5 is exactly when it must come off.

**(2) Add `blocking_functions` block** referencing T4 function via Terraform interpolation:

```hcl
blocking_functions {
  triggers {
    event_type   = "beforeCreate"
    function_uri = google_cloudfunctions_function.before_create.https_trigger_url
  }
}
```

NOT hardcoded URL — Terraform reads the function's `https_trigger_url` attribute (computed post-create from T4 resource).

**(3) Updated comments** document the load-bearing nature + deploy ordering contract.

## Terraform plan expectations (run by PO at T8)

- 1 removal: `blocking_functions` exits ignore_changes (in-place modify of the resource's lifecycle attributes).
- 1 in-place update on `google_identity_platform_config.default.blocking_functions` (adding the new triggers block).

## Atomic deploy contract

T7b workflow (`.github/workflows/sprint-2c-b-deploy-gate.yml`, shipping in T7b PR) will enforce mechanical inter-apply ordering when subsequent PRs touch `identity-platform.tf` `blocking_functions` block. **For THIS PR specifically, no T7b workflow exists yet** — reviewer-honor-system on the apply ordering (PO follows T6 runbook §Deploy procedure).

The 4-step apply sequence (documented in T4 file header + T6 runbook):
1. `terraform apply -target=google_cloudfunctions_function.before_create` (T4 resource).
2. Cloud Build deploy step (T3 cloudbuild) replaces placeholder source.
3. `verify-auth-blocking-deployed` (T3 cloudbuild step) asserts `sourceArchiveUrl` + `status=ACTIVE`.
4. `terraform apply -target=google_identity_platform_config.default` (THIS PR — T5).

Step 4 cannot proceed until step 3 verifies.

## Local verification

```
$ terraform fmt infrastructure/identity-platform.tf   # clean
$ # validate in temp dir without backend (ADC reauth issue in session):
$ terraform validate
Success! The configuration is valid.
```

## ADR-052 gate behavior

Plan v4 contingency clause: ADR-052 still Proposed → `sprint-2c-build-gate.yml` path-filter covers `infrastructure/identity-platform.tf` → gate WILL fire + fail. Same pattern as T3 + T4 PRs. Gate is informational (not in `required_status_checks`). PR merges via `gh pr merge` once `CI Success` passes.

## Dependencies

- ✅ Plan v4 Approved (#381).
- ✅ T1-T4 SHIPPED.
- Next: T6 runbook (`docs/qa/google-blocking-function-runbook.md` — operational reference for T8/T9/T11/T12b).

## Test plan

- [x] Local terraform fmt + validate pass
- [x] Pre-commit hooks pass
- [x] Commitlint pass
- [ ] CI green (sprint-2c-build-gate expected to fail; "CI Success" expected to pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)