### PR TITLE
fix(telemetry): observabilidad — msg→message + alerta consumer-stall

### DIFF
--- a/.specs/telemetry-monitoring-observability/spec.md
+++ b/.specs/telemetry-monitoring-observability/spec.md
@@ -1,0 +1,121 @@
+# Spec — Telemetry monitoring observability fix
+
+**Estado**: DEFINE
+**Fecha**: 2026-06-08
+**Autor**: Claude (agente) + Felipe Vicencio (PO)
+**Gatillo**: incidente 2026-06-07/08 — telemetría Teltonika→Booster caída ~26h sin que ninguna alerta sonara.
+
+## 1. Contexto / problema
+
+El 2026-06-07 19:09 UTC el `telemetry-processor` (Cloud Run, consumidor Pub/Sub
+StreamingPull) dejó de consumir `telemetry-events-processor-sub` al escalar a cero
+(`min-instances=0` + `cpu-throttling=true` incompatibles con un consumer pull). La
+ingesta a `telemetria_puntos` estuvo caída **~26h** y **ninguna alerta disparó**.
+
+Investigación (datos en vivo, ver §Evidencia) reveló **tres** problemas, no uno:
+
+1. **No existe alerta de "consumer detenido".** La única señal cercana
+   (`pubsub_backlog_p2`, umbral conteo 1000) es estructuralmente lenta: de noche el
+   fleet estaciona → casi no llega telemetría → el backlog se mantuvo en ~100-120 toda
+   la madrugada y **recién cruzó 1000 a las ~09:30 (14h tarde)**. El conteo absoluto
+   enmascara al consumer caído.
+
+2. **🔴 Bug sistémico: todos los log-based metrics de telemetría están rotos.** El
+   logger Booster (Pino) emite el mensaje en el campo `message` (`messageKey: 'message'`
+   en `packages/logger/src/createLogger.ts:66`), pero los filtros usan
+   `jsonPayload.msg=...`. Verificado: el filtro real de `device_records_per_minute`
+   matchea **0** entradas en 20 min; con `jsonPayload.message` matchea **30**. Afecta a
+   `device_records_per_minute`, `tcp_connection_resets`, `parser_errors`, `crash_events`
+   (telemetry-monitoring.tf) y `crash_trace_persistence_failures` (crash-traces.tf).
+
+3. **`unplug_events` y `gnss_jamming_critical_events` están doblemente bloqueados**: su
+   filtro usa `jsonPayload.eventName`, pero **nada emite ese campo** — el
+   `notification-service` es un skeleton (`apps/notification-service/src/main.ts:10`).
+   No se arreglan con un rename; dependen de implementar el pipeline de ruteo de eventos.
+
+## 2. Objetivo
+
+Que la capa de observabilidad de telemetría **funcione de verdad** y que un corte de
+ingesta o de consumo **dispare una alerta en < ~35 min**, sin falsos positivos por el
+parking nocturno.
+
+## 3. Alcance (decidido por PO: "fix completo")
+
+### IN
+- **A. Fix `msg`→`message`** en los 5 metrics realmente emitidos (telemetry-monitoring.tf)
+  + 1 en crash-traces.tf (`crash_trace_persistence_failures`). + sweep de queries
+  `jsonPayload.msg` muertas en el runbook y en api-cost-guardrails.tf (doc).
+- **B. Alerta nueva P1 — consumer detenido**: `oldest_unacked_message_age` sobre
+  `telemetry-events-processor-sub` > 30 min. Métrica **nativa** de Pub/Sub
+  (independiente del bug de logs). Baseline 0, sin FP nocturnos, habría disparado a
+  ~35 min del inicio. (Post-review: se acotó a UNA sub — sacar `crash-traces-processor-sub`,
+  que es bursty y podía flapear; su stall lo cubren `pubsub_dlq` + `crash_trace_persistence_failures`.)
+- **D. Documentar honestamente** unplug/jamming como BLOCKED-on-notification-service,
+  y corregir el comentario falso "push consumer" en compute.tf (el processor es PULL).
+- **E. Runbook**: secciones nuevas en `docs/runbooks/oncall-telemetry-incidents.md`.
+- **F. Validación**: `terraform fmt` + `validate` + `plan`.
+
+### OUT (movido a follow-up por el review)
+- **C. Alerta de ingreso detenido** — DIFERIDA. La versión sobre `device_records_per_minute`
+  (REDUCE_SUM + missing-data) se descartó: en un apagón total las series por-IMEI
+  desaparecen y la serie reducida no tiene identidad estable → podría NO disparar (el
+  review lo marcó blocking). El detector correcto es un liveness POSITIVO del pod del
+  gateway (`kubernetes.io/container/uptime`), que requiere validación empírica (parar
+  el gateway en prueba) antes de confiar en él. → follow-up `telemetry-gateway-liveness-alert`.
+- Implementar el `notification-service` / ruteo de eventos (desbloquea unplug/jamming).
+- **Codificar `min-instances=1` + CPU always-on del processor en IaC** — chip aparte
+  (`telemetry-processor-min-instances`). ⚠️ El fix de runtime YA está aplicado (rev 00312)
+  pero la IaC sigue en `min=0`: un `terraform apply` lo revierte. Documentado en compute.tf.
+- Añadir canales de notificación nuevos (PagerDuty/Slack). Se reutiliza `email_alerts`.
+
+## 4. Diseño de las alertas
+
+| Alerta | Métrica | Tipo | Umbral | Ventana | Sev | Caza |
+|---|---|---|---|---|---|---|
+| `telemetry_consumer_stalled_p1` | `subscription/oldest_unacked_message_age` (nativa) | threshold GT | 1800s (30m) | 300s | ERROR/P1 | consumer caído (el incidente) |
+| ~~`telemetry_ingress_stopped_p2`~~ | DIFERIDA → follow-up gateway-liveness | — | — | — | — | ingreso/gateway down |
+
+**Por qué `oldest_unacked_message_age` y no el conteo de backlog**: la antigüedad del
+mensaje más viejo sin ack sube +60s/min apenas muere el consumer, **independiente del
+volumen** → cruza 30 min incluso de madrugada con poco tráfico. El conteo depende del
+volumen y de noche tarda horas. Evidencia en vivo: durante el incidente (Cloud Run en
+CERO instancias) la métrica subió lineal 0.8h→25.6h sin volverse sparse — por eso es
+threshold positivo, no detección por ausencia. `pubsub_backlog_p2` se conserva como
+señal secundaria (processor lento pero vivo / backpressure parcial).
+
+**Por qué la alerta de ingreso se difiere** (cambio post-review): detección por ausencia
+de un log-metric por-IMEI con REDUCE_SUM es poco confiable justo en el apagón total que
+busca cazar (series desaparecen → la reducida no tiene identidad estable). Además los
+Network Pings no cuentan como records, así que de noche puede dar 0 legítimo. El detector
+correcto (liveness positivo del pod, `kubernetes.io/container/uptime`) necesita validación
+empírica antes de shipear. Una alerta de ingreso que no dispara es peor que ninguna.
+
+## 5. Criterios de aceptación
+
+1. `terraform validate` OK; `fmt` sin diff.
+2. Los 6 filtros corregidos usan `jsonPayload.message` y matchean logs reales; sin
+   queries `jsonPayload.msg` muertas en runbook/docs de telemetría.
+3. Existe la alert policy `telemetry_consumer_stalled_p1` apuntando a `email_alerts`,
+   con `documentation` linkeando el runbook. `plan` = 1 add + 6 change + 0 destroy.
+4. unplug/jamming quedan con comentario explícito de bloqueo (no se fingen arregladas);
+   compute.tf ya no rotula al processor como "push consumer".
+5. Runbook actualizado: sección consumer-stalled (con alerta) + ingress (playbook
+   manual, alerta diferida) + nota del fix de campo.
+6. PR con sección Evidencia (incidente + outputs de validación + landmine min-instances).
+
+## 7. Revisiones post-review (devils-advocate / 4 lentes adversariales)
+
+- **[blocking]** alerta de ingreso device_records no dispararía en apagón total → DIFERIDA.
+- **[major]** consumer alert acotada a `telemetry-events-processor-sub` (saca crash-sub).
+- **[major]** comentario falso "push consumer" en compute.tf corregido + landmine
+  min-instances documentado (apply revierte el fix de runtime hasta que el chip IaC entre).
+- **[major]** queries `jsonPayload.msg` muertas del runbook + api-cost-guardrails corregidas.
+- **[minor]** header acotado (no overclaim sobre unplug/jamming); `trigger { count=1 }`
+  explícito; caveat de pings corregido (Network Pings no cuentan como records).
+
+## 6. Evidencia (datos en vivo, 2026-06-08)
+
+- Backlog 26h: ~100-120 toda la madrugada; cruzó 1000 a las ~09:30 (14h tarde).
+- `oldest_unacked_message_age`: lineal 0.8h→25.6h desde ~20:00; baseline post-fix = 0s.
+- `device_records_per_minute` con filtro real (`msg`) = 0 matches/20m; con `message` = 30.
+- `notification-service/src/main.ts:10` = "starting (skeleton)"; `eventName` no se loguea.

