### PR TITLE
fix(sec-001-cierre/sprint-2b): T13-fix canary tag 46-char limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,17 +82,17 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
       - name: Trigger Cloud Build (production)
-        # T13-fix (2026-05-28): pass both `_COMMIT_SHA` (full 40-char SHA
-        # for image tags + commit labels) AND `_COMMIT_SHA_SHORT` (12-char
-        # SHA for canary traffic tag — Cloud Run requires tag+service ≤ 46
-        # chars; full SHA exceeds the budget). gcloud builds submit rechaza
-        # substitutions no declaradas, así que ambas DEBEN existir en el
-        # bloque substitutions de cloudbuild.production.yaml con defaults.
+        # _COMMIT_SHA es la única substitution que pasamos — _REGION/_REGISTRY
+        # tienen defaults en cloudbuild.production.yaml, y _ENV no se usa.
+        # gcloud builds submit rechaza substitutions no declaradas (era el bug
+        # `_ENV no matched in template`).
+        # T13-fix (2026-05-28) NOTE: canary traffic tag short SHA derives
+        # inline from `${_COMMIT_SHA}` inside the cloudbuild canary steps
+        # (bash ${VAR:0:12} slice). No separate substitution needed.
         run: |
-          COMMIT_SHA_SHORT="$(echo ${{ github.sha }} | cut -c1-12)"
           gcloud builds submit --config=cloudbuild.production.yaml \
             --region=${{ env.GCP_REGION }} \
-            --substitutions=_COMMIT_SHA=${{ github.sha }},_COMMIT_SHA_SHORT=${COMMIT_SHA_SHORT}
+            --substitutions=_COMMIT_SHA=${{ github.sha }}
 
       # Post-deploy: smoke tests + notificación
       - name: Smoke test — API health

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,14 +82,17 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v3
       - name: Trigger Cloud Build (production)
-        # _COMMIT_SHA es la única substitution que pasamos — _REGION/_REGISTRY
-        # tienen defaults en cloudbuild.production.yaml, y _ENV no se usa.
-        # gcloud builds submit rechaza substitutions no declaradas (era el bug
-        # `_ENV no matched in template`).
+        # T13-fix (2026-05-28): pass both `_COMMIT_SHA` (full 40-char SHA
+        # for image tags + commit labels) AND `_COMMIT_SHA_SHORT` (12-char
+        # SHA for canary traffic tag — Cloud Run requires tag+service ≤ 46
+        # chars; full SHA exceeds the budget). gcloud builds submit rechaza
+        # substitutions no declaradas, así que ambas DEBEN existir en el
+        # bloque substitutions de cloudbuild.production.yaml con defaults.
         run: |
+          COMMIT_SHA_SHORT="$(echo ${{ github.sha }} | cut -c1-12)"
           gcloud builds submit --config=cloudbuild.production.yaml \
             --region=${{ env.GCP_REGION }} \
-            --substitutions=_COMMIT_SHA=${{ github.sha }}
+            --substitutions=_COMMIT_SHA=${{ github.sha }},_COMMIT_SHA_SHORT=${COMMIT_SHA_SHORT}
 
       # Post-deploy: smoke tests + notificación
       - name: Smoke test — API health

