### PR TITLE
fix(ci): timeout del deploy job 30→75 min — moría durante el canary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,13 @@ jobs:
     name: Deploy to production
     needs: version-or-publish
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 75 y no 30 (fix 2026-06-12): el canary duerme 30 min DENTRO de Cloud
+    # Build mientras este job streamea `gcloud builds submit` — con 30 el
+    # job moría SIEMPRE cancelado a mitad del canary (el build seguía y
+    # completaba server-side, pero el run quedaba 'cancelled' y el smoke
+    # final nunca corría). Presupuesto: gate CI ~10 + build/push ~15 +
+    # canary 30 + verify/promoción ~10 + smoke.
+    timeout-minutes: 75
     environment:
       name: production  # Requires manual approval via GitHub Environments
       url: ${{ vars.PRODUCTION_URL }}


### PR DESCRIPTION
## Resumen
⚠️ Archivo sensible del pipeline — revisión PO. Bug descubierto operando los deploys de ambas olas: `timeout-minutes: 30` en el job de deploy es MENOR que la ventana de canary (30 min) que el job streamea vía `gcloud builds submit` → GitHub cancela el job SIEMPRE a mitad del canary. El Cloud Build continúa server-side y completa bien, pero: (1) el run queda 'cancelled' mintiendo sobre un deploy exitoso, (2) el smoke test final del workflow nunca corre, (3) cada deploy genera una falsa alarma.

Evidencia: deploys de la ola 1 (run 27371090665) y ola 2 (run 27425096843) — ambos 'cancelled' en GitHub, ambos SUCCESS en Cloud Build (06050cda, d64cd8f3), ambos sirviendo al 100% verificado en Cloud Run.

## Evidencia
- YAML válido (parse).
- Presupuesto del nuevo límite documentado en el comentario: gate CI ~10 + build ~15 + canary 30 + verify/promoción ~10 + smoke, con margen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)