### PR TITLE
docs(specs): 6 follow-ups de la auditoría arquitectónica

### DIFF
--- a/.specs/_followups/canary-verify-mql-real.md
+++ b/.specs/_followups/canary-verify-mql-real.md
@@ -1,0 +1,20 @@
+# Follow-up: canary-verify real en cloudbuild.production.yaml
+
+**Origen**: Auditoría 2026-06-09 (riesgo alto CI/CD) + inventario adr-vs-prod Finding #1. Confirmado: el step `canary-verify` loguea umbrales (error_rate <1%, p95 <500ms) y hace `exit 0` (cloudbuild.production.yaml:255-274).
+**Prioridad**: P2.
+
+## Problema
+
+La promoción del canary del API a 100% ocurre tras 30 min de sleep sin verificación automática: depende 100% de observación humana + el synthetic monitor signup_probe. Un deploy con regresión sutil que no dispare el probe se promueve solo. Además `release.yml` no espera a `ci.yml` verde (se disparan en paralelo en push a main) y el canary solo cubre el servicio API — el resto deploya directo a 100%.
+
+## Acción propuesta
+
+1. Implementar la query real en canary-verify: `gcloud monitoring` (MQL o PromQL API) sobre `run.googleapis.com/request_count` filtrado por la revisión canary (tag `canary-signup-*`): error rate 5xx y p95 de latencia de la ventana de 30 min; `exit 1` si excede umbrales → el build aborta sin promover.
+2. Encadenar release.yml a ci.yml (workflow_run o gh api check de status) para que el deploy no corra con CI rojo.
+3. Evaluar extender el patrón canary a web/telemetry-processor (hoy 100% directo).
+
+**Atención**: toca el pipeline de deploy (archivo sensible per CLAUDE.md §archivos críticos) — requiere PR revisado por el PO y prueba en un deploy real observado.
+
+## Estado
+
+Pendiente. Sin asignar a ciclo.

--- a/.specs/_followups/cloudbuild-submit-iam-gating.md
+++ b/.specs/_followups/cloudbuild-submit-iam-gating.md
@@ -1,0 +1,18 @@
+# Follow-up: gatear a nivel IAM quién puede ejecutar builds de producción
+
+**Origen**: Eliminación de deploy-phase-2.sh (`.specs/ops-eliminar-deploy-phase-2/`, 2026-06-10) + seguimiento "Tooling operacional fuera de CI/CD" de la auditoría 2026-06-09.
+**Prioridad**: P2.
+
+## Problema
+
+El gate de aprobación humana del deploy vive SOLO en GitHub Actions (Environment `production` con required_reviewers). La API de Cloud Build no está gateada: cualquier principal con `cloudbuild.builds.create` en el proyecto puede `gcloud builds submit --config=cloudbuild.production.yaml` desde una laptop y desplegar a prod sin CI ni aprobación (el vector de deploy-phase-2.sh, ya eliminado, pero la capacidad IAM persiste).
+
+## Acción propuesta
+
+- Auditar qué principals tienen `cloudbuild.builds.create`/`editor` hoy (humanos vía grupos Workspace + SAs).
+- Restringir el rol a `github-deployer@` (WIF) y decidir el flujo de emergencia humano (¿break-glass documentado con justificación en ledger? ¿rol otorgable por tiempo acotado vía PAM de Google?).
+- Considerar `gcloud builds submit` bloqueado por org policy o condición IAM si Cloud Build lo soporta para el caso.
+
+## Estado
+
+Pendiente. Requiere decisión PO sobre el flujo de emergencia antes de restringir.