--- a/.specs/_followups/cloud-run-canary-tag-cleanup.md
+++ b/.specs/_followups/cloud-run-canary-tag-cleanup.md
@@ -1,0 +1,39 @@
+# Followup: Cloud Run canary traffic tag accumulation cleanup
+
+**Created**: 2026-05-28 (Sprint 2b T13-fix DA v1 P1 residual)
+**Owner**: PO (Felipe Vicencio)
+**Priority**: P1
+
+## Problem
+
+Sprint 2b T13 canary lane creates a per-deploy traffic tag `canary-signup-<sha12>` via `gcloud run services update --tag=...` on `booster-ai-api`. Cloud Run retains the tag on the revision until explicitly removed. With daily deploys, tags accumulate.
+
+Cloud Run hard limits relevant here:
+- **1000 revisions** per service (oldest get auto-deleted when above).
+- **Tags persist** on revisions whether traffic is routed or not. A revision with a stale tag still counts toward operational ceiling for tag-based traffic-update commands.
+
+Neither `deploy-canary`, `route-canary`, `canary-verify`, nor `deploy-api` step in the current T13 pipeline removes the previous deploy's `canary-signup-<sha12>` tag. After 100+ deploys the service has 100+ stale canary tags, each occupying tag-namespace + revision metadata.
+
+## Why this is P1 not P2
+
+- DA v1 of T13-fix correctly flagged this as P1.
+- T13 was DONE 2026-05-26 with no cleanup mechanism; T13-fix (2026-05-28) didn't add one because its scope was the tag-length defect.
+- Booster's deploy cadence (multiple PRs/day) puts the quota hit within weeks, not months.
+- Detection lag: the first symptom is `route-canary` step failing with "tag already in use" or `update-traffic` quota errors — surfaces during canary procedure, not before. That means the next canary deploy AFTER quota hit will fail at runtime, blocking the very mechanism that's supposed to validate deploys.
+
+## Options
+
+- **A — Remove old canary tag during deploy-api**: in the final `deploy-api` step, before `--to-latest`, call `gcloud run services update-traffic booster-ai-api --remove-tags=$(gcloud run revisions list ... --filter='tags ~ canary-signup-' --format='value(metadata.name)' | tail -n +2)`. Keeps the most recent canary tag for audit, removes older ones. ~15 LOC.
+- **B — Add a separate scheduled cleanup job**: Cloud Scheduler → small Cloud Function that runs daily and removes canary tags older than N days. Decouples cleanup from deploy timing. ~50 LOC + Terraform.
+- **C — Use a single rotating tag (`canary` instead of `canary-signup-<sha>`)**: the deploy-canary step adds `--tag=canary --remove-tags-other` (if supported) or pre-removes. Eliminates accumulation entirely. Breaks the per-deploy audit trail unless the commit label provides equivalent identification.
+
+Recommendation: **A** as the cheapest unblock, with **C** as an ADR-worthy redesign for the next quarter. **B** is overengineering for this cadence.
+
+## Triggering condition for prioritization
+
+Bump from P1 to P0 when either:
+- The first `route-canary` step fails with `tag already in use` on a fresh deploy.
+- Cloud Run service `booster-ai-api` has >50 tags on inactive revisions.
+- The service is within 100 of its 1000-revision quota.
+
+Monitor via `gcloud run revisions list --service=booster-ai-api --filter='-status.conditions.type=Active' --format='value(metadata.name)' | wc -l` weekly.

--- a/.specs/_followups/cloudbuild-substitution-canonicalization.md
+++ b/.specs/_followups/cloudbuild-substitution-canonicalization.md
@@ -2,7 +2,12 @@
 
 **Created**: 2026-05-28 (Sprint 2c-B T3-fix DA v5 residual)
 **Owner**: PO (Felipe Vicencio)
-**Priority**: P2
+**Priority**: **P1** (escalated 2026-05-28 by Sprint 2b T13-fix DA v1 P1 finding — second plan amendment in 48h triggered the escalation clause below)
+
+## Escalation log
+
+- 2026-05-28 — Sprint 2c-B T3-fix DA v5: original creation as P2 residual.
+- 2026-05-28 — Sprint 2b T13-fix DA v1: detected second amendment in same 48h window; T13-fix violates the ≤1-file rule (touches 2 files after option-B refactor; touched 4 in initial draft). Escalated to **P1**. Per §"Item 2" exception clause, the **third amendment is now blocked** until a process ADR is produced.
 
 ## Two unrelated items tracked in one stub
 

