### PR TITLE
ci(release): no disparar deploy en pushes docs-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,17 @@ name: Release + Deploy
 on:
   push:
     branches: [main]
+    # Pushes docs-only NO disparan deploy (era no-op + ensuciaba la lane de
+    # concurrency). Denylist: lo NO listado siempre despliega (falla seguro).
+    # NO agregar '**/*.md' acá: matchearía .changeset/*.md y rompería el
+    # release de versiones. '*.md' (un solo '*') es root-only. Ver
+    # .specs/ci-release-skip-docs-only/spec.md (R1/SC-3).
+    paths-ignore:
+      - 'docs/**'
+      - '.specs/**'
+      - 'references/**'
+      - 'playbooks/**'
+      - '*.md'
 
 concurrency:
   group: release-${{ github.workflow }}-main

--- a/.specs/_followups/verify-release-paths-ignore-post-merge.md
+++ b/.specs/_followups/verify-release-paths-ignore-post-merge.md
@@ -1,0 +1,29 @@
+# Follow-up — Verificar `release.yml paths-ignore` post-merge (V4)
+
+**Origen**: `.specs/ci-release-skip-docs-only/` (DA P2-4)
+**Prioridad**: P2 (verificación observacional, no bloqueante)
+**Owner**: PO (Felipe)
+**Creado**: 2026-06-06
+
+## Qué verificar
+
+Tras mergear el cambio de `paths-ignore` en `release.yml` (PR de la rama `ci/release-skip-docs-only`), confirmar empíricamente en GitHub Actions:
+
+1. **SC-1**: el **primer PR docs-only** mergeado a `main` después de este cambio **NO** crea un run de `Release + Deploy`. (Candidato natural: el próximo `docs(handoff): CURRENT.md ...`.)
+2. **SC-2**: el **primer PR con código** mergeado después **SÍ** crea el run y despliega normal.
+
+## Cómo
+
+```bash
+# tras un merge docs-only:
+gh run list --workflow=release.yml --limit 3 --json headSha,event,createdAt,displayTitle
+# esperado: NO aparece un run nuevo para el commit docs-only
+```
+
+## Condición de cierre
+
+Ambas observaciones confirmadas (1 docs-only sin run + 1 con-código con run). Anotar en este archivo y cerrar.
+
+## Disparador de escalación
+
+Si un PR **con código** NO dispara release (SC-2 roto) → P0: revertir el `paths-ignore` de inmediato (`git revert`), un deploy real se estaría omitiendo silenciosamente.