--- a/.specs/_followups/deploy-telemetry-gateway-repo-root-bug.md
+++ b/.specs/_followups/deploy-telemetry-gateway-repo-root-bug.md
@@ -1,0 +1,18 @@
+# Follow-up: bug REPO_ROOT en deploy-telemetry-gateway.sh + banner post-ADR-059
+
+**Origen**: Auditoría 2026-06-09 (seguimiento "Tooling operacional"), riesgo bajo.
+**Prioridad**: P3 (fix de 1 línea; el path de update funciona).
+
+## Problema
+
+1. `scripts/deploy-telemetry-gateway.sh:62`: `REPO_ROOT="$(git rev-parse --show-toplevel ...)/.."` apunta al PADRE del repo, por lo que el branch de PRIMER deploy (`kubectl apply -f ${REPO_ROOT}/infrastructure/k8s/telemetry-tcp-gateway.yaml`) referencia un archivo inexistente. Solo funciona el branch de update (`kubectl set image`).
+2. El header del script (líneas 2-16) justifica el deploy manual por "VPC peering no transitivo", pero ADR-059 (2026-06-06) resolvió el acceso vía DNS endpoint + pipelines `cloudbuild-primary-{deploy,check}.yaml` y declara "deprecar el deploy manual kubectl desde laptop". El script no tiene banner de deprecación.
+
+## Acción propuesta
+
+- Fix de 1 línea: quitar el `/..` de REPO_ROOT.
+- Agregar banner: "DEPRECADO POST-ADR-059 — usar cloudbuild-primary-deploy.yaml; este script queda como vía de emergencia" (o eliminarlo si los pipelines ADR-059 ya están validados end-to-end — verificar con el PO).
+
+## Estado
+
+Pendiente. Sin asignar a ciclo.

--- a/.specs/_followups/segundo-canal-alertas-sre.md
+++ b/.specs/_followups/segundo-canal-alertas-sre.md
@@ -1,0 +1,20 @@
+# Follow-up: segundo canal de notificación para alertas (P0 incluidas)
+
+**Origen**: Auditoría 2026-06-09 (infraestructura), riesgo medio "canal de alertas único".
+**Prioridad**: P2 (P1 si se firma el primer cliente B2B).
+
+## Problema
+
+TODAS las alertas de Cloud Monitoring — incluidas las P0 de crash forensics y el consumer-stall de telemetría — notifican a un único canal: email a dev@boosterchile.com (`infrastructure/monitoring.tf:8-18`). Un email no leído de madrugada = incidente sin atender. El secret `sre-notification-webhook` (Slack) existe como shell (`security-hotfixes-2026-05-14.tf:44-46`) pero ningún `google_monitoring_notification_channel` tipo webhook lo consume.
+
+## Acción propuesta
+
+1. **PO**: crear el webhook (Slack incoming webhook del workspace Booster, o canal Telegram/SMS según preferencia) y poblar el secret `sre-notification-webhook`.
+2. Terraform: `google_monitoring_notification_channel` tipo `webhook_tokenauth` (o `slack` nativo con OAuth) + agregarlo a `notification_channels` de las alert policies P0/P1 (mantener email como secundario).
+3. Verificación: disparar una alerta de prueba (bajar el umbral de pubsub_backlog durante la prueba y restaurarlo en el mismo PR) y confirmar la entrega en ambos canales.
+
+**Bloqueado por**: insumo del PO (webhook URL) — el agente no puede crear el endpoint de Slack.
+
+## Estado
+
+Pendiente, bloqueado por insumo PO.

--- a/.specs/_followups/shared-schemas-contratos-canonicos.md
+++ b/.specs/_followups/shared-schemas-contratos-canonicos.md
@@ -1,0 +1,22 @@
+# Follow-up: consolidar contratos canónicos en shared-schemas (telemetría + estados de viaje)
+
+**Origen**: Auditoría arquitectónica 2026-06-09 (corte transversal de datos + fundaciones), riesgos altos "contrato telemetry-events duplicado" y "domain de trips desalineado".
+**Prioridad**: P2.
+
+## Problema
+
+Dos contratos núcleo tienen doble fuente de verdad:
+
+1. **Wire format de `telemetry-events`**: la interface real es `RecordMessage` en `apps/telemetry-tcp-gateway/src/pubsub-publisher.ts:21-26` con espejo Zod copiado a mano en `apps/telemetry-processor/src/persist.ts:13-39`. El schema "canónico" `telemetryEventSchema` (`packages/shared-schemas/src/domain/telemetry.ts`) tiene OTRA forma y nadie lo usa en el wire. Un cambio en el publisher sin actualizar el espejo = descarte silencioso de mensajes (ack de malformados).
+2. **Estados de viaje**: `tripStateSchema` define 17 estados en inglés (ADR-004) sin consumidores; el enum vivo `estado_viaje` tiene 9 en español (`apps/api/src/db/schema.ts:211-221`). `tripStateChangedEventSchema` referencia los estados muertos. ~18 de 38 tablas no tienen schema domain (regla CLAUDE.md incumplida).
+
+## Acción propuesta
+
+- Mover `recordMessageSchema` (el wire REAL) a `packages/shared-schemas/src/events/` e importarlo desde gateway (tipo) y processor (validación). Eliminar el espejo.
+- Decidir el destino de `domain/telemetry.ts` y `tripStateSchema`: actualizarlos a la realidad o eliminarlos con nota (ADR corto si se abandona el vocabulario ADR-004).
+- Coordinar con el refactor trip-state-machine (`.specs/arch-trip-state-machine-refactor/`) — la tabla de transiciones del package nuevo debe derivar del enum REAL, no del domain muerto.
+- Cerrar el gap de las ~18 tablas sin schema domain o ajustar la regla del CLAUDE.md a la realidad deliberada.
+
+## Estado
+
+Pendiente. Sin asignar a ciclo.