--- a/.specs/_followups/sprint-2c-b-gate-bypasses.md
+++ b/.specs/_followups/sprint-2c-b-gate-bypasses.md
@@ -11,6 +11,7 @@ Each invocation of the escape-hatch is logged here.
 | Date | PR | Branch | Justification | Run ID |
 |---|---|---|---|---|
 | 2026-05-28 | [#392](https://github.com/boosterchile/booster-ai/pull/392) | `fix/2cb-t3-cloudbuild-gen2-gate` | Regression-hotfix bootstrap. T3 (PR #384) shipped two defects (`--gen2=false` syntax bug + missing substitution gate) that broke every Cloud Build for 28h, blocking all api/web/whatsapp/telemetry deploys. The same 28h window prevented the api Cloud Build deploy that would run the 5-step canary + 2h watch that flips ADR-052 → Accepted. The build-gate (which requires ADR-052 Accepted) therefore cannot pass until this PR merges, because this PR IS the unblock. Strict circular dependency. **Used the documented escape-hatch path (b) per plan v4 §Pre-conditions.** | [26601188853](https://github.com/boosterchile/booster-ai/actions/runs/26601188853) |
+| 2026-05-28 | [#393](https://github.com/boosterchile/booster-ai/pull/393) | `fix/2b-t13-canary-tag-length` | Sprint 2b T13-fix: tag-length 46-char limit. Same circular dependency as PR #392 — the build-gate requires ADR-052 Accepted, ADR-052 requires canary success, canary requires this fix. Path (b) per plan v4 §Pre-conditions. | [26605290697](https://github.com/boosterchile/booster-ai/actions/runs/26605290697) |
 
 ## Cumulative count
 

--- a/.specs/sec-001-cierre/plan-sprint-2b.md
+++ b/.specs/sec-001-cierre/plan-sprint-2b.md
@@ -463,22 +463,33 @@ name cannot exceed 46 characters.
 
 This was masked for 28h by the T3 syntax bug — Cloud Build cancelled `deploy-canary` along with every other step before it could run. Once T3-fix (PR #392) restored upstream execution, the next Cloud Build (`255e393e`, post-merge 2026-05-28 21:07Z) reached `deploy-canary` and failed at this constraint.
 
-### T13-fix: introduce `_COMMIT_SHA_SHORT` substitution for tag-length budget
+### T13-fix: derive canary tag short SHA inline (option B, post DA v1)
+
+DA v1 (BLOCK_MERGE) flagged the original draft's `_COMMIT_SHA_SHORT: '0000000000aa'` placeholder as the same anti-pattern T3-fix DA v5 rejected: any operator who forgets to pass the override creates a garbage `canary-signup-0000000000aa` tag on prod. Adopted DA's option (b) — eliminate the substitution entirely; compute the 12-char short SHA inline from `${_COMMIT_SHA}` inside each canary step. Side effect: no `release.yml` change needed; no T6 runbook addition needed.
 
 - **Files**:
-  - `cloudbuild.production.yaml` (MODIFY, ~+5 LOC): add `_COMMIT_SHA_SHORT: '0000000'` default substitution (placeholder; release.yml must pass real value); replace `${_COMMIT_SHA}` with `${_COMMIT_SHA_SHORT}` in 3 canary tag refs (line 184 `--tag=`, line 204 `--to-tags=`, line 252 bash `REVISION_TAG`). All other `${_COMMIT_SHA}` references (image tags, labels) remain unchanged — they have no length constraint.
-  - `.github/workflows/release.yml` (MODIFY, ~+1 LOC): extend `--substitutions=` to also pass `_COMMIT_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-12)`. 12-char SHA chosen: tag becomes `canary-signup-` (14) + 12 = 26 chars; combined with `booster-ai-api` (14) = 40 chars total, 6 chars under the 46 limit. 12-char abbreviation is git-standard for collision-resistant uniqueness over Booster's deploy cadence.
-- **LOC estimate**: ~6.
+  - `cloudbuild.production.yaml` (MODIFY, ~+15 LOC net): convert `deploy-canary` + `route-canary` from `entrypoint: gcloud` (args list) to `entrypoint: bash` (script). Each script computes `FULL_SHA='${_COMMIT_SHA}'; SHORT_SHA="$${FULL_SHA:0:12}"` (Cloud Build substitution + bash substring slice; the `$$` escapes Cloud Build's substitution at the bash position) and uses `$${SHORT_SHA}` in the tag. `canary-verify` already uses `entrypoint: bash` — just compute SHORT_SHA + use in `REVISION_TAG`. All other `${_COMMIT_SHA}` references (image tags, commit labels) unchanged — no length constraint there.
+  - `.github/workflows/release.yml`: **unchanged**. The original `_COMMIT_SHA=${{ github.sha }}` substitution is sufficient; short SHA derives inline.
+  - `docs/qa/google-blocking-function-runbook.md`: **unchanged**. The original T3-fix updated Step 2 invocation does not need a `_COMMIT_SHA_SHORT` addition.
+- **LOC estimate**: ~15.
 - **Depends on**: T13 merged ✅ (2026-05-26).
 - **Acceptance**:
-  - Next Cloud Build run on main: `deploy-canary` step SUCCEEDS — `gcloud run services update` accepts the shorter tag. Cloud Run revision created with tag `canary-signup-<12-char-sha>`. Combined length ≤ 46 verified.
-  - `route-canary` step SUCCEEDS — routes 1% traffic to the new tag.
-  - `canary-sleep` runs for 30 min. `canary-verify` runs (currently placeholder per spec line 248-251).
+  - Next Cloud Build run on main: `deploy-canary` step SUCCEEDS — bash computes `SHORT_SHA` (12 chars from `_COMMIT_SHA`); `gcloud run services update` accepts the shorter tag. Cloud Run revision created with tag `canary-signup-<12-char-sha>`. Combined length 40 chars ≤ 46 verified.
+  - `route-canary` step SUCCEEDS — same inline computation; routes 1% traffic to the new tag.
+  - `canary-sleep` runs for 30 min. `canary-verify` runs (currently a placeholder per spec line 248-251) computing the same `SHORT_SHA` so `REVISION_TAG` matches deploy-canary.
   - `deploy-api` final step routes 100% to latest.
-  - T6 runbook `docs/qa/google-blocking-function-runbook.md` §2 Step 2 invocation must also pass `_COMMIT_SHA_SHORT=$(git rev-parse --short=12 HEAD)` when manually triggered; runbook updated.
-- **Rollback (forward-fix only — never revert)**: same rationale as T3-fix. Reverting reintroduces the canary deploy failure. If `_COMMIT_SHA_SHORT` budget needs adjustment (e.g., service name grows), ship a forward-fix commit reducing the short SHA further or shortening the `canary-signup-` prefix.
+- **Rollback (forward-fix only — never revert)**: same rationale as T3-fix. Reverting reintroduces the canary deploy failure. If 12-char SHA budget needs adjustment (e.g., service name grows), ship a forward-fix commit reducing the slice (`:0:8`) or shortening the `canary-signup-` prefix.
 - **Verification path**: post-merge auto Cloud Build run on main observes `deploy-canary` SUCCESS. Same constraint as T3-fix (cloudbuild.production.yaml only runs on main, not PR branches). The previous failure signature is loud + dispositive (any green `deploy-canary` after 21:07Z 2026-05-28 = fix works).
-- **Why amendment, not new sub-spec**: ~6 LOC repairing a defect in T13 (already DONE). Same precedent as T3-fix amendment for Sprint 2c-B; tracked exception in `.specs/_followups/cloudbuild-substitution-canonicalization.md`.
+- **DA v1 findings closed**:
+  - P0 placeholder anti-pattern → eliminated by option (b); no substitution + no default.
+  - P1 release.yml shell expansion quoting → moot (no release.yml change).
+  - P1 amendment-vs-sub-spec rule violation (4 files vs ≤1) → acknowledged: T13-fix is the **second amendment in 48 h**, triggers the escalation clause in `.specs/_followups/cloudbuild-substitution-canonicalization.md` §43-45. With option (b), file count drops from 4 to 2 (cloudbuild + plan), still violates the ≤1-file rule. Documented as exception in updated followup (escalated P2 → P1; next session must produce process ADR before any third amendment).
+  - P1 tag accumulation → separate followup `.specs/_followups/cloud-run-canary-tag-cleanup.md`.
+- **DA v1 residual accepted**:
+  - P2 12-char SHA collision recovery → runbook addendum pending; until then, `gcloud --tag=` rejects collision loudly + manual `--remove-tags` recovers.
+  - P2 `canary-verify` placeholder still placeholder → out of scope; tracked separately.
+  - P2 Hyrum's Law on `${_COMMIT_SHA}` consumers → audit out of scope; commit labels still use full SHA so external label-filter queries are unaffected.
+- **Why amendment, not new sub-spec**: ~15 LOC repairing a defect in T13 (already DONE). Same precedent as T3-fix amendment for Sprint 2c-B. **Acknowledged DA v1 P1 amendment-rule violation**: see followup escalation.
 
 ### Post-merge state
 

--- a/.specs/sec-001-cierre/plan-sprint-2b.md
+++ b/.specs/sec-001-cierre/plan-sprint-2b.md
@@ -445,3 +445,43 @@ Sprint 2b devils-advocate round 1 reveló 3 amendments necesarios al spec v3.3 a
 - Drizzle migrations location: `apps/api/drizzle/`.
 - Cloud Run traffic ignore_changes: `infrastructure/modules/cloud-run-service/main.tf:97-110`.
 - Sprint 2c Google Blocking Function follow-up: [`.specs/_followups/sprint-2c-google-blocking-function.md`](../_followups/sprint-2c-google-blocking-function.md) _(crear en pre-build)_.
+
+## Amendment: T13-fix (regression hotfix, 2026-05-28)
+
+### Background
+
+T13 (DONE 2026-05-26) shipped the 5-step canary deploy sequence in `cloudbuild.production.yaml:173-187` per acceptance §283-289. The `deploy-canary` step constructs the Cloud Run traffic tag as `canary-signup-${_COMMIT_SHA}`, where `_COMMIT_SHA` is the full 40-char `${{ github.sha }}` propagated from `.github/workflows/release.yml:92`.
+
+Cloud Run enforces: **combined traffic tag + service name ≤ 46 characters**. With `booster-ai-api` (14 chars) + `canary-signup-` (14 chars) + 40-char SHA = 68 chars, the deploy fails:
+
+```
+ERROR: (gcloud.run.services.update) spec.traffic.tag: traffic tag
+'canary-signup-f744ef0db0b979f586b0c2ad6ce453e23be33447' and service name
+'booster-ai-api' together are too long. Combined traffic tag and service
+name cannot exceed 46 characters.
+```
+
+This was masked for 28h by the T3 syntax bug — Cloud Build cancelled `deploy-canary` along with every other step before it could run. Once T3-fix (PR #392) restored upstream execution, the next Cloud Build (`255e393e`, post-merge 2026-05-28 21:07Z) reached `deploy-canary` and failed at this constraint.
+
+### T13-fix: introduce `_COMMIT_SHA_SHORT` substitution for tag-length budget
+
+- **Files**:
+  - `cloudbuild.production.yaml` (MODIFY, ~+5 LOC): add `_COMMIT_SHA_SHORT: '0000000'` default substitution (placeholder; release.yml must pass real value); replace `${_COMMIT_SHA}` with `${_COMMIT_SHA_SHORT}` in 3 canary tag refs (line 184 `--tag=`, line 204 `--to-tags=`, line 252 bash `REVISION_TAG`). All other `${_COMMIT_SHA}` references (image tags, labels) remain unchanged — they have no length constraint.
+  - `.github/workflows/release.yml` (MODIFY, ~+1 LOC): extend `--substitutions=` to also pass `_COMMIT_SHA_SHORT=$(echo ${{ github.sha }} | cut -c1-12)`. 12-char SHA chosen: tag becomes `canary-signup-` (14) + 12 = 26 chars; combined with `booster-ai-api` (14) = 40 chars total, 6 chars under the 46 limit. 12-char abbreviation is git-standard for collision-resistant uniqueness over Booster's deploy cadence.
+- **LOC estimate**: ~6.
+- **Depends on**: T13 merged ✅ (2026-05-26).
+- **Acceptance**:
+  - Next Cloud Build run on main: `deploy-canary` step SUCCEEDS — `gcloud run services update` accepts the shorter tag. Cloud Run revision created with tag `canary-signup-<12-char-sha>`. Combined length ≤ 46 verified.
+  - `route-canary` step SUCCEEDS — routes 1% traffic to the new tag.
+  - `canary-sleep` runs for 30 min. `canary-verify` runs (currently placeholder per spec line 248-251).
+  - `deploy-api` final step routes 100% to latest.
+  - T6 runbook `docs/qa/google-blocking-function-runbook.md` §2 Step 2 invocation must also pass `_COMMIT_SHA_SHORT=$(git rev-parse --short=12 HEAD)` when manually triggered; runbook updated.
+- **Rollback (forward-fix only — never revert)**: same rationale as T3-fix. Reverting reintroduces the canary deploy failure. If `_COMMIT_SHA_SHORT` budget needs adjustment (e.g., service name grows), ship a forward-fix commit reducing the short SHA further or shortening the `canary-signup-` prefix.
+- **Verification path**: post-merge auto Cloud Build run on main observes `deploy-canary` SUCCESS. Same constraint as T3-fix (cloudbuild.production.yaml only runs on main, not PR branches). The previous failure signature is loud + dispositive (any green `deploy-canary` after 21:07Z 2026-05-28 = fix works).
+- **Why amendment, not new sub-spec**: ~6 LOC repairing a defect in T13 (already DONE). Same precedent as T3-fix amendment for Sprint 2c-B; tracked exception in `.specs/_followups/cloudbuild-substitution-canonicalization.md`.
+
+### Post-merge state
+
+- Canary deploy lane functional → next api Cloud Build runs canary 30 min → `canary-verify` placeholder exits 0 → `deploy-api` routes 100% → full deploy completes.
+- ADR-052 Status flip Proposed → Accepted becomes possible (per plan §4 out-of-band) once 2h watch elapses without `signup_probe_failure` alerts.
+- Sprint 2c-B T8 unblocked thereafter.

--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -181,7 +181,14 @@ steps:
       - --image=${_REGISTRY}/api:${_COMMIT_SHA}
       - --region=${_REGION}
       - --platform=managed
-      - --tag=canary-signup-${_COMMIT_SHA}
+      # T13-fix (2026-05-28): traffic tag uses _COMMIT_SHA_SHORT (12 chars).
+      # Cloud Run limit: tag + service name ≤ 46 chars. With service name
+      # `booster-ai-api` (14 chars) + tag prefix `canary-signup-` (14 chars),
+      # SHA portion can be up to 18 chars; 12 leaves 6-char headroom for
+      # prefix changes. The full `_COMMIT_SHA` is still used in image tag +
+      # commit label (no length constraint there). release.yml passes both
+      # substitutions; T6 runbook §2 Step 2 invocation must also pass both.
+      - --tag=canary-signup-${_COMMIT_SHA_SHORT}
       - --no-traffic
       - --update-labels=commit=${_COMMIT_SHA}
     waitFor: [push-api]
@@ -201,7 +208,8 @@ steps:
       - booster-ai-api
       - --region=${_REGION}
       - --platform=managed
-      - --to-tags=canary-signup-${_COMMIT_SHA}=1
+      # T13-fix (2026-05-28): _COMMIT_SHA_SHORT matches deploy-canary tag.
+      - --to-tags=canary-signup-${_COMMIT_SHA_SHORT}=1
     waitFor: [deploy-canary]
 
   - id: canary-sleep
@@ -249,7 +257,9 @@ steps:
         # T13 round 3 P1-1 fix: el step DEBE existir con id canary-verify
         # para que el downstream waitFor sea explícito; el contenido real
         # del check se itera post-primer-corrida.
-        REVISION_TAG="canary-signup-${_COMMIT_SHA}"
+        # T13-fix (2026-05-28): use _COMMIT_SHA_SHORT to match the
+        # actual revision tag created by deploy-canary step.
+        REVISION_TAG="canary-signup-${_COMMIT_SHA_SHORT}"
         echo "  - target tag: $$REVISION_TAG"
         echo "  - window: last 30min"
         echo "  - error_rate threshold: < 1%"
@@ -527,6 +537,16 @@ substitutions:
   _REGION: southamerica-west1
   _REGISTRY: southamerica-west1-docker.pkg.dev/booster-ai-494222/containers
   _COMMIT_SHA: manual
+
+  # Sprint 2b T13-fix (2026-05-28): 12-char SHA for canary traffic tag.
+  # Cloud Run limit: tag + service name ≤ 46 chars. Tag prefix
+  # `canary-signup-` (14) + service `booster-ai-api` (14) = 28 chars
+  # fixed → SHA portion ≤ 18 chars. 12 chosen for collision resistance
+  # while keeping a 6-char headroom. Placeholder default '0000000000aa'
+  # (12 chars, lexically valid). release.yml passes the real value
+  # `cut -c1-12` from github.sha; T6 runbook §2 Step 2 manual
+  # invocation must also pass `_COMMIT_SHA_SHORT=$(git rev-parse --short=12 HEAD)`.
+  _COMMIT_SHA_SHORT: '0000000000aa'
 
   # Sprint 2c-B T3-fix (2026-05-28): gate auth-blocking deploy lane.
   # Default 'false' = auto-triggered push-to-main builds skip the lane.

--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -170,46 +170,48 @@ steps:
   # Runbook detallado: docs/qa/signup-canary-rollback.md
   # =========================================================================
 
+  # T13-fix (2026-05-28): step uses `entrypoint: bash` (was `gcloud`) so the
+  # short SHA can be derived inline from `${_COMMIT_SHA}` without an extra
+  # Cloud Build substitution + release.yml change. Cloud Run requires the
+  # combined traffic tag + service name ≤ 46 chars; `booster-ai-api` (14) +
+  # `canary-signup-` (14) + 12-char short SHA = 40 chars, 6-char headroom.
   - id: deploy-canary
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
+    entrypoint: bash
     args:
-      - run
-      - services
-      - update
-      - booster-ai-api
-      - --image=${_REGISTRY}/api:${_COMMIT_SHA}
-      - --region=${_REGION}
-      - --platform=managed
-      # T13-fix (2026-05-28): traffic tag uses _COMMIT_SHA_SHORT (12 chars).
-      # Cloud Run limit: tag + service name ≤ 46 chars. With service name
-      # `booster-ai-api` (14 chars) + tag prefix `canary-signup-` (14 chars),
-      # SHA portion can be up to 18 chars; 12 leaves 6-char headroom for
-      # prefix changes. The full `_COMMIT_SHA` is still used in image tag +
-      # commit label (no length constraint there). release.yml passes both
-      # substitutions; T6 runbook §2 Step 2 invocation must also pass both.
-      - --tag=canary-signup-${_COMMIT_SHA_SHORT}
-      - --no-traffic
-      - --update-labels=commit=${_COMMIT_SHA}
+      - -c
+      - |
+        set -e
+        FULL_SHA='${_COMMIT_SHA}'
+        SHORT_SHA="$${FULL_SHA:0:12}"
+        gcloud run services update booster-ai-api \
+          --image=${_REGISTRY}/api:${_COMMIT_SHA} \
+          --region=${_REGION} \
+          --platform=managed \
+          --tag=canary-signup-$${SHORT_SHA} \
+          --no-traffic \
+          --update-labels=commit=${_COMMIT_SHA}
     waitFor: [push-api]
 
   - id: route-canary
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
-    # Rutea 1% del traffic al tag canary-signup-<sha>. El resto (99%)
+    entrypoint: bash
+    # Rutea 1% del traffic al tag canary-signup-<sha-12>. El resto (99%)
     # permanece en la revision LATEST que estaba antes del deploy. Cloud
     # Run accepta `--to-tags=<tag>=<weight>` donde weight es el porcentaje
     # (0-100). Si la sintaxis cambia entre versiones gcloud, validar con
     # `gcloud run services update-traffic --help`.
+    # T13-fix (2026-05-28): same inline short-SHA derivation as deploy-canary.
     args:
-      - run
-      - services
-      - update-traffic
-      - booster-ai-api
-      - --region=${_REGION}
-      - --platform=managed
-      # T13-fix (2026-05-28): _COMMIT_SHA_SHORT matches deploy-canary tag.
-      - --to-tags=canary-signup-${_COMMIT_SHA_SHORT}=1
+      - -c
+      - |
+        set -e
+        FULL_SHA='${_COMMIT_SHA}'
+        SHORT_SHA="$${FULL_SHA:0:12}"
+        gcloud run services update-traffic booster-ai-api \
+          --region=${_REGION} \
+          --platform=managed \
+          --to-tags=canary-signup-$${SHORT_SHA}=1
     waitFor: [deploy-canary]
 
   - id: canary-sleep
@@ -257,9 +259,11 @@ steps:
         # T13 round 3 P1-1 fix: el step DEBE existir con id canary-verify
         # para que el downstream waitFor sea explícito; el contenido real
         # del check se itera post-primer-corrida.
-        # T13-fix (2026-05-28): use _COMMIT_SHA_SHORT to match the
+        # T13-fix (2026-05-28): inline short-SHA derivation matches the
         # actual revision tag created by deploy-canary step.
-        REVISION_TAG="canary-signup-${_COMMIT_SHA_SHORT}"
+        FULL_SHA='${_COMMIT_SHA}'
+        SHORT_SHA="$${FULL_SHA:0:12}"
+        REVISION_TAG="canary-signup-$${SHORT_SHA}"
         echo "  - target tag: $$REVISION_TAG"
         echo "  - window: last 30min"
         echo "  - error_rate threshold: < 1%"
@@ -537,16 +541,6 @@ substitutions:
   _REGION: southamerica-west1
   _REGISTRY: southamerica-west1-docker.pkg.dev/booster-ai-494222/containers
   _COMMIT_SHA: manual
-
-  # Sprint 2b T13-fix (2026-05-28): 12-char SHA for canary traffic tag.
-  # Cloud Run limit: tag + service name ≤ 46 chars. Tag prefix
-  # `canary-signup-` (14) + service `booster-ai-api` (14) = 28 chars
-  # fixed → SHA portion ≤ 18 chars. 12 chosen for collision resistance
-  # while keeping a 6-char headroom. Placeholder default '0000000000aa'
-  # (12 chars, lexically valid). release.yml passes the real value
-  # `cut -c1-12` from github.sha; T6 runbook §2 Step 2 manual
-  # invocation must also pass `_COMMIT_SHA_SHORT=$(git rev-parse --short=12 HEAD)`.
-  _COMMIT_SHA_SHORT: '0000000000aa'
 
   # Sprint 2c-B T3-fix (2026-05-28): gate auth-blocking deploy lane.
   # Default 'false' = auto-triggered push-to-main builds skip the lane.

--- a/docs/qa/google-blocking-function-runbook.md
+++ b/docs/qa/google-blocking-function-runbook.md
@@ -36,9 +36,11 @@ terraform apply \
 # T3-fix (2026-05-28): the 3 auth-blocking steps default to SKIP on
 # every push-to-main build; this invocation must pass
 # `_AUTH_BLOCKING_DEPLOY=true` to actually run the lane.
+# T13-fix (2026-05-28): `_COMMIT_SHA_SHORT` (12 chars) is required for
+# the canary deploy step's traffic tag (Cloud Run constraint ≤46 chars).
 gcloud builds submit \
   --config=cloudbuild.production.yaml \
-  --substitutions=_AUTH_BLOCKING_DEPLOY=true,_COMMIT_SHA=$(git rev-parse HEAD) \
+  --substitutions=_AUTH_BLOCKING_DEPLOY=true,_COMMIT_SHA=$(git rev-parse HEAD),_COMMIT_SHA_SHORT=$(git rev-parse --short=12 HEAD) \
   --project=booster-ai-494222
 # This triggers build-auth-blocking → deploy-auth-blocking →
 # verify-auth-blocking-deployed. All other deploy steps in the

--- a/docs/qa/google-blocking-function-runbook.md
+++ b/docs/qa/google-blocking-function-runbook.md
@@ -36,11 +36,9 @@ terraform apply \
 # T3-fix (2026-05-28): the 3 auth-blocking steps default to SKIP on
 # every push-to-main build; this invocation must pass
 # `_AUTH_BLOCKING_DEPLOY=true` to actually run the lane.
-# T13-fix (2026-05-28): `_COMMIT_SHA_SHORT` (12 chars) is required for
-# the canary deploy step's traffic tag (Cloud Run constraint ≤46 chars).
 gcloud builds submit \
   --config=cloudbuild.production.yaml \
-  --substitutions=_AUTH_BLOCKING_DEPLOY=true,_COMMIT_SHA=$(git rev-parse HEAD),_COMMIT_SHA_SHORT=$(git rev-parse --short=12 HEAD) \
+  --substitutions=_AUTH_BLOCKING_DEPLOY=true,_COMMIT_SHA=$(git rev-parse HEAD) \
   --project=booster-ai-494222
 # This triggers build-auth-blocking → deploy-auth-blocking →
 # verify-auth-blocking-deployed. All other deploy steps in the


### PR DESCRIPTION
## Incident summary

T3-fix (PR #392, merged 2026-05-28 21:06Z) restored Cloud Build execution past the auth-blocking lane. The next post-merge build (`255e393e`, 21:07Z) reached Sprint 2b T13's `deploy-canary` step — which then failed at Cloud Run's 46-char tag+service-name constraint:

```
ERROR: (gcloud.run.services.update) spec.traffic.tag: traffic tag
'canary-signup-f744ef0db0b979f586b0c2ad6ce453e23be33447' and service
name 'booster-ai-api' together are too long. Combined traffic tag and
service name cannot exceed 46 characters.
```

T13 was DONE 2026-05-26 but never actually ran a canary end-to-end in prod because the T3 syntax bug masked all downstream failures for 28h.

## What this PR does (option B per DA v1 P0)

Convert the 3 canary steps (`deploy-canary`, `route-canary`, `canary-verify`) to compute a 12-char short SHA inline from `${_COMMIT_SHA}` using bash substring slice:

```yaml
- id: deploy-canary
  name: gcr.io/google.com/cloudsdktool/cloud-sdk
  entrypoint: bash
  args:
    - -c
    - |
      set -e
      FULL_SHA='${_COMMIT_SHA}'
      SHORT_SHA="$${FULL_SHA:0:12}"
      gcloud run services update booster-ai-api \
        ... \
        --tag=canary-signup-$${SHORT_SHA} \
        ...
```

Cloud Build expands `${_COMMIT_SHA}` at YAML parse time; bash slices the first 12 chars at runtime. The `$$` escapes Cloud Build's substitution operator at the bash position.

- 14 (service) + 14 (`canary-signup-`) + 12 (sha) = 40 chars, 6 under the 46 limit.
- No new Cloud Build substitution declaration.
- No release.yml change (the existing `_COMMIT_SHA=${{ github.sha }}` is sufficient).
- No T6 runbook addition for manual T8 procedure.

After merge, the first push-to-main triggers a Cloud Build whose `deploy-canary` step succeeds → `canary-sleep` 30 min → `canary-verify` placeholder exits 0 → `deploy-api` routes 100% to latest. After 2h watch without `signup_probe_failure` alerts, ADR-052 Status can flip Proposed → Accepted per `plan-sprint-2b.md` §4 (out-of-band). Sprint 2c-B T8 unblocks thereafter.

## Devils-advocate review

DA v1 returned BLOCK_MERGE on initial draft (`88ef756`) with 1 P0 + 3 P1 findings. All closed in `6cb2345`:

| Finding | Resolution |
|---|---|
| P0 placeholder `_COMMIT_SHA_SHORT=0000000000aa` same anti-pattern T3-fix rejected | Eliminated substitution entirely; option (b) inline derivation. |
| P1 release.yml unquoted shell expansion | Moot — release.yml change reverted. |
| P1 amendment-vs-sub-spec rule violated (4 files vs ≤1) | Acknowledged; option (b) reduces to 2 files (still violates ≤1). Followup escalated P2→P1: third amendment now blocked pending process ADR. |
| P1 Cloud Run tag accumulation unaddressed | New followup `.specs/_followups/cloud-run-canary-tag-cleanup.md` (P1). |
| P2 12-char collision, canary-verify placeholder, Hyrum's Law | Documented residual in plan amendment. |

## Test plan

`cloudbuild.production.yaml` does NOT run on PR branches (production trigger is main-push-only via release.yml). Empirical verification path: after merge, the first auto-triggered Cloud Build on main runs `deploy-canary` successfully with tag `canary-signup-<12-char-sha>` (length 40, ≤46 ✓). Any failure at `deploy-canary` after 21:07Z 2026-05-28 with the same error signature would refute the fix.

- [ ] Post-merge: `gcloud builds describe <build-id>` shows `deploy-canary` step SUCCESS + tag in `--tag=canary-signup-<12chars>` form.
- [ ] `canary-sleep` runs 30 min.
- [ ] `canary-verify` exits 0 (placeholder).
- [ ] `deploy-api` routes 100% to latest.
- [ ] Synthetic monitor `signup_probe` keeps emitting OK for 2h post-deploy.

## Evidencia

- Reference failure: build `255e393e-acad-45e6-a0d6-705d94e1e9e5` (2026-05-28T21:07Z) `deploy-canary` step error: tag `canary-signup-f744ef0db0b979f586b0c2ad6ce453e23be33447` (53 chars) + service `booster-ai-api` (14) = 67 chars > 46.
- Pre-commit hooks PASS: lint-staged (Biome), `check-adr-numbering`, `spec-canonical-drift`.
- YAML structural parse: `pnpm dlx js-yaml@4 cloudbuild.production.yaml` returns 4 canary steps with `entrypoint: bash`; `_COMMIT_SHA_SHORT` substitution removed from substitutions block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)