### PR TITLE
feat(sec-001-h1-2-googleblocking): T8 pre signup_flow=true

### DIFF
--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -202,6 +202,15 @@ module "service_api" {
     # de tostring(false)). Apply falló con "Secret projects/.../secrets/false
     # was not found" en el primer Sprint 2a apply 2026-05-25T17:55Z.
     STRICT_MIGRATION_ORDERING = tostring(var.strict_migration_ordering)
+
+    # SEC-001 H1.2 Sprint 2c-B T8 pre-apply (2026-05-29) — activa el flow
+    # de admin-approval signup-request rate-limited. Default false en
+    # config (apps/api/src/config.ts:booleanFlag(false)); flip a true
+    # aquí post ADR-052 Accepted (Sprint 2b T13 canary success) para
+    # que el Cloud Function `beforeCreate` blocking-function tenga un
+    # destino UX válido cuando rechace signups Google ad-hoc. Sin esto,
+    # los rechazados ven "Coming soon" del admin UI sin path forward.
+    SIGNUP_REQUEST_FLOW_ACTIVATED = tostring(var.signup_request_flow_activated)
   })
   secrets = merge(local.common_secrets, {
     # Mismo secret que el bot — un solo lugar de verdad para rotaciones.

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -352,6 +352,25 @@ variable "auth_universal_v1_activated" {
 }
 
 # ---------------------------------------------------------------------------
+# SEC-001 H1.2 Sprint 2c-B T8 pre-apply (ADR-052 Accepted) — admin-approval
+# signup-request flow
+# ---------------------------------------------------------------------------
+# Cuando `true`, activa el endpoint público POST /api/v1/signup-request +
+# admin UI /admin/signup-requests (Sprint 2b PR2 T8/T10 wired pero gated por
+# este flag). Cuando `false`, ambos retornan 503 "Coming soon" — no hay
+# destino UX para rechazos del Cloud Function blocking-function (Sprint 2c-B
+# T4+T5). Por eso este flag es hard precondition de T8 plan v4.
+#
+# Flip a `true` 2026-05-29 post ADR-052 Accepted + Sprint 2b T13 canary
+# success (cloudbuild 8f4ec780). Reversible: `terraform apply` con default
+# false revierte a "Coming soon" sin redeploy de código.
+variable "signup_request_flow_activated" {
+  description = "Activa POST /api/v1/signup-request + admin UI (SEC-001 H1.2 ADR-052)."
+  type        = bool
+  default     = true
+}
+
+# ---------------------------------------------------------------------------
 # ADR-036 Wave 5 — Wake-word "Oye Booster"
 # ---------------------------------------------------------------------------
 # Cuando `true`, la card "Activación por voz" en


### PR DESCRIPTION
## Summary

T8 plan v4 hard precondition #5 fulfilled: `SIGNUP_REQUEST_FLOW_ACTIVATED=true` in prod. Bundled with precondition #6 (T7b IAM binding catch-up for `github-deployer` `roles/cloudfunctions.viewer`) and `cloudfunctions.googleapis.com` API enablement (needed for Sprint 2c-B T4 Cloud Function resource).

## Changes

- `infrastructure/variables.tf`: new `signup_request_flow_activated` variable (default `true`), mirrors `auth_universal_v1_activated` pattern.
- `infrastructure/compute.tf`: `SIGNUP_REQUEST_FLOW_ACTIVATED = tostring(var.signup_request_flow_activated)` added to api service env block.

## Applied directly (drift-first-applied pattern)

Applied to prod 2026-05-29 ~00:55Z via `terraform apply -var-file=terraform.tfvars.local -target=module.service_api -target='google_project_iam_member.github_deployer_bindings["roles/cloudfunctions.viewer"]'`.

Plan: **2 to add, 1 to change, 0 to destroy**. This PR ships the code matching the already-applied state to close the drift window.

## Verification

- `gcloud run services describe booster-ai-api ...` → env `SIGNUP_REQUEST_FLOW_ACTIVATED=true` ✅
- `gcloud projects get-iam-policy ... github-deployer ... roles/cloudfunctions.viewer` ✅
- `gcloud services list --enabled ... cloudfunctions.googleapis.com` ✅

## Test plan

- [ ] CI green (terraform validate via SBOM, lint, etc.)
- [ ] Post-merge: optional terraform plan shows no changes (state matches code).

## Next

Unblocks T8 Step 1 (`terraform apply -target=google_cloudfunctions_function.before_create` + bucket + IAM) per T6 runbook §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)