### PR TITLE
feat(sec-001-h1-2-google-blocking-b): T7 atomic deploy verify script

### DIFF
--- a/apps/api/scripts/check-cloud-function-deployed.ts
+++ b/apps/api/scripts/check-cloud-function-deployed.ts
@@ -1,0 +1,120 @@
+#!/usr/bin/env tsx
+/**
+ * Sprint 2c-B T7 — atomic deploy verification script.
+ *
+ * Spec: `.specs/sec-001-h1-2-google-blocking-b/plan.md` v4 §T7
+ * acceptance. Wired into Cloud Build via `cloudbuild.production.yaml`
+ * `verify-auth-blocking-deployed` step (T3) and into the
+ * `sprint-2c-b-deploy-gate.yml` workflow (T7b — next PR).
+ *
+ * **Mechanical scope** (F-B3 honest framing):
+ *
+ *   Post-deploy verification of the Cloud Function ARTIFACT only.
+ *   Asserts: `sourceArchiveUrl` non-empty + `status === 'ACTIVE'`.
+ *
+ *   This is NOT an inter-apply ordering gate. The atomic deploy
+ *   contract (T4 resource → Cloud Build deploy → THIS verify → T5
+ *   wire) is enforced by:
+ *     1. PO discipline following T6 runbook §Deploy procedure.
+ *     2. T7b CI workflow path-filter on `infrastructure/identity-
+ *        platform.tf` modifications that touch `blocking_functions`
+ *        (forces this script to run against prod state before T5
+ *        wire PR can merge).
+ *
+ * Defeat scenarios this script does NOT catch:
+ *   - Stale `sourceArchiveUrl` pointing at a previous good deploy
+ *     (the new deploy uploaded successfully but the API state
+ *     reflects an earlier ACTIVE revision).
+ *   - Function in `ACTIVE` status but executing wrong code (e.g.,
+ *     deployment swap raced with a different branch's artifact).
+ *
+ * Defenses for the above live in T9 smoke E2E + T10 production
+ * perf measurement + T12b 7-day watch.
+ *
+ * Ejecución:
+ *   pnpm --filter @booster-ai/api exec tsx \
+ *     scripts/check-cloud-function-deployed.ts
+ *
+ * Exit codes:
+ *   0 — function exists, `sourceArchiveUrl` non-empty, `status` ACTIVE.
+ *   1 — file absent, gcloud failed, missing sourceArchiveUrl, or
+ *       status not ACTIVE.
+ */
+
+import { execSync } from 'node:child_process';
+
+const FUNCTION_NAME = 'beforeCreate';
+const REGION = 'us-east1';
+const PROJECT = 'booster-ai-494222';
+
+export interface CheckResult {
+  ok: boolean;
+  reason: string;
+}
+
+export interface CheckOptions {
+  /** Override the shell invocation (test injection). */
+  exec?: (cmd: string) => string;
+}
+
+export function checkCloudFunctionDeployed(options: CheckOptions = {}): CheckResult {
+  const run =
+    options.exec ??
+    ((cmd: string) => execSync(cmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }));
+  let raw: string;
+  try {
+    raw = run(
+      `gcloud functions describe ${FUNCTION_NAME} --region=${REGION} --project=${PROJECT} --format=json`,
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'unknown';
+    return {
+      ok: false,
+      reason: `gcloud functions describe failed (function may not exist or gcloud unavailable): ${message}`,
+    };
+  }
+  let parsed: { sourceArchiveUrl?: string; status?: string };
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `gcloud output is not valid JSON: ${err instanceof Error ? err.message : 'unknown'}`,
+    };
+  }
+  const src = parsed.sourceArchiveUrl ?? '';
+  const status = parsed.status ?? '';
+  if (!src) {
+    return {
+      ok: false,
+      reason:
+        'sourceArchiveUrl is empty (function never deployed or Cloud Build deploy step skipped)',
+    };
+  }
+  if (status !== 'ACTIVE') {
+    return {
+      ok: false,
+      reason: `status is "${status}" (expected ACTIVE; deploy may be in progress or failed)`,
+    };
+  }
+  return {
+    ok: true,
+    reason: `function ${FUNCTION_NAME} ACTIVE with sourceArchiveUrl=${src}`,
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const result = checkCloudFunctionDeployed();
+  if (result.ok) {
+    console.log(`[check-cloud-function-deployed] OK — ${result.reason}`);
+    process.exit(0);
+  }
+  console.error(`[check-cloud-function-deployed] FAIL — ${result.reason}`);
+  console.error('');
+  console.error('Sprint 2c-B atomic deploy contract requires the Cloud Function to be');
+  console.error('ACTIVE with non-empty sourceArchiveUrl BEFORE wiring `blocking_functions`');
+  console.error('in Identity Platform config (T5 terraform apply).');
+  console.error('See docs/qa/google-blocking-function-runbook.md §2 Deploy procedure.');
+  process.exit(1);
+}