--- a/docs/runbooks/oncall-telemetry-incidents.md
+++ b/docs/runbooks/oncall-telemetry-incidents.md
@@ -117,7 +117,7 @@ del parser, cambio de protocolo del device, o tráfico malicioso.
 1. **Identificar IMEIs** en logs:
    ```
    resource.type="k8s_container"
-   jsonPayload.msg="parse error, ack 0 + cerramos"
+   jsonPayload.message="parse error, ack 0 + cerramos"
    ```
 
 2. **Si todos los errores son del mismo IMEI**: device problemático,
@@ -165,6 +165,100 @@ bug en el handler.
 
 ---
 
+## Telemetry consumer stalled
+
+**Métrica** (P1): `telemetry_consumer_stalled_p1` — `oldest_unacked_message_age`
+de `telemetry-events-processor-sub` (o `crash-traces-processor-sub`) > 30 min.
+
+**Significado**: el `telemetry-processor` **dejó de consumir** Pub/Sub. Los
+mensajes envejecen sin ack → no se escribe nada en `telemetria_puntos`. Este es
+el modo de falla del incidente del 2026-06-07 (processor escaló a cero ~26h).
+
+> Por qué esta alerta y no el backlog por conteo: `oldest_unacked_message_age`
+> sube +60s/min apenas muere el consumer, **independiente del volumen**, así que
+> dispara también de madrugada (fleet estacionado). El conteo (`pubsub_backlog_p2`)
+> de noche tardó 14h en cruzar 1000 — es solo señal secundaria.
+
+### Pasos
+
+1. **¿Hay instancias del processor corriendo?**
+   ```bash
+   gcloud run services describe booster-ai-telemetry-processor \
+     --region=southamerica-west1 \
+     --format="value(spec.template.metadata.annotations['autoscaling.knative.dev/minScale'], spec.template.metadata.annotations['run.googleapis.com/cpu-throttling'])"
+   ```
+   El processor es un **consumer Pub/Sub pull** (StreamingPull dentro del
+   container). Requiere `min-instances>=1` **y** `cpu-throttling=false` (CPU
+   always-on); si no, escala a cero cuando no hay requests HTTP y deja de tirar
+   de la cola.
+
+2. **Fix inmediato** si está en `min=0` / throttled:
+   ```bash
+   gcloud run services update booster-ai-telemetry-processor \
+     --region=southamerica-west1 --min-instances=1 --no-cpu-throttling
+   ```
+   La instancia levanta, drena el backlog acumulado (Pub/Sub retiene 7 días,
+   no se pierde nada) y la ingesta vuelve.
+
+3. **Verificar recuperación**: el backlog (`num_undelivered_messages`) baja a ~0
+   y `telemetria_puntos` recibe escrituras nuevas (último `timestamp_recibido_en`
+   en segundos).
+
+4. **Errores en el handler** (si hay instancia viva pero igual no drena): logs
+   del processor `severity>=ERROR` — DB caída, Redis (dedup) inalcanzable, etc.
+   Tras 5 fallos por mensaje, va al DLQ (`pubsub-dead-letter`).
+
+5. **Permanente**: que el `min-instances=1` + CPU always-on quede en IaC (no solo
+   aplicado a mano) para que un deploy/terraform apply no lo revierta.
+
+---
+
+## Telemetry ingress stopped
+
+**Alerta automática**: ⏳ PENDIENTE (follow-up `telemetry-gateway-liveness-alert`).
+Mientras ese follow-up no entregue la alerta, esta sección es un **playbook de
+diagnóstico manual**.
+
+> Por qué la alerta queda en follow-up y no en este PR: detectar "no entra
+> telemetría" es detección por ausencia, y en GCP es sutil. La primera versión
+> (sobre `device_records_per_minute` en 0) se descartó en review porque (a) en un
+> apagón total las series por-IMEI desaparecen y `REDUCE_SUM`+missing-data podría
+> no disparar, y (b) con el fleet estacionado de noche la tasa puede bajar a 0
+> records legítimamente — ojo: los Network Pings Teltonika (0xFF) **no** cuentan
+> como records, sólo los AVL. El detector correcto es un liveness POSITIVO del pod
+> del gateway (`kubernetes.io/container/uptime`, serie única estable 24/7), pero
+> debe validarse parando el gateway en una prueba antes de confiar en él. Una
+> alerta de ingreso que no dispara es peor que ninguna.
+
+**Significado** (cuando se sospecha): **no llegan AVL records de ningún device**.
+Falla del lado de ingreso: pod del gateway caído, LB/DNS desalineado, cert TLS
+(5061) vencido, o todos los devices offline. (Distinto de "consumer stalled": acá
+los mensajes ni siquiera entran a Pub/Sub — el consumer-stall sí tiene alerta.)
+
+### Pasos
+
+1. **Pod del gateway** (single replica, GKE):
+   ```bash
+   gcloud container clusters get-credentials booster-ai-telemetry --region=southamerica-west1
+   kubectl get pods -n telemetry
+   kubectl logs -n telemetry deploy/telemetry-tcp-gateway --tail=50
+   ```
+   Si el control plane no es alcanzable desde la laptop (master authorized
+   networks), usar Cloud Logging: `resource.labels.container_name="gateway"`.
+
+2. **LB / DNS**: `telemetry.boosterchile.com` (plain 5027) y
+   `telemetry-tls.boosterchile.com` (TLS 5061) deben resolver a las IP estáticas
+   del Service (ver `infrastructure/k8s/telemetry-tcp-gateway.yaml`). Outage
+   2026-05-07 fue por IP efímera vs estática.
+
+3. **Cert TLS** (si los devices usan 5061): `kubectl get certificate -n telemetry`
+   + `openssl s_client -connect telemetry-tls.boosterchile.com:5061` (¿vencido?).
+
+4. **Devices**: si gateway + LB + cert OK, revisar si los devices están online
+   (operador móvil, energía). De madrugada con fleet estacionado puede ser normal.
+
+---
+
 ## Crash trace persistence failed (P0)
 
 **Métrica**: `crash_trace_persistence_failures > 0`.
