### PR TITLE
fix(infra): saca comentario del filtro de crash_trace_persistence_failures

### DIFF
--- a/infrastructure/crash-traces.tf
+++ b/infrastructure/crash-traces.tf
@@ -291,12 +291,14 @@ resource "google_logging_metric" "crash_trace_persistence_failures" {
 
   description = "Cuenta errores al persistir Crash Traces (upload GCS o insert BQ falló)."
 
+  # Campo = jsonPayload.message (Pino messageKey='message'); ver nota en
+  # infrastructure/telemetry-monitoring.tf. Con `msg` matcheaba 0 (métrica muerta).
+  # NOTA: el filtro NO admite comentarios `#` — Cloud Logging los rechaza con
+  # "Unparseable filter" (el comentario va acá afuera, no dentro del heredoc).
   filter = <<-EOT
     resource.type="cloud_run_revision"
     resource.labels.service_name="booster-ai-telemetry-processor"
     severity>=ERROR
-    # Campo = jsonPayload.message (Pino messageKey='message'); ver nota en
-    # infrastructure/telemetry-monitoring.tf. Con `msg` matcheaba 0 (métrica muerta).
     jsonPayload.message="error persistiendo crash-trace, nack para reintento"
   EOT
 


### PR DESCRIPTION
Hotfix de #429. El `terraform apply` falló al actualizar el log-metric `crash_trace_persistence_failures` con `Error 400: Unparseable filter: syntax error ... token ';'`.

**Causa:** en #429 el comentario explicativo `# Campo = jsonPayload.message...` quedó **dentro** del heredoc `filter = <<-EOT ... EOT`. Los filtros de Cloud Logging no admiten comentarios `#` → la API los rechaza. `terraform validate`/`plan` no validan la sintaxis del filtro (es un string opaco para TF), por eso pasó CI y solo falló en apply.

**Fix:** comentario movido afuera del heredoc. Las otras 5 métricas (msg→message de #429) aplicaron OK porque no tenían comentarios dentro del filtro.

**Verify:** filtro corregido validado contra la API (`gcloud logging read '<filtro>'` → exit 0, parsea) · `terraform validate` OK · `fmt` limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)