### PR TITLE
fix(infra): telemetry-processor min-instances=1 + CPU always-on en IaC

### DIFF
--- a/.specs/telemetry-processor-min-instances/spec.md
+++ b/.specs/telemetry-processor-min-instances/spec.md
@@ -1,0 +1,51 @@
+# Spec — telemetry-processor min-instances + CPU always-on en IaC
+
+**Estado**: SHIP
+**Fecha**: 2026-06-08
+**Gatillo**: follow-up del incidente 2026-06-07 (ver `.specs/telemetry-monitoring-observability`).
+**Stack**: sobre la rama del PR #429 (alertas).
+
+## Problema
+
+El `telemetry-processor` es un consumidor Pub/Sub **PULL/StreamingPull** que corre el
+loop dentro del container (`apps/telemetry-processor/src/main.ts:148`). En Cloud Run eso
+requiere `min_instances>=1` **y** `cpu_idle=false` (CPU always-on): el loop de pull no es
+request-driven, así que con `min=0` la instancia escala a cero (nadie consume) y con
+`cpu_idle=true` queda CPU-throttled entre requests (el pull se starvea). La config previa
+(`min_instances=0` + módulo con `cpu_idle=true` hardcodeado) causó el corte de ~26h.
+
+El fix de runtime ya está aplicado (`gcloud run services update --min-instances=1
+--no-cpu-throttling`, revisión 00312), pero la IaC seguía en `min=0` → **drift activo**
+(drift-check rojo) y un `terraform apply` manual REVERTIRÍA el fix.
+
+## Cambio
+
+1. **Módulo `cloud-run-service`**: `cpu_idle` pasa de hardcodeado `true` a **variable**
+   con default `true` (backward-compatible: cero cambio para los demás servicios).
+2. **compute.tf (processor)**: `min_instances = 1` + `cpu_idle = false`.
+3. **cloudbuild.production.yaml**: el step `deploy-telemetry-processor` agrega
+   `--min-instances=1 --no-cpu-throttling` explícitos (idempotencia + auto-doc).
+
+## Alcance / no-alcance
+
+- **Único servicio afectado**: telemetry-processor. Verificado (tarea #3) que es el único
+  consumidor pull de fondo: el otro `subscription.on('message')` (api `routes/chat.ts:457`)
+  es request-scoped (se crea/destruye dentro del request → CPU asignada durante el request).
+  El resto de los Cloud Run son request/push-driven → `min=0` correcto.
+- **Costo**: ~1 instancia always-on con CPU continua 24/7. Ya se está pagando desde el fix
+  de runtime; este cambio solo lo hace durable.
+
+## Verificación
+
+- `terraform validate` OK; `fmt` limpio.
+- `terraform plan`: el processor muestra **0 cambios** (la IaC pasa a COINCIDIR con el
+  estado vivo → drift resuelto, `apply` ya no revierte el fix). Otros servicios sin cambios
+  por `cpu_idle` (default `true` preservado; api solo muestra el drift benigno `revision→null`,
+  pre-existente y ajeno a este cambio).
+
+## Criterios de aceptación
+
+1. Processor: `min_instances=1` + `cpu_idle=false` en IaC; `plan` sin diff del processor.
+2. Módulo: `cpu_idle` variable con default `true`; ningún otro servicio cambia su CPU.
+3. cloudbuild explícito con los flags de escalado.
+4. PR con Evidencia (ciclo agent-rigor).

--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -337,7 +337,10 @@ steps:
       - --update-labels=commit=${_COMMIT_SHA}
     waitFor: [push-web]
 
-  # apps/telemetry-processor — Cloud Run consumer Pub/Sub.
+  # apps/telemetry-processor — Cloud Run PULL consumer (StreamingPull).
+  # min-instances=1 + no-cpu-throttling son OBLIGATORIOS para un consumer pull
+  # (ver compute.tf / incidente 2026-06-07). Explícitos acá para idempotencia y
+  # auto-documentación, aunque `update --image` ya preserva la config existente.
   - id: deploy-telemetry-processor
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
     entrypoint: gcloud
@@ -349,6 +352,8 @@ steps:
       - --image=${_REGISTRY}/telemetry-processor:${_COMMIT_SHA}
       - --region=${_REGION}
       - --platform=managed
+      - --min-instances=1
+      - --no-cpu-throttling
       - --update-labels=commit=${_COMMIT_SHA}
     waitFor: [push-telemetry-processor]
 

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -401,25 +401,20 @@ module "service_telemetry_processor" {
   service_name          = "booster-ai-telemetry-processor"
   service_account_email = google_service_account.cloud_run_runtime.email
 
-  # ⚠️ CORRECCIÓN 2026-06-08: este servicio NO es un push consumer. Las subscriptions
-  # `telemetry-events-processor-sub` y `crash-traces-processor-sub` no tienen
-  # pushConfig (son PULL); el código usa `subscription.on('message')` (StreamingPull
-  # dentro del container). El comentario previo ("Pub/Sub push... retry cubre el cold
-  # start") era factualmente falso y es la CAUSA LATENTE del incidente 2026-06-07:
-  # con `min_instances=0` + CPU throttling, al apagarse la instancia nadie tira de la
-  # cola → telemetría caída ~26h. Un consumer pull REQUIERE min_instances>=1 + CPU
-  # always-on (cpu_idle=false).
+  # Pub/Sub PULL consumer (StreamingPull dentro del container:
+  # apps/telemetry-processor/src/main.ts → `subscription.on('message')`). NO es push:
+  # las subscriptions `telemetry-events-processor-sub` y `crash-traces-processor-sub`
+  # no tienen pushConfig.
   #
-  # El fix de runtime ya está aplicado a mano (revisión 00312): min=1 + cpu_idle=false.
-  # Codificarlo en IaC es el follow-up `telemetry-processor-min-instances`: requiere
-  # (a) min_instances=1 acá y (b) exponer cpu_idle como variable del módulo
-  # cloud-run-service (hoy está hardcodeado `cpu_idle = true` en modules/.../main.tf:37).
-  # Mientras eso no entre, hay DRIFT (el drift-check lo marca) y un `terraform apply`
-  # manual REVERTIRÍA el fix → re-rompe la telemetría. El apply NO es automático en
-  # merge (terraform-drift.yml solo corre plan), así que mergear no revierte; el peligro
-  # es un apply manual. La alerta `telemetry_consumer_stalled_p1` detecta recurrencia ~35min.
-  min_instances = 0
+  # ⚠️ min_instances=1 + cpu_idle=false son OBLIGATORIOS, no optimización: el loop de
+  # pull NO es request-driven, así que con min=0 la instancia escala a cero (nadie
+  # consume) y con cpu_idle=true queda CPU-throttled entre requests (el pull se starvea).
+  # Causa del incidente 2026-06-07 (telemetría caída ~26h con la config previa min=0 +
+  # "push consumer"). La recurrencia ahora la detecta `telemetry_consumer_stalled_p1`
+  # (telemetry-monitoring.tf) en ~35min. Coincide con el fix de runtime (revisión 00312).
+  min_instances = 1
   max_instances = 50
+  cpu_idle      = false
   cpu           = "2"
   memory        = "1Gi"
   concurrency   = 10 # control de rate a Firestore/BigQuery

--- a/infrastructure/modules/cloud-run-service/main.tf
+++ b/infrastructure/modules/cloud-run-service/main.tf
@@ -34,7 +34,7 @@ resource "google_cloud_run_v2_service" "service" {
           cpu    = var.cpu
           memory = var.memory
         }
-        cpu_idle          = true
+        cpu_idle          = var.cpu_idle
         startup_cpu_boost = true
       }
 

--- a/infrastructure/modules/cloud-run-service/variables.tf
+++ b/infrastructure/modules/cloud-run-service/variables.tf
@@ -42,6 +42,20 @@ variable "cpu" {
   default = "1"
 }
 
+variable "cpu_idle" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    Cloud Run CPU allocation. `true` (default) = "CPU only during request
+    processing" — correcto para servicios request/push-driven (la mayoría),
+    ahorra costo al permitir scale-to-zero efectivo. `false` = "CPU always
+    allocated" — REQUERIDO para servicios con trabajo de fondo continuo, p.ej.
+    un consumidor Pub/Sub StreamingPull dentro del container (el loop de pull
+    NO es request-driven, así que con cpu_idle=true queda CPU-throttled entre
+    requests y deja de consumir). Usar junto con min_instances>=1.
+  EOT
+}
+
 variable "memory" {
   type    = string
   default = "512Mi"


### PR DESCRIPTION
> Reemplaza #430, que GitHub cerró automáticamente al borrar la rama base de #429 (squash-merge del stack). Rama rebaseada sobre `main`; diff limpio = solo este cambio.

Cierra el landmine de #429: el fix de runtime (`min-instances=1` + CPU always-on, rev 00312) estaba aplicado a mano pero la IaC seguía en `min=0` → un `terraform apply` lo revertía.

El `telemetry-processor` es un consumidor **PULL/StreamingPull** ([main.ts:148](apps/telemetry-processor/src/main.ts)); el loop no es request-driven, así que `min=0` lo escala a cero y `cpu_idle=true` lo CPU-throttlea. Ambos juntos causaron el corte de ~26h.

**Cambios:** `modules/cloud-run-service` expone `cpu_idle` como variable (default `true`, backward-compatible) · `compute.tf` processor → `min_instances=1` + `cpu_idle=false` · `cloudbuild.production.yaml` → `--min-instances=1 --no-cpu-throttling` explícitos.

**Verify:** `terraform validate` OK · `plan`: el processor muestra **0 cambios** (IaC coincide con el vivo → drift resuelto, apply ya no revierte); otros servicios sin cambio de `cpu_idle`. Único servicio afectado (verificado).

Spec: `.specs/telemetry-processor-min-instances/spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)