### PR TITLE
chore(deploy): gate de aprobación prod + reconciliar §Deploy con realidad

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,10 +153,10 @@ Todo input externo pasa por Zod **antes** de tocar lógica:
 
 ### Deploy
 
-- **Staging automático** vía Cloud Build trigger en merge a `main`.
-- **Producción**: manual approval en Cloud Build.
+- **No existe entorno staging** (backlog `#STAGING-ENV`: requiere un 2º GCP project con infra paralela). El `cloudbuild.staging.yaml` está inactivo; `release.yml` removió el job `deploy-staging`.
+- **Producción**: merge a `main` → `release.yml` (GitHub Actions vía Workload Identity Federation) → **requiere aprobación humana** en el GitHub Environment `production` (`required_reviewers`, enforced desde 2026-05-29) → Cloud Build `cloudbuild.production.yaml` canary (1% tráfico → 30 min → 100%). El step `canary-verify` es placeholder (`exit 0`): la promoción a 100% se observa/decide humanamente, no por verificación automática. Ver inventario `.specs/adr-vs-prod-inventory/inventory.md` finding #1.
 - **Monitoreo 2h post-deploy**: error rate, latency P95, logs limpios.
-- **NO deploy viernes después de las 16:00 hora Chile** sin waiver explícito + plan de sábado.
+- **Regla de horario de deploy eliminada 2026-05-29 por decisión del PO**: el control de riesgo de deploy se ejerce vía gate de aprobación (`required_reviewers` en el GitHub Environment `production`) + observación humana del canary, no vía restricción de calendario.
 - Detalles en skill `booster-deploy-cloud-run`.
 
 > **Recordatorio**: Estas reglas son la columna vertebral de "Cero deuda técnica desde day 0". Saltearlas requiere waiver explícito documentado en `.claude/ledger/`.


### PR DESCRIPTION
## Qué

Cierra el **finding #1** del inventario ADR-vs-prod (`.specs/adr-vs-prod-inventory/inventory.md`): merge→main auto-desplegaba a PROD **sin gate de aprobación humana** (el environment `production` no tenía `required_reviewers`), y no existe staging.

Dos partes:
1. **Gate de aprobación** (aplicado por separado vía `gh api`, GitHub settings — no es archivo de repo): `required_reviewers: [boosterchile]`, `prevent_self_review=false` en el GitHub Environment `production`. Desde ahora el job `deploy-production` de `release.yml` queda **pendiente de aprobación humana** antes de disparar el Cloud Build de prod.
2. **CLAUDE.md §Deploy reconciliado** (este PR):
   - Eliminada la regla de horario viernes (decisión PO: riesgo vía gate + observación canary, no calendario).
   - "staging automático / producción manual approval" → realidad: no hay staging (#STAGING-ENV); merge→main→release.yml(WIF)→aprobación humana→canary (1%→30min→100%); `canary-verify` es placeholder.

## Evidencia

Config del environment tras aplicar el gate:
```
protection_rules:
  - branch_policy
  - required_reviewers: ['boosterchile (id 251076982)']  prevent_self_review=False
```

El merge de este PR es además la **prueba del gate**: con `required_reviewers` activo, `deploy-production` debe quedar en estado **"waiting for approval"** en vez de auto-arrancar el build de prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)