@@ -178,7 +272,7 @@ o BigQuery. Cada falla = evidencia forense potencialmente perdida.
    ```
    resource.type="cloud_run_revision"
    resource.labels.service_name="booster-ai-telemetry-processor"
-   jsonPayload.msg="error persistiendo crash-trace, nack para reintento"
+   jsonPayload.message="error persistiendo crash-trace, nack para reintento"
    ```
 
 2. **Identificar la causa del error** (`err.message`):

--- a/docs/runbooks/oncall-telemetry-incidents.md
+++ b/docs/runbooks/oncall-telemetry-incidents.md
@@ -168,7 +168,9 @@ bug en el handler.
 ## Telemetry consumer stalled
 
 **Métrica** (P1): `telemetry_consumer_stalled_p1` — `oldest_unacked_message_age`
-de `telemetry-events-processor-sub` (o `crash-traces-processor-sub`) > 30 min.
+de `telemetry-events-processor-sub` > 30 min. (La sub `crash-traces-processor-sub`
+NO está en esta alerta: es bursty y un único crash-trace lento podría flapearla; su
+stall lo cubren `pubsub_dlq` + `crash_trace_persistence_failures`.)
 
 **Significado**: el `telemetry-processor` **dejó de consumir** Pub/Sub. Los
 mensajes envejecen sin ack → no se escribe nada en `telemetria_puntos`. Este es