--- a/.specs/ci-release-skip-docs-only/review.md
+++ b/.specs/ci-release-skip-docs-only/review.md
@@ -1,0 +1,50 @@
+# Devils-advocate review — ci-release-skip-docs-only — 2026-06-06T00:00:00Z
+
+## Premise
+- Asumido: que el deploy de produccion se origina SIEMPRE desde un push con archivos de codigo/infra "no-docs". Si esa premisa falla, el filtro silencia un deploy real.
+- Asumido: que el run docs-only es "no-op". Pero el job `version-or-publish` NO es no-op para docs: corre `changeset publish` y puede publicar paquetes con changesets pendientes acumulados.
+- Mas doloroso si es falso: el caso del PR "Version Packages" de Changesets (ver Failure modes F1). Ese merge puede tocar solo `package.json` + `CHANGELOG.md` + borrado de `.changeset/*.md`.
+
+## Scope and second-order effects
+- El filtro mata el workflow COMPLETO, no solo `deploy-production`. Eso incluye `version-or-publish`. Consecuencia no consultada: si alguien acumula changesets y luego hace un push docs-only encima de un estado con changesets pendientes, ese push no avanza el pipeline de publish. (Atenuado: un push con changeset toca `.changeset/*.md` que NO esta ignorado; pero ver F1 sobre el flujo de 2 fases.)
+- Hyrum's Law: hoy algo puede depender de que "todo merge a main produce un run de release.yml" como senal observable (badge, auditoria de compliance, "cada cambio a prod tiene un run"). Tras el cambio, los merges docs-only desaparecen del historial de Actions. Para un repo con objetivo TRL 10 / compliance, perder la traza "este merge no toco prod" puede importar. No se documento.
+- `.github/workflows/*.yml` NO esta en la denylist: un push que solo edita workflows dispara release. Correcto (falla seguro), pero significa que editar este mismo archivo dispara un deploy real no-op. No mencionado.
+
+## Alternatives discarded
+- Considerado en spec: `paths` allowlist (rechazado por riesgo de olvido que produciria el fallo peligroso). Rechazo bien fundado y documentado. Direccion correcta.
+- NO considerado (debio serlo): filtro a nivel de JOB (`if:` sobre `deploy-production`) en vez de workflow-level paths-ignore. Diferencia material: con `if:` el run SI aparece en Actions (traza de compliance preservada) y `version-or-publish` siempre corre (Changesets nunca se salta), mientras `deploy-production` se skipea condicionalmente. paths-ignore sacrifica ambas cosas. El spec descarta job-level diciendo "es la unica forma soportada por GitHub para paths-ignore": eso es un strawman. La alternativa real no es job-level paths-ignore, es job-level `if` alimentado por `dorny/paths-filter` o `tj-actions/changed-files`. No fue evaluada.
+- NO considerado: guard explicito via mensaje de commit. Menor, pero es alternativa.
+
+## Failure modes
+- F1 (CRITICO conceptual, OK en estado actual): Changesets opera en dos fases. Fase A: merge de feature (codigo + `.changeset/x.md`) dispara release y la action crea/actualiza el PR "chore(release): version packages" (NO publica). Fase B: merge de ESE PR de version a main debe disparar release de nuevo para que `changeset publish` corra. El diff del PR de version contiene `package.json`, `**/package.json`, `**/CHANGELOG.md` y el borrado de `.changeset/x.md`. Verifique: `.changeset/config.json` tiene `"commit": false`, asi que el bot NO auto-commitea; el merge es manual (squash). Ese squash toca `package.json` (no ignorado), por lo que SI dispara. Hoy funciona. Riesgo residual: la matriz de verify.md NO incluye el caso "merge del PR Version Packages", que es el path por el cual se publica. Si en el futuro los CHANGELOG generados se reubicaran a una ruta ignorada se romperia silenciosamente. Deteccion: ninguna automatica; se notaria cuando un consumidor falle por paquete no publicado.
+- F2 (push directo a main): la doc de GitHub indica que para pushes a branches existentes el filtro usa diff head-vs-base de los SHAs del push. Con squash merge (1 commit) es seguro. Pero `git log` muestra commits directos a main sin numero de PR (`b6132d4 chore(ci): bump release NODE_VERSION`, `5c8c00b`, etc.), lo que sugiere pushes directos fuera del flujo squash-PR. Un push directo docs-only a main ahora NO se registra como run. Deteccion: ninguna. Riesgo bajo, pero contradice el supuesto R3 "squash merge = 1 commit con el diff completo".
+- F3 (perdida de heartbeat): hoy un merge docs-only fuerza un re-deploy que reejecuta canary + smoke test, actuando como heartbeat accidental de que prod responde. Tras el cambio se pierde. No es funcion disenada; alguien podria depender de ella. Cost: bajo. Deteccion: ninguna.
+
+## Reversibility
+- Costo de deshacer en 30 dias: trivial. Borrar el bloque `paths-ignore` (6 lineas) y commitear. Sin migracion, sin estado persistente, sin flag necesario.
+- Mecanismo de reversa: revert del commit. De los cambios mas reversibles posibles. Mayor fortaleza del cambio.
+
+## Drift signals
+- Comentario preexistente sobre el job deploy-staging (linea 72): fuera de este cambio, no objetable aqui.
+- El spec usa "Bajo/nulo" en R3. "nulo" es una afirmacion de certeza no justificada: F2 muestra que NO es nulo si hay pushes directos a main. Reclasificar R3 a "Bajo, asume 100% squash-PR".
+- No hay marcadores de deuda sin ticket en el cambio. V4 queda como verificacion observacional post-merge: aceptable por su naturaleza, pero NO hay issue ni owner que la fuerce. Un V4 sin owner es un control latente que nadie ejecutara.
+
+## Evidence quality
+- Claim "`*.md` no matchea `.changeset/*.md`" -> Evidence: doc oficial GitHub confirma que `*` no cruza `/`; verifique que `.changeset/` contiene README.md+config.json y los changesets viven en `.changeset/<nombre>.md` (un nivel de dir) -> SUFICIENTE. SC-3 sostiene.
+- Claim "es no-op" -> Evidence: ninguna sobre `version-or-publish`. Verifique que hoy no hay changesets pendientes ni CHANGELOG.md generado, o sea el pipeline de publish probablemente nunca se ejercio -> DEBIL. "no-op" se sostiene por estado actual accidental, no por diseno.
+- Claim "ningun paso de build consume docs/**, *.md root" -> Evidence: grepe referencias a README/CLAUDE/AGENTS.md; todas son comentarios, ninguna es input de build -> SUFICIENTE.
+- Claim SC-4 "no altera required checks" -> Evidence: confirme que el required check es `CI Success` de ci.yml (linea 225); release.yml no expone checks required; ci.yml tiene su propio trigger sin paths-ignore -> SUFICIENTE. SC-4 sostiene.
+- Claim "4/5 runs docs-only" -> Evidence: cita run IDs pero no los verifique contra la API de Actions -> DEBIL pero plausible, no load-bearing.
+
+## Verdict
+- Veredicto: APPROVE_WITH_RESERVATIONS.
+- Objeciones fuertes (atender o documentar como riesgo aceptado):
+  1. [P1] La alternativa real (job-level `if:` con changed-files) NO fue evaluada; preserva traza en Actions y nunca salta Changesets. El spec la descarto con un strawman. Documentar por que workflow-level gana pese a sacrificar traza de compliance + ejecucion incondicional de Changesets.
+  2. [P1] El caso "merge del PR Version Packages" (flujo 2 fases) NO esta en la matriz de verify.md. Es el path por el que se publica. Agregar fila.
+  3. [P2] R3: "nulo" es falso si existen pushes directos docs-only a main (git log sugiere que ocurren). Cambiar a "Bajo, asume squash-PR".
+  4. [P2] V4 sin owner/ticket: nadie esta obligado a verificar post-merge que un PR con codigo si disparo. Crear follow-up.
+- Riesgos residuales (aceptar y documentar):
+  - Perdida de la traza "cada merge a main tiene un run de release" (compliance TRL 10).
+  - Perdida del heartbeat accidental de prod en merges docs-only.
+- Fuera de alcance: `cancel-in-progress:false`, canary placeholder (`exit 0`), gate de approval (preexistentes).
+- NO hay objecion P0 bloqueante: la direccion (denylist falla-seguro) es correcta, el glob es correcto, SC-4 sostiene, y el cambio es trivialmente reversible.

