### PR TITLE
ci(infra): SA dedicado read-only para el drift check (opción C, #412)

### DIFF
--- a/.github/workflows/terraform-drift.yml
+++ b/.github/workflows/terraform-drift.yml
@@ -6,23 +6,20 @@
 # `terraform plan -detailed-exitcode` periódicamente y FALLA si hay drift (exit 2),
 # para que aparezca en la pestaña Actions / notificaciones.
 #
-# ── PREREQUISITOS ──
-#  1. Repo VARIABLES ya existentes (las usa release.yml): vars.WIF_PROVIDER,
-#     vars.WIF_SERVICE_ACCOUNT_DEPLOY.  ✅
-#  2. ⬜ PENDIENTE (única acción manual restante): crear la repo variable
-#     vars.TF_BILLING_ACCOUNT = el billing account ID (única var sin default en
-#     variables.tf). Settings → Secrets and variables → Actions → Variables.
-#     (No es secreto sensible; se deja como var para no hardcodearlo.)
-#  3. ✅ PERMISOS de lectura: `roles/viewer` otorgado a github-deployer vía
-#     iam.tf (github_deployer_roles) — un `terraform plan` refresca TODOS los
-#     recursos. Aplicado 2026-06-06.
-#  4. ✅ RUIDO perpetuo resuelto: el plan completo da "No changes" tras declarar
-#     multi_tenant/phone_number en identity-platform.tf y ignore_changes del
-#     dashboard_json en telemetry-monitoring.tf. Baseline limpio = el check
-#     solo dispara ante drift REAL.
+# ── SETUP (todo en código/IaC; sin pasos manuales pendientes) ──
+#  - Auth: WIF (vars.WIF_PROVIDER, ya existente) impersonando un SA dedicado
+#    READ-ONLY `terraform-drift@` (iam.tf): roles/viewer + un custom role acotado
+#    (redis.getAuthString + iap.getIamPolicy, los 2 reads que viewer no incluye y
+#    que un plan completo necesita). NO se le da write. Email hardcodeado abajo
+#    (no es secreto). El binding workloadIdentityUser lo limita a este repo.
+#  - billing_account: `var.billing_account` es opcional para el check — el
+#    proyecto lo tiene en `ignore_changes` (project.tf), así que si la var está
+#    vacía no genera falso diff ni intenta desvincular billing.
+#  - Ruido perpetuo: resuelto (multi_tenant/phone_number declarados en
+#    identity-platform.tf + ignore_changes del dashboard_json). Plan = "No changes".
 #
-# Una vez creada vars.TF_BILLING_ACCOUNT (paso 2), este workflow corre verde
-# (estado actual: plan = "No changes"). Validar con un workflow_dispatch manual.
+# Estado: una vez aplicado el IaC del SA drift (iam.tf), el check corre verde
+# (plan = "No changes"). Disparable por cron diario o workflow_dispatch.
 
 name: Terraform Drift Check
 
@@ -49,7 +46,8 @@ jobs:
         uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ vars.WIF_PROVIDER }}
