### PR TITLE
docs(spec): boundary-closure → Merged (PR #402 en main)

### DIFF
--- a/.specs/sec-001-h1-2-google-boundary-closure/ship.md
+++ b/.specs/sec-001-h1-2-google-boundary-closure/ship.md
@@ -5,6 +5,7 @@
 - Date: 2026-06-05
 - Version: apps/api `0.0.0` (private, no publicado — deploy vía Cloud Build, no npm)
 - Modelo de release: **merge a `main` → `release.yml` → aprobación humana en GitHub Environment `production` → Cloud Build canary**. No hay tag manual.
+- **Merge confirmado**: PR #402 squash-merged a `main` el **2026-06-05 16:11 UTC** → merge commit **`d867bdf`** (20/20 checks verdes). `release.yml` disparado; **pendiente**: aprobación en Environment `production` + `terraform apply` per-entorno + verificación 24-48h → recién entonces `spec.md` → `Shipped`.
 
 ## R-SHIP (resuelto — decisión PO: merge main→rama + 1 PR delineado)
 
@@ -15,7 +16,7 @@ La rama era multi-sesión (25 commits previos de docs/housekeeping + el feature)
 
 ## Checklist (12 puntos)
 
-- [ ] **1. CI verde en el merge commit** — ⏳ **PENDIENTE de confirmar con el run de Actions sobre el head del PR** (devils-advocate SHIP: no marcar ✓ con evidencia local). Evidencia local: suite del feature (`@booster-ai/api`) **1407 passed | 2 skipped** (skips ajenos); `tsc` + Biome + `terraform validate` limpios. **Web**: 67 fallos LOCALES por App Check (`indexedDB is not defined` en jsdom), **preexistentes** — `git diff main HEAD -- apps/web` = **0** (web idéntico a main; #401 ya en main). Probabilidad de regresión web ≈ nula, pero **el gate del merge es el run verde de CI sobre el PR, no la corrida local** → el PO confirma el run antes de mergear.
+- [x] **1. CI verde en el merge commit** — ✅ **CONFIRMADO**: PR #402 con **20/20 checks en verde** sobre el head del PR (`6df10c3`), `mergeStateStatus: CLEAN`. Squash-merge a `main` el 2026-06-05 16:11 UTC → merge commit **`d867bdf`**. CodeQL pasó tras el fix `6df10c3` (alerta high `js/incomplete-sanitization` en `escapeCell` del reporte de clasificación → backslash escapado antes del pipe + test de regresión). Evidencia previa local: suite del feature (`@booster-ai/api`) **1407 passed | 2 skipped**; `tsc` + Biome + `terraform validate` limpios. Web idéntico a main (`git diff main HEAD -- apps/web` = 0; #401 ya en main).
 - [x] **2. Changelog** — N/A: monorepo con Changesets; `apps/api` privado `0.0.0` (no publicado). Cambio interno de seguridad/infra, documentado en ADR-057 + este ship.md + body del PR. CI no exige changeset.
 - [x] **3. Version bump** — N/A (paquete privado no versionado; deploy por imagen Cloud Build, no SemVer de consumidor).
 - [x] **4. Migration guides** — N/A: sin breaking de API pública. ADR-057 documenta el cambio de dirección (supersede ADR-054).

--- a/.specs/sec-001-h1-2-google-boundary-closure/spec.md
+++ b/.specs/sec-001-h1-2-google-boundary-closure/spec.md
@@ -5,7 +5,7 @@
 
 - **Author**: Felipe Vicencio (with agent-rigor)
 - **Date**: 2026-05-29 (v1) · **2026-06-04 (v2 re-centrado)**
-- **Status**: **Ship-ready — PR [#402](https://github.com/boosterchile/booster-ai/pull/402) abierto (2026-06-05)**, pendiente de: run verde de CI + merge PO + aprobación Environment `production` + `terraform apply` per-entorno. Transición a `Shipped` tras deploy+verificación. BUILD (T1–T11) + VERIFY + REVIEW + SHIP(`ship.md`) completos; reaper en dry-run + scheduler paused. (Histórico: Reviewed 2026-06-05; Draft v2 DA R2 2026-06-04.)
+- **Status**: **Merged — PR [#402](https://github.com/boosterchile/booster-ai/pull/402) squash-merged a `main` (merge commit `d867bdf`, 2026-06-05 16:11 UTC, 20/20 checks verdes)**. Pendiente para `Shipped`: aprobación humana en Environment `production` (`release.yml` ya disparado) + `terraform apply` per-entorno (scheduler + metric + decomiso) + verificación post-deploy 24-48h. BUILD (T1–T11) + VERIFY + REVIEW + SHIP(`ship.md`) completos; reaper en dry-run + scheduler paused. (Histórico: Ship-ready/PR abierto 2026-06-05; Reviewed 2026-06-05; Draft v2 DA R2 2026-06-04.)
 - **Linked**:
   - Parent: [`.specs/sec-001-cierre/spec.md`](../sec-001-cierre/spec.md) §3 SC-1.2.2 (Google leg = `TRACKED_RESIDUAL` → este spec lo lleva a `MET`)
   - **Mitigación P0-1**: [`.specs/sec-001-empresa-onboarding-gate-hotfix/`](../sec-001-empresa-onboarding-gate-hotfix/) (self-serve onboarding OFF)


### PR DESCRIPTION
Actualiza los artefactos del ciclo tras el merge de #402 a `main`.

## Cambios
- `ship.md`: checklist #1 (CI verde) → ✓ confirmado (20/20 checks, CodeQL pasó tras el fix del `escapeCell`); encabezado con merge commit `d867bdf`.
- `spec.md`: Status `Ship-ready` → **Merged**; pendiente para `Shipped`: aprobación Environment `production` + `terraform apply` per-entorno + verificación 24-48h.

## Evidencia
- PR #402 squash-merged a `main` el 2026-06-05 16:11 UTC → `d867bdf`, 20/20 checks verdes.
- Docs-only (solo `.specs/`); sin cambios de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)