### PR TITLE
feat(telemetry): alerta P1 gateway-down (pod liveness) + test de validación

### DIFF
--- a/.specs/telemetry-gateway-liveness-alert/spec.md
+++ b/.specs/telemetry-gateway-liveness-alert/spec.md
@@ -1,0 +1,56 @@
+# Spec — Alerta de ingreso de telemetría (gateway down)
+
+**Estado**: SHIP (alerta) + validación post-deploy pendiente
+**Fecha**: 2026-06-08
+**Gatillo**: follow-up diferido en el review de `.specs/telemetry-monitoring-observability`.
+**Stack**: sobre la rama del PR #429.
+
+## Problema
+
+El consumer-stall (`telemetry_consumer_stalled_p1`, #429) caza "el processor no
+consume", pero NO el modo "el gateway está caído" (sin mensajes entrando, oldest_unacked
+se queda en 0 → el consumer-stall nunca dispara). Falta una alerta para "no entra
+telemetría" (pod del gateway muerto, evicción, OOM, etc.). Es el modo del outage
+2026-05-07 (LB/DNS).
+
+## Por qué liveness del pod y no `device_records == 0`
+
+El review descartó `device_records_per_minute` en 0 porque:
+1. En apagón total las series por-IMEI desaparecen; un REDUCE_SUM sin inputs no se
+   marca como ausente de forma confiable → podría no disparar.
+2. Falso positivo nocturno: con el fleet estacionado los AVL records caen a 0
+   legítimamente (los Network Pings 0xFF no cuentan como records).
+
+El detector correcto es `kubernetes.io/container/uptime` del container `gateway`:
+serie estable 24/7 (verificada en vivo: **0 huecos en 96h**) que sólo desaparece si
+el pod muere — sin enmascaramiento nocturno.
+
+## Diseño
+
+`google_monitoring_alert_policy.telemetry_gateway_down_p1`:
+- `condition_absent` sobre uptime del gateway, `duration=600s` (10 min).
+- Agregación `REDUCE_COUNT` agrupando por cluster/namespace/container → **colapsa
+  `pod_name`**: un rolling restart (pod_name nuevo) mantiene la serie presente y no
+  falsea; sólo dispara si NO hay ningún pod del gateway.
+- Severidad ERROR/P1: es el ÚNICO detector de un apagón total de ingreso.
+
+## Validación (gate real — correr post-deploy)
+
+Una alerta por ausencia no se confía sin verla disparar. Test: `kubectl scale
+deployment/telemetry-tcp-gateway --replicas=0` en horario de bajo tráfico (~3 min;
+los devices buffean y reenvían → pérdida ≈ 0), confirmar que la policy abre,
+restaurar. Procedimiento en el runbook §Telemetry ingress stopped.
+
+## Alcance / no-alcance
+
+- Único modo cubierto: gateway/pod down. Degradación parcial (algunos devices) o
+  LB/DNS con pod sano NO la dispara (el pod sigue reportando uptime) — diagnóstico
+  manual en el runbook.
+- No toca otros servicios.
+
+## Criterios de aceptación
+
+1. `terraform validate` OK; `fmt` limpio; `plan` = 1 add (la alerta), 0 destroy.
+2. Alerta con `condition_absent` + colapso de `pod_name`, apuntando a `email_alerts`.
+3. Runbook actualizado: métrica + razón del diseño + procedimiento de test.
+4. PR con Evidencia. **Validación empírica marcada como paso post-deploy obligatorio.**

--- a/docs/runbooks/oncall-telemetry-incidents.md
+++ b/docs/runbooks/oncall-telemetry-incidents.md
@@ -217,22 +217,23 @@ el modo de falla del incidente del 2026-06-07 (processor escaló a cero ~26h).
 
 ## Telemetry ingress stopped
 
-**Alerta automática**: ⏳ PENDIENTE (follow-up `telemetry-gateway-liveness-alert`).
-Mientras ese follow-up no entregue la alerta, esta sección es un **playbook de
-diagnóstico manual**.
+**Métrica** (P1): `telemetry_gateway_down_p1` — `condition_absent` sobre
+`kubernetes.io/container/uptime` del container `gateway` (ns `telemetry`),
+agregado colapsando `pod_name`, ausente > 10 min.
 