-          service_account: ${{ vars.WIF_SERVICE_ACCOUNT_DEPLOY }}
+          # SA dedicado read-only (iam.tf). Hardcodeado: un email de SA no es secreto.
+          service_account: terraform-drift@booster-ai-494222.iam.gserviceaccount.com
 
       - name: Setup gcloud
         uses: google-github-actions/setup-gcloud@v3

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -184,7 +184,6 @@ locals {
     "roles/container.developer",               # Deploy a GKE (telemetry gateway)
     "roles/logging.viewer",                    # Leer logs de Cloud Build (gcloud builds submit los streamea)
     "roles/logging.logWriter",                 # Escribir logs del build a Cloud Logging
-    "roles/viewer",                            # Drift check CI (#412): `terraform plan` refresca TODOS los recursos → read-only project-wide. Trade-off aceptado: el deploy SA gana lectura amplia (ya tiene write potente via run.admin/storage.admin).
     # SEC-001 boundary-closure T10 (SC-G7): `roles/cloudfunctions.viewer`
     # REMOVIDO — existía solo para el workflow sprint-2c-b-deploy-gate.yml
     # (gcloud functions describe beforeCreate), decomisado con la blocking
@@ -309,6 +308,68 @@ resource "google_iam_workload_identity_pool_provider" "github" {
 # Permitir que el WIF del repo asuma la identidad del github-deployer SA
 resource "google_service_account_iam_member" "wif_to_deployer" {
   service_account_id = google_service_account.github_deployer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repository}"
+}
+
+# -----------------------------------------------------------------------------
+# Terraform drift check — SA dedicado READ-ONLY (#412, issue #410 remediación #4)
+# -----------------------------------------------------------------------------
+# Least-privilege: corre `terraform plan -detailed-exitcode` en el workflow
+# terraform-drift.yml. NO se le da write. roles/viewer cubre la mayoría de los
+# reads; los 2 que viewer NO incluye (redis auth_string e IAP IAM policy) van en
+# un custom role acotado en vez de redis.editor/iap.admin (que darían write).
+resource "google_service_account" "terraform_drift" {
+  account_id   = "terraform-drift"
+  display_name = "Terraform drift check (read-only, #412)"
+  project      = google_project.booster_ai.project_id
+}
+
+resource "google_project_iam_custom_role" "drift_extra_reads" {
+  role_id     = "driftExtraReads"
+  title       = "Terraform Drift — extra reads"
+  description = "Reads sensibles que los roles read-only no incluyen, para refrescar el plan completo (drift check)."
+  project     = google_project.booster_ai.project_id
+  permissions = [
+    "redis.instances.getAuthString",    # refresca google_redis_instance.auth_string (no está en ningún rol read-only)
+    "iap.tunnelInstances.getIamPolicy", # refresca google_iap_tunnel_instance_iam_member (redundante con securityReviewer, defensivo)
+    "storage.buckets.getIamPolicy",     # refresca google_storage_bucket_iam_member (securityReviewer NO lo cubre para GCS)
+  ]
+}
+
+# Roles read-only del SA drift. Un `terraform plan` completo necesita:
+#   - viewer: get/list de recursos
+#   - iam.securityReviewer: *.getIamPolicy (buckets, SAs, iap, pubsub, kms, ...)
+#   - serviceusage.serviceUsageConsumer: serviceusage.services.use (API calls)
+# Ninguno otorga write.
+resource "google_project_iam_member" "terraform_drift_read_roles" {
+  for_each = toset([
+    "roles/viewer",
+    "roles/iam.securityReviewer",
+    "roles/serviceusage.serviceUsageConsumer",
+  ])
+  project = google_project.booster_ai.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.terraform_drift.email}"
+}
+
+resource "google_project_iam_member" "terraform_drift_extra_reads" {
+  project = google_project.booster_ai.project_id
+  role    = google_project_iam_custom_role.drift_extra_reads.id
+  member  = "serviceAccount:${google_service_account.terraform_drift.email}"
+}
+
+# Lectura del state remoto (backend GCS)
+resource "google_storage_bucket_iam_member" "terraform_drift_state" {
+  bucket = "booster-ai-tfstate-494222"
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.terraform_drift.email}"
+}
+
+# GitHub Actions del repo puede impersonar el drift SA via WIF (mismo principalSet
+# que el deployer, restringido al repo por attribute_condition del provider).
+resource "google_service_account_iam_member" "wif_to_drift" {
+  service_account_id = google_service_account.terraform_drift.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repository}"
 }

--- a/infrastructure/project.tf
+++ b/infrastructure/project.tf
@@ -31,7 +31,10 @@ resource "google_project" "booster_ai" {
     prevent_destroy = true
     # auto_create_network es CREATE-time only — no aplicar drift
     # post-creacion. Trivy ve el atributo en codigo (alert closes).
-    ignore_changes = [auto_create_network]
+    # billing_account: gestionado una sola vez; se ignora para (a) que el drift
+    # check (#412) no falsee si var.billing_account no se provee, y (b) evitar el
+    # footgun de que una var vacía intente DESVINCULAR billing del proyecto.
+    ignore_changes = [auto_create_network, billing_account]
   }
 }
 


### PR DESCRIPTION
Implementa la **opción C** (SA dedicado reader) para el drift check de #412, reemplazando el enfoque previo de darle `roles/viewer` al deploy SA. **Validado impersonando el SA: `terraform plan` completo = `No changes` (exit 0 = verde).**

## Cambios
- **`iam.tf`**: revierte `roles/viewer` del `github-deployer`; crea `terraform-drift@` (read-only) + WIF binding (mismo principalSet del repo) con roles:
  - `roles/viewer`, `roles/iam.securityReviewer` (`*.getIamPolicy`), `roles/serviceusage.serviceUsageConsumer`
  - custom role `driftExtraReads`: `redis.instances.getAuthString`, `iap.tunnelInstances.getIamPolicy`, `storage.buckets.getIamPolicy` (los reads que ningún rol read-only cubre). **Sin write.**
- **`project.tf`**: `ignore_changes=[billing_account]` — el check no falsea si la var está vacía y elimina el footgun de desvincular billing.
- **`terraform-drift.yml`**: usa el SA dedicado (email hardcodeado, no secreto); `TF_BILLING_ACCOUNT` ahora opcional.

## Validación (impersonación local del SA)
Iterando con el SA real se descubrieron y cerraron los gaps de permisos que un viewer puro no cubre (serviceusage.use, iap/storage/redis getIamPolicy+getAuthString). Resultado final:
```
terraform plan -lock=false -detailed-exitcode  (como terraform-drift@)
→ No changes. Your infrastructure matches the configuration.  (exit 0)
```

Aplicado a prod 2026-06-06 (SA + roles + custom role; viewer del deployer revocado). Tras mergear, el workflow corre verde por cron o `workflow_dispatch`.

Refs #410, #412.

🤖 Generated with [Claude Code](https://claude.com/claude-code)