### PR TITLE
docs(followups): cierra verify-release-paths-ignore-post-merge (SC-1/SC-2 OK)

### DIFF
--- a/.specs/_followups/verify-release-paths-ignore-post-merge.md
+++ b/.specs/_followups/verify-release-paths-ignore-post-merge.md
@@ -1,9 +1,19 @@
-# Follow-up — Verificar `release.yml paths-ignore` post-merge (V4)
+# Follow-up — Verificar `release.yml paths-ignore` post-merge (V4) — ✅ CERRADO
 
 **Origen**: `.specs/ci-release-skip-docs-only/` (DA P2-4)
 **Prioridad**: P2 (verificación observacional, no bloqueante)
 **Owner**: PO (Felipe)
 **Creado**: 2026-06-06
+**Cerrado**: 2026-06-07 — ambos criterios confirmados en vivo.
+
+## ✅ Resultado (2026-06-07)
+
+- **SC-2** (con-código → dispara): el merge de #415 (`6f88393`, toca `.github/`) **creó** run `27076264007`. ✓
+- **SC-1** (docs-only → 0 runs): el merge de #416 (`40a349a`, solo `docs/handoff/CURRENT.md`) **NO creó** ningún run de `release.yml` (último run siguió siendo `27076264007 @ 6f88393`). ✓
+
+Filtro `paths-ignore` validado end-to-end. Nada más que hacer.
+
+---
 
 ## Qué verificar
 


### PR DESCRIPTION
Cierra el follow-up de verificación del filtro `paths-ignore` (#415), con ambos criterios confirmados en vivo:

- **SC-1** (docs-only → 0 runs): merge `40a349a` (#416) NO disparó `release.yml`. ✓
- **SC-2** (con-código → dispara): merge `6f88393` (#415, toca `.github/`) creó run `27076264007`. ✓

## Evidencia
Solo-docs (1 archivo `.specs/_followups/`). Este PR es además docs-only → no dispara deploy (filtro ya validado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)