--- a/infrastructure/api-cost-guardrails.tf
+++ b/infrastructure/api-cost-guardrails.tf
@@ -143,7 +143,7 @@ resource "google_monitoring_alert_policy" "gemini_api_rate" {
         4. Prompt injection forzando reintentos
 
       Mitigación inmediata:
-        - Revisar logs api con jsonPayload.msg="coaching persistido" — ¿mismo
+        - Revisar logs api con jsonPayload.message="coaching persistido" — ¿mismo
           tripId repetido?
         - El package coaching-generator tiene fallback a plantilla — apagar
           el genFn temporalmente seteando GEMINI_API_KEY a "" via secret rota

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -392,7 +392,7 @@ module "service_matching_engine" {
   labels = { app = "matching-engine", env = var.environment }
 }
 
-# --- apps/telemetry-processor (Pub/Sub push consumer) ---
+# --- apps/telemetry-processor (Pub/Sub PULL consumer / StreamingPull) ---
 module "service_telemetry_processor" {
   source = "./modules/cloud-run-service"
 
@@ -401,11 +401,23 @@ module "service_telemetry_processor" {
   service_name          = "booster-ai-telemetry-processor"
   service_account_email = google_service_account.cloud_run_runtime.email
 
-  # ADR-034: a 2026-05 el procesador recibió ~0.27 req/día (Wave 3 todavía sin
-  # TCP gateway productivo desplegado). Pub/Sub push tiene retry exponencial
-  # automático que cubre el cold start (~5s). Cuando Wave 3 entre en producción
-  # y la tasa supere ~50 msg/min sostenidos, volver a min=1 para evitar latencia
-  # acumulada en el ack deadline.
+  # ⚠️ CORRECCIÓN 2026-06-08: este servicio NO es un push consumer. Las subscriptions
+  # `telemetry-events-processor-sub` y `crash-traces-processor-sub` no tienen
+  # pushConfig (son PULL); el código usa `subscription.on('message')` (StreamingPull
+  # dentro del container). El comentario previo ("Pub/Sub push... retry cubre el cold
+  # start") era factualmente falso y es la CAUSA LATENTE del incidente 2026-06-07:
+  # con `min_instances=0` + CPU throttling, al apagarse la instancia nadie tira de la
+  # cola → telemetría caída ~26h. Un consumer pull REQUIERE min_instances>=1 + CPU
+  # always-on (cpu_idle=false).
+  #
+  # El fix de runtime ya está aplicado a mano (revisión 00312): min=1 + cpu_idle=false.
+  # Codificarlo en IaC es el follow-up `telemetry-processor-min-instances`: requiere
+  # (a) min_instances=1 acá y (b) exponer cpu_idle como variable del módulo
+  # cloud-run-service (hoy está hardcodeado `cpu_idle = true` en modules/.../main.tf:37).
+  # Mientras eso no entre, hay DRIFT (el drift-check lo marca) y un `terraform apply`
+  # manual REVERTIRÍA el fix → re-rompe la telemetría. El apply NO es automático en
+  # merge (terraform-drift.yml solo corre plan), así que mergear no revierte; el peligro
+  # es un apply manual. La alerta `telemetry_consumer_stalled_p1` detecta recurrencia ~35min.
   min_instances = 0
   max_instances = 50
   cpu           = "2"

--- a/infrastructure/crash-traces.tf
+++ b/infrastructure/crash-traces.tf
@@ -295,7 +295,9 @@ resource "google_logging_metric" "crash_trace_persistence_failures" {
     resource.type="cloud_run_revision"
     resource.labels.service_name="booster-ai-telemetry-processor"
     severity>=ERROR
-    jsonPayload.msg="error persistiendo crash-trace, nack para reintento"
+    # Campo = jsonPayload.message (Pino messageKey='message'); ver nota en
+    # infrastructure/telemetry-monitoring.tf. Con `msg` matcheaba 0 (métrica muerta).
+    jsonPayload.message="error persistiendo crash-trace, nack para reintento"
   EOT
 
   metric_descriptor {
@@ -343,7 +345,7 @@ resource "google_monitoring_alert_policy" "crash_trace_persistence_failures" {
       Crash Trace persistence failed in telemetry-processor.
 
       Investigación:
-      1. Logs del processor con jsonPayload.msg="error persistiendo crash-trace" en
+      1. Logs del processor con jsonPayload.message="error persistiendo crash-trace" en
          Cloud Logging.
       2. Verificar bucket gs://${google_storage_bucket.crash_traces.name} (CMEK
          disponible? IAM correcto?).

--- a/infrastructure/telemetry-monitoring.tf
+++ b/infrastructure/telemetry-monitoring.tf
@@ -5,6 +5,17 @@
 # requerir cambios en código (los logs estructurados Pino ya tienen los
 # campos necesarios). Lo que requiere instrumentation OpenTelemetry
 # (latency p99) queda como TODO en docs/runbooks/oncall-telemetry-incidents.md.
+#
+# ⚠️ CAMPO DEL MENSAJE = `jsonPayload.message` (no `jsonPayload.msg`).
+# El logger Booster configura Pino con `messageKey: 'message'`
+# (packages/logger/src/createLogger.ts). Los filtros originales usaban
+# `jsonPayload.msg=...` → matcheaban 0 entradas → los log-metrics que SÍ se
+# emiten (device_records_per_minute, tcp_connection_resets, parser_errors,
+# crash_events, sms_fallback_received, y crash_trace_persistence_failures en
+# crash-traces.tf) estuvieron MUERTOS desde su creación.
+# (unplug_events y gnss_jamming_critical_events están muertos por OTRA razón:
+# dependen de jsonPayload.eventName que nadie emite todavía — ver sus notas.)
+# Corregido 2026-06-08 (.specs/telemetry-monitoring-observability).
 
 # =============================================================================
 # LOGGING METRICS — derivadas de logs estructurados
@@ -21,7 +32,7 @@ resource "google_logging_metric" "device_records_per_minute" {
   filter = <<-EOT
     resource.type="k8s_container"
     resource.labels.container_name="gateway"
-    jsonPayload.msg="avl packet procesado"
+    jsonPayload.message="avl packet procesado"
   EOT
 
   metric_descriptor {
@@ -53,7 +64,7 @@ resource "google_logging_metric" "tcp_connection_resets" {
     resource.type="k8s_container"
     resource.labels.container_name="gateway"
     severity>=WARNING
-    (jsonPayload.msg=~"preamble inesperado" OR jsonPayload.msg=~"CRC inválido")
+    (jsonPayload.message=~"preamble inesperado" OR jsonPayload.message=~"CRC inválido")
   EOT
 
   metric_descriptor {
@@ -74,7 +85,7 @@ resource "google_logging_metric" "parser_errors" {
   filter = <<-EOT
     resource.type="k8s_container"
     resource.labels.container_name="gateway"
-    jsonPayload.msg="parse error, ack 0 + cerramos"
+    jsonPayload.message="parse error, ack 0 + cerramos"
   EOT
 
   metric_descriptor {
@@ -96,7 +107,7 @@ resource "google_logging_metric" "crash_events" {
   filter = <<-EOT
     resource.type="cloud_run_revision"
     resource.labels.service_name="booster-ai-telemetry-processor"
-    jsonPayload.msg="crash-trace persistido"
+    jsonPayload.message="crash-trace persistido"
   EOT
 
   metric_descriptor {
@@ -124,6 +135,13 @@ resource "google_logging_metric" "crash_events" {
 
 # Unplug events — derivado del log del notification-service cuando
 # rutea un evento safety-p0 con eventName=Unplug.
+#
+# ⚠️ BLOQUEADO: este filtro depende de `jsonPayload.eventName`, pero NINGÚN
+# servicio lo emite todavía — el `notification-service` es un skeleton
+# (apps/notification-service/src/main.ts). La métrica produce 0 series y la
+# alerta `unplug_event_p0` no puede disparar hasta implementar el ruteo de
+# eventos. NO es un bug de campo (no se arregla con msg→message). Se deja el
+# filtro con el campo final esperado. Desbloqueo: follow-up notification-service.
 resource "google_logging_metric" "unplug_events" {
   name    = "telemetry/unplug_events"
   project = google_project.booster_ai.project_id
@@ -145,6 +163,10 @@ resource "google_logging_metric" "unplug_events" {
 }
 
 # GNSS Jamming critical — AVL 318 con valor=2.
+#
+# ⚠️ BLOQUEADO igual que `unplug_events`: depende de `jsonPayload.eventName`
+# (+ `jsonPayload.rawValue`) que aún nadie emite (notification-service skeleton).
+# La alerta `gnss_jamming_p0` no dispara hasta implementar el ruteo de eventos.
 resource "google_logging_metric" "gnss_jamming_critical_events" {
   name    = "telemetry/gnss_jamming_critical_events"
   project = google_project.booster_ai.project_id
@@ -176,7 +198,7 @@ resource "google_logging_metric" "sms_fallback_received" {
   filter = <<-EOT
     resource.type="cloud_run_revision"
     resource.labels.service_name="booster-ai-sms-fallback-gateway"
-    jsonPayload.msg=~"sms fallback procesado"
+    jsonPayload.message=~"sms fallback procesado"
   EOT
 
   metric_descriptor {
@@ -336,10 +358,85 @@ resource "google_monitoring_alert_policy" "pubsub_backlog_p2" {
   notification_channels = [google_monitoring_notification_channel.email_alerts.id]
 
   documentation {
-    content   = "Backlog en subscription telemetría. Verificar processor health, ver runbook."
+    content   = "Backlog (conteo) en subscription telemetría. Señal SECUNDARIA: el conteo depende del volumen y de noche (fleet estacionado, poco tráfico) tarda horas en cruzar 1000 → enmascara un consumer caído. El detector PRIMARIO de consumer detenido es `telemetry_consumer_stalled_p1` (oldest_unacked_message_age). Ver runbook: docs/runbooks/oncall-telemetry-incidents.md#telemetry-consumer-stalled"
     mime_type = "text/markdown"
   }
 }
+
+# P1 — Consumer de telemetría DETENIDO (el modo de falla del incidente
+# 2026-06-07: el telemetry-processor escaló a cero y dejó de consumir ~26h).
+#
+# Detector: `oldest_unacked_message_age` — la antigüedad del mensaje más viejo
+# sin ack. Sube +60s/min apenas muere el consumer, INDEPENDIENTE del volumen, así
+# que cruza el umbral incluso de madrugada con poco tráfico (a diferencia del
+# conteo de backlog, que de noche tardó 14h en cruzar 1000).
+#
+# Evidencia (incidente real, verificada en vivo): durante el corte con el Cloud
+# Run en CERO instancias, esta métrica subió linealmente 0.8h→25.6h (no se volvió
+# sparse ni desapareció), y su baseline sano post-fix es 0s. Por eso es threshold
+# positivo (GT 1800), no detección por ausencia. Umbral 30min + 5min sostenido →
+# dispara a ~35min del inicio.
+#
+# Sólo `telemetry-events-processor-sub` (el stream de alto volumen, que es el
+# incidente). NO incluye `crash-traces-processor-sub`: es bursty/raro y un único
+# crash-trace lento (upload GCS + insert BQ con retries) podría envejecer >30min y
+# flapear sin outage real. El stall del consumer de crash-traces ya está cubierto
+# por `pubsub_dlq` (monitoring.tf) + `crash_trace_persistence_failures` (crash-traces.tf).
+resource "google_monitoring_alert_policy" "telemetry_consumer_stalled_p1" {
+  display_name = "Telemetry consumer stalled — oldest unacked > 30min (P1)"
+  project      = google_project.booster_ai.project_id
+  combiner     = "OR"
+  severity     = "ERROR"
+
+  conditions {
+    display_name = "oldest unacked message age > 30 min"
+    condition_threshold {
+      filter          = "resource.type=\"pubsub_subscription\" AND resource.labels.subscription_id=\"telemetry-events-processor-sub\" AND metric.type=\"pubsub.googleapis.com/subscription/oldest_unacked_message_age\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 1800 # 30 min
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_MAX"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email_alerts.id]
+
+  documentation {
+    content   = "El telemetry-processor no está consumiendo Pub/Sub (mensajes envejeciendo sin ack). Causa típica: el Cloud Run escaló a cero (es un consumer PULL/StreamingPull — necesita min-instances>=1 + CPU always-on). Cubre 'consumer muerto', NO 'consumer vivo pero fallando el write' (ese es pubsub_dlq + crash_trace_persistence_failures). Runbook: docs/runbooks/oncall-telemetry-incidents.md#telemetry-consumer-stalled"
+    mime_type = "text/markdown"
+  }
+}
+
+# P2 — Ingreso de telemetría detenido (gateway down): DIFERIDO a follow-up.
+#
+# La primera versión usaba `device_records_per_minute` (log-metric por-IMEI) con
+# REDUCE_SUM + evaluation_missing_data=ACTIVE para disparar en "0 records". El
+# review adversarial (.specs/telemetry-monitoring-observability) detectó dos
+# defectos que la harían poco confiable JUSTO en el apagón que busca cazar:
+#   1. En un apagón total TODAS las series por-IMEI desaparecen; una serie
+#      reducida (REDUCE_SUM) sin inputs no tiene identidad estable, así que
+#      evaluation_missing_data podría no marcarla como ausente → no dispara.
+#   2. Falso positivo nocturno: los Network Pings Teltonika (0xFF) NO incrementan
+#      device_records (sólo los AVL records sí); con el fleet estacionado la tasa
+#      puede caer legítimamente a 0.
+#
+# El detector correcto es un liveness POSITIVO del pod del gateway
+# (`kubernetes.io/container/uptime`, serie única estable 24/7 que sólo desaparece
+# si el pod muere — sin enmascaramiento nocturno). Requiere validación EMPÍRICA
+# (parar el gateway en una ventana de prueba y confirmar que la policy abre) antes
+# de confiar en ella, por eso no se incluye acá. Una alerta de ingreso que no
+# dispara es peor que ninguna. Follow-up: telemetry-gateway-liveness-alert.
+#
+# NOTA: el incidente 2026-06-07 fue consumer-stall, no ingress — cubierto al 100%
+# por `telemetry_consumer_stalled_p1` arriba.
 
 # =============================================================================
 # DASHBOARD — Telemetría Overview


### PR DESCRIPTION
## Contexto

El 2026-06-07 la telemetría Teltonika→Booster estuvo caída **~26h sin que ninguna alerta sonara**. El root cause inmediato (el `telemetry-processor` escaló a cero y dejó de consumir Pub/Sub) ya se mitigó en runtime. Este PR ataca **por qué nadie se enteró**: la capa de observabilidad de telemetría estaba muerta.

## Qué cambia

1. **🔴 Bug sistémico `msg`→`message`.** Los log-based metrics filtraban por `jsonPayload.msg`, pero el logger Booster (Pino) usa `messageKey:'message'` (`packages/logger/src/createLogger.ts`) → **matcheaban 0 entradas**. Corregido en 6 métricas: `device_records_per_minute`, `tcp_connection_resets`, `parser_errors`, `crash_events`, `sms_fallback_received` y `crash_trace_persistence_failures` (crash-traces.tf). + sweep de queries `jsonPayload.msg` muertas en el runbook y en `api-cost-guardrails.tf` (doc).
2. **Alerta nueva P1 `telemetry_consumer_stalled_p1`.** `oldest_unacked_message_age` de `telemetry-events-processor-sub` > 30 min. Métrica **nativa** de Pub/Sub, baseline 0, **independiente del volumen** → caza el consumer-stall en ~35 min, sin falsos positivos nocturnos (a diferencia del backlog por conteo, que de noche tardó 14h en cruzar 1000).
3. **compute.tf honesto.** Corrige el comentario falso "Pub/Sub push consumer" (es **PULL/StreamingPull**) que era la causa latente, y documenta el landmine de `min-instances`.
4. **unplug/jamming** documentados como bloqueados por el `notification-service` (skeleton) — no se fingen arreglados.
5. **Alerta de ingreso (gateway down) DIFERIDA** a follow-up tras review adversarial (ver abajo).

## Evidencia

**Datos en vivo del incidente (2026-06-08):**
- `oldest_unacked_message_age`: subió lineal `0.8h→25.6h` con el Cloud Run en CERO instancias; baseline sano post-fix = `0s`. → justifica el umbral de 30 min como detector positivo.
- backlog por conteo: se mantuvo en ~100-120 toda la madrugada (fleet estacionado) y **recién cruzó 1000 a las ~09:30 (14h tarde)**. → el conteo es mal detector; por eso la alerta usa antigüedad.
- `device_records_per_minute` con filtro `msg` = **0 matches/20min**; con `message` = **30**. → confirma el bug.

**Validación Terraform:**
```
terraform validate  → Success! The configuration is valid.
terraform fmt       → sin diff
terraform plan      → Plan: 1 to add, 6 to change, 0 to destroy
```
Los 6 metric son **update in-place** (no recreate → sin pérdida de descriptor/historial; las series corregidas pueblan forward-only desde el apply, sin backfill del período muerto). El 1 add es la alert policy P1.

**Review adversarial:** 4 lentes (Terraform/GCP, falsos-positivos, detección-perdida, honestidad) — `.specs/telemetry-monitoring-observability/spec.md §7`. Hallazgos incorporados:
- *(blocking)* la alerta de ingreso sobre `device_records` no dispararía en apagón total (REDUCE_SUM sobre series por-IMEI que desaparecen) → **diferida** a follow-up con el approach correcto (pod liveness `kubernetes.io/container/uptime`, requiere test empírico).
- *(major)* consumer alert acotada a una sola sub (saca `crash-traces-processor-sub`, bursty/flapeable).
- *(major)* comentario falso "push consumer" + queries `msg` muertas del runbook corregidos.

## ⚠️ Landmine conocido (follow-up aparte)

El fix de runtime (`min-instances=1` + CPU always-on, revisión 00312) **NO está en IaC todavía**: `compute.tf` sigue en `min_instances=0`. Un `terraform apply` completo **revertiría el fix y volvería a romper la telemetría**. Lo cierra el chip `telemetry-processor-min-instances`. Documentado en `compute.tf`. La nueva alerta P1 detecta la recurrencia en ~35min si llegara a pasar.

## Follow-ups
- `telemetry-gateway-liveness-alert` — alerta de ingreso vía pod liveness (con test empírico).
- `telemetry-processor-min-instances` — codificar min=1 + CPU always-on en IaC.
- `notification-service` — implementar ruteo de eventos (desbloquea unplug/jamming P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)