-> Por qué la alerta queda en follow-up y no en este PR: detectar "no entra
-> telemetría" es detección por ausencia, y en GCP es sutil. La primera versión
-> (sobre `device_records_per_minute` en 0) se descartó en review porque (a) en un
-> apagón total las series por-IMEI desaparecen y `REDUCE_SUM`+missing-data podría
-> no disparar, y (b) con el fleet estacionado de noche la tasa puede bajar a 0
-> records legítimamente — ojo: los Network Pings Teltonika (0xFF) **no** cuentan
-> como records, sólo los AVL. El detector correcto es un liveness POSITIVO del pod
-> del gateway (`kubernetes.io/container/uptime`, serie única estable 24/7), pero
-> debe validarse parando el gateway en una prueba antes de confiar en él. Una
-> alerta de ingreso que no dispara es peor que ninguna.
+> ⚠️ Validación pendiente: es una alerta por ausencia; confirmar que dispara con un
+> **stop controlado del gateway** (~3 min, en horario de bajo tráfico). Los devices
+> Teltonika buffean y reenvían al reconectar → pérdida ≈ 0. Procedimiento de test al
+> final de esta sección.
+>
+> Diseño: se usa liveness POSITIVO del pod (uptime), NO `device_records` en 0,
+> porque (a) en un apagón total las series por-IMEI desaparecen y un REDUCE_SUM sin
+> inputs no se marca como ausente de forma confiable, y (b) con el fleet estacionado
+> de noche los records caen a 0 legítimamente (los Network Pings 0xFF no cuentan).
+> El uptime del pod es estable 24/7 y sólo desaparece si el pod muere. Se colapsa
+> `pod_name` para que un rolling restart no falsee.
 
-**Significado** (cuando se sospecha): **no llegan AVL records de ningún device**.
+**Significado**: **no llegan AVL records de ningún device**.
 Falla del lado de ingreso: pod del gateway caído, LB/DNS desalineado, cert TLS
 (5061) vencido, o todos los devices offline. (Distinto de "consumer stalled": acá
 los mensajes ni siquiera entran a Pub/Sub — el consumer-stall sí tiene alerta.)
@@ -258,6 +259,29 @@ los mensajes ni siquiera entran a Pub/Sub — el consumer-stall sí tiene alerta
 
 4. **Devices**: si gateway + LB + cert OK, revisar si los devices están online
    (operador móvil, energía). De madrugada con fleet estacionado puede ser normal.
+
+### Validación de la alerta (test controlado, correr 1 vez post-deploy)
+
+Confirmar que `telemetry_gateway_down_p1` realmente dispara. Hacerlo en **horario
+de bajo tráfico** (los devices buffean y reenvían → pérdida ≈ 0).
+
+```bash
+gcloud container clusters get-credentials booster-ai-telemetry --region=southamerica-west1
+# 1. Bajar el gateway a 0 réplicas
+kubectl scale deployment/telemetry-tcp-gateway -n telemetry --replicas=0
+# 2. Esperar > duration de la alerta (10 min) + margen de propagación (~5 min)
+#    Confirmar que la alerta abre: GCP Console → Monitoring → Alerting,
+#    o revisar el email del canal email_alerts.
+# 3. Restaurar
+kubectl scale deployment/telemetry-tcp-gateway -n telemetry --replicas=1
+kubectl rollout status deployment/telemetry-tcp-gateway -n telemetry
+```
+
+- **Si la alerta abrió** → validada; nada más que hacer.
+- **Si NO abrió tras ~15 min** → revisar la condición `condition_absent` (¿la
+  agregación produce serie?, ¿`duration`?). NO confiar en ella hasta que dispare.
+- Tras restaurar, verificar que la telemetría vuelve a fluir (ver §Telemetry
+  consumer stalled paso 3).
 
 ---
 

--- a/infrastructure/telemetry-monitoring.tf
+++ b/infrastructure/telemetry-monitoring.tf
@@ -415,28 +415,64 @@ resource "google_monitoring_alert_policy" "telemetry_consumer_stalled_p1" {
   }
 }
 
-# P2 — Ingreso de telemetría detenido (gateway down): DIFERIDO a follow-up.
+# P1 — Gateway de telemetría CAÍDO (no hay capacidad de ingreso).
 #
-# La primera versión usaba `device_records_per_minute` (log-metric por-IMEI) con
-# REDUCE_SUM + evaluation_missing_data=ACTIVE para disparar en "0 records". El
-# review adversarial (.specs/telemetry-monitoring-observability) detectó dos
-# defectos que la harían poco confiable JUSTO en el apagón que busca cazar:
-#   1. En un apagón total TODAS las series por-IMEI desaparecen; una serie
-#      reducida (REDUCE_SUM) sin inputs no tiene identidad estable, así que
-#      evaluation_missing_data podría no marcarla como ausente → no dispara.
-#   2. Falso positivo nocturno: los Network Pings Teltonika (0xFF) NO incrementan
-#      device_records (sólo los AVL records sí); con el fleet estacionado la tasa
-#      puede caer legítimamente a 0.
+# Modo de falla complementario al consumer-stall: si el pod del gateway muere
+# (crash, OOM, evicción sin reschedule, config error) o el cluster lo pierde, NO
+# entra telemetría a Pub/Sub. El consumer-stall NO lo caza (sin mensajes nuevos,
+# oldest_unacked se queda en 0), así que esta es la ÚNICA alerta de ese modo.
 #
