### PR TITLE
feat(sec-001-h1-2-google-blocking-b): T7b deploy-gate workflow + IAM grant

### DIFF
--- a/.github/workflows/sprint-2c-b-deploy-gate.yml
+++ b/.github/workflows/sprint-2c-b-deploy-gate.yml
@@ -1,0 +1,120 @@
+# ---------------------------------------------------------------------------
+# Sprint 2c-B T7b — Inter-apply deploy-gate (DA G-03 mechanical enforcement).
+#
+# Spec: .specs/sec-001-h1-2-google-blocking-b/plan.md v4 §T7b.
+# Wired script: apps/api/scripts/check-cloud-function-deployed.ts (T7).
+# Companion runbook: docs/qa/google-blocking-function-runbook.md §2.
+#
+# Purpose: When a PR wires `blocking_functions` in
+# `infrastructure/identity-platform.tf` (T5), this workflow verifies
+# the Cloud Function is ALREADY deployed and ACTIVE in prod before
+# the wire PR can merge. Converts the F-B3 honor-system runbook
+# ordering into mechanical CI enforcement.
+#
+# Path-filter scope:
+#   - infrastructure/identity-platform.tf (when diff touches
+#     `blocking_functions` block, detected via grep step).
+#
+# Auth: Workload Identity Federation per N-B1 plan v4 fix
+# (matches `.github/workflows/release.yml` precedent — NOT a long-
+# lived `GCP_SA_KEY` secret). The WIF SA `github-deployer` has
+# `roles/cloudfunctions.viewer` granted via `infrastructure/iam.tf`
+# `local.github_deployer_roles` for_each pickup (N-B6 plan v4 fix).
+#
+# Escape-hatch:
+#   gh workflow run sprint-2c-b-deploy-gate.yml -f force=true
+#
+# Use when the gate has a bug OR an edit to identity-platform.tf is
+# unrelated to blocking_functions wiring. Trace stays in Actions tab.
+# Document each use in `.specs/_followups/sprint-2c-b-gate-bypasses.md`
+# per plan v4 contingency clause.
+#
+# Post-Sprint-2c-B CERRADO: this workflow is deleted by T14b along
+# with sprint-2c-build-gate.yml + sprint-2c-handler-completeness.yml.
+# ---------------------------------------------------------------------------
+
+name: Sprint 2c-B deploy gate
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'infrastructure/identity-platform.tf'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Bypass gate (escape-hatch). Use only if gate has a bug or change unrelated to blocking_functions wiring.'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+concurrency:
+  group: sprint-2c-b-deploy-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: read
+
+jobs:
+  check-function-deployed-in-prod:
+    name: Sprint 2c-B deploy gate (function ACTIVE in prod)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Bypass gate (escape-hatch)
+        if: github.event_name == 'workflow_dispatch' && inputs.force == 'true'
+        run: |
+          echo "::warning::Sprint 2c-B deploy gate bypassed via workflow_dispatch force=true"
+          echo "Reason must be documented in .specs/_followups/sprint-2c-b-gate-bypasses.md"
+          exit 0
+
+      - uses: actions/checkout@v4
+        if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.force != 'true')
+        with:
+          fetch-depth: 0
+
+      - name: Confirm PR diff touches blocking_functions block
+        if: github.event_name == 'pull_request'
+        id: diff-check
+        run: |
+          if git diff --unified=0 origin/main...HEAD -- infrastructure/identity-platform.tf | grep -qE '^\+.*blocking_functions \{'; then
+            echo "diff_has_blocking_functions=true" >> "$GITHUB_OUTPUT"
+            echo "PR diff adds a blocking_functions block — gate must verify prod state."
+          else
+            echo "diff_has_blocking_functions=false" >> "$GITHUB_OUTPUT"
+            echo "PR diff does NOT add a blocking_functions block — gate is informational only."
+          fi
+
+      - uses: google-github-actions/auth@v2
+        if: github.event_name == 'workflow_dispatch' || steps.diff-check.outputs.diff_has_blocking_functions == 'true'
+        with:
+          project_id: booster-ai-494222
+          workload_identity_provider: ${{ vars.WIF_PROVIDER }}
+          service_account: ${{ vars.WIF_SERVICE_ACCOUNT_DEPLOY }}
+
+      - uses: google-github-actions/setup-gcloud@v3
+        if: github.event_name == 'workflow_dispatch' || steps.diff-check.outputs.diff_has_blocking_functions == 'true'
+
+      - uses: pnpm/action-setup@v6
+        if: github.event_name == 'workflow_dispatch' || steps.diff-check.outputs.diff_has_blocking_functions == 'true'
+        with:
+          version: '9.15.4'
+
+      - uses: actions/setup-node@v6
+        if: github.event_name == 'workflow_dispatch' || steps.diff-check.outputs.diff_has_blocking_functions == 'true'
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - name: Install dependencies
+        if: github.event_name == 'workflow_dispatch' || steps.diff-check.outputs.diff_has_blocking_functions == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify Cloud Function deployed + ACTIVE in prod
+        if: github.event_name == 'workflow_dispatch' || steps.diff-check.outputs.diff_has_blocking_functions == 'true'
+        run: pnpm --filter @booster-ai/api exec tsx scripts/check-cloud-function-deployed.ts

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -184,6 +184,12 @@ locals {
     "roles/container.developer",               # Deploy a GKE (telemetry gateway)
     "roles/logging.viewer",                    # Leer logs de Cloud Build (gcloud builds submit los streamea)
     "roles/logging.logWriter",                 # Escribir logs del build a Cloud Logging
+    # Sprint 2c-B T7b — `.github/workflows/sprint-2c-b-deploy-gate.yml`
+    # runs `gcloud functions describe beforeCreate` against prod to
+    # assert ACTIVE + sourceArchiveUrl non-empty BEFORE T5 IdP wire PR
+    # can merge. Read-only on cloudfunctions; bound to the WIF service
+    # agent via the for_each pickup below.
+    "roles/cloudfunctions.viewer",
   ]
 }
 


