### PR TITLE
chore(infra): right-sizing pre-comercial de disponibilidad (ADR-058)

### DIFF
--- a/.specs/_followups/revertir-ha-al-firmar-b2b-sla.md
+++ b/.specs/_followups/revertir-ha-al-firmar-b2b-sla.md
@@ -1,0 +1,14 @@
+# Follow-up — Revertir postura HA pre-comercial al firmar el primer B2B con SLA
+
+**Origen:** ADR-058 (reclasificación a pre-comercial) · **Gatillo:** firma del primer contrato B2B con SLA de uptime.
+**Estado:** latente (no accionar hasta el gatillo).
+
+Al firmar el primer contrato B2B con SLA, revertir las palancas de `cost-optimization-precomercial`:
+
+- [ ] Cloud SQL: `cloudsql_high_availability = true` (ZONAL → REGIONAL) + `terraform apply` (runbook en `.specs/cost-optimization-precomercial/`).
+- [ ] Redis: `redis_tier = "STANDARD_HA"` (BASIC → HA) en `terraform.tfvars` + default en `variables.tf`.
+- [ ] Gateway primary: `replicas`/HPA `minReplicas` 1 → 2.
+- [ ] DR: reactivar gateway DR (`replicas` > 0 + recrear HPA) + scale-up.
+- [ ] **Upgrade correcto, NO el warm anterior**: evaluar DR multi-región completo con **read replica de Postgres cross-region** (presupuesto dedicado). El DR previo nunca replicó la BD (ver ADR-058 §"Estado de la infraestructura").
+
+Owner del gatillo: PO (Felipe Vicencio). Referencia: ADR-058, ADR-035 (superseded).

--- a/.specs/cost-optimization-precomercial/drift-findings.md
+++ b/.specs/cost-optimization-precomercial/drift-findings.md
@@ -1,0 +1,35 @@
+# Drift prod ↔ main — hallazgos FUERA DE ALCANCE del PR de costos
+
+**Fecha:** 2026-06-05 · **Detectado por:** `terraform plan` (rama `chore/cost-optimization-precomercial`) + verificación `gcloud` read-only contra prod (`booster-ai-494222`).
+**No aplicar junto con la optimización de costos.** Cada ítem requiere su propio tracking/revisión.
+
+## 1. SEC-001 — control de seguridad en estado inconsistente (PRIORITARIO)
+
+`main` migró SEC-001 H1.2 (cierre leg Google) de "blocking Cloud Function `beforeCreate`" a "logging metric + alert" (ADR-057, commit `d867bdf`; cierre marcado *Shipped* en `5f2b411`). El estado real de prod NO refleja la migración:
+
+| Componente | Esperado (según `main`/git) | Real en prod (verificado) |
+|---|---|---|
+| `beforeCreate` Cloud Function | eliminada | **existe, STATE=OFFLINE** (us-east1, 1st gen) — gestionada por TF (plan la marca DELETE) |
+| buckets `auth_blocking_*` | eliminados | existen (plan los marca DELETE) |
+| `logging_metric.auth_is_demo_blocked` | creado | **NO existe** |
+| `monitoring_alert_policy.auth_is_demo_blocked_anomaly` | creado | NO existe |
+
+**Riesgo:** control viejo OFFLINE + control nuevo ausente ⇒ posible hueco de cobertura del control de auth en prod, mientras el repo lo da por cerrado. **Acción:** investigar por qué el `terraform apply` del cierre no se reflejó en prod (¿nunca corrió? ¿rollback? ¿apply parcial?). Verificar si Identity Platform (`google_identity_platform_config.default`, que el plan marca UPDATE) sigue apuntando a la función OFFLINE. Tratar como issue de seguridad con revisor que tenga rol Owner actual.
+
+## 2. IAM humana — downgrade de Owner
+
+- Prod: `roles/owner` = `group:admins@boosterchile.com` (único Owner, verificado).
+- `main` (vía `var.human_owners` en tfvars): `["user:dev@boosterchile.com"]`.
+- El plan REEMPLAZARÍA el grupo por un usuario individual como único Owner del proyecto.
+
+**Riesgo:** cambio de control de acceso; un único usuario como sole Owner es frágil (orfandad si pierde acceso). **Acción:** PR dedicado, aprobado por un Owner actual del grupo `admins@`. Prohibido mezclar con costos o aplicar vía `-target`. (CLAUDE.md: IAM humana requiere PR revisado.)
+
+## 3. helloTest — Cloud Function huérfana
+
+`helloTest` (us-east1, 1st gen, OFFLINE) **no está en el código Terraform** (no aparece en el plan) → desplegada fuera de banda, probable artefacto de debugging. **Acción:** revisar y limpiar por separado.
+
+---
+
+## Resumen para quien aplique costos
+
+El `terraform plan` de la rama de costos arrastra los ítems #1 y #2 (9 cambios). **No correr `terraform apply opt.plan` completo.** Opciones para aislar costos: resolver primero el drift (#1, #2) y re-planear; o aplicar costos por recurso (`-target`) asumiendo el smell. Ver pregunta abierta al PO.

--- a/.specs/cost-optimization-precomercial/plan.md
+++ b/.specs/cost-optimization-precomercial/plan.md
@@ -1,0 +1,23 @@
+# Plan — Optimización de costos GCP pre-comercial
+
+Rama: `chore/cost-optimization-precomercial`. Orden de edición libre (no hay deps entre archivos); el orden de **aplicación** (humano) es A3 → A4 → A2 → B1 → C → A1 → D.
+
+## Tareas (edición de código)
+
+- [x] **T1 · A3** `data.tf`: `log_temp_files` `0`→`-1`; eliminados bloques `log_connections` y `log_disconnections`. Mantiene checkpoints/lock_waits/ddl.
+- [x] **T2 · A2** `compute.tf` (`module "service_api"`): `min_instances` → `0`.
+- [x] **T3 · A1** `variables.tf`: `redis_tier` default `STANDARD_HA`→`BASIC`. **Y** `terraform.tfvars` (local, gitignored): `redis_tier = "BASIC"`.
+- [x] **T4 · B1** `k8s/telemetry-tcp-gateway.yaml`: Deployment `replicas: 1`; HPA `minReplicas: 1`.
+- [x] **T5 · C1** `k8s/telemetry-tcp-gateway-dr.yaml`: Deployment `replicas: 0`; objeto `HorizontalPodAutoscaler` eliminado.
+- [x] **T6 · D** `variables.tf`: nueva var `cloudsql_high_availability` (bool, default `false`). `data.tf`: `availability_type = var.cloudsql_high_availability ? "REGIONAL" : "ZONAL"`.
+
+## Verificación (VERIFY)
+
+- [x] **V1** `terraform fmt -check` + `terraform validate` → limpios.
+- [ ] **V2** `terraform plan -out=opt.plan` → **bloqueado por creds GCP expiradas**. Re-correr tras `gcloud auth application-default login`. Confirmar **0 `replace`/`destroy`**; Cloud SQL in-place.
+- [x] **V3** manifiestos K8s validados (estructura + valores correctos).
+
+## Fuera de alcance del agente (runbook humano)
+
+- A4: rechazar CUDs en Centro de FinOps.
+- Aplicación a prod: `terraform apply` y `kubectl/gcloud` uno por uno, ventana baja, backup previo en D. Documentado en `ship.md`.