-# El detector correcto es un liveness POSITIVO del pod del gateway
-# (`kubernetes.io/container/uptime`, serie única estable 24/7 que sólo desaparece
-# si el pod muere — sin enmascaramiento nocturno). Requiere validación EMPÍRICA
-# (parar el gateway en una ventana de prueba y confirmar que la policy abre) antes
-# de confiar en ella, por eso no se incluye acá. Una alerta de ingreso que no
-# dispara es peor que ninguna. Follow-up: telemetry-gateway-liveness-alert.
+# Detector: liveness POSITIVO del pod vía `kubernetes.io/container/uptime`. Es una
+# serie estable 24/7 que existe mientras el container corre y DESAPARECE si el pod
+# muere — sin enmascaramiento nocturno (a diferencia de device_records, que cae a 0
+# legítimamente con el fleet estacionado; los Network Pings 0xFF no cuentan como
+# records). Verificado en vivo: serie continua, 0 huecos en 96h.
 #
-# NOTA: el incidente 2026-06-07 fue consumer-stall, no ingress — cubierto al 100%
-# por `telemetry_consumer_stalled_p1` arriba.
+# `condition_absent` + agregación que COLAPSA pod_name (REDUCE_COUNT por
+# cluster/namespace/container): así un rolling restart (pod_name nuevo) mantiene la
+# serie presente y NO falsea; sólo dispara si NO hay ningún pod del gateway por
+# `duration`. duration=600s (10min) > cualquier gap de restart normal (0 restarts
+# en 96h observados); el consumer-stall (30min) queda como backstop.
+#
+# ⚠️ PENDIENTE VALIDACIÓN EMPÍRICA: una alerta por ausencia no se confía sin verla
+# disparar. Validar con un stop controlado del gateway (~3min, los devices Teltonika
+# buffean y reenvían → pérdida ≈0). Ver runbook §Telemetry ingress stopped y
+# .specs/telemetry-gateway-liveness-alert.
+resource "google_monitoring_alert_policy" "telemetry_gateway_down_p1" {
+  display_name = "Telemetry gateway pod down — no ingress (P1)"
+  project      = google_project.booster_ai.project_id
+  combiner     = "OR"
+  severity     = "ERROR"
+
+  conditions {
+    display_name = "no gateway container reporting uptime > 10 min"
+    condition_absent {
+      filter   = "resource.type=\"k8s_container\" AND resource.labels.cluster_name=\"booster-ai-telemetry\" AND resource.labels.namespace_name=\"telemetry\" AND resource.labels.container_name=\"gateway\" AND metric.type=\"kubernetes.io/container/uptime\""
+      duration = "600s"
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_MEAN"
+        # Colapsar pod_name → "cuántos pods del gateway reportan". Sobrevive
+        # rolling restarts (el pod nuevo entra al mismo grupo); ausente sólo
+        # cuando NO hay ningún pod del gateway.
+        cross_series_reducer = "REDUCE_COUNT"
+        group_by_fields = [
+          "resource.label.cluster_name",
+          "resource.label.namespace_name",
+          "resource.label.container_name",
+        ]
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email_alerts.id]
+
+  documentation {
+    content   = "El pod del gateway de telemetría no reporta hace >10min — no hay capacidad de ingreso (devices Teltonika no pueden conectar). Revisar pod (kubectl get pods -n telemetry), evicción/OOM, LB/DNS, cert TLS. Runbook: docs/runbooks/oncall-telemetry-incidents.md#telemetry-ingress-stopped"
+    mime_type = "text/markdown"
+  }
+}
 
 # =============================================================================
 # DASHBOARD — Telemetría Overview


### PR DESCRIPTION
> Reemplaza #431, cerrado por GitHub al borrar la rama base de #429. Rama rebaseada sobre `main`; diff limpio.

Cierra el follow-up de ingreso diferido en #429. El consumer-stall no caza "gateway caído" (sin mensajes entrando, `oldest_unacked` se queda en 0). Falta el detector de ese modo (pod muerto/evicción/OOM; el outage 2026-05-07 fue así).

**Diseño:** `telemetry_gateway_down_p1` = `condition_absent` sobre `kubernetes.io/container/uptime` del container `gateway`, `duration=600s`, agregación `REDUCE_COUNT` colapsando `pod_name` (sobrevive rolling restarts; dispara sólo si no hay ningún pod). Liveness positivo, sin enmascaramiento nocturno (verificado: serie continua, 0 huecos en 96h). P1 = único detector de apagón total de ingreso.

**Verify:** `terraform validate` OK · `plan` = 1 add, 0 destroy.

**⚠️ Validación empírica POST-DEPLOY obligatoria:** una alerta por ausencia no se confía sin verla disparar. `kubectl scale deployment/telemetry-tcp-gateway -n telemetry --replicas=0` (~3min, bajo tráfico; los devices buffean y reenvían → pérdida ≈0), confirmar que abre, restaurar. Procedimiento en el runbook.

Spec: `.specs/telemetry-gateway-liveness-alert/spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)