### PR DESCRIPTION
## Summary

Sprint 2c-B T7b — inter-apply CI workflow that converts T6 runbook's honor-system ordering into **mechanical enforcement** (DA G-03 fix per plan v4). Plus `infrastructure/iam.tf` grant `roles/cloudfunctions.viewer` to the WIF SA `github-deployer` via `for_each` pickup (N-B6 fix).

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `.github/workflows/sprint-2c-b-deploy-gate.yml` | 120 | NEW (WIF auth + diff-check + script invocation) |
| `infrastructure/iam.tf` | +6 LOC | MODIFY (add `roles/cloudfunctions.viewer` to `local.github_deployer_roles`) |

## Workflow design (N-B1 fix)

- **Path-filter**: `infrastructure/identity-platform.tf` (any modify).
- **Diff-check step**: greps `^\+.*blocking_functions \{` to confirm the PR is actually adding the wire. If the modification is unrelated (e.g., `authorized_domains` edit), the real check skips — reduces false-positive friction.
- **WIF auth** (per `release.yml` precedent — NOT a long-lived `GCP_SA_KEY`):
  ```yaml
  permissions: { contents: read, id-token: write, pull-requests: read }
  - uses: google-github-actions/auth@v2
    with:
      project_id: booster-ai-494222
      workload_identity_provider: ${{ vars.WIF_PROVIDER }}
      service_account: ${{ vars.WIF_SERVICE_ACCOUNT_DEPLOY }}
  ```
- **Real check**: `pnpm --filter @booster-ai/api exec tsx scripts/check-cloud-function-deployed.ts` (T7).
- **`workflow_dispatch` with `force=true`** escape-hatch (bypass tracker documented in `.specs/_followups/sprint-2c-b-gate-bypasses.md` per plan v4 contingency + T6 runbook §9).

## IAM grant via `for_each` pickup (N-B6 fix)

```diff
   github_deployer_roles = [
     ...
     "roles/logging.viewer",
     "roles/logging.logWriter",
+    # Sprint 2c-B T7b — `.github/workflows/sprint-2c-b-deploy-gate.yml`
+    # runs `gcloud functions describe beforeCreate` against prod to
+    # assert ACTIVE + sourceArchiveUrl non-empty BEFORE T5 IdP wire PR
+    # can merge. Read-only on cloudfunctions; bound to the WIF service
+    # agent via the for_each pickup below.
+    "roles/cloudfunctions.viewer",
   ]
 }
```

Existing `google_project_iam_member.github_deployer_bindings` `for_each = toset(local.github_deployer_roles)` picks up the new role + grants to WIF SA on next `terraform apply`. **NO terraform apply happens in this PR** — that's an out-of-band PO action documented in the commit message.

## Local verification

- `terraform fmt iam.tf` clean.
- `terraform validate` (temp dir, no backend): **Success! The configuration is valid.**
- YAML structure: name + on + concurrency + permissions + jobs all top-level.

## Future-self note

Once this PR merges + PO runs the targeted terraform apply (one IAM binding), **the next PR touching `infrastructure/identity-platform.tf` blocking_functions block** (operationally: a re-wire or rollback) will fire T7b workflow which asserts the prod function is ACTIVE before allowing merge. This is the mechanical enforcement F-B3 demanded.

For THIS PR specifically: T7b workflow path-filter does NOT cover `.github/workflows/` itself, so it does not gate its own merge. Standard CI passes.

## Dependencies

- ✅ Plan v4 (#381).
- ✅ T7 merged (#388) — wired script exists.
- Next: T8 operational terraform apply (PO runs the 4-step sequence per T6 runbook §2).

## Test plan

- [x] Local terraform fmt + validate pass
- [x] YAML structural sanity
- [x] Pre-commit hooks pass
- [x] Commitlint pass (1 cosmetic warning on body line length; non-blocking)
- [ ] CI green (this PR; T7b path-filter does not match this PR's paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)