### PR TITLE
feat(sec-001-h1-2-google-blocking-b): T12b script — 7d watch log check

### DIFF
--- a/apps/api/scripts/check-7d-watch-log.ts
+++ b/apps/api/scripts/check-7d-watch-log.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env tsx
+/**
+ * Sprint 2c-B T12b — 7-day watch log integrity check.
+ *
+ * Spec: `.specs/sec-001-h1-2-google-blocking-b/plan.md` v4 §T12b
+ * acceptance (F-B8 mechanical fix). Runs as the gate before T13
+ * ADR-054 Status flip Proposed → Accepted.
+ *
+ * Asserts:
+ *   (a) Exactly 7 dated entries in `7day-watch-log.md` (one per day
+ *       between T-WIRE-PROD-APPLY and T-WIRE-PROD-APPLY + 7 days).
+ *   (b) The 7 dates form a contiguous sequence anchored at the
+ *       T-WIRE-PROD-APPLY timestamp from `T-WIRE-PROD-APPLY.txt`.
+ *   (c) Any 48h+ gap explicitly logged as a "GAP — extended by N days"
+ *       entry (instead of being silently skipped).
+ *   (d) If `T-WIRE-PROD-APPLY-amendments.md` exists (re-apply events),
+ *       the watch log accounts for the amendments per runbook §4.
+ *
+ * **Mechanical scope**: this is a file-format integrity check, NOT a
+ * semantic validation of the watch entries themselves. Whether the
+ * entries report meaningful baseline rates / 3-sigma thresholds / alert
+ * firings is a PO judgment captured manually in the log body. Per
+ * plan-a v3 anti-pattern lesson: keep the gate honest about what it
+ * does and does not enforce.
+ *
+ * Ejecución (post-T12b 7-day window):
+ *   pnpm --filter @booster-ai/api exec tsx \
+ *     scripts/check-7d-watch-log.ts
+ *
+ * Exit codes:
+ *   0 — all assertions pass; T13 ADR flip cleared.
+ *   1 — any assertion fails; T13 blocked, fix log + re-run.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+
+const EVIDENCE_DIR = '.specs/sec-001-h1-2-google-blocking-b/sprint-2c-b-evidence';
+const WATCH_LOG_PATH = `${EVIDENCE_DIR}/7day-watch-log.md`;
+const ANCHOR_PATH = `${EVIDENCE_DIR}/T-WIRE-PROD-APPLY.txt`;
+const AMENDMENTS_PATH = `${EVIDENCE_DIR}/T-WIRE-PROD-APPLY-amendments.md`;
+
+export interface CheckOptions {
+  /** Override evidence file paths for testing. */
+  watchLogPath?: string;
+  anchorPath?: string;
+  amendmentsPath?: string;
+}
+
+export interface CheckResult {
+  ok: boolean;
+  reason: string;
+}
+
+export interface ParsedEntry {
+  /** Day number (1..7 or higher if extended). */
+  day: number;
+  /** ISO 8601 date (YYYY-MM-DD). */
+  date: string;
+  /** True if entry headline contains 'GAP'. */
+  isGap: boolean;
+}
+
+const ENTRY_HEADING = /^## Day (\d+)\s+\((\d{4}-\d{2}-\d{2})\)(.*)$/gm;
+
+export function parseWatchLog(content: string): ParsedEntry[] {
+  const entries: ParsedEntry[] = [];
+  for (const match of content.matchAll(ENTRY_HEADING)) {
+    const day = Number(match[1]);
+    const date = match[2] ?? '';
+    const headlineRest = match[3] ?? '';
+    entries.push({
+      day,
+      date,
+      isGap: /GAP\b/i.test(headlineRest),
+    });
+  }
+  return entries;
+}
+
+export function parseAnchorTimestamp(content: string): string | null {
+  const match = content.match(/T-WIRE-PROD-APPLY:\s*(\d{4}-\d{2}-\d{2})/);
+  return match?.[1] ?? null;
+}
+
+function addDays(yyyymmdd: string, days: number): string {
+  const date = new Date(`${yyyymmdd}T00:00:00Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+export function checkWatchLog(options: CheckOptions = {}): CheckResult {
+  const watchLogPath = options.watchLogPath ?? WATCH_LOG_PATH;
+  const anchorPath = options.anchorPath ?? ANCHOR_PATH;
+  const amendmentsPath = options.amendmentsPath ?? AMENDMENTS_PATH;
+
+  if (!existsSync(watchLogPath)) {
+    return { ok: false, reason: `Watch log not found at ${watchLogPath}` };
+  }
+  if (!existsSync(anchorPath)) {
+    return { ok: false, reason: `T-WIRE-PROD-APPLY anchor not found at ${anchorPath}` };
+  }
+
+  const watchLog = readFileSync(watchLogPath, 'utf-8');
+  const anchorContent = readFileSync(anchorPath, 'utf-8');
+  const anchorDate = parseAnchorTimestamp(anchorContent);
+  if (!anchorDate) {
+    return {
+      ok: false,
+      reason: `T-WIRE-PROD-APPLY.txt missing valid timestamp (expected line "T-WIRE-PROD-APPLY: YYYY-MM-DDTHH:MM:SSZ")`,
+    };
+  }
+
+  const entries = parseWatchLog(watchLog);
+  if (entries.length === 0) {
+    return { ok: false, reason: 'No dated entries found in watch log (expected at least 7)' };
+  }
+
+  // (a) Exactly 7 entries — but accept >7 if extensions documented as GAP.
+  if (entries.length < 7) {
+    return {
+      ok: false,
+      reason: `Watch log has ${entries.length} dated entries; expected at least 7 (one per day from T-WIRE-PROD-APPLY)`,
+    };
+  }
+
+  // (b) Sequence anchored at T-WIRE-PROD-APPLY.
+  // The first entry's date should be `anchorDate + 1 day` (Day 1 of watch).
+  const expectedDay1 = addDays(anchorDate, 1);
+  if (entries[0]?.date !== expectedDay1) {
+    return {
+      ok: false,
+      reason: `Day 1 entry date "${entries[0]?.date}" does not match expected "${expectedDay1}" (T-WIRE-PROD-APPLY + 1 day)`,
+    };
+  }
+
+  // (b/c) Each subsequent entry advances exactly 1 day OR is explicitly
+  // marked as a GAP extension. Non-gap entries with 48h+ gaps fail.
+  for (let i = 1; i < entries.length; i += 1) {
+    const prev = entries[i - 1];
+    const curr = entries[i];
+    if (!prev || !curr) {
+      continue;
+    }
+    const expected = addDays(prev.date, 1);
+    if (curr.date !== expected && !curr.isGap) {
+      return {
+        ok: false,
+        reason: `Entry "Day ${curr.day} (${curr.date})" does not follow "Day ${prev.day} (${prev.date})" by exactly 1 day, and is not flagged as a GAP extension. Add "GAP — extended by N days" to the heading or fix the date sequence.`,
+      };
+    }
+  }
+
+  // (d) Amendments file presence cross-check. If file exists, the watch
+  // log SHOULD reference at least one GAP entry (re-apply events usually
+  // require log extension).
+  if (existsSync(amendmentsPath)) {
+    const hasGap = entries.some((e) => e.isGap);
+    if (!hasGap) {
+      return {
+        ok: false,
+        reason: `${amendmentsPath} exists (re-apply events documented) but watch log has NO GAP entries. Verify whether the re-apply reset/extended the watch clock per runbook §4.`,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    reason: `Watch log integrity OK — ${entries.length} dated entries, contiguous from ${anchorDate} + 1 day, GAP entries handled correctly`,
+  };
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  const result = checkWatchLog();
+  if (result.ok) {
+    console.log(`[check-7d-watch-log] OK — ${result.reason}`);
+    process.exit(0);
+  }
+  console.error(`[check-7d-watch-log] FAIL — ${result.reason}`);
+  console.error('');
+  console.error('Sprint 2c-B T13 ADR-054 Status flip gated on T12b watch log integrity.');
+  console.error('See docs/qa/google-blocking-function-runbook.md §4 7-day watch semantics.');
+  process.exit(1);
+}

--- a/apps/api/test/scripts/check-7d-watch-log.test.ts
+++ b/apps/api/test/scripts/check-7d-watch-log.test.ts
@@ -1,0 +1,212 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  checkWatchLog,
+  parseAnchorTimestamp,
+  parseWatchLog,
+} from '../../scripts/check-7d-watch-log.js';
+
+/**
+ * Sprint 2c-B T12b — tests for the 7-day watch log integrity check.
+ *
+ * Uses real temp files (mkdtemp) instead of mocks because the script
+ * reads via fs.readFileSync directly; injecting fs would complicate
+ * the production-path API. Temp files are auto-cleaned in afterEach.
+ */
+
+const ANCHOR_HAPPY = `T-WIRE-PROD-APPLY: 2026-06-01T10:00:00Z
+Applied by: dev@boosterchile.com
+Terraform apply run: abc-123
+Notes: clean apply
+`;
+
+const WATCH_LOG_HAPPY = `# 7-day watch log — Sprint 2c-B
+T-WIRE-PROD-APPLY: 2026-06-01T10:00:00Z
+
+## Day 1 (2026-06-02)
+- blocked count: 0
+- baseline: n/a
+- alerts: 0
+- reviewer: dev
+
+## Day 2 (2026-06-03)
+- blocked count: 1
+- alerts: 0
+- reviewer: dev
+
+## Day 3 (2026-06-04)
+- blocked count: 0
+- alerts: 0
+- reviewer: dev
+
+## Day 4 (2026-06-05)
+- blocked count: 0
+- alerts: 0
+- reviewer: dev
+
+## Day 5 (2026-06-06)
+- blocked count: 0
+- alerts: 0
+- reviewer: dev
+
+## Day 6 (2026-06-07)
+- blocked count: 0
+- alerts: 0
+- reviewer: dev
+
+## Day 7 (2026-06-08)
+- blocked count: 0
+- alerts: 0
+- reviewer: dev
+`;
+
+describe('parseAnchorTimestamp', () => {
+  it('parses ISO date from T-WIRE-PROD-APPLY line', () => {
+    expect(parseAnchorTimestamp(ANCHOR_HAPPY)).toBe('2026-06-01');
+  });
+
+  it('returns null when anchor line missing', () => {
+    expect(parseAnchorTimestamp('# Not the right file')).toBeNull();
+  });
+});
+
+describe('parseWatchLog', () => {
+  it('extracts 7 dated entries from happy log', () => {
+    const entries = parseWatchLog(WATCH_LOG_HAPPY);
+    expect(entries).toHaveLength(7);
+    expect(entries[0]).toEqual({ day: 1, date: '2026-06-02', isGap: false });
+    expect(entries[6]).toEqual({ day: 7, date: '2026-06-08', isGap: false });
+  });
+
+  it('detects GAP in heading', () => {
+    const log = '## Day 1 (2026-06-02)\n## Day 2 (2026-06-04) — GAP — extended by 1 day\n';
+    const entries = parseWatchLog(log);
+    expect(entries[1]?.isGap).toBe(true);
+  });
+
+  it('returns empty array on empty input', () => {
+    expect(parseWatchLog('')).toEqual([]);
+  });
+});
+
+describe('checkWatchLog', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'watch-log-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeFiles(opts: { watchLog?: string; anchor?: string; amendments?: string | null }) {
+    const watchLogPath = join(dir, '7day-watch-log.md');
+    const anchorPath = join(dir, 'T-WIRE-PROD-APPLY.txt');
+    const amendmentsPath = join(dir, 'T-WIRE-PROD-APPLY-amendments.md');
+    if (opts.watchLog !== undefined) {
+      writeFileSync(watchLogPath, opts.watchLog);
+    }
+    if (opts.anchor !== undefined) {
+      writeFileSync(anchorPath, opts.anchor);
+    }
+    if (opts.amendments) {
+      writeFileSync(amendmentsPath, opts.amendments);
+    }
+    return { watchLogPath, anchorPath, amendmentsPath };
+  }
+
+  it('happy path: 7 contiguous entries anchored at T-WIRE → ok', () => {
+    const paths = writeFiles({ watchLog: WATCH_LOG_HAPPY, anchor: ANCHOR_HAPPY });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(true);
+    expect(result.reason).toMatch(/integrity OK/);
+  });
+
+  it('missing watch log → fail', () => {
+    const paths = writeFiles({ anchor: ANCHOR_HAPPY });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/Watch log not found/);
+  });
+
+  it('missing anchor → fail', () => {
+    const paths = writeFiles({ watchLog: WATCH_LOG_HAPPY });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/anchor not found/);
+  });
+
+  it('malformed anchor → fail', () => {
+    const paths = writeFiles({ watchLog: WATCH_LOG_HAPPY, anchor: 'no T-WIRE line here' });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/missing valid timestamp/);
+  });
+
+  it('< 7 entries → fail', () => {
+    const shortLog = '## Day 1 (2026-06-02)\n## Day 2 (2026-06-03)\n## Day 3 (2026-06-04)\n';
+    const paths = writeFiles({ watchLog: shortLog, anchor: ANCHOR_HAPPY });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/expected at least 7/);
+  });
+
+  it('Day 1 date mismatch (not anchor + 1 day) → fail', () => {
+    const wrongLog = WATCH_LOG_HAPPY.replace('Day 1 (2026-06-02)', 'Day 1 (2026-06-10)');
+    const paths = writeFiles({ watchLog: wrongLog, anchor: ANCHOR_HAPPY });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/Day 1 entry date/);
+  });
+
+  it('non-contiguous dates without GAP → fail', () => {
+    const gappy =
+      '## Day 1 (2026-06-02)\n## Day 2 (2026-06-03)\n## Day 3 (2026-06-04)\n' +
+      '## Day 4 (2026-06-05)\n## Day 5 (2026-06-06)\n## Day 6 (2026-06-09)\n## Day 7 (2026-06-10)\n';
+    const paths = writeFiles({ watchLog: gappy, anchor: ANCHOR_HAPPY });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/does not follow.*by exactly 1 day/);
+  });
+
+  it('non-contiguous dates WITH explicit GAP flag → ok', () => {
+    const gappy =
+      '## Day 1 (2026-06-02)\n## Day 2 (2026-06-03)\n## Day 3 (2026-06-04)\n' +
+      '## Day 4 (2026-06-05)\n## Day 5 (2026-06-06)\n' +
+      '## Day 6 (2026-06-09) — GAP — extended by 2 days (PO unavailable; no signups during gap)\n' +
+      '## Day 7 (2026-06-10)\n';
+    const paths = writeFiles({ watchLog: gappy, anchor: ANCHOR_HAPPY });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(true);
+  });
+
+  it('amendments file present + no GAP entries in log → fail', () => {
+    const paths = writeFiles({
+      watchLog: WATCH_LOG_HAPPY,
+      anchor: ANCHOR_HAPPY,
+      amendments:
+        '## Re-apply event 2026-06-05T14:00:00Z\nReason: drift fix\nDecision: continue clock\n',
+    });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/amendments.md exists.*NO GAP entries/);
+  });
+
+  it('amendments file present + GAP entry present → ok', () => {
+    const logWithGap = WATCH_LOG_HAPPY.replace(
+      'Day 5 (2026-06-06)',
+      'Day 5 (2026-06-06) — GAP — extended by 0 days (re-apply continue clock per amendments.md)',
+    );
+    const paths = writeFiles({
+      watchLog: logWithGap,
+      anchor: ANCHOR_HAPPY,
+      amendments:
+        '## Re-apply event 2026-06-05T14:00:00Z\nReason: drift fix\nDecision: continue clock\n',
+    });
+    const result = checkWatchLog(paths);
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 2c-B T12b (code-only portion) — `check-7d-watch-log.ts` + 15 fixture tests. F-B8 mechanical fix converts honor-system clock-anchor + gap-handling into mechanical gate before T13 ADR-054 Status flip.

**Code ships now; the actual `7day-watch-log.md` file accumulates during the operational 7-day window post-T8 deploy.**

## Files

| Archivo | Líneas | Status |
|---|---|---|
| `apps/api/scripts/check-7d-watch-log.ts` | 145 | NEW |
| `apps/api/test/scripts/check-7d-watch-log.test.ts` | 191 | NEW (15 tests) |

## Assertions

| # | Check |
|---|---|
| (a) | ≥ 7 dated entries in `7day-watch-log.md` |
| (b) | Day 1 date = T-WIRE-PROD-APPLY + 1 day (anchor) |
| (c) | Each entry advances exactly 1 day OR is flagged "GAP" (48h+ gaps must be explicit) |
| (d) | If `T-WIRE-PROD-APPLY-amendments.md` exists, watch log MUST have ≥ 1 GAP entry (runbook §4 cross-reference) |

## Tests (15)

| Group | Tests |
|---|---|
| `parseAnchorTimestamp` | happy path + missing anchor line |
| `parseWatchLog` | 7 entries + GAP detection + empty input |
| `checkWatchLog` | happy + missing files + malformed anchor + < 7 entries + Day 1 mismatch + non-contiguous w/o GAP (fail) + non-contiguous w/ GAP (ok) + amendments w/o GAP (fail) + amendments w/ GAP (ok) |

Tests use real fs (`mkdtemp` + `writeFileSync` + `afterEach` cleanup), no fs mocking. Hermetic in CI.

## Honest framing

File-format integrity check only — NOT semantic validation of entry content (PO judgment in `## Day N` body captured manually; meaningful baseline rates, alert firings, etc.).

## Gate behavior

`apps/api/scripts/` outside path-filter → no gate fires. Standard CI passes.

## Dependencies

- ✅ Plan v4 (#381).
- ✅ T1-T12a SHIPPED.
- Next: operational phase (T8/T9/T10/T11/T12b log entries gated on ADR-052 Accepted + Sprint-2b T13 canary).

## Test plan

- [x] Local 15/15 tests pass
- [x] Local typecheck clean
- [x] Pre-commit hooks pass (biome auto-fix on unused template literals)
- [x] Commitlint pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)