### PR TITLE
feat(infra): DNS endpoint + pipelines CD del gateway primary (ADR-059); aplica B1/C

### DIFF
--- a/docs/adr/059-deploy-gateways-via-dns-endpoint-cloudbuild.md
+++ b/docs/adr/059-deploy-gateways-via-dns-endpoint-cloudbuild.md
@@ -1,0 +1,50 @@
+# ADR 059 — Deploy de los gateways de telemetría vía DNS-based control plane endpoint + Cloud Build pools
+
+**Estado**: Aceptado
+**Fecha**: 2026-06-06
+**Autor**: Felipe Vicencio (PO) + Claude
+**Relacionado**: ADR-005 (GKE para TCP), ADR-058 (pre-comercial), dr-region.tf (DR DNS endpoint, #194)
+
+---
+
+## Contexto
+
+Aplicar cambios K8s al gateway de telemetría (B1: primary 2→1, C: DR→cold, y deploys en general) reveló que **no existía una vía de acceso reproducible al cluster primario** `booster-ai-telemetry`:
+
+- `kubectl` directo desde laptop → timeout: el endpoint IP del master está protegido por `master_authorized_networks_config` + `privateEndpointEnforcement`, y la IP del operador no está en el allowlist.
+- Cloud Build pool (`booster-production-pool`) contra el endpoint **IP público** → timeout: el pool tiene `egressOption: PUBLIC_EGRESS`, así que sale por una IP NAT pública de Google que **no** está en el allowlist (y `gcpPublicCidrsAccessEnabled=false`). El rango de peering del pool sí está en el allowlist, pero no es la IP origen del egress público.
+- Cloud Build pool con `--internal-ip` (endpoint privado) → timeout: **VPC peering es no-transitivo** (pool ↔ booster-ai-vpc ↔ master no encadena).
+
+El cluster **DR** ya había resuelto esto el 2026-05-13 (issue #194) habilitando el **DNS-based control plane endpoint**. El primario no lo tenía.
+
+## Decisión
+
+Estandarizar el acceso a **ambos** clusters de telemetría vía el **DNS-based control plane endpoint** (`controlPlaneEndpointsConfig.dnsEndpointConfig.allowExternalTraffic = true`) + autorización por **IAM** (`roles/container.developer`):
+
+1. **Primary**: habilitar `allow_external_traffic = true` en `google_container_cluster.telemetry` (`infrastructure/compute.tf`). Aplicado 2026-06-06 vía `terraform apply -target` (in-place, sin downtime). El DR ya lo tenía (dr-region.tf).
+2. **kubectl** (laptop u operador) y **Cloud Build pools** acceden con `gcloud container clusters get-credentials ... --dns-endpoint`. No depende de red/VPC peering; la autorización es IAM. El endpoint IP + `master_authorized_networks` se conservan como capa adicional para quien esté en red autorizada.
+3. **Pipelines reproducibles** en `infrastructure/k8s/`:
+   - `cloudbuild-primary-deploy.yaml` + `cloudbuild-primary-check.yaml` (nuevos, espejo del DR), pool `booster-production-pool`, `--dns-endpoint`.
+   - `cloudbuild-dr-deploy.yaml` + `cloudbuild-dr-check.yaml` (existentes).
+4. **Deprecar** el deploy manual `kubectl` desde laptop (frágil por authorized networks). El `check.yaml` es gate no-mutante previo al deploy.
+
+## Consecuencias
+
+### Positivas
+- Acceso reproducible y auditable a ambos masters sin abrir el endpoint IP a internet ni montar túneles IAP.
+- El DNS endpoint cuesta ~$0/mes y funciona desde cualquier red (laptop, pool de cualquier región, Cloud Run jobs) con IAM.
+- Cierra el gap de CD del gateway primario (antes solo el DR tenía pipeline).
+
+### Negativas / notas
+- El acceso al master ahora depende también de IAM correcto (`container.developer`). Gobernar ese rol con cuidado (hoy: `github-deployer`; operadores vía membresía de grupo).
+- `master_authorized_networks_config` y el endpoint IP siguen declarados; no se removieron (defensa en profundidad).
+
+## Seguridad
+- NO se abrió `0.0.0.0/0` ni se tocó `master_authorized_networks_config`. El único cambio en el primary fue `dns_endpoint_config.allow_external_traffic`. El DNS endpoint exige IAM; no es acceso anónimo.
+- Sin relación con el drift SEC-001 / IAM Owner (esos van en flujo separado).
+
+## Referencias
+- `infrastructure/compute.tf` (cluster primary, `control_plane_endpoints_config`)
+- `infrastructure/dr-region.tf` (cluster DR, mismo bloque, #194)
+- `infrastructure/k8s/cloudbuild-primary-{deploy,check}.yaml`
+- ADR-058 (reclasificación pre-comercial, habilita B1/C)

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -652,6 +652,17 @@ resource "google_container_cluster" "telemetry" {
     }
   }
 
+  # DNS-based control plane endpoint (ADR-058 / CD del gateway). Habilita acceso
+  # al master via DNS + IAM (sin depender de red/VPC peering, que es no-transitivo
+  # entre el pool de Cloud Build y el master). Permite que el pool same-region y
+  # operadores con container.developer corran kubectl. master_authorized_networks
+  # (arriba) sigue protegiendo el endpoint IP; el DNS endpoint se gobierna por IAM.
+  control_plane_endpoints_config {
+    dns_endpoint_config {
+      allow_external_traffic = true
+    }
+  }
+
   private_cluster_config {
     enable_private_nodes    = true
     enable_private_endpoint = false

--- a/infrastructure/k8s/cloudbuild-primary-check.yaml
+++ b/infrastructure/k8s/cloudbuild-primary-check.yaml
@@ -1,0 +1,41 @@
+# Cloud Build pipeline minimal: verificar acceso al cluster PRIMARIO + estado
+# cert-manager. SOLO LECTURA — no aplica ningún manifest. Es el GATE del Paso 2:
+# si pasa, cloudbuild-primary-deploy.yaml tiene acceso para el deploy real.
+#
+# Run:
+#   gcloud builds submit --no-source \
+#     --config=infrastructure/k8s/cloudbuild-primary-check.yaml \
+#     --region=southamerica-west1 \
+#     --project=booster-ai-494222
+
+steps:
+- id: check
+  name: gcr.io/cloud-builders/kubectl
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -euxo pipefail
+    # SIN --internal-ip: endpoint público allowlisted para el pool saw1.
+    # Misma región pool/cluster, a diferencia del check DR (cross-region).
+    gcloud container clusters get-credentials booster-ai-telemetry \
+      --location=southamerica-west1 \
+      --project=booster-ai-494222
+    echo "--- nodes ---"
+    kubectl get nodes
+    echo "--- cert-manager status ---"
+    kubectl get ns cert-manager 2>&1 || echo "(cert-manager namespace NOT FOUND)"
+    kubectl get deployment -n cert-manager cert-manager 2>&1 || echo "(cert-manager deployment NOT FOUND)"
+    echo "--- existing namespaces ---"
+    kubectl get ns
+    echo "--- existing clusterissuers ---"
+    kubectl get clusterissuer 2>&1 || echo "(no clusterissuers)"
+    echo "--- telemetry workloads (estado actual del gateway) ---"
+    kubectl get deploy,svc -n telemetry 2>&1 || echo "(namespace telemetry NOT FOUND)"
+
+options:
+  pool:
+    name: projects/booster-ai-494222/locations/southamerica-west1/workerPools/booster-production-pool
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 300s

--- a/infrastructure/k8s/cloudbuild-primary-check.yaml
+++ b/infrastructure/k8s/cloudbuild-primary-check.yaml
@@ -16,11 +16,13 @@ steps:
   - -c
   - |
     set -euxo pipefail
-    # SIN --internal-ip: endpoint público allowlisted para el pool saw1.
-    # Misma región pool/cluster, a diferencia del check DR (cross-region).
+    # DNS-based control plane endpoint (--dns-endpoint): kubectl alcanza el master
+    # via DNS + IAM, sin depender de red/peering. El endpoint IP NO es alcanzable
+    # desde el pool. Requiere allow_external_traffic=true (compute.tf, ADR-059).
     gcloud container clusters get-credentials booster-ai-telemetry \
       --location=southamerica-west1 \
-      --project=booster-ai-494222
+      --project=booster-ai-494222 \
+      --dns-endpoint
     echo "--- nodes ---"
     kubectl get nodes
     echo "--- cert-manager status ---"

--- a/infrastructure/k8s/cloudbuild-primary-deploy.yaml
+++ b/infrastructure/k8s/cloudbuild-primary-deploy.yaml
@@ -3,12 +3,13 @@
 #
 # Por qué Cloud Build private worker pool y NO kubectl desde laptop:
 # El cluster primario tiene master_authorized_networks_config restringido
-# (privateEndpointEnforcement). El pool saw1 `booster-production-pool` YA ESTÁ
-# en la allowlist via `cloudbuild_pool_range` (ver infrastructure/compute.tf,
-# bloque master_authorized_networks_config del cluster booster-ai-telemetry).
-# A diferencia del DR, aquí pool y cluster están en la MISMA región (saw1),
-# así que NO aplica el límite cross-region documentado en el pipeline DR
-# (por eso NO usamos --internal-ip; vamos por el endpoint público allowlisted).
+# (privateEndpointEnforcement) y el endpoint IP NO es alcanzable desde el pool
+# (egress PUBLIC_EGRESS no está en el allowlist; VPC peering es no-transitivo
+# entre el pool y el master). Se usa el DNS-based control plane endpoint
+# (`--dns-endpoint`), habilitado en compute.tf via
+# control_plane_endpoints_config.dns_endpoint_config.allow_external_traffic=true
+# (ADR-059). kubectl alcanza el master via DNS + IAM (roles/container.developer),
+# sin depender de red/peering. Mismo mecanismo que el DR (ver dr-region.tf).
 #
 # Validar acceso ANTES con cloudbuild-primary-check.yaml (no mutante).
 #
@@ -37,7 +38,8 @@ steps:
     set -euxo pipefail
     gcloud container clusters get-credentials booster-ai-telemetry \
       --location=southamerica-west1 \
-      --project=booster-ai-494222
+      --project=booster-ai-494222 \
+      --dns-endpoint
     kubectl get nodes
 
 # ----------------------------------------------------------------------

--- a/infrastructure/k8s/cloudbuild-primary-deploy.yaml
+++ b/infrastructure/k8s/cloudbuild-primary-deploy.yaml
@@ -1,0 +1,155 @@
+# Cloud Build pipeline para deployar telemetry-tcp-gateway en el cluster
+# PRIMARIO (southamerica-west1). Espejo de cloudbuild-dr-deploy.yaml.
+#
+# Por qué Cloud Build private worker pool y NO kubectl desde laptop:
+# El cluster primario tiene master_authorized_networks_config restringido
+# (privateEndpointEnforcement). El pool saw1 `booster-production-pool` YA ESTÁ
+# en la allowlist via `cloudbuild_pool_range` (ver infrastructure/compute.tf,
+# bloque master_authorized_networks_config del cluster booster-ai-telemetry).
+# A diferencia del DR, aquí pool y cluster están en la MISMA región (saw1),
+# así que NO aplica el límite cross-region documentado en el pipeline DR
+# (por eso NO usamos --internal-ip; vamos por el endpoint público allowlisted).
+#
+# Validar acceso ANTES con cloudbuild-primary-check.yaml (no mutante).
+#
+# Run:
+#   gcloud builds submit --no-source \
+#     --config=infrastructure/k8s/cloudbuild-primary-deploy.yaml \
+#     --region=southamerica-west1 \
+#     --project=booster-ai-494222
+#
+# Pre-requisitos (idempotentes — el pipeline los verifica):
+#   - Imagen telemetry-tcp-gateway:bootstrap taggeada en Artifact Registry
+#   - cert-manager instalado en el cluster primario (si falta, install via helm)
+#   - ClusterIssuer letsencrypt-prod aplicado en el cluster primario
+
+steps:
+# ----------------------------------------------------------------------
+# 1. Get kubectl credentials del cluster primario (endpoint público
+#    allowlisted para el rango del pool saw1; misma región = sin cross-region)
+# ----------------------------------------------------------------------
+- id: get-credentials-primary
+  name: gcr.io/cloud-builders/kubectl
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -euxo pipefail
+    gcloud container clusters get-credentials booster-ai-telemetry \
+      --location=southamerica-west1 \
+      --project=booster-ai-494222
+    kubectl get nodes
+
+# ----------------------------------------------------------------------
+# 2. Verify cert-manager + install si falta (idempotente)
+# ----------------------------------------------------------------------
+- id: ensure-cert-manager
+  name: alpine/helm:3.16.3
+  entrypoint: sh
+  args:
+  - -c
+  - |
+    set -eux
+    cp -r /workspace/.kube ~/.kube 2>/dev/null || true
+    export KUBECONFIG=~/.kube/config
+
+    if kubectl get namespace cert-manager 2>/dev/null; then
+      echo "cert-manager namespace exists, checking deployment..."
+      if kubectl get deployment -n cert-manager cert-manager 2>/dev/null; then
+        echo "cert-manager already installed, skipping helm install"
+        exit 0
+      fi
+    fi
+
+    echo "Installing cert-manager via helm..."
+    helm repo add jetstack https://charts.jetstack.io
+    helm repo update
+    helm install cert-manager jetstack/cert-manager \
+      --namespace cert-manager --create-namespace \
+      --set crds.enabled=true \
+      --set serviceAccount.annotations."iam\.gke\.io/gcp-service-account"="cert-manager-cloud-dns@booster-ai-494222.iam.gserviceaccount.com" \
+      --wait --timeout=5m
+
+    kubectl annotate serviceaccount cert-manager \
+      --namespace cert-manager \
+      iam.gke.io/gcp-service-account=cert-manager-cloud-dns@booster-ai-494222.iam.gserviceaccount.com \
+      --overwrite
+
+# ----------------------------------------------------------------------
+# 3. Apply ClusterIssuer (letsencrypt-prod) — pre-req del Certificate
+# ----------------------------------------------------------------------
+- id: apply-issuers
+  name: gcr.io/cloud-builders/kubectl
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -euxo pipefail
+    kubectl apply -f infrastructure/k8s/cert-manager-issuers.yaml
+    for i in $$(seq 1 30); do
+      if kubectl get clusterissuer letsencrypt-prod -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' | grep -q True; then
+        echo "ClusterIssuer Ready"
+        break
+      fi
+      echo "Waiting for ClusterIssuer Ready... ($$i/30)"
+      sleep 5
+    done
+
+# ----------------------------------------------------------------------
+# 4. Apply Certificate (cert-primary.yaml) — cert-manager hace DNS-01 challenge
+# ----------------------------------------------------------------------
+- id: apply-cert-primary
+  name: gcr.io/cloud-builders/kubectl
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -euxo pipefail
+    kubectl create namespace telemetry --dry-run=client -o yaml | kubectl apply -f -
+    kubectl apply -f infrastructure/k8s/cert-primary.yaml
+    echo "Cert applied — DNS-01 challenge en curso (puede tomar ~2-5min)"
+
+# ----------------------------------------------------------------------
+# 5. Apply telemetry-tcp-gateway.yaml (Deployment + Service + SA)
+# ----------------------------------------------------------------------
+- id: apply-gateway-primary
+  name: gcr.io/cloud-builders/kubectl
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -euxo pipefail
+    kubectl apply -f infrastructure/k8s/telemetry-tcp-gateway.yaml
+    echo "Rollout watch (max 5min)..."
+    kubectl rollout status deployment/telemetry-tcp-gateway \
+      --namespace=telemetry --timeout=300s
+
+# ----------------------------------------------------------------------
+# 6. Verificar Service obtuvo el loadBalancerIP esperado del primario
+# ----------------------------------------------------------------------
+- id: verify-service
+  name: gcr.io/cloud-builders/kubectl
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -euxo pipefail
+    for i in $$(seq 1 30); do
+      IP=$$(kubectl get svc -n telemetry telemetry-tcp-gateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+      if [ "$$IP" = "34.176.238.106" ]; then
+        echo "Service LoadBalancer IP correcto: $$IP"
+        break
+      fi
+      echo "Waiting for LoadBalancer IP... current=$$IP expected=34.176.238.106 ($$i/30)"
+      sleep 10
+    done
+    kubectl get pods,svc,certificate -n telemetry
+
+options:
+  # Worker pool saw1 (MISMA región que el cluster primario). Allowlisted en
+  # master_authorized_networks_config del cluster via cloudbuild_pool_range.
+  pool:
+    name: projects/booster-ai-494222/locations/southamerica-west1/workerPools/booster-production-pool
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 900s


### PR DESCRIPTION
## Qué y por qué

Cierra el gap de acceso/CD a los clusters de telemetría y **aplica las palancas de costo B1 y C** (ADR-058 pre-comercial).

El cluster primario no tenía vía de acceso reproducible: el endpoint IP no es alcanzable ni desde laptop ni desde el pool de Cloud Build (`PUBLIC_EGRESS` no allowlisted; VPC peering no-transitivo pool↔master). Solución (ADR-059): habilitar el **DNS-based control plane endpoint** + IAM, igual que ya hacía el DR (#194).

## Cambios
- `compute.tf`: `control_plane_endpoints_config.dns_endpoint_config.allow_external_traffic=true` en `google_container_cluster.telemetry`.
- `k8s/cloudbuild-primary-deploy.yaml` + `cloudbuild-primary-check.yaml`: pipelines espejo del DR, pool `booster-production-pool`, `--dns-endpoint`. `check` es gate no-mutante.
- `docs/adr/059-*.md`: documenta el patrón; depreca el kubectl manual desde laptop.

## Evidencia

**Opción A (DNS endpoint primary)** — `terraform apply -target=google_container_cluster.telemetry`:
```
Plan: 0 to add, 1 to change, 0 to destroy.
~ dns_endpoint_config { allow_external_traffic = false -> true }
Apply complete! Resources: 0 added, 1 changed, 0 destroyed.
```
Verificado en prod: `allowExternalTraffic=True`. Solo ese campo; sin SEC-001/IAM/replace.

**Gate (acceso)** — `kubectl --dns-endpoint` alcanza el master ✅.

**B1 — gateway primary 2→1** (kubectl vía DNS, scale+patch targeteado):
```
deployment.apps/telemetry-tcp-gateway   1/1   ...
hpa telemetry-tcp-gateway   MINPODS 1   REPLICAS 1
```

**C — DR → cold** (DR ya tenía DNS endpoint, #194):
```
deployment telemetry-tcp-gateway   0/0
hpa telemetry-tcp-gateway   NotFound (eliminado)
```

## Guardas respetadas
- NO se tocó `master_authorized_networks_config`, ni SEC-001, ni IAM Owner. Único cambio en el cluster: `allow_external_traffic`.
- terraform apply siempre con `-target`. Manifiestos B1/C aplicados con cambios mínimos (scale/patch/delete), sin barrer drift.
- DNS endpoint exige IAM (`container.developer`); no es acceso anónimo.

## Estado de palancas de costo
✅ A3, A2 (PR #406, aplicadas) · ✅ **B1, C (este PR, aplicadas a clusters)** · ⬜ A1 (Redis) y D (Cloud SQL) — Terraform, requieren ventana + OK del PO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)