--- a/.specs/ci-release-skip-docs-only/spec.md
+++ b/.specs/ci-release-skip-docs-only/spec.md
@@ -1,0 +1,100 @@
+# Spec — `release.yml` no dispara en pushes docs-only
+
+**Feature slug**: `ci-release-skip-docs-only`
+**Estado**: Draft
+**Fecha**: 2026-06-06
+**Autor**: Claude (agente) + Felipe Vicencio (PO)
+**Tipo**: cambio de CI/CD (archivo sensible `.github/workflows/release.yml` — requiere justificación per CLAUDE.md §"Qué archivos NUNCA toco sin permiso explícito")
+
+---
+
+## 1. Objetivo
+
+Evitar que un push a `main` que **solo** toca documentación dispare el workflow `Release + Deploy` (`release.yml`), que ejecuta el deploy de producción a GCP.
+
+## 2. Por qué ahora
+
+`release.yml` corre en **todo** push a `main` (`on.push.branches: [main]`, sin filtro de paths). El merge de PRs docs-only — por ejemplo el handoff `docs/handoff/CURRENT.md` (#414) o el análisis de drift (#410/#411) — dispara un run de release/deploy que:
+
+- Es un **no-op**: no hay imagen nueva ni código; el deploy redeploya la misma imagen.
+- Frecuentemente queda **`pending` con 0 jobs** por cola de runners / incidentes de GitHub Actions (observado empíricamente en runs `27073359900` del #413 y `27075451377` del #414, ambos docs-only).
+- Ensucia la **lane de concurrency** (`concurrency.cancel-in-progress: false` → los runs se encolan): un run docs-only colgado puede bloquear el siguiente deploy **real**.
+- No es accionable por el agente (cancelar da HTTP 403; requiere intervención humana en la UI).
+
+Evidencia de frecuencia: de los últimos 5 runs de `release.yml` (2026-06-06), **4 fueron de commits docs-only o infra-doc** (`docs(...)`, `ci(infra)`), todos no-op respecto al binario desplegado.
+
+## 3. Criterios de éxito
+
+- **SC-1**: Un push a `main` cuyo diff toca **exclusivamente** rutas de documentación NO dispara `release.yml` (0 runs creados).
+- **SC-2**: Un push a `main` que toca **cualquier** archivo fuera de las rutas de documentación SÍ dispara `release.yml` (comportamiento actual preservado).
+- **SC-3**: Un push que toca un archivo de Changesets (`.changeset/*.md`) SÍ dispara `release.yml`, aunque sea `.md` y aunque venga junto a docs (el release de versiones no se rompe).
+- **SC-4**: El cambio no altera ningún **required status check** de la branch protection de `main` (`release.yml` no es required; los gates de merge — `CI Success` de `ci.yml` — quedan intactos).
+
+## 4. Comportamiento visible
+
+Cambio en `release.yml`:
+
+```yaml
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '.specs/**'
+      - 'references/**'
+      - 'playbooks/**'
+      - '*.md'            # markdown de root (README, CLAUDE, AGENTS) — un solo '*' NO matchea .changeset/*.md
+```
+
+Semántica de GitHub Actions: el workflow se **omite** únicamente si **todos** los archivos del push matchean algún patrón de `paths-ignore`. Si **cualquier** archivo queda fuera (código, infra, `.changeset/**`, `package.json`, lockfiles…), el workflow corre normal.
+
+## 5. Boundaries técnicos
+
+- Se usa `paths-ignore` (denylist), **no** `paths` (allowlist). Razón: una allowlist obligaría a enumerar **todo** lo deployable (apps/**, packages/**, infrastructure/**, cloudbuild*.yaml, Dockerfiles, lockfiles…) y un olvido produciría el fallo peligroso (deploy real omitido). La denylist falla del lado seguro: lo no enumerado **siempre** despliega.
+
+### 5.1 Alternativa considerada: filtro job-level (`if:` + changed-files)
+
+`paths-ignore` opera a **nivel `on.push`** (mata el workflow completo para pushes docs-only, incluido el job `version-or-publish` de Changesets). La alternativa real **no** es "paths-ignore a nivel job" (no existe), sino un condicional `if:` sobre el job `deploy-production`, alimentado por una action de detección de cambios (`dorny/paths-filter`). Esa opción **preservaría** dos cosas que `paths-ignore` sacrifica:
+
+- (a) el run **sigue apareciendo** en Actions aun para docs-only → traza "cada merge a main tiene un run de release" (relevante para compliance TRL 10);
+- (b) `version-or-publish` (Changesets) **corre incondicionalmente**.
+
+**Por qué se elige igual el `paths-ignore` workflow-level:**
+
+1. **Cero dependencias de terceros.** El job-level requiere una action externa de detección de cambios → superficie supply-chain adicional en el camino de deploy de producción (no aceptable sin ADR; `tj-actions/changed-files` sufrió un compromiso de supply-chain en 2025). `paths-ignore` es sintaxis nativa de GitHub.
+2. **Simplicidad y reversibilidad.** 6 líneas declarativas vs. un job condicional + checkout + step de detección.
+3. **La traza no se pierde de verdad.** "Cada merge a main" queda en `git log main` y en el PR mismo; el run de release no es la única fuente. El heartbeat de prod (smoke test) se obtiene del deploy check programado/cron, no de re-desplegar imágenes idénticas.
+4. **El job Changesets para docs-only es no-op por diseño esperado** (un cambio docs no genera `.changeset/*.md`); no perder ese run no tiene costo operativo.
+
+Trade-off aceptado por el PO en este spec: ver §7 riesgos residuales. Si el PO prioriza la traza de compliance sobre la simplicidad, el enfoque job-level queda documentado acá como pivote disponible (requeriría su propio ADR por la dependencia de terceros).
+
+## 6. Fuera de alcance
+
+- Cambiar `concurrency` o la política `cancel-in-progress` de `release.yml`.
+- Filtrar `ci.yml`, `security.yml` u otros workflows (este spec es solo `release.yml`).
+- Tocar el gate de aprobación del Environment `production`.
+- Resolver el run `27075451377` ya colgado (decisión humana, fuera de este cambio).
+
+## 7. Riesgos y mitigaciones
+
+| # | Riesgo | Severidad | Mitigación |
+|---|---|---|---|
+| R1 | Un glob `**/*.md` ingenuo ignoraría `.changeset/*.md` → un release de versiones legítimo no correría | **Alto** | **NO se usa `**/*.md`.** Se enumeran directorios de docs + `*.md` (un solo `*`, solo root). `.changeset/` nunca está en la lista → SC-3. |
+| R2 | Un futuro archivo deployable cae bajo una ruta ignorada (p.ej. un `.md` en root que el build consume) | Bajo | Denylist conservadora; ningún paso de build consume `docs/**`, `.specs/**`, `references/**`, `playbooks/**` ni markdown de root. Si algo cambia, el default (no listado) despliega. |
+| R3 | Un PR mezcla docs + código pero el merge squash "parece" docs | **Bajo (asume squash-PR)** | GitHub evalúa **todos** los archivos del push; basta un archivo de código para disparar. Squash merge = 1 commit con el diff completo. **Caveat (DA P2-3)**: el `git log` de main muestra **commits directos sin PR** (p.ej. `b6132d4 chore(ci): bump release NODE_VERSION`). Un push directo docs-only a main tampoco generará run — esperado, pero no es "nulo": depende de la disciplina squash-PR. |
+| R4 | Alguien asume que docs-only "se desplegó" | Bajo | Es exactamente lo deseado: docs no se despliegan. Documentado en comentario inline del workflow. |
+| R5 | Pérdida de traza "cada merge a main → run de release" (compliance TRL 10) | **Residual aceptado** | La traza vive en `git log main` + el PR. Si el PO la requiere como run de Actions, pivotar al enfoque job-level (§5.1, requiere ADR). |
+| R6 | Pérdida del "heartbeat" accidental de prod (los merges docs-only hoy reejecutan canary + smoke test) | **Residual aceptado** | El smoke/health de prod debe venir de un check programado, no de re-desplegar imágenes idénticas. Fuera de alcance de este spec. |
+
+## 8. Lista de tests / verificación
+
+No hay test unitario para YAML de workflow. Verificación:
+
+- **V1 (sintaxis)**: el YAML parsea sin error (`python3 -c yaml.safe_load` o `actionlint` si está disponible).
+- **V2 (SC-3 razonado)**: confirmar que `.changeset/` no matchea ninguno de los patrones (`*.md` es root-only; los demás son directorios `docs/.specs/references/playbooks`).
+- **V3 (SC-1/SC-2 razonado)**: matriz de casos documentada en `verify.md` (docs-only → skip; código → run; mixto → run; changeset → run).
+- **V4 (post-merge, observacional)**: el primer PR docs-only tras el merge de este cambio NO crea un run de `release.yml`. El primer PR con código SÍ. (Se observa, no se ejecuta acá.)
+
+## 9. Decisiones abiertas
+
+Ninguna bloqueante. Lista de rutas en §4 propuesta como conservadora; el PO puede ampliar/reducir en review.

--- a/.specs/ci-release-skip-docs-only/verify.md
+++ b/.specs/ci-release-skip-docs-only/verify.md
@@ -1,0 +1,41 @@
+# Verify — `ci-release-skip-docs-only`
+
+**Fecha**: 2026-06-06
+
+## V1 — YAML válido
+
+`js-yaml@4.1.1` strict load de `.github/workflows/release.yml`:
+- `on.push.branches = ["main"]`
+- `on.push.paths-ignore = ["docs/**", ".specs/**", "references/**", "playbooks/**", "*.md"]`
+- `jobs = version-or-publish, deploy-production` (intactos)
+- ✓ parsea sin error.
+
+## V2 + V3 — Matriz de matching (SC-1/2/3)
+
+Simulación de la semántica GitHub (`**` cruza `/`, `*` no cruza `/`; el push se omite solo si **todos** los archivos matchean):
+
+| Archivo del push | Resultado | SC |
+|---|---|---|
+| `.changeset/cool-cats.md` | **DISPARA release** | SC-3 ✓ |
+| `.changeset/config.json` | DISPARA release | SC-3 ✓ |
+| `docs/handoff/CURRENT.md` | ignorado (`docs/**`) | SC-1 ✓ |
+| `.specs/x/spec.md` | ignorado (`.specs/**`) | SC-1 ✓ |
+| `README.md`, `CLAUDE.md` | ignorado (`*.md` root-only) | SC-1 ✓ |
+| `apps/api/src/index.ts` | DISPARA release | SC-2 ✓ |
+| `package.json`, `pnpm-lock.yaml` | DISPARA release | SC-2 ✓ |
+| `infrastructure/iam.tf` | DISPARA release | SC-2 ✓ |
+| **Changesets fase B** — merge del PR `chore(release): version packages` (toca `package.json` + `CHANGELOG.md`) | **DISPARA release** → `pnpm changeset publish` corre | SC-3 ✓ |
+
+Clave (R1): `.changeset/*.md` **NO** matchea `*.md` (tiene un directorio) → el release de versiones se preserva.
+
+**Changesets opera en dos fases (DA P1-2):**
+- **Fase A** — un push con un `.changeset/*.md` nuevo → no ignorado → corre `version-or-publish` (crea/actualiza el PR "Version Packages").
+- **Fase B** — el merge de ese PR `chore(release): version packages` toca `package.json` (+ `CHANGELOG.md`), **no** rutas ignoradas → dispara release → `pnpm changeset publish`. Es el camino real de publicación y queda cubierto. (`.changeset/config.json` tiene `"commit": false` → ese PR se mergea manual por squash, tocando `package.json`.)
+
+## V4 — Observacional (post-merge)
+
+Pendiente tras merge: el primer PR docs-only no debe crear run de `release.yml`; el primer PR con código sí. Se observa en Actions, no se ejecuta aquí.
+
+## Veredicto
+
+V1–V3 PASS. SC-1, SC-2, SC-3, SC-4 cubiertos por razonamiento + simulación. V4 queda como verificación observacional post-merge.


### PR DESCRIPTION
## Problema

`release.yml` corre en **todo** push a `main` (`on.push.branches:[main]`, sin filtro de paths). Los merges **docs-only** (handoff, specs, análisis de drift) disparan un run de Release + Deploy que:
- es **no-op** (misma imagen, sin código);
- queda **`pending` con 0 jobs** por cola de runners de GitHub Actions (observado en runs `27073359900` del #413 y `27075451377` del #414);
- ensucia la lane de `concurrency` (`cancel-in-progress:false` → se encolan) pudiendo bloquear el próximo deploy **real**;
- no es cancelable por el agente (HTTP 403 → requiere acción humana).

De los últimos 5 runs de `release.yml`, **4 fueron docs/infra-doc** no-op.

## Cambio

`paths-ignore` en el trigger (denylist, **falla-seguro**: lo no listado siempre despliega):

```yaml
on:
  push:
    branches: [main]
    paths-ignore: [ 'docs/**', '.specs/**', 'references/**', 'playbooks/**', '*.md' ]
```

⚠️ **NO** se usa `**/*.md` a propósito: matchearía `.changeset/*.md` y rompería el release de versiones de Changesets. `*.md` (un solo `*`) es **root-only** y no cruza `/`.

## Evidencia

- **YAML válido** (js-yaml@4.1.1 strict load): `paths-ignore` aplicado, jobs `version-or-publish` + `deploy-production` intactos.
- **Matriz de matching** (verify.md): `.changeset/*.md` → DISPARA (SC-3 ✓) · docs/specs/root-md → ignorado (SC-1 ✓) · código/infra/lockfile/package.json → DISPARA (SC-2 ✓).
- **SC-4**: no toca required checks — el gate de merge es `CI Success` (de `ci.yml`, sin `paths-ignore`); `release.yml` no expone checks required.
- **REVIEW devils-advocate**: APPROVE_WITH_RESERVATIONS, **0 P0**. Reservas resueltas: strawman job-level corregido (spec §5.1 evalúa honestamente la alternativa `dorny/paths-filter` y por qué se descarta — supply-chain), fila Changesets fase B en verify, R3 reclasificado, follow-up V4 post-merge creado. R5/R6 (traza de compliance / heartbeat) documentados como residuales aceptados.

## Verificación post-merge (follow-up)

`.specs/_followups/verify-release-paths-ignore-post-merge.md`: confirmar que el 1er PR docs-only no crea run y el 1er PR con código sí. Escalación P0 documentada (revertir si un PR con código no despliega).

## Artefactos

`.specs/ci-release-skip-docs-only/{spec,verify,review}.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)