--- a/.specs/cost-optimization-precomercial/review.md
+++ b/.specs/cost-optimization-precomercial/review.md
@@ -1,0 +1,82 @@
+
+# Devils-advocate review — cost-optimization-precomercial — 2026-06-05T21:15:18Z
+
+## Premise
+- Asumido: "pre-comercial <=10 camiones => no se necesita HA/redundancia". Premisa razonable pero no verificada contra contratos firmados: el spec dice "SLA que aun no tiene clientes asociados" pero no cita evidencia (ni un contrato, ni un correo del PO confirmando que NINGUN cliente actual exige 99.9%). Si existe un piloto pagado con expectativa de uptime, A1/D/C1 lo violan.
+- Asumido: "todo es reversible con un flip de variable". Falso para A1 (Redis) y parcialmente para D: el spec mismo admite que A1 RECREA la instancia y cambia `host`; D cambia `availability_type` in-place pero el camino de vuelta REGIONAL->ZONAL->REGIONAL no es instantaneo ni gratis. "Reversible" no es lo mismo que "reversible sin downtime".
+- Mas doloroso si es falso: que exista un cliente/piloto con expectativa de disponibilidad. Colapsa la justificacion de 4 de 6 palancas.
+
+## Scope and second-order effects
+- DR cold (C1) interactua con `cloudbuild-dr-check.yaml` y `cloudbuild-dr-deploy.yaml` (infrastructure/k8s/). El deploy DR (`cloudbuild-dr-deploy.yaml:142`) espera la IP `136.116.208.86` del LoadBalancer. Con `replicas: 0` + `externalTrafficPolicy: Local`, el Service DR no tiene endpoints sanos => el L4 LB no tiene backend healthy. Nadie verifico si el pipeline DR pasa o si futuros `apply` del DR fallan. No consultado.
+- `externalTrafficPolicy: Local` + replicas 0 (telemetry-tcp-gateway-dr.yaml:185): con Local, el health check del LB solo pasa en nodos que corren un pod. Con 0 pods, 0 nodos sanos => el LB DR queda permanentemente unhealthy. El device Teltonika usa `telemetry-dr.boosterchile.com:5061` como Backup (cert-dr.yaml:8): si el primary cae, el device hace failover al backup tras 5 timeouts => conecta a un LB sin backends => conexion rechazada/colgada. El RTO no es "15-40 min runbook"; durante esos 15-40 min el device NO tiene a donde ir. Eso no es DR latente, es DR ausente. El spec lo vende como "base DR latente" (C2): enganoso.
+- A2 (api min 1->0) elimina el ternario `var.environment == "prod"` (compute.tf:69). Antes prod tenia garantia de 1 instancia caliente; ahora prod = no-prod = 0. Hyrum: cualquier health-check externo, uptime monitor o cron que pegue al `/health` del api paga cold start de 5-10s. Si hay un uptime check de GCP Monitoring con timeout < 10s, generara falsas alertas de downtime. No verificado.
+- Quitar `log_connections`/`log_disconnections` (A3): el security-auditor Booster (agents/security-auditor.md) exige compliance Ley 19.628 + retencion SII/DTE 6 anos. `log_connections` es senal de auditoria de acceso a BD; eliminarlo reduce capacidad forense ante acceso no autorizado. No se evaluo si alguna politica de compliance lo consume. (Verifique: no hay alerta en *.tf que los referencie hoy, pero ausencia de alerta no es ausencia de requisito de compliance.)
+
+## Alternatives discarded
+- Considerado en spec: ninguna alternativa por palanca; el spec toma el "paquete Optimizar Costos" como dado.
+- No considerado (debio estarlo):
+  1. A2: min_instances=1 solo para `service_api` (el critico) y 0 para los 6 services secundarios. Captura ~85% del ahorro sin exponer el endpoint principal a cold starts. El diff puso TODO a 0.
+  2. D: en vez de REGIONAL->ZONAL, mantener REGIONAL y bajar el `tier`. El spec no muestra el desglose de costo REGIONAL-vs-tier; quiza el ahorro real venia del tier, no del availability_type. Sin ese numero, bajar availability es a ciegas.
+  3. C1: `replicas: 1` sin HPA en vez de 0. Mantiene el LB con backend sano y failover real del device, a costo de 1 pod Autopilot. El ahorro marginal de 1->0 no justifica romper el failover.
+
+## Failure modes
+- F1 (Caida de zona Cloud SQL, post-D): deteccion = alertas de conexion BD fallida (si existen). Recuperacion = restore desde backup/PITR, "minutos-1h". Costo: producto caido esa hora + posible perdida de datos entre ultimo backup y la caida (RPO no declarado). El spec no declara RPO.
+- F2 (Caida regional + failover device a DR, post-C1): deteccion = device hace 5 timeouts y switchea. Recuperacion = NINGUNA automatica; DR tiene 0 pods => device conecta a LB sin backend. Costo: perdida total de telemetria hasta que un humano corra el runbook. Es el escenario exacto que dr-region.tf:16 dice que justifico el DR ("hubo 1 caida en 2024 y 1 en 2025").
+- F3 (Rolling update gateway primary con 1 replica, post-B1): el deployment NO tiene `strategy:` explicito (verifique: 0 ocurrencias en telemetry-tcp-gateway.yaml) => default RollingUpdate maxUnavailable 25%. Con 1 replica puede tumbar el unico pod antes de que el nuevo este Ready => corte TCP de los Teltonika en CADA deploy de imagen. El comentario admite "breve corte" pero no se anadio `strategy: Recreate` ni se cuantifico.
+- F4 (Redis BASIC recreacion, A1): si algun proceso usa Redis para correctness (locks distribuidos, idempotencia de matching) y no solo cache, la ventana de recreacion puede causar doble-procesamiento. No evaluado.
+
+## Reversibility
+- Costo de deshacer en 30 dias: ALTO para A1 (otra recreacion de Redis + cambio de host + re-deploy Cloud Run) y MEDIO-ALTO para D (cambio de availability_type, ventana). BAJO para A2/B1. MEDIO para C1 (recrear HPA + scale-up + esperar cert/pod).
+- Mecanismo: flip de variable + apply. PERO al borrar el ternario `var.environment == "prod"` en compute.tf:69 y data.tf:120 se perdio la diferenciacion prod-HA / dev-ZONAL. Con ADR-055 (entorno de desarrollo separado) ya existente, prod y dev compartiran `cloudsql_high_availability=false` salvo que se re-introduzca logica por entorno. Regresion de diseno.
+- NO hay ADR. Se bajan 4 contratos de disponibilidad (Redis HA, Cloud SQL REGIONAL, gateway redundancia, DR failover). CLAUDE.md exige ADR cuando "cambio un patron que aplica a multiples modulos" y para desviar del stack. Pasar de "disenado para 99.9% / 1k-10k devices" a "single-zone, single-replica, sin DR" ES cambio de patron arquitectonico.
+
+## Drift signals
+- "pre-comercial" / "Volver a ... al firmar B2B" se repite como justificacion en variables.tf:163/172, compute.tf:65, dr-yaml. Es la version Booster del vocabulario de aplazamiento. El gatillo "firmar B2B con SLA" no tiene owner ni tracking; no hay stub en `.specs/_followups/` que diga "revertir cost-opt al cliente N". Sin eso, el aplazamiento se vuelve permanente. Objecion: crear el follow-up de reversion ligado a un evento de negocio.
+- verify.md:13 dice V2 "bloqueado por creds" y verify.md:31 muestra V2 corrido. Estado contradictorio en el mismo doc. Menor pero indica edicion apresurada.
+
+## Evidence quality
+- Claim "ahorra ~CLP 350-450k/mes (-45%)" -> Evidencia: ninguna en los artefactos (viene del paquete no incluido). Verdict: ABSENT. Sin desglose por palanca no se sabe si el grueso del ahorro viene de palancas baratas y de bajo riesgo o de las 4 que rompen disponibilidad.
+- Claim "Cloud SQL es update in-place, no replace" -> Evidencia: terraform plan (verify.md:36). Verdict: SUFICIENTE (unico load-bearing con evidencia real).
+- Claim "cache medido practicamente vacio" (variables.tf:172) -> Evidencia: "medido" sin cita. Verdict: WEAK. Si Redis tiene locks/idempotencia, "vacio" es irrelevante para el riesgo de correctness en la recreacion.
+- Claim "RTO 15-40 min" DR (dr-yaml:42) -> Evidencia: ninguna; sin runbook ejecutado ni drill. Verdict: ABSENT + contradicho por el hallazgo de LB DR sin backend.
+- Claim "rolling update puede tener breve corte" -> Evidencia: vibes; no medido, sin Recreate. Verdict: WEAK.
+
+## Verdict
+- Strong objections (must address):
+  1. DR queda funcionalmente roto, no "latente" (C1 + externalTrafficPolicy: Local + replicas 0): el failover del device Teltonika apunta a un LB sin backend sano, contradiciendo dr-region.tf. O `replicas: 1` en DR, o documentar explicitamente que NO hay failover y aceptarlo con firma del PO.
+  2. Falta ADR para bajar 4 contratos de disponibilidad simultaneos (CLAUDE.md lo exige para cambio de patron multi-modulo).
+  3. Plan contaminado / `-target` peligroso: verify.md:49 dice que `apply opt.plan` arrastra teardown SEC-001 + downgrade de IAM humana (prohibido por CLAUDE.md). Aislar con `-target` es un smell: salta el grafo de dependencias, puede dejar el state inconsistente y NO resuelve que el proximo apply full re-arrastrara el drift. La pregunta correcta no es "como aislo con -target" sino "por que el state de prod no refleja SEC-001 marcado como Shipped" (drift-findings #1, posible hueco de seguridad). Resolver el drift ANTES, no sortearlo.
+  4. Borrar el ternario `var.environment` (compute.tf:69, data.tf:120) elimina la diferenciacion prod/dev justo cuando ADR-055 introduce un entorno separado. Conservar capacidad por-entorno o documentar la regresion.
+- Residual risks (accept and document):
+  - Cold starts en api (A2): aceptable si no hay uptime check con timeout corto; verificar.
+  - Perdida de `log_connections` para forense de acceso BD: que lo confirme security-auditor contra Ley 19.628.
+  - Corte TCP en rolling update del gateway (1 replica): aceptar con `strategy: Recreate` explicito o cuantificar el corte.
+  - RPO/RTO de Cloud SQL ZONAL no declarado: documentar el peor caso de perdida de datos.
+- Out of scope: el detalle de costo CLP por palanca (no provisto) y la ejecucion del runbook humano de apply.
+
+---
+
+# Resolución (2026-06-05, post-decisión PO)
+
+**code-reviewer** dio `REQUEST_CHANGES` (4 blockers); **devils-advocate** 4 strong objections. Resolución:
+
+## Blockers resueltos en código/docs
+- ✅ **Falta ADR** (DA#2, CR-consistency) → **ADR-058** creado (supersede ADR-035, decisión PO: reclasificación a pre-comercial). ADR-035 marcado Superseded. Premisa "sin contratos B2B" confirmada por el PO (resuelve también la objeción DA-premise).
+- ✅ **`terraform.tfvars.example` stale** (CR-blocking) → `redis_tier = "BASIC"` + añadida `cloudsql_high_availability = false` con comentarios de reversión.
+- ✅ **`verify.md` contradictorio** (DA drift-signal, CR) → corregido; V2 ejecutado tras reauth.
+- ✅ **Diferenciación por entorno** (DA#4, CR): `data.tf` ahora usa `var.cloudsql_high_availability` (per-entorno vía tfvars) → **restaura** capacidad por-entorno (mejor que el ternario). `compute.tf` min_instances=0 es decisión deliberada pre-comercial (dev ya era 0; solo prod cambia 1→0).
+- ✅ **Gatillo de reversión sin tracking** (DA drift-signal) → stub `_followups/revertir-ha-al-firmar-b2b-sla.md` ligado al evento "firmar primer B2B con SLA".
+- ✅ **dr-region.tf narrativa contradictoria** (CR-question) → comentario actualizado apuntando a ADR-058 (estado cold).
+
+## Riesgos aceptados por el PO (ADR-058 §Negativas) — documentados, no bloqueantes
+- **DR funcionalmente cold, no failover automático** (DA#1, F2): aceptado explícitamente en ADR-058. `replicas: 0` se mantiene; el device Teltonika NO tiene failover regional hasta reactivación manual (RTO 15-40 min). `cloudbuild-dr-deploy.yaml` healthcheck quedará rojo en DR — esperado mientras DR esté cold.
+- **A1 recrea Redis = ventana de 503 en auth** (F4, NUEVO hallazgo): Redis sostiene rate-limit **fail-closed** (`rate-limit-pin` /auth/driver-activate, `rate-limit-signup`). Durante la recreación esos endpoints dan 503. ⇒ Aplicar A1 en ventana baja real; esperar 503 transitorio en driver-activate/signup. No es "caché vacío sin impacto".
+- **Cold starts api** (A2): aceptado; verificar que ningún uptime check tenga timeout <10s antes de aplicar.
+- **Rolling update gateway 1 réplica** (F3): el default RollingUpdate (maxSurge 25%→1, maxUnavailable→0) **surge antes de matar**, así que el rollout no tumba el pod; pero con 1 réplica las conexiones TCP persistentes se reconectan en cada deploy (Teltonika auto-reconecta). Aceptado; no se añade `strategy: Recreate` (sería peor: mata-antes-de-crear).
+- **Pérdida `log_connections`/`log_disconnections`** (MINOR): Cloud Audit Logs + `cloudsql.iam_authentication` siguen activos (forense de acceso independiente de estos flags Postgres). Aceptado para pre-comercial.
+- **RPO/RTO Cloud SQL ZONAL**: RPO ≈ continuo (PITR transaction logs, retención 7d) → pérdida de datos cercana a cero; RTO = restore (minutos-1h). Documentado.
+
+## Apply (no en este PR)
+- `terraform apply opt.plan` completo PROHIBIDO (arrastra SEC-001 + IAM). Aplicar **palanca por palanca con `-target` explícito** de los recursos de costo, o reconciliar el drift SEC-001/IAM primero (issues separados). Detalle en `drift-findings.md`. El PR solo aterriza CÓDIGO; el apply es paso humano separado.
+
+**Veredicto post-resolución:** blockers de merge resueltos. Apto para PR (no para apply automático).

--- a/.specs/cost-optimization-precomercial/ship.md
+++ b/.specs/cost-optimization-precomercial/ship.md
@@ -1,0 +1,25 @@
+# Ship — Optimización de costos GCP pre-comercial
+
+**Fecha:** 2026-06-05 · **ADR:** ADR-058 (supersede ADR-035)
+**PR:** [#406](https://github.com/boosterchile/booster-ai/pull/406) — `chore/cost-optimization-precomercial` → `main`
+**Estado:** PR abierto. **NO mergeado, NO aplicado a prod.**
+
+## Commits
+- `824d5cd` chore(infra): right-sizing pre-comercial de disponibilidad (ADR-058) — rama de costos.
+- `d08c09b` docs(security): corrige cierre SEC-001 (falso negativo -target) — rama `docs/sec-001-post-ship-drift` (local, separada, no pusheada).
+
+## Pendiente (decisión/acción humana)
+1. **Merge del PR #406** (review humano + gate de aprobación `production` no aplica a infra manual, pero el merge a main sí requiere PR aprobado).
+2. **Apply palanca por palanca** con `terraform apply -target` explícito (NO `apply` completo — arrastra drift SEC-001 + IAM). Orden: A3 → A2 → B1 → C → A1 → D.
+   - A1 (Redis): ventana baja real; 503 transitorio en /auth/driver-activate + signup (rate-limit fail-closed) durante la recreación.
+   - D (Cloud SQL): backup on-demand previo; abortar si plan muestra `replace`.
+3. **A4**: rechazar CUDs 3 años en Centro de FinOps (manual).
+4. **Reconciliar drift** SEC-001 (decomiso + métrica T4) e IAM Owner en sus propios flujos antes/separado del apply de costos.
+
+## Checklist
+- [x] CI local (pre-commit): gitleaks, biome, ADR numbering, spec-drift → verdes en `824d5cd`.
+- [x] ADR-058 (Accepted) + ADR-035 Superseded.
+- [x] Review (code-reviewer + devils-advocate) resuelto — `review.md` §Resolución.
+- [x] Reversión trackeada — `_followups/revertir-ha-al-firmar-b2b-sla.md`.
+- [ ] Merge + apply (humano).
+- [ ] Monitoreo 2h post-apply de cada palanca (error rate, P95, logs).

--- a/.specs/cost-optimization-precomercial/spec.md
+++ b/.specs/cost-optimization-precomercial/spec.md
@@ -1,0 +1,53 @@
+# Spec — Optimización de costos GCP pre-comercial
+
+**Estado:** DEFINE → BUILD
+**Fecha:** 2026-06-05
+**Owner:** Felipe Vicencio (`dev@boosterchile.com`)
+**Origen:** paquetes `Optimizar Costos 1.md` / `Optimizar Costos 2.md` (validados contra el código vivo el 2026-06-05).
+**ADR habilitante:** [ADR-058](../../docs/adr/058-precomercial-rightsizing-disponibilidad-supersedes-035.md) — reclasificación a pre-comercial, supersede ADR-035 (que rechazaba estas palancas bajo objetivo TRL 10). Reversión trackeada en [`_followups/revertir-ha-al-firmar-b2b-sla.md`](../_followups/revertir-ha-al-firmar-b2b-sla.md).
+
+## 1. Objetivo
+
+Reducir el gasto mensual de GCP del proyecto `booster-ai-494222` de ~CLP 774.000/mes a ~CLP 350.000–450.000/mes (−45% aprox.) ajustando la infraestructura al tamaño real de lanzamiento (≤10 camiones), sin perder la capacidad de revertir cada palanca.
+
+## 2. Por qué ahora
+
+La infra está dimensionada para 1.000–10.000 dispositivos y un SLA B2B 99.9% que aún no tiene clientes asociados. El gasto subió +127% MoM. Pre-comercial no justifica HA/redundancia plena.
+
+## 3. Criterios de éxito
+
+- Todos los cambios de código aplicados como `update in-place` o scale-down — **ningún `replace`/`destroy` inesperado** en `terraform plan` (especialmente Bloque D / Cloud SQL).
+- Cada palanca reversible vía flip de variable + `apply` o re-scale.
+- `terraform validate` + `terraform fmt -check` limpios.
+
+## 4. Alcance — palancas
+
+| # | Cambio | Archivo | Toca disponibilidad |
+|---|---|---|---|
+| A1 | Redis `STANDARD_HA` → `BASIC` | `variables.tf` **+ `terraform.tfvars`** | Sí (failover) |
+| A2 | Cloud Run `api` `min_instances` 1→0 | `compute.tf` | Sí (cold starts) |
+| A3 | Logging Cloud SQL menos verboso | `data.tf` | No |
+| A4 | Posponer CUDs 3 años | (acción FinOps, no código) | No |
+| B1 | Gateway primary 2→1 réplica | `k8s/telemetry-tcp-gateway.yaml` | Sí (redundancia) |
+| C1 | Gateway DR → 0 (borrar HPA + `replicas:0`) | `k8s/telemetry-tcp-gateway-dr.yaml` | Sí (failover regional) |
+| C2 | Mantener base DR latente | (sin cambio: no borrar `dr-region.tf`) | — |
+| D | Cloud SQL REGIONAL→ZONAL | `variables.tf` + `data.tf` | Sí (failover BD) |
+
+### Corrección sobre el paquete original (defecto detectado)
+
+- **A1**: el paquete solo cambiaba el `default` en `variables.tf`, pero `terraform.tfvars` setea `redis_tier = "STANDARD_HA"` explícito (gana sobre el default). Para que A1 surta efecto **hay que cambiar `terraform.tfvars`**. Cambiamos ambos por consistencia.
+
+## 5. Fuera de alcance (lo ejecuta el humano, no el agente)
+
+- `terraform apply` y `kubectl/gcloud` contra producción. Las palancas con downtime/recreación (D, A1) y las que reducen disponibilidad (A2, B1, C1) se aplican **una por una, en ventana baja, con backup previo en D**, según runbook. El agente deja el código + plan validado; la mutación de prod es decisión/acción humana (gate de aprobación, CLAUDE.md §Deploy).
+- A4: acción manual en el Centro de FinOps.
+
+## 6. Riesgos
+
+- **D (Cloud SQL)**: si `terraform plan` muestra `replace` en `google_sql_database_instance.main` → **ABORTAR** (riesgo de pérdida de datos). Esperado: `~ update in-place` con `availability_type: "REGIONAL" -> "ZONAL"`. Backup on-demand obligatorio previo; el nombre de instancia es dinámico (`booster-ai-pg-${random_id.cloudsql_suffix.hex}`) → confirmar el sufijo real antes del backup.
+- **A1 (Redis)**: el cambio de tier recrea la instancia (caché vacío, sin pérdida) y cambia `host`; Cloud Run re-despliega al leer el nuevo `REDIS_HOST`.
+- Todos reversibles. Volver a HA/REGIONAL al firmar B2B con SLA 99.9%.
+
+## 7. Reversión
+
+Cada palanca: flip de variable (`BASIC→STANDARD_HA`, `false→true`) o re-scale + `terraform apply` / `kubectl apply`.

--- a/.specs/cost-optimization-precomercial/verify.md
+++ b/.specs/cost-optimization-precomercial/verify.md
@@ -1,0 +1,53 @@
+# Verify — Optimización de costos GCP pre-comercial
+
+**Fecha:** 2026-06-05
+**Rama:** `chore/cost-optimization-precomercial`
+
+## Resultados
+
+| Check | Resultado |
+|---|---|
+| V1 · `terraform fmt -check -recursive` | ✅ exit 0 (sin cambios de formato pendientes) |
+| V1 · `terraform validate` | ✅ "Success! The configuration is valid." |
+| V3 · YAML manifiestos K8s | ✅ ver abajo |
+| V2 · `terraform plan` | ✅ **ejecutado** 2026-06-05 tras `gcloud auth application-default login`. Resultado completo en §"V2 · Resultado". (El primer intento falló por creds expiradas; reautenticado y corrido.) |
+
+## V3 · Manifiestos K8s (validación estructural)
+
+`k8s/telemetry-tcp-gateway.yaml` (primary) — 6 objetos:
+- Deployment `telemetry-tcp-gateway`: `replicas = 1` ✅ (B1)
+- HorizontalPodAutoscaler `telemetry-tcp-gateway`: `minReplicas = 1` ✅ (B1)
+
+`k8s/telemetry-tcp-gateway-dr.yaml` (DR) — 4 objetos (antes 5):
+- Deployment `telemetry-tcp-gateway`: `replicas = 0` ✅ (C1)
+- HorizontalPodAutoscaler: **eliminado** ✅ (C1 — Autopilot no soporta `minReplicas: 0`)
+
+## V2 pendiente — criterio de aceptación
+
+Al re-correr `terraform plan -out=opt.plan` con credenciales válidas, confirmar:
+- **0 `replace` / 0 `destroy`**. Especialmente `google_sql_database_instance.main` debe ser `~ update in-place` con `availability_type: "REGIONAL" -> "ZONAL"`. Si aparece `-/+` (replace) → **ABORTAR** (riesgo de pérdida de datos).
+- Cambios esperados: Redis tier (recreación de Memorystore — esperada, caché vacío), `service_api` min_instances 1→0, flags Cloud SQL (log_temp_files, drop log_connections/log_disconnections), availability_type.
+
+## V2 · Resultado `terraform plan` (2026-06-05, post-reauth)
+
+`Plan: 4 to add, 10 to change, 7 to destroy.`
+
+### Mis cambios — todos correctos
+- ✅ **Cloud SQL (D): `~ update in-place`** — NO replace. Criterio de aceptación cumplido (sin riesgo de datos).
+- ✅ **Redis (A1): `REPLACE`** — esperado (cambio de tier recrea Memorystore; caché vacío).
+- ✅ **Cloud Run api (A2) + 6 services**: `update in-place` (min_instances + propagación de nuevo `REDIS_HOST`).
+
+### 🔴 BLOQUEANTE — plan contaminado con drift prod↔main NO relacionado
+El plan arrastra 9 cambios ajenos a la optimización de costos (drift entre código `main` y estado desplegado):
+
+- **DELETE**: `google_cloudfunctions_function.before_create`, `google_storage_bucket.auth_blocking_source`, `google_storage_bucket_object.auth_blocking_placeholder`, `google_project_iam_member.compute_default_storage_viewer`, `github_deployer_bindings["roles/cloudfunctions.viewer"]`, `human_owners["group:admins@boosterchile.com"]`
+- **CREATE**: `google_logging_metric.auth_is_demo_blocked`, `google_monitoring_alert_policy.auth_is_demo_blocked_anomaly`, `human_owners["user:dev@boosterchile.com"]`
+- **UPDATE**: `google_identity_platform_config.default`, `google_monitoring_dashboard.telemetry_overview`
+
+**Diagnóstico**: el código de `main` ya migró SEC-001 H1.2 (boundary closure, ADR-057, commit `d867bdf`) de "blocking Cloud Function" a "logging metric + alert", pero **el estado de prod no lo refleja** — pese a que `5f2b411` marca el cierre como *Shipped (terraform apply validado)*. Además, drift de IAM humana (`human_owners`: `group:admins` desplegado vs `user:dev` en código).
+
+**Implicación**: `terraform apply opt.plan` aplicaría cost-opt **+** teardown SEC-001 **+** cambio de IAM humana en un solo apply. Prohibido por CLAUDE.md (IAM humana requiere PR revisado). **No aplicar opt.plan tal cual.**
+
+## Nota — `terraform.tfvars` gitignored
+
+`infrastructure/terraform.tfvars` está en `.gitignore`. El cambio `redis_tier = "BASIC"` se aplicó al archivo local (lo usa el `plan`/`apply` desde esta máquina) pero **no se commitea**. Lo permanente en repo es el `default = "BASIC"` en `variables.tf`. Quien aplique en prod debe asegurar que su tfvars tenga `redis_tier = "BASIC"`, o el override `STANDARD_HA` persistiría.

--- a/docs/adr/035-trl10-mantener-ha-recortar-ruido.md
+++ b/docs/adr/035-trl10-mantener-ha-recortar-ruido.md
@@ -1,6 +1,8 @@
 # ADR 035 — TRL 10: mantener HA productiva, recortar solo ruido sin valor
 
-**Estado**: Aceptado
+> **Superseded by [ADR-058](./058-precomercial-rightsizing-disponibilidad-supersedes-035.md) (2026-06-05).** El objetivo del producto se reclasificó de TRL 10 a **pre-comercial** (≤10 camiones, sin contratos B2B con SLA). La premisa de este ADR (clientes B2B con 99.9% vigente) dejó de cumplirse, por lo que las palancas de HA/DR que aquí se rechazaron quedan habilitadas en ADR-058. Este ADR fue correcto bajo su premisa; se conserva como registro histórico, sin editar más allá de este marcador.
+
+**Estado**: Superseded por ADR-058 (era: Aceptado)
 **Fecha**: 2026-05-13
 **Autor**: Claude (Opus 4.7) + Felipe Vicencio
 **Extiende**: ADR-034 (right-sizing)

--- a/docs/adr/058-precomercial-rightsizing-disponibilidad-supersedes-035.md
+++ b/docs/adr/058-precomercial-rightsizing-disponibilidad-supersedes-035.md
@@ -1,0 +1,97 @@
+# ADR 058 — Reclasificación a pre-comercial: habilitar right-sizing de disponibilidad (supersedes ADR-035 TRL 10)
+
+**Estado**: Aceptado
+**Fecha**: 2026-06-05
+**Autor**: Felipe Vicencio (PO) + Claude
+**Supersedes**: ADR-035 (`035-trl10-mantener-ha-recortar-ruido.md`)
+**Relacionado**: ADR-034 (right-sizing, sigue vigente)
+
+---
+
+## Contexto
+
+ADR-035 (Aceptado, 2026-05-13) fijó el objetivo del producto como **TRL 10**:
+sistema certificado, listo para despliegue comercial, con clientes B2B grandes
+y contratos firmados que exigen 99.9% uptime. Bajo esa premisa rechazó tres
+palancas de ahorro por incompatibles con el SLA:
+
+1. Eliminar/reducir el DR cluster (`booster-ai-telemetry-dr`)
+2. Cloud SQL `REGIONAL` → `ZONAL`
+3. Memorystore Redis `STANDARD_HA` → `BASIC`
+
+Solo aceptó la log exclusion del ruido de control plane GKE (ortogonal a HA).
+
+**Lo que cambió (aclaración del PO, 2026-06-05):** el objetivo real a la fecha
+NO es TRL 10. El lanzamiento es **pre-comercial**: a pocas semanas de operar, con
+un **máximo de 10 camiones** (parte con equipos Teltonika que usan el gateway TCP,
+parte solo con posicionamiento Google Maps que reporta por HTTP a Cloud Run).
+**No hay todavía clientes B2B con contratos firmados** que exijan 99.9% uptime.
+
+La premisa central de ADR-035 (contratos B2B con SLA vigente) **no se cumple hoy**.
+Por tanto su conclusión — sostener el premium de HA/DR — deja de aplicar para el
+estado actual del producto. ADR-035 no fue un error: fue correcto bajo su premisa.
+Este ADR documenta que la premisa cambió, no que la decisión anterior estuviera mal.
+
+## Estado de la infraestructura construida bajo ADR-035
+
+El follow-up de ADR-035 ("desplegar el gateway en el cluster DR") **sí se ejecutó**:
+`infrastructure/k8s/telemetry-tcp-gateway-dr.yaml` existe con `replicas: 2` y está
+corriendo en us-central1 (verificado en consola 2026-06-05). Es decir, hay
+infraestructura de DR caliente realmente desplegada. Deshacerla es una acción
+deliberada, no la simple no-creación de algo.
+
+Hallazgo adicional relevante para el SLA: aun con el gateway DR desplegado, **Cloud
+SQL NO tiene réplica cross-region** (es REGIONAL HA en una sola región). Ante una
+caída regional completa, el gateway DR levantaría sin base de datos. El "DR" actual
+nunca entregó el RTO completo que TRL 10 asumía.
+
+## Decisión
+
+Se reclasifica el objetivo operativo a **pre-comercial** mientras no existan
+contratos B2B con SLA. En consecuencia, las tres palancas que ADR-035 rechazó
+quedan **habilitadas** para evaluación/aplicación, junto con el right-sizing de
+redundancia del gateway:
+
+- **DR → cold** (latente): gateway DR escalado a cero, conservando subnet/IP/DNS/
+  cluster en Terraform para reactivar con `terraform apply` + scale-up (RTO 15–40 min).
+- **Cloud SQL `REGIONAL` → `ZONAL`** (vía nueva variable, reversible, con runbook).
+- **Redis `STANDARD_HA` → `BASIC`**.
+- **Gateway primary `replicas`/HPA `min` 2 → 1**.
+- Se mantienen: la **log exclusion** de ADR-035 y todo **ADR-034** (tier Cloud SQL,
+  `min_instances=0` en servicios marginales).
+
+El detalle de diffs, runbooks y priorización vive en
+`.specs/cost-optimization-precomercial/` y en el PR de costos asociado.
+
+## Consecuencias
+
+### Positivas
+- Gasto mensual proyectado de ~CLP 774k a ~CLP 350–450k (−45% aprox.).
+- La infra deja de pagar un premium de SLA por clientes que aún no existen.
+- Elimina la falsa sensación de seguridad de un "DR" que no replicaba la BD.
+
+### Negativas / riesgos aceptados
+- Se reduce redundancia: failover Redis, cold starts del api, un solo pod de
+  gateway, sin failover regional automático, BD single-zone.
+- Ante caída de zona/región, el RTO pasa a ser de minutos a decenas de minutos
+  (manual), no automático. Aceptable para ≤10 camiones en pre-comercial con
+  backups + PITR de Cloud SQL.
+
+### Condición de reversión (gatillo explícito)
+**Al firmar el primer contrato B2B con SLA de uptime**, este ADR se revierte:
+volver a `REGIONAL` (flip de `cloudsql_high_availability`), Redis `STANDARD_HA`,
+reactivar DR. Y en ese momento el upgrade correcto NO es el warm anterior sino
+**DR multi-región completo con read replica de Postgres** — evaluar con presupuesto
+dedicado. Hasta entonces, rige la postura pre-comercial de este ADR.
+
+## Fuera de alcance de este ADR (drift de seguridad detectado)
+Durante la revisión apareció drift no relacionado entre `main` y prod (Cloud
+Function `beforeCreate` viva pese a ADR-057; binding de Owner group vs user). Se
+tratan en issues/PRs de seguridad separados — **no** se tocan aquí ni en el PR de
+costos.
+
+## Referencias
+- ADR-035 (superseded) — `035-trl10-mantener-ha-recortar-ruido.md`
+- ADR-034 — right-sizing (vigente)
+- `infrastructure/dr-region.tf`, `infrastructure/data.tf`, `infrastructure/k8s/telemetry-tcp-gateway*.yaml`
+- Conversación 2026-06-05 con PO: reclasificación a pre-comercial (≤10 camiones, sin contratos B2B)

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -63,7 +63,10 @@ module "service_api" {
   service_name          = "booster-ai-api"
   service_account_email = google_service_account.cloud_run_runtime.email
 
-  min_instances = var.environment == "prod" ? 1 : 0
+  # Pre-comercial (<=10 camiones): min=0 acepta cold starts de 5-10s tras
+  # inactividad a cambio de ~CLP 50k/mes. Volver a 1 al firmar B2B con SLA.
+  # Ver .specs/cost-optimization-precomercial.
+  min_instances = 0
   max_instances = 20
   cpu           = "1"
   memory        = "1Gi"

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -117,7 +117,7 @@ resource "google_sql_database_instance" "main" {
   settings {
     tier              = var.cloudsql_tier
     edition           = "ENTERPRISE" # ENTERPRISE_PLUS requiere tiers dedicados (db-perf-optimized-*); ENTERPRISE es el default comercial.
-    availability_type = var.environment == "prod" ? "REGIONAL" : "ZONAL"
+    availability_type = var.cloudsql_high_availability ? "REGIONAL" : "ZONAL"
     disk_type         = "PD_SSD"
     disk_size         = 50 # GB inicial
     disk_autoresize   = true
@@ -163,22 +163,16 @@ resource "google_sql_database_instance" "main" {
       value = "on"
     }
     database_flags {
-      name  = "log_connections"
-      value = "on"
-    }
-    database_flags {
-      name  = "log_disconnections"
-      value = "on"
-    }
-    database_flags {
       name  = "log_lock_waits"
       value = "on"
     }
     database_flags {
-      # 0 = log todos los archivos temporales (consultas que spillan a disk).
-      # >0 = solo logs si tamano excede ese valor (en KB).
+      # -1 = desactivado (no loguea spills a disco). >0 = solo si el spill excede
+      # ese tamano (KB). Bajado de "0" (loguear TODO spill) a "-1" en pre-comercial
+      # por costo de Cloud Logging; subir a un umbral en KB para investigar spills.
+      # Ver .specs/cost-optimization-precomercial.
       name  = "log_temp_files"
-      value = "0"
+      value = "-1"
     }
 
     insights_config {

--- a/infrastructure/dr-region.tf
+++ b/infrastructure/dr-region.tf
@@ -16,6 +16,13 @@
 # SLA: contratos B2B grandes piden 99.9% uptime. Sin DR, una caída de
 # southamerica-west1 (hubo 1 en 2024 y 1 en 2025) tira el producto.
 # Con DR, la caída es transparente.
+#
+# ESTADO ACTUAL (ADR-058, 2026-06-05): DR en modo **cold** pre-comercial.
+# El gateway DR está escalado a 0 (ver k8s/telemetry-tcp-gateway-dr.yaml);
+# subnet/IP/DNS/cluster se conservan latentes acá para reactivar con
+# `terraform apply` + scale-up (RTO 15-40 min). NO hay failover automático
+# mientras no existan contratos B2B con SLA. Al firmar el primer SLA, revertir
+# (reactivar gateway + Cloud SQL REGIONAL + idealmente read-replica cross-region).
 
 # =============================================================================
 # GKE AUTOPILOT en DR region

--- a/infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
+++ b/infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
@@ -39,7 +39,10 @@ metadata:
     app: telemetry-tcp-gateway
     role: disaster-recovery
 spec:
-  replicas: 2
+  # DR "cold" pre-comercial: 0 pods corriendo. Reactivación = scale-up + apply
+  # (RTO 15-40 min, runbook). El cluster y la base de red DR siguen declarados
+  # (dr-region.tf, deletion_protection=true). Ver .specs/cost-optimization-precomercial.
+  replicas: 0
   selector:
     matchLabels:
       app: telemetry-tcp-gateway
@@ -187,23 +190,8 @@ spec:
       protocol: TCP
       port: 5061
       targetPort: teltonika-tls
----
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: telemetry-tcp-gateway
-  namespace: telemetry
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: telemetry-tcp-gateway
-  minReplicas: 2
-  maxReplicas: 20
-  metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        target:
-          type: Utilization
-          averageUtilization: 70
+# NOTA: el HorizontalPodAutoscaler del gateway DR se eliminó deliberadamente.
+# DR "cold" mantiene el Deployment en replicas: 0; un HPA estándar no admite
+# minReplicas: 0 (requiere HPAScaleToZero, no disponible en GKE Autopilot) y
+# pelearía por subir a 1, reactivando el gasto. Reactivar DR = recrear este HPA
+# + scale-up. Ver .specs/cost-optimization-precomercial.

--- a/infrastructure/k8s/telemetry-tcp-gateway.yaml
+++ b/infrastructure/k8s/telemetry-tcp-gateway.yaml
@@ -35,7 +35,7 @@ metadata:
   labels:
     app: telemetry-tcp-gateway
 spec:
-  replicas: 2 # HA — al menos 2 para rolling updates sin caída
+  replicas: 1 # pre-comercial (<=10 Teltonika); rolling update puede tener breve corte. Ver .specs/cost-optimization-precomercial
   selector:
     matchLabels:
       app: telemetry-tcp-gateway
@@ -245,7 +245,7 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: telemetry-tcp-gateway
-  minReplicas: 2
+  minReplicas: 1
   maxReplicas: 20
   metrics:
     - type: Resource

--- a/infrastructure/terraform.tfvars.example
+++ b/infrastructure/terraform.tfvars.example
@@ -50,8 +50,14 @@ github_repository = "boosterchile/booster-ai"
 cloudsql_tier                  = "db-custom-2-7680"
 cloudsql_backup_retention_days = 30
 
-# Memorystore Redis
-redis_tier      = "STANDARD_HA" # o "BASIC" para dev
+# Cloud SQL alta disponibilidad (ADR-058 pre-comercial):
+#   false = ZONAL  (single-zone, sin failover automático) — postura pre-comercial
+#   true  = REGIONAL (HA multi-zona con failover) — volver al firmar B2B con SLA
+cloudsql_high_availability = false
+
+# Memorystore Redis (ADR-058 pre-comercial): BASIC = single node, sin failover.
+# Volver a "STANDARD_HA" al firmar B2B con SLA de uptime.
+redis_tier      = "BASIC" # "STANDARD_HA" para HA con failover
 redis_memory_gb = 1
 
 # =============================================================================

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -155,13 +155,24 @@ variable "cloudsql_backup_retention_days" {
   default     = 30
 }
 
+variable "cloudsql_high_availability" {
+  description = "true = REGIONAL (HA con failover automático); false = ZONAL (single-zone)."
+  type        = bool
+  # Pre-comercial: ZONAL (sin standby; caída de zona = BD no disponible, RTO
+  # minutos-1h con backups + PITR). Volver a true al firmar B2B con SLA 99.9%.
+  # Ver .specs/cost-optimization-precomercial.
+  default = false
+}
+
 # -----------------------------------------------------------------------------
 # Memorystore Redis
 # -----------------------------------------------------------------------------
 variable "redis_tier" {
   description = "Redis tier: BASIC (single node) o STANDARD_HA (con failover)"
   type        = string
-  default     = "STANDARD_HA"
+  # Pre-comercial: BASIC (cache medido practicamente vacio). STANDARD_HA al
+  # firmar B2B con SLA. Ver .specs/cost-optimization-precomercial.
+  default = "BASIC"
 }
 
 variable "redis_memory_gb" {


### PR DESCRIPTION
## Qué y por qué

Reclasificación a **pre-comercial** (≤10 camiones, sin contratos B2B con SLA): habilita el right-sizing de disponibilidad que ADR-035 rechazaba bajo objetivo TRL 10. **[ADR-058](docs/adr/058-precomercial-rightsizing-disponibilidad-supersedes-035.md)** supersede ADR-035 (decisión PO 2026-06-05). Objetivo: ~CLP 774k → ~350–450k/mes.

> ⚠️ **Este PR solo aterriza CÓDIGO. No se aplica a prod acá.** Las palancas con downtime/recreación se aplican una por una (runbook abajo).

## Palancas

| # | Cambio | Archivo | Disponibilidad |
|---|---|---|---|
| A1 | Redis `STANDARD_HA`→`BASIC` | `variables.tf` + `terraform.tfvars.example` | ↓ failover |
| A2 | api `min_instances` 1→0 | `compute.tf` | ↓ cold starts |
| A3 | Cloud SQL logging (`log_temp_files` -1; quita conn/disconn) | `data.tf` | — |
| B1 | Gateway primary 2→1 | `k8s/telemetry-tcp-gateway.yaml` | ↓ redundancia |
| C1 | Gateway DR → 0 + HPA eliminado | `k8s/telemetry-tcp-gateway-dr.yaml` | ↓ failover regional |
| D | Cloud SQL `REGIONAL`→`ZONAL` (nueva var) | `variables.tf` + `data.tf` | ↓ failover BD |

A4 (no aceptar CUDs 3 años) = acción FinOps manual, no código.

## Evidencia

- **fmt/validate**: `terraform fmt -check -recursive` exit 0; `terraform validate` → `Success! The configuration is valid.`
- **plan** (post-reauth): **Cloud SQL = `~ update in-place`** (NO replace — criterio crítico de D cumplido); Redis = `replace` (esperado, recrea instancia); api + services = update in-place. Detalle y reconciliación de drift en [`verify.md`](.specs/cost-optimization-precomercial/verify.md).
- **manifiestos K8s**: validados — primary Deployment `replicas:1` + HPA `minReplicas:1`; DR Deployment `replicas:0`, HPA eliminado (4 objetos, era 5).
- **Review** (code-reviewer + devils-advocate): `REQUEST_CHANGES` inicial → resuelto. Ver [`review.md`](.specs/cost-optimization-precomercial/review.md) §Resolución.

### ADR compliance
- ✅ ADR-058 creado (supersede ADR-035, marcado Superseded). Riesgos de disponibilidad aceptados explícitamente por el PO.
- ✅ Defecto corregido: `terraform.tfvars.example` (trackeado) tenía `redis_tier=STANDARD_HA` que anulaba A1 — ahora `BASIC` + añadida `cloudsql_high_availability`.
- ✅ Reversión trackeada: [`_followups/revertir-ha-al-firmar-b2b-sla.md`](.specs/_followups/revertir-ha-al-firmar-b2b-sla.md).

## ⚠️ Apply — NO usar `terraform apply` completo

`terraform plan` arrastra **drift NO relacionado** (decomiso SEC-001 + downgrade IAM Owner `group:admins@`→`user:dev@`). **Un `apply` completo desmantelaría el control SEC-001 y cambiaría el Owner del proyecto.** Ver [`drift-findings.md`](.specs/cost-optimization-precomercial/drift-findings.md).

Aplicar **palanca por palanca con `-target` explícito**, en ventana baja, orden A3→A2→B1→C→A1→D:
- **A1 (Redis)**: recrea la instancia → Redis sostiene rate-limit **fail-closed** ⇒ `/auth/driver-activate` y signup darán **503** durante la recreación. Ventana baja real.
- **D (Cloud SQL)**: backup on-demand previo obligatorio; abortar si el plan muestra `replace`.
- **C1 (DR cold)**: el LB DR quedará sin backend sano (failover device a endpoint muerto hasta reactivación manual). Aceptado en ADR-058.

## Fuera de alcance (ramas/issues separados)
- Corrección `ship.md` + investigación drift SEC-001 → rama `docs/sec-001-post-ship-drift` (local) + `drift-issue-DRAFT.md`.
- IAM Owner drift → PR propio con revisor Owner del grupo `admins@`.
- `helloTest` Cloud Function huérfana → limpiar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)