### PR TITLE
docs(followups): corrobora 3 follow-ups + tfvars.example stale (post-deploy SEC-001)

### DIFF
--- a/.specs/_followups/app-check-enforcement-activation.md
+++ b/.specs/_followups/app-check-enforcement-activation.md
@@ -27,6 +27,14 @@ fuera del repo.
 - Sin kill-switch en runtime: el init de App Check es incondicional; revertir requiere redeploy.
   Evaluar si vale un flag de runtime para desactivar sin redeploy.
 
+## Corroboración 2026-06-05 (verificación post-deploy SEC-001 boundary-closure)
+
+Con `feat/app-check` ya en prod (#401 mergeado 2026-06-04), smoke read-only contra `https://app.boosterchile.com`:
+
+- **Confirmado que App Check NO está enforced server-side**: cero referencias a `appcheck`/`X-Firebase-AppCheck`/`verifyAppCheck` en `apps/api/src`; **cero HTTP 403 en `booster-ai-api`** en 3h de logs. La API acepta requests sin token App Check → el lado cliente no protege nada todavía (consistente con el origen de este stub).
+- El browser headless **sí** recibió un `403` de `content-firebaseappcheck.googleapis.com/.../exchangeRecaptchaV3Token` — es **detección de bot de reCAPTCHA v3** contra automatización, NO un fallo para usuarios reales (la página renderiza, los flujos responden 200).
+- Implica: el "reloj de observación" de métricas (paso 2) ya puede correr — el cliente está desplegado emitiendo tokens. Falta que el PO observe App Check → APIs → Métricas con tráfico real antes de activar enforcement.
+
 ## Estado
 
 Pendiente. No bloquea el merge del cliente; bloquea la activación de enforcement.

--- a/.specs/_followups/cloud-run-canary-tag-cleanup.md
+++ b/.specs/_followups/cloud-run-canary-tag-cleanup.md
@@ -37,3 +37,7 @@ Bump from P1 to P0 when either:
 - The service is within 100 of its 1000-revision quota.
 
 Monitor via `gcloud run revisions list --service=booster-ai-api --filter='-status.conditions.type=Active' --format='value(metadata.name)' | wc -l` weekly.
+
+## Medición 2026-06-05 (post-deploy SEC-001 boundary-closure)
+
+Observado en el traffic split de `booster-ai-api` (vía `gcloud run services describe`, región southamerica-west1): **10 revisiones con tag `canary-signup-<sha12>`** acumuladas (una por deploy, desde fines de mayo hasta `db0c00b`), todas en 0% salvo la última (`00367-jor`, 100%). Lejos aún del umbral P0 (>50), pero confirma la acumulación lineal: 10 tags a la fecha. Sigue P1; revisar el conteo en la cadencia semanal.

--- a/.specs/_followups/release-deploy-job-timeout-vs-canary.md
+++ b/.specs/_followups/release-deploy-job-timeout-vs-canary.md
@@ -28,6 +28,16 @@
 2. **Async + poll**: `gcloud builds submit --async` + step que pollea el build por ID hasta completar (desacopla el stream del timeout). Más robusto ante reinicios del runner, más código.
 3. **Desacoplar el canary**: mover la observación de 30 min fuera del Cloud Build síncrono (ej. job/step separado o verificación posterior). Refactor mayor.
 
+## Segunda reproducción 2026-06-05 (SEC-001 boundary-closure, PR #402+#403)
+
+Patrón **reproducido idéntico** y ahora con duración medida que sustenta el fix #1:
+
+- Run `#27027572287` (`#437`, commit `db0c00b`): job `Deploy to production` corrió **17:02:32 → 17:32:47 = ~30m15s** → cortado por `timeout-minutes: 30`. Step `Trigger Cloud Build` = `cancelled`, `Smoke test` = `skipped`, run = `cancelled`.
+- Cloud Build regional `d61e54bc` (commit `db0c00b`) = **SUCCESS**, corrió 17:03:34 → **17:41:57 = ~38 min** (build + canary 30m + promote). El build **sobrevivió** al cancel del job de GHA y aplicó el deploy.
+- `booster-ai-api` → revisión `00367-jor` (tag `canary-signup-db0c00b29ddc`), **100% tráfico**. Verificación post-deploy sana (0 errores, 0 5xx).
+
+⇒ **Dato duro para el fix #1**: el job tarda ~38 min reales; `timeout-minutes: 30` es insuficiente por ~8 min. Subir a **~50 min** deja margen. Esto ya ocurrió 3 veces (2026-05-29, 2026-06-04, 2026-06-05) → el estado `cancelled` engañoso es sistemático, no anecdótico.
+
 ## Relación
 
 - Liga con el **finding #1 del inventario** (`canary-verify` placeholder `exit 0`) y con [`docs/adr/056-cicd-github-actions-supersedes-gitlab.md`](../../docs/adr/056-cicd-github-actions-supersedes-gitlab.md) (CI/CD vigente).

--- a/.specs/_followups/terraform-tfvars-example-stale.md
+++ b/.specs/_followups/terraform-tfvars-example-stale.md
@@ -1,0 +1,34 @@
+# Follow-up — `infrastructure/terraform.tfvars.example` desactualizado vs estado real
+
+**Origen**: `terraform plan` del 2026-06-05 (apply pendiente de SEC-001 boundary-closure: scheduler reaper + metric + alert).
+**Tipo**: IaC / safety del onboarding. **Riesgo**: medio — un `terraform apply` reconstruido desde el `.example` propone cambios NO deseados a recursos de prod. **Estado**: pendiente.
+
+## Problema
+
+`infrastructure/terraform.tfvars` es **gitignored** (no hay tfvars canónico en el repo). El único punto de partida versionado es `terraform.tfvars.example`, y está **stale** respecto a la realidad de prod. Quien reconstruya su tfvars desde el example va a planear cambios espurios:
+
+- **`cloudsql_tier`**: el example dice `db-custom-2-7680`, pero la instancia real `booster-ai-pg-07d9e939` está en **`db-custom-1-6144`**. Un `terraform plan` con el valor del example propone **resize de la DB de prod** (`db-custom-1-6144 → db-custom-2-7680`) — confirmado y descartado como falso positivo el 2026-06-05.
+- **`organization_id`**: el example sugiere `null` ("si no estás bajo org, dejar null"), pero el proyecto **sí** está bajo organización (`gcloud projects describe booster-ai-494222` → `parent.type=organization`, `parent.id=435506363892`). Dejarlo en `null` puede divergir de cómo se aplicó el state (IAM/recursos a nivel org).
+
+Pueden existir **otros overrides** del tfvars real que el example no refleja (no auditado exhaustivamente).
+
+## Impacto
+
+- Riesgo de un apply que **muta recursos no relacionados** (resize de Cloud SQL = posible downtime/costo) cuando alguien intenta aplicar un cambio acotado.
+- Mitigación práctica usada el 2026-06-05: aplicar SEC-001 con `terraform apply -target=...` para limitar el blast radius — pero eso es un parche, no la cura.
+
+## Fixes (NO ejecutados — elegir)
+
+1. **Mínimo**: actualizar `terraform.tfvars.example` con los valores reales no-secretos (`cloudsql_tier = "db-custom-1-6144"`, comentar que el proyecto está bajo org `435506363892`). Reduce la deriva del onboarding.
+2. **Mejor**: versionar un tfvars canónico no-secreto (sin billing/org sensibles) o moverlo a Secret Manager / un mecanismo declarativo, para que `terraform plan` sea reproducible y no dependa de reconstrucción manual. Liga con `main-branch-protection-terraform-iac.md`.
+3. **Auditoría**: correr un `terraform plan` completo (no `-target`) contra un tfvars reconciliado y catalogar TODO el drift real entre código y state (ej. el `google_identity_platform_config.default` quiere remover `multi_tenant`/`phone_number`; el Cloud Run `template.revision → null` por deploys out-of-band). Resolver o documentar cada uno.
+
+## Evidencia (2026-06-05)
+
+- `terraform plan` (token de `gcloud auth print-access-token`, sin ADC): con `cloudsql_tier=db-custom-2-7680` (del example) → proponía resize de `google_sql_database_instance.main`. Corregido a `db-custom-1-6144` → el diff desapareció.
+- Drift adicional catalogado (no de SEC-001): `google_identity_platform_config.default` (remueve `multi_tenant`/`phone_number`; el `blocking_functions` del decomiso ya estaba ausente) y `module.service_api...service` (`template.revision → null`, benigno: `image` está en `ignore_changes` por ADR-013).
+
+## Relación
+
+- Surgió preparando el `terraform apply` de [`.specs/sec-001-h1-2-google-boundary-closure/`](../sec-001-h1-2-google-boundary-closure/ship.md) (scheduler reaper + metric + alert).
+- Liga con `main-branch-protection-terraform-iac.md` (IaC governance).


### PR DESCRIPTION
Registra los follow-ups detectados durante la verificación post-deploy de SEC-001 boundary-closure (2026-06-05). No toca código ni infra — solo `.specs/_followups/`.

## Cambios
- **app-check-enforcement-activation.md** (update): corroborado que App Check NO está enforced server-side (0 403s en la API; sin referencias en `apps/api/src`). El 403 de `exchangeRecaptchaV3Token` fue bot-detection del browser headless, no usuarios reales.
- **release-deploy-job-timeout-vs-canary.md** (update): 3ª reproducción, ahora con duración medida — build `db0c00b` tardó ~38 min vs `timeout-minutes: 30` → sustenta subir el timeout a ~50.
- **cloud-run-canary-tag-cleanup.md** (update): medición real = 10 tags `canary-signup-*` acumulados (lejos del P0 >50, pero crecimiento lineal confirmado).
- **terraform-tfvars-example-stale.md** (nuevo): el `.example` desfasa prod (`cloudsql_tier` `db-custom-2-7680` vs real `db-custom-1-6144`; `organization_id` null vs org real) → un apply reconstruido propone resize de la DB. Detectado armando el `terraform plan` del reaper.

## Evidencia
- Deploy SEC-001 verificado sano: build `d61e54bc` SUCCESS, rev `00367-jor` 100% tráfico, 0 errores/5xx.
- `terraform plan` (targeted) del reaper: 3 add limpios; drift no relacionado catalogado en el nuevo follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)