### PR TITLE
docs(adr-052): Accepted post-canary cloudbuild 8f4ec780

### DIFF
--- a/apps/api/test/scripts/check-adr-status-accepted.test.ts
+++ b/apps/api/test/scripts/check-adr-status-accepted.test.ts
@@ -11,7 +11,8 @@ import { checkAdrFile, isAdrStatusAccepted } from '../../scripts/check-adr-statu
  * (c) ADR-014 `**Estado:** Aceptado` (colon-inside-bold) → exit 1 (out-of-scope by design).
  * (d) ADR file absent / malformed → exit 1.
  * (e) Integration test: open actual `docs/adr/052-signup-migration-admin-sdk-gate.md`
- *     → exit 1 (Proposed at time of T2a, will flip post-Sprint-2b T13).
+ *     → exit 0 (flipped Proposed → Accepted 2026-05-29 post-canary
+ *     success cloudbuild 8f4ec780; T2a sentinel updated in same commit).
  *
  * Plus negative fixtures covering the 6+ Status formats explicitly NOT
  * matched by design (per file-level doc-comment).
@@ -153,10 +154,10 @@ describe('check-adr-status-accepted: integration against real ADR-052 file', () 
     expect(existsSync(realPath)).toBe(true);
   });
 
-  it('fixture (e): real ADR-052 currently NOT Accepted (Proposed at time of T2a)', () => {
+  it('fixture (e): real ADR-052 IS Accepted (flipped 2026-05-29 post-canary cloudbuild 8f4ec780)', () => {
     const result = checkAdrFile(realPath);
-    expect(result.ok).toBe(false);
-    expect(result.reason).toMatch(/Status not Accepted/);
+    expect(result.ok).toBe(true);
+    expect(result.reason).toMatch(/matches ADR-052\/053\/054 lineage form/);
   });
 
   it('fixture (e): real ADR-052 line 3 starts with the lineage form', () => {

--- a/docs/adr/052-signup-migration-admin-sdk-gate.md
+++ b/docs/adr/052-signup-migration-admin-sdk-gate.md
@@ -1,6 +1,6 @@
 # ADR-052: Signup público migrado a Admin SDK + admin-approval gate + Identity Platform self-signup OFF (email/password leg)
 
-- **Status**: Proposed (2026-05-26; T6 Sprint 2b H1.2 PR2). Transición a `Accepted` agendada en T13 post-canary 30 min success + 2 h watch.
+- **Status**: Accepted (2026-05-29 00:40Z; post-canary success cloudbuild `8f4ec780` 2026-05-28T22:42:55Z → T23:21:33Z, 38m38s, todos 26 steps SUCCESS incluyendo `deploy-canary` + `route-canary` + `canary-sleep` 30min + `canary-verify` + `deploy-api`; watch ~76min/120min con waiver PO firmado por signals all-green: signup_probe alert policy enabled sin incidents en 2h logging window, direct curl `/health/signup-flow` 200 `{"status":"ok","flow":"signup-request"}`, Cloud Run prod revision `booster-ai-api-00339-qud` 100% traffic con tag `canary-signup-11aab2635f34`).
 - **Date**: 2026-05-26
 - **Deciders**: Felipe Vicencio (PO)
 - **Linked**:


### PR DESCRIPTION
## Summary

Flip ADR-052 Status `Proposed` → `Accepted` per `plan-sprint-2b §4` (out-of-band separate commit), gated by Sprint 2b T13 canary success.

Single-line change at line 3 of `docs/adr/052-signup-migration-admin-sdk-gate.md` (1+/1-).

## Evidencia

- **Cloud Build `8f4ec780-c835-472f-ae16-b82a146ae56a`** SUCCESS 2026-05-28T22:42:55Z → T23:21:33Z (38m38s); all 26 steps green incluyendo `deploy-canary` (T13-fix verified), `route-canary`, `canary-sleep` 30min, `canary-verify`, `deploy-api` 100% routing, smoke-api-health, and 3 auth-blocking SKIP steps (T3-fix gate verified).
- **Cloud Run** `booster-ai-api-00339-qud` 100% traffic, tagged `canary-signup-11aab2635f34` (commit `11aab26` = T13-fix merge).
- **signup_probe** alert policy `Signup probe — /health/signup-flow failures (2 consecutive)` (projects/booster-ai-494222/alertPolicies/10210334940192920598) enabled; **0 incidents** in 2h logging window.
- **Direct curl** `https://api.boosterchile.com/health/signup-flow` → `200 {"status":"ok","flow":"signup-request","service":"booster-ai-api","version":"0.0.0","timestamp":"2026-05-29T00:37:44.379Z"}`.
- **Watch** ~76min/120min elapsed. **Partial-watch waiver** signed off by PO; logged in session ledger event `waiver_granted` 2026-05-29T00:38Z.

## Test plan

- [ ] Verify ADR-052 line 3 reads `Accepted (2026-05-29 00:40Z; post-canary success cloudbuild 8f4ec780 ...)`.
- [ ] Confirm `check-adr-status-accepted.ts` script (Sprint 2c-A T2a) now exits 0 against ADR-052.
- [ ] Confirm the `Sprint 2c-B build gate (ADR-052 Accepted)` check on the next PR touching Sprint 2c-B paths PASSES naturally without needing the escape-hatch.

## Next steps post-merge

1. Sprint 2c-B T8 (terraform apply T4+T5 + Cloud Build submit with `_AUTH_BLOCKING_DEPLOY=true` + IdP wire) per T6 runbook §2.
2. T9 smoke E2E, T10 prod perf measurement, T11 ghost user inventory, T13 ADR-054 flip post 7d watch, T14a/b/c branch-protection cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)