--- a/apps/api/test/scripts/check-cloud-function-deployed.test.ts
+++ b/apps/api/test/scripts/check-cloud-function-deployed.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { checkCloudFunctionDeployed } from '../../scripts/check-cloud-function-deployed.js';
+
+/**
+ * Sprint 2c-B T7 — atomic deploy verification fixture tests.
+ *
+ * Tests inject a mock `exec` callback (instead of real `child_process.
+ * execSync` against `gcloud`) so the harness is hermetic and runs in
+ * CI without prod credentials.
+ *
+ * Fixtures per plan v4 §T7 acceptance:
+ *   1. ACTIVE + sourceArchiveUrl present → exit 0.
+ *   2. Missing sourceArchiveUrl → exit 1.
+ *   3. status=DEPLOY_IN_PROGRESS → exit 1.
+ *   4. gcloud failure (e.g., function not found OR gcloud absent) → exit 1.
+ *   5. Non-JSON output (gcloud crash, partial stream) → exit 1.
+ */
+
+describe('checkCloudFunctionDeployed', () => {
+  it('ACTIVE + sourceArchiveUrl present → ok', () => {
+    const result = checkCloudFunctionDeployed({
+      exec: () =>
+        JSON.stringify({
+          name: 'projects/booster-ai-494222/locations/us-east1/functions/beforeCreate',
+          status: 'ACTIVE',
+          sourceArchiveUrl: 'gs://gcf-sources-469283083998-us-east1/beforeCreate-deadbeef.zip',
+        }),
+    });
+    expect(result.ok).toBe(true);
+    expect(result.reason).toMatch(/ACTIVE/);
+  });
+
+  it('missing sourceArchiveUrl → fail with clear message', () => {
+    const result = checkCloudFunctionDeployed({
+      exec: () =>
+        JSON.stringify({
+          name: 'projects/booster-ai-494222/locations/us-east1/functions/beforeCreate',
+          status: 'ACTIVE',
+          // sourceArchiveUrl intentionally omitted
+        }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/sourceArchiveUrl is empty/);
+  });
+
+  it('status=DEPLOY_IN_PROGRESS → fail with status in reason', () => {
+    const result = checkCloudFunctionDeployed({
+      exec: () =>
+        JSON.stringify({
+          name: 'projects/booster-ai-494222/locations/us-east1/functions/beforeCreate',
+          status: 'DEPLOY_IN_PROGRESS',
+          sourceArchiveUrl: 'gs://gcf-sources-469283083998-us-east1/beforeCreate-deadbeef.zip',
+        }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/DEPLOY_IN_PROGRESS/);
+  });
+
+  it('gcloud failure (exec throws) → fail with gcloud-failed message', () => {
+    const result = checkCloudFunctionDeployed({
+      exec: () => {
+        throw new Error('gcloud: command not found');
+      },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/gcloud functions describe failed/);
+  });
+
+  it('non-JSON output → fail with parse-error message', () => {
+    const result = checkCloudFunctionDeployed({
+      exec: () => 'not-json-output',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/not valid JSON/);
+  });
+
+  it('explicit empty sourceArchiveUrl → fail (not just undefined)', () => {
+    const result = checkCloudFunctionDeployed({
+      exec: () =>
+        JSON.stringify({
+          name: 'projects/booster-ai-494222/locations/us-east1/functions/beforeCreate',
+          status: 'ACTIVE',
+          sourceArchiveUrl: '',
+        }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/sourceArchiveUrl is empty/);
+  });
+
+  it('explicit OFFLINE status → fail', () => {
+    const result = checkCloudFunctionDeployed({
+      exec: () =>
+        JSON.stringify({
+          name: 'projects/booster-ai-494222/locations/us-east1/functions/beforeCreate',
+          status: 'OFFLINE',
+          sourceArchiveUrl: 'gs://gcf-sources-469283083998-us-east1/beforeCreate-deadbeef.zip',
+        }),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/OFFLINE/);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 2c-B T7 — standalone TypeScript script + 7 fixture tests for the atomic-deploy verification logic already inlined in T3 cloudbuild `verify-auth-blocking-deployed` step. T7b workflow (next PR) wires this script into a CI gate that fires on `identity-platform.tf` `blocking_functions` modifications.

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `apps/api/scripts/check-cloud-function-deployed.ts` | 120 | NEW |
| `apps/api/test/scripts/check-cloud-function-deployed.test.ts` | 102 | NEW (7 tests) |

## Mechanical scope (F-B3 honest framing)

Script asserts post-deploy artifact state:
- `sourceArchiveUrl` non-empty (function actually deployed via gcloud).
- `status === 'ACTIVE'` (deploy completed, not in-progress or failed).

**NOT** an inter-apply ordering gate. The 4-step atomic contract is enforced by:
1. PO discipline following [T6 runbook §Deploy procedure](../../docs/qa/google-blocking-function-runbook.md).
2. T7b workflow path-filter on `infrastructure/identity-platform.tf` mods (next PR).

Defeat scenarios NOT caught here (defenses live in T9 smoke + T10 perf + T12b watch):
- Stale `sourceArchiveUrl` pointing at a previous good deploy.
- Function ACTIVE with wrong code (race condition).

## Tests (all 7 passing locally)

| # | Fixture | Expected |
|---|---|---|
| 1 | `ACTIVE + sourceArchiveUrl present` | ok |
| 2 | `missing sourceArchiveUrl` | fail with clear message |
| 3 | `status=DEPLOY_IN_PROGRESS` | fail with status in reason |
| 4 | `gcloud failure (exec throws)` | fail with gcloud-failed message |
| 5 | `non-JSON output` | fail with parse-error message |
| 6 | `explicit empty sourceArchiveUrl` | fail (not just undefined) |
| 7 | `explicit OFFLINE status` | fail |

Tests inject a mock `exec` callback (no real `gcloud` invocation; hermetic, runs in CI without prod credentials).

## Design — dependency injection for testability

```typescript
export function checkCloudFunctionDeployed(options: CheckOptions = {}): CheckResult {
  const run = options.exec ?? defaultExecSync;
  // ... gcloud invocation + JSON parse + assertions ...
}
```

Test path passes `{ exec: () => JSON.stringify({ ... }) }`. Production path uses `execSync` against real gcloud.

## Gate behavior

`apps/api/scripts/` path is NOT in `sprint-2c-build-gate.yml` or `sprint-2c-b-deploy-gate.yml` path-filter → no gate fires on this PR. Standard CI path (typecheck + tests + lint) passes.

## Dependencies

- ✅ T3 merged (cloudbuild has inline equivalent of this script).
- Next: T7b deploy-gate workflow that calls this script via WIF auth.

## Test plan

- [x] Local 7/7 tests pass
- [x] Local typecheck clean
- [x] Pre-commit hooks pass (biome auto-reformatted dependency injection block)
- [x] Commitlint pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)