--- a/.specs/_followups/telemetria-particion-y-retencion.md
+++ b/.specs/_followups/telemetria-particion-y-retencion.md
@@ -1,0 +1,23 @@
+# Follow-up: partición y retención de tablas de telemetría
+
+**Origen**: Auditoría arquitectónica 2026-06-09 (seguimiento "Modelo de datos Postgres"), riesgo alto "sin particionamiento ni retención".
+**Prioridad**: P2 (sube a P1 si la flota crece o la latencia del processor degrada).
+
+## Problema
+
+`telemetria_puntos` (~2.16M filas/mes estimadas a 50 devices), `posiciones_movil_conductor` (browser GPS ~1/10s por conductor, sin dedup) y `eventos_conduccion_verde` crecen sin límite en una instancia ZONAL de 1 vCPU/6GB. Cero `PARTITION BY` en las migraciones; ningún cron borra datos (los 5 de scheduling.tf no tocan estas tablas). La migración 0025 promete "políticas de retención independientes" que no existen. `/flota` (DISTINCT ON no-LATERAL con polling 20s) degrada linealmente con el histórico.
+
+Nota: el COUNT(*) por insert ya fue eliminado (fix/telemetry-persist, 2026-06-10).
+
+## Acción propuesta
+
+- Partición mensual por `timestamp_device` en telemetria_puntos (pg_partman o particiones nativas + cron de creación).
+- Retención hot 90d con archivado a BigQuery (el propio schema.ts:1543 plantea migrar a BQ >500 devices — adelantar el sink).
+- Retención corta (30d) para posiciones_movil_conductor (solo se consume el último punto).
+- DROP de índices redundantes detectados: `idx_telemetria_imei_ts` (duplica el UNIQUE), `idx_eventos_conduccion_vehiculo_ts` (prefijo del UNIQUE), `idx_telemetria_vehiculo_recibido` (sin queries), `idx_vehiculos_teltonika_imei` (duplica .unique()).
+- Reescribir `/flota` como LATERAL o tabla `ultima_posicion_vehiculo` con UPSERT desde el processor.
+- `log_acceso_stakeholder`: partición por `accedido_en` + sink BigQuery real ANTES de abrir el portal stakeholder.
+
+## Estado
+
+Pendiente. Requiere ventana de mantenimiento para la migración de partición (tabla viva).


### PR DESCRIPTION
## Contexto

Backlog P2 de la auditoría 2026-06-09 (decisión PO: specs en `_followups`, ejecución en ciclos futuros).

## Cambios (`.specs/_followups/`)

- `shared-schemas-contratos-canonicos` — wire de telemetría + estados de viaje (doble fuente de verdad).
- `telemetria-particion-y-retencion` — partición/retención + índices redundantes + `/flota` LATERAL.
- `canary-verify-mql-real` — verificación real del canary + encadenar release.yml a ci.yml.
- `segundo-canal-alertas-sre` — bloqueado por webhook del PO.
- `cloudbuild-submit-iam-gating` — gatear `builds.create` por IAM.
- `deploy-telemetry-gateway-repo-root-bug` — fix REPO_ROOT + banner post-ADR-059.

## Evidencia

- Stubs de planificación (convención `_followups` existente). Sin código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)