### PR TITLE
docs(runbooks): corrige staleness operacional post-auditoría

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -35,6 +35,12 @@ description = "Claves web públicas por diseño (Firebase via App Check+Rules; M
 regexes = [
   '''AIzaSyDrmKjRa1i0RVAJQKtFsVcQCF_uuJ6IxZk''',
   '''AIzaSyAVy84hArL08alVL2JEGfNCgTSqu4eTyNg''',
+  # Falso positivo recurrente de `generic-api-key`: el "secreto" detectado
+  # es el nombre de la región GCP (alta entropía aparente, cero secreto;
+  # gitleaks matchea las regexes contra el secret detectado). Mismo caso ya
+  # allowlisteado por path para sprint-1-evidence; esto cubre runbooks que
+  # documentan comandos gcloud con la región (ej. secret-init).
+  '''^southamerica-west1$''',
 ]
 
 paths = [

--- a/.specs/docs-runbooks-staleness/plan.md
+++ b/.specs/docs-runbooks-staleness/plan.md
@@ -1,0 +1,17 @@
+# Plan: docs-runbooks-staleness
+
+- Spec: .specs/docs-runbooks-staleness/spec.md
+- Created: 2026-06-10
+- Status: Active
+
+## Tasks
+
+### T1: Correcciones in-place (dr-failover banner, oncall, content-sids, secret-init, guía demo, goal-templates)
+- Files: docs/runbooks/{dr-failover-test,oncall-telemetry-incidents,load-content-sids,secret-init-runbook,goal-templates}.md, docs/demo/guia-uso-demo.md
+- LOC estimate: ~80
+- Acceptance: spec §10 T1–T3, T5.
+
+### T2: Archivar 4 runbooks ejecutados/obsoletos + catálogo
+- Files: docs/runbooks/{wave-2-3-deploy,dns-migration-godaddy-to-cloud-dns,twilio-sender-registration,credential-rotation-2026-04}.md → docs/archive/2026-06-10-*.md, docs/archive/README.md
+- LOC estimate: ~50 (frontmatter ×4 + catálogo)
+- Acceptance: spec §10 T4.

--- a/.specs/docs-runbooks-staleness/spec.md
+++ b/.specs/docs-runbooks-staleness/spec.md
@@ -1,0 +1,77 @@
+# Spec: docs-runbooks-staleness
+
+- Author: Felipe Vicencio (with agent-rigor)
+- Date: 2026-06-10
+- Status: Approved
+- Linked: Auditoría 2026-06-09, seguimiento "Documentación operacional vs estado real" (riesgos altos dr-failover y wave-2-3; medios msg→message, región, oncall P0 muertas, guía demo)
+
+## 1. Objective
+
+Corregir o archivar la documentación operacional que daría instrucciones incorrectas en un incidente: el runbook de DR provoca outage total si se ejecuta hoy (asume DR caliente pre-ADR-058), dos runbooks verifican con filtros de log muertos (`jsonPayload.msg` vs `message`), el de secrets apunta a la región equivocada, el on-call documenta alertas P0 que no pueden disparar, la guía de demo lista cuentas retiradas, y 4 runbooks de eventos ya ejecutados siguen "Pendiente" fuera de `docs/archive/`.
+
+## 2. Why now
+
+Operador único + runbooks incorrectos = tiempo perdido o daño en el peor momento (un incidente). El costo del fix es solo edición.
+
+## 3. Success criteria
+
+- [ ] dr-failover-test.md con banner bloqueante post-ADR-058 + procedimiento real de reactivación DR cold referenciado.
+- [ ] oncall-telemetry-incidents.md: secciones Unplug/Jamming marcadas "ALERTA HOY INOPERANTE" con referencia al TF; canal real (email) en vez de Slack/PagerDuty.
+- [ ] load-content-sids.md usa `jsonPayload.message`.
+- [ ] secret-init-runbook.md usa `--region=southamerica-west1`.
+- [ ] wave-2-3-deploy, dns-migration, twilio-sender-registration y credential-rotation-2026-04 movidos a docs/archive/ con frontmatter de convención (git mv) + catálogo actualizado.
+- [ ] guia-uso-demo.md lista las cuentas demo-2026-* reales (seed-demo.ts).
+- [ ] goal-templates.md sin paths rotos (/Users/fvicencio → /Users/felipevicencio; settings.local.json).
+
+## 4. User-visible behaviour
+
+Solo documentación interna de operación.
+
+## 5. Out of scope
+
+- Crear el runbook completo de failover DR cold (requiere rehearsal real; el banner referencia dr-region.tf y ADR-058 como fuente).
+- docs/specs/ y docs/plans/ legacy (PR-3 de ADR-049 pendiente — anotado en specs P2/_followups).
+- Hacer disparables las alertas P0 muertas (requiere implementar notification-service — spec P2).
+
+## 6. Constraints
+
+1. Archivar = `git mv` + frontmatter YAML de docs/archive/README.md (history preservada).
+2. No editar ADRs.
+3. Las correcciones citan la fuente viva (TF/código) para que el próximo drift sea detectable.
+
+## 7. Approach
+
+Edición dirigida por archivo según los hallazgos verificados de la auditoría (cada uno con archivo:línea); archivado con la convención existente; catálogo del archive actualizado.
+
+## 8. Alternatives considered
+
+- **A. Borrar los runbooks obsoletos** — Rechazada: la regla del archive es NUNCA borrar (trazabilidad).
+- **B. Reescribir dr-failover-test.md completo para DR cold** — Rechazada en este ciclo, con condición de reapertura explícita: un runbook de failover sin rehearsal real es teoría peligrosa; el banner + referencia a ADR-058/dr-region.tf es la fuente honesta hasta que el PO agende el rehearsal DR (al agendarlo, se escribe el runbook nuevo con evidencia del ensayo).
+
+## 9. Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Archivar algo aún citado por docs vivos | L | L | grep de referencias antes del mv; el archive preserva contenido |
+| Banner insuficiente (operador igual ejecuta) | L | H | Banner al inicio con NO EJECUTAR + outcome explícito (outage total de ingesta) |
+
+## 10. Test list
+
+- T1: grep `jsonPayload.msg` en docs/runbooks → 0 resultados.
+- T2: grep `us-central1` en secret-init-runbook → 0 resultados.
+- T3: grep `/Users/fvicencio/` en docs/runbooks → 0.
+- T4: los 4 archivados existen bajo docs/archive/2026-06-10-*.md con frontmatter y no en docs/runbooks/.
+- T5: guia-uso-demo menciona demo-2026-shipper/carrier/stakeholder.
+
+## 11. Rollout
+
+- Rollback: git revert.
+- Monitoring: n/a.
+
+## 12. Open questions
+
+None as of 2026-06-10.
+
+## 13. Decision log
+
+- 2026-06-10 — Draft + aprobación PO vía punto 6. §8.B registrado con condición de reapertura (rehearsal DR); el hook anti-drift bloqueó la redacción inicial y se reformuló (evento drift_blocked en ledger).

--- a/docs/archive/2026-06-10-credential-rotation-2026-04.md
+++ b/docs/archive/2026-06-10-credential-rotation-2026-04.md
@@ -1,3 +1,16 @@
+---
+archived_at: 2026-06-10
+archived_in: docs(runbooks) correcciones staleness post-auditoría 2026-06-09
+superseded_by:
+  - infrastructure/security-hotfixes-2026-05-14.tf (patrón vigente de rotación post-disclosure)
+  - docs/runbooks/secret-init-runbook.md
+archived_reason: |
+  Runbook de evento puntual (exposición en chat 2026-04-29) ya superado: el
+  patrón vigente es placeholder REPLACE_ME + init script idempotente + CI
+  gate. Asumía además el bot en sandbox (productivo desde 2026-04-29).
+status: archived
+---
+
 # Runbook: Rotación de credenciales expuestas (Sesión 2026-04-29)
 
 **Fecha:** 2026-04-29

--- a/docs/archive/2026-06-10-dns-migration-godaddy-to-cloud-dns.md
+++ b/docs/archive/2026-06-10-dns-migration-godaddy-to-cloud-dns.md
@@ -1,3 +1,15 @@
+---
+archived_at: 2026-06-10
+archived_in: docs(runbooks) correcciones staleness post-auditoría 2026-06-09
+superseded_by:
+  - infrastructure/networking.tf (zona Cloud DNS viva, DNSSEC on)
+archived_reason: |
+  Migración ejecutada y completada el 2026-04-30 (su propia Fase 7 documenta
+  TTL bump y smoke test, commit 8ed82f2). El header decía "Pendiente" por
+  falta del paso de archivado.
+status: archived
+---
+
 # Runbook: Migración DNS boosterchile.com de GoDaddy a Google Cloud DNS
 
 **Fecha:** 2026-04-29

--- a/docs/archive/2026-06-10-twilio-sender-registration.md
+++ b/docs/archive/2026-06-10-twilio-sender-registration.md
@@ -1,3 +1,15 @@
+---
+archived_at: 2026-06-10
+archived_in: docs(runbooks) correcciones staleness post-auditoría 2026-06-09
+superseded_by:
+  - infrastructure/variables.tf (sender +19383365293 registrado 2026-04-29, WABA 874993441667738, default productivo)
+archived_reason: |
+  Registro del sender ejecutado el 2026-04-29; el header quedó en "Pendiente.
+  Sandbox como workaround" pese a estar productivo. La sección Rollback
+  conserva valor de referencia histórica.
+status: archived
+---
+
 # Runbook: Registrar +1 938-336-5293 como Twilio WhatsApp Sender
 
 **Fecha:** 2026-04-29

--- a/docs/archive/2026-06-10-wave-2-3-deploy.md
+++ b/docs/archive/2026-06-10-wave-2-3-deploy.md
@@ -1,3 +1,19 @@
+---
+archived_at: 2026-06-10
+archived_in: docs(runbooks) correcciones staleness post-auditoría 2026-06-09
+superseded_by:
+  - cloudbuild.production.yaml (pipeline canónico Cloud Run)
+  - infrastructure/cloudbuild.tf + ADR-059 (deploy GKE vía DNS endpoint)
+  - scripts/deploy-telemetry-gateway.sh (vía manual GKE vigente)
+archived_reason: |
+  Deploy de Waves 2/3 ejecutado en mayo 2026. Sus pasos hoy son imposibles
+  o dañinos: SA JSON keys bloqueadas por org policy, manifests renombrados,
+  staging inexistente, tooling GitLab superseded (ADR-056), réplicas y
+  filtros de verificación (jsonPayload.msg) desactualizados. Su propio §7.4
+  ordenaba archivarlo post-deploy.
+status: archived
+---
+
 # Wave 2 + Wave 3 — Deploy runbook
 
 Procedimiento de despliegue de los 9 tracks del brief

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -32,6 +32,10 @@ status: archived
 | `2026-05-17-audit.md` | `AUDIT.md` (raíz, 2026-05-01) | `.specs/audit-2026-05-14/inventory.md` |
 | `2026-05-17-plan-phase-0.md` | `PLAN-PHASE-0.md` (raíz, greenfield init) | `.specs/production-readiness/spec.md+roadmap.md`, ADR-042, ADR-043, `CLAUDE.md §"Reglas de naming bilingüe"` |
 | `2026-05-17-design.md` | `DESIGN.md` (raíz, 2026-04-30) | `packages/ui-tokens/`, `design-system/MASTER.md` (futuro) |
+| `2026-06-10-wave-2-3-deploy.md` | `docs/runbooks/wave-2-3-deploy.md` | `cloudbuild.production.yaml`, ADR-059, `scripts/deploy-telemetry-gateway.sh` |
+| `2026-06-10-dns-migration-godaddy-to-cloud-dns.md` | `docs/runbooks/dns-migration-godaddy-to-cloud-dns.md` | `infrastructure/networking.tf` (zona Cloud DNS) |
+| `2026-06-10-twilio-sender-registration.md` | `docs/runbooks/twilio-sender-registration.md` | `infrastructure/variables.tf` (sender registrado) |
+| `2026-06-10-credential-rotation-2026-04.md` | `docs/runbooks/credential-rotation-2026-04.md` | `infrastructure/security-hotfixes-2026-05-14.tf`, `docs/runbooks/secret-init-runbook.md` |
 
 ## No-goals
 

--- a/docs/demo/guia-uso-demo.md
+++ b/docs/demo/guia-uso-demo.md
@@ -77,15 +77,15 @@ Respuesta (guarda esto — el PIN no se vuelve a mostrar):
   "ok": true,
   "credentials": {
     "shipper_owner": {
-      "email": "demo-shipper@boosterchile.com",
+      "email": "demo-2026-shipper@boosterchile.com",
       "password": "<DEMO_SEED_PASSWORD>"
     },
     "carrier_owner": {
-      "email": "demo-carrier@boosterchile.com",
+      "email": "demo-2026-carrier@boosterchile.com",
       "password": "<DEMO_SEED_PASSWORD>"
     },
     "stakeholder": {
-      "email": "demo-stakeholder@boosterchile.com",
+      "email": "demo-2026-stakeholder@boosterchile.com",
       "password": "<DEMO_SEED_PASSWORD>"
     },
     "conductor": {
@@ -110,9 +110,9 @@ El seed es **idempotente** — corriéndolo de nuevo no duplica entidades, sólo
 
 | Usuario | Identificador | Credencial | Empresa | Rol |
 |---|---|---|---|---|
-| Dueño Andina Demo | demo-shipper@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Andina Demo S.A. (RUT 76999111-1) | dueno (shipper) |
-| Dueño Transportes Demo Sur | demo-carrier@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Transportes Demo Sur S.A. (RUT 77888222-K) | dueno (carrier) |
-| Stakeholder Demo | demo-stakeholder@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Transportes Demo Sur (auditoría externa) | stakeholder_sostenibilidad |
+| Dueño Andina Demo | demo-2026-shipper@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Andina Demo S.A. (RUT 76999111-1) | dueno (shipper) |
+| Dueño Transportes Demo Sur | demo-2026-carrier@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Transportes Demo Sur S.A. (RUT 77888222-K) | dueno (carrier) |
+| Stakeholder Demo | demo-2026-stakeholder@boosterchile.com | password leído de Secret Manager (`demo-seed-password`) | Transportes Demo Sur (auditoría externa) | stakeholder_sostenibilidad |
 | Pedro González | RUT `12345678-5` | PIN 6 dígitos (del seed response) | Transportes Demo Sur | conductor |
 
 **Nota sobre RUT**: el sistema acepta RUT con o sin puntos al tipear, pero siempre persiste en formato canónico **sin puntos** (`12345678-5`). Los inputs de la UI muestran placeholder y hint indicando "Sin puntos, con guión".
@@ -140,7 +140,7 @@ El seed es **idempotente** — corriéndolo de nuevo no duplica entidades, sólo
 
 ## 4. Walkthrough paso a paso
 
-### A. Como shipper — `demo-shipper@boosterchile.com`
+### A. Como shipper — `demo-2026-shipper@boosterchile.com`
 
 1. **Login**: `https://app.boosterchile.com/login` → email + password.
 2. **Dashboard `/app`**: vas a ver cards para "Crear carga", "Mis cargas", **"Sucursales"** (D7b), **"Certificados de huella de carbono"** (D5).
@@ -151,7 +151,7 @@ El seed es **idempotente** — corriéndolo de nuevo no duplica entidades, sólo
 4. **Click en "Crear carga"** → publica una oferta. Origen Bodega Maipú, destino CD Quilicura por ejemplo (demuestra el caso "transporte entre sucursales").
 5. **Click en "Certificados"** → al pie, ves el card "Cómo calculamos la huella de carbono" con la metodología GLEC v3 + ejemplo Santiago → Concepción (D5).
 
-### B. Como carrier — `demo-carrier@boosterchile.com`
+### B. Como carrier — `demo-2026-carrier@boosterchile.com`
 
 1. **Login**: mismo `/login`, email + password.
 2. **Dashboard `/app`**: cards para transportista:
@@ -211,7 +211,7 @@ El seed es **idempotente** — corriéndolo de nuevo no duplica entidades, sólo
 - La data del IMEI 863238075489155 fluye normalmente a Van Oosterwyk AND simultáneamente se refleja en el vehículo DEMO01 del carrier demo (via columna `teltonika_imei_espejo`).
 - **Cero contaminación** — Van Oosterwyk no ve nada del demo.
 
-### E. Como stakeholder — `demo-stakeholder@boosterchile.com`
+### E. Como stakeholder — `demo-2026-stakeholder@boosterchile.com`
 
 1. **Login**: `https://app.boosterchile.com/login` → email + password leído de Secret Manager (`demo-seed-password`).
 2. **Surface guard**: si entra a `/app` se redirige automáticamente a `/app/stakeholder/zonas` (su único hub útil).

--- a/docs/research/teltonika-fmc150/CONFIGURACION-BOOSTER-DETALLADA.md
+++ b/docs/research/teltonika-fmc150/CONFIGURACION-BOOSTER-DETALLADA.md
@@ -341,5 +341,5 @@ firmware version.
 - Catálogo IDs en código:
   - `packages/shared-schemas/src/avl-ids/low-priority.ts` (14 Low Priority).
   - `packages/shared-schemas/src/avl-ids/high-panic.ts` (10 eventuales).
-- Runbook deploy Wave 2/3: `docs/runbooks/wave-2-3-deploy.md`.
+- Runbook deploy Wave 2/3 (archivado 2026-06-10): `docs/archive/2026-06-10-wave-2-3-deploy.md`. Pipeline vigente: `cloudbuild.production.yaml` + ADR-059.
 - ADR 005 telemetry-iot: `docs/adr/005-telemetry-iot.md`.

--- a/docs/runbooks/dr-failover-test.md
+++ b/docs/runbooks/dr-failover-test.md
@@ -1,5 +1,24 @@
 # Runbook — DR failover test (Wave 3 D4)
 
+> ## ⛔ NO EJECUTAR — OBSOLETO POST-ADR-058 (2026-06-05)
+>
+> Este runbook fue escrito para DR **caliente** (réplicas activas en
+> us-central1). Desde ADR-058 el DR es **cold**: el deployment DR está en
+> `replicas: 0` (`infrastructure/k8s/telemetry-tcp-gateway-dr.yaml:45`) y
+> el primary corre con `replicas: 1` (no 2, como asume el paso de
+> restauración).
+>
+> **Ejecutar el Test 1 hoy (scale primary a 0) corta el 100% de la
+> ingesta de telemetría: no hay backup que tome el tráfico.**
+>
+> Fuente vigente de reactivación DR: `infrastructure/dr-region.tf:20-25`
+> (procedimiento manual, RTO 15–40 min: terraform apply + scale-up del
+> deployment DR + redireccionar devices a telemetry-dr.boosterchile.com
+> vía SMS-MT) y ADR-058. El runbook nuevo de failover cold se escribirá
+> con el rehearsal DR que agende el PO (condición de reapertura,
+> `.specs/docs-runbooks-staleness/spec.md §8.B`).
+
+
 Procedimiento para validar el failover del telemetry-tcp-gateway
 desde primary (southamerica-west1) al DR (us-central1) y de vuelta.
 

--- a/docs/runbooks/goal-templates.md
+++ b/docs/runbooks/goal-templates.md
@@ -4,7 +4,7 @@
 **Origen**: refinamiento de los 5 planes iniciales tras la sesión de ejecución real (`#166` + `#226` + `#227` mergeados con `/goal` + intervención).
 **Audiencia**: Felipe Vicencio (solo dev), agentes Claude operando bajo `agent-rigor`.
 
-`/goal` es ideal cuando la condición de cierre es **objetivamente verificable desde la transcripción** y el trabajo NO requiere decisiones de producto. Estas plantillas asumen que `.claude/settings.json` (local) ya tiene la allowlist amplia aplicada — sin eso, cada `/goal` se atasca en prompts de autorización.
+`/goal` es ideal cuando la condición de cierre es **objetivamente verificable desde la transcripción** y el trabajo NO requiere decisiones de producto. Estas plantillas asumen que `.claude/settings.local.json` ya tiene la allowlist amplia aplicada — sin eso, cada `/goal` se atasca en prompts de autorización.
 
 ---
 
@@ -26,7 +26,7 @@ Lección observada el 2026-05-16: un `/goal Cerrar PR #<PR>` (placeholder litera
 
 ### Pre-flight obligatorio (primer turno del agente, post-sanity check)
 
-1. Leer `/Users/fvicencio/.claude/plugins/cache/agent-rigor/agent-rigor/0.2.0/CLAUDE.md` y escribir `skill_read` al ledger antes de cualquier `Write`/`Edit`. Sin esto, el primer `Write` se bloquea por `PreToolUse`.
+1. Leer `/Users/felipevicencio/.claude/plugins/cache/agent-rigor/agent-rigor/0.2.0/CLAUDE.md` y escribir `skill_read` al ledger antes de cualquier `Write`/`Edit`. Sin esto, el primer `Write` se bloquea por `PreToolUse`.
 2. Declarar `phase_enter` (con feature slug) **o** `skip-cycle` con justificación, también al ledger.
 3. Verificar la premisa antes de actuar (lección hoy: el `/goal` inicial afirmó "colisión ADR-033 entre #164 y #166" sin abrir los archivos; era falso). Usar `gh pr view --json files` + leer el contenido real, no inferir de títulos/body.
 
@@ -64,7 +64,7 @@ El agente DEBE abortar `/goal` y reportar en chat si:
 ```
 Actualizar docs/handoff/CURRENT.md para reflejar el estado real de main hoy.
 
-Pre-flight: leer /Users/fvicencio/.claude/plugins/cache/agent-rigor/agent-rigor/0.2.0/CLAUDE.md y escribir skill_read al ledger. Declarar skip-cycle (snapshot documental sin código de producción).
+Pre-flight: leer /Users/felipevicencio/.claude/plugins/cache/agent-rigor/agent-rigor/0.2.0/CLAUDE.md y escribir skill_read al ledger. Declarar skip-cycle (snapshot documental sin código de producción).
 
 Steps:
 1. `git fetch github main` y crear branch `chore/current-md-update-YYYY-MM-DD` desde github/main.

--- a/docs/runbooks/load-content-sids.md
+++ b/docs/runbooks/load-content-sids.md
@@ -113,7 +113,7 @@ gcloud run services update booster-ai-api \
 # Verificar que el api lee el nuevo SID:
 gcloud logging read 'resource.type="cloud_run_revision"
   resource.labels.service_name="booster-ai-api"
-  jsonPayload.msg=~"oferta enviada"' \
+  jsonPayload.message=~"oferta enviada"' \
   --limit=5 --project=booster-ai-494222
 ```
 

--- a/docs/runbooks/oncall-telemetry-incidents.md
+++ b/docs/runbooks/oncall-telemetry-incidents.md
@@ -4,10 +4,10 @@ Procedimientos para responder alertas del sistema de telemetría
 Booster (gateway + processor + apps consumer de eventos AVL).
 
 **Cuando recibas una alerta**:
-1. Acusá recibo en Slack/PagerDuty (no resolver hasta validar fix).
+1. Acusá recibo (canal real hoy: email a dev@boosterchile.com — único notification channel, `infrastructure/monitoring.tf:8-18`; no hay Slack/PagerDuty configurado).
 2. Ubicá la sección correspondiente abajo.
 3. Seguí los pasos en orden — no saltar.
-4. Si no podés resolver en 30 min, escalá a ingeniería backend.
+4. Si no podés resolver en 30 min, registrá el estado en docs/handoff/CURRENT.md antes de seguir (operador único — no existe escalamiento a otro equipo).
 
 ---
 
@@ -52,6 +52,13 @@ processor lo guardó en GCS + BigQuery.
 
 ## Unplug event (P0)
 
+> **⚠️ ALERTA HOY INOPERANTE**: la métrica `unplug_events` depende de
+> `jsonPayload.eventName` que ningún servicio emite todavía
+> (notification-service es skeleton — `infrastructure/telemetry-monitoring.tf:139-144`
+> lo documenta). Esta alerta NO puede disparar: no hay cobertura
+> automática anti-tamper. El procedimiento de abajo aplica solo si el
+> evento se detecta por otra vía (revisión manual de io_data AVL 252).
+
 **Métrica**: `telemetry/unplug_events` incrementó.
 
 **Significado**: el device perdió alimentación externa (cable
@@ -79,6 +86,11 @@ device.
 ---
 
 ## GNSS Jamming critical (P0)
+
+> **⚠️ ALERTA HOY INOPERANTE**: misma causa que Unplug — la métrica
+> depende de `jsonPayload.eventName` sin emisor
+> (`infrastructure/telemetry-monitoring.tf:166-169`). Sin cobertura
+> automática anti-jamming hasta implementar el consumer de eventos.
 
 **Métrica**: `telemetry/gnss_jamming_critical_events` incrementó.
 

--- a/docs/runbooks/secret-init-runbook.md
+++ b/docs/runbooks/secret-init-runbook.md
@@ -85,7 +85,7 @@ Cloud Run mountea la version `latest` al startup. Para tomar la nueva version si
 
 ```bash
 gcloud run services update booster-ai-api \
-  --region=us-central1 \
+  --region=southamerica-west1 \
   --project=booster-ai-494222
 ```
 
@@ -122,7 +122,7 @@ openssl rand -base64 32 | gcloud secrets versions add demo-seed-password \
   --project=booster-ai-494222 --data-file=-
 
 # 2. Restart Cloud Run para que tome la nueva latest
-gcloud run services update booster-ai-api --region=us-central1 --project=booster-ai-494222
+gcloud run services update booster-ai-api --region=southamerica-west1 --project=booster-ai-494222
 
 # 3. Verificar que el nuevo cold-start funciona, luego deshabilitar la version anterior
 gcloud secrets versions disable <previous-version-number> \


### PR DESCRIPTION
## Contexto

Auditoría 2026-06-09, seguimiento "Documentación operacional vs estado real": runbooks que darían instrucciones incorrectas en un incidente.

Spec: `.specs/docs-runbooks-staleness/spec.md`

## Cambios

- `dr-failover-test.md`: banner **NO EJECUTAR** (post-ADR-058 el DR es cold; ejecutarlo provoca outage total de ingesta).
- `oncall-telemetry-incidents.md`: secciones Unplug/Jamming P0 marcadas inoperantes (métricas sin emisor); canal real = email único.
- `load-content-sids.md`: filtro `jsonPayload.msg`→`message`; `secret-init-runbook.md`: región `southamerica-west1`; `guia-uso-demo.md`: cuentas `demo-2026-*`; `goal-templates.md`: home correcto.
- Archivados con frontmatter: wave-2-3-deploy, dns-migration, twilio-sender-registration, credential-rotation-2026-04.

## Evidencia

- **Verificación** (spec §10): `grep jsonPayload.msg` → 0; `grep us-central1` en secret-init → 0; `grep fvicencio/` → 0; 4 archivados bajo `docs/archive/2026-06-10-*`.
- **gitleaks**: limpio (allowlist del falso positivo región GCP, con precedente en sprint-1-evidence).
- **Review**: devils-advocate (observaciones menores anotadas; banner DR validado como bloqueante).

🤖 Generated with [Claude Code](https://claude.com/claude-code)