### PR TITLE
style(infra): fmt storage.tf + gate terraform fmt -check en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,24 @@ jobs:
         run: pnpm format:check
 
   # ---------------------------------------------------------------------------
+  # Terraform fmt — gate que faltaba: el drift de alineación de #449
+  # (storage.tf) llegó a main porque ningún check de CI corría `fmt -check`.
+  # No necesita GCP/WIF (es puro formateo), corre en cada PR. El drift de
+  # ESTADO real (plan) lo cubre terraform-drift.yml (cron + WIF) por separado.
+  # ---------------------------------------------------------------------------
+  terraform-fmt:
+    name: Terraform fmt
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+      - name: terraform fmt -check
+        run: terraform fmt -check -recursive infrastructure/
+
+  # ---------------------------------------------------------------------------
   # Typecheck — tsc --noEmit por workspace (Turborepo paraleliza)
   # ---------------------------------------------------------------------------
   typecheck:
@@ -223,13 +241,14 @@ jobs:
   # ---------------------------------------------------------------------------
   ci-success:
     name: CI Success
-    needs: [lint, typecheck, test, integration-tests, build]
+    needs: [lint, terraform-fmt, typecheck, test, integration-tests, build]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Check all jobs succeeded
         run: |
           if [ "${{ needs.lint.result }}" != "success" ] || \
+             [ "${{ needs.terraform-fmt.result }}" != "success" ] || \
              [ "${{ needs.typecheck.result }}" != "success" ] || \
              [ "${{ needs.test.result }}" != "success" ] || \
              [ "${{ needs.integration-tests.result }}" != "success" ] || \

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -229,7 +229,7 @@ resource "google_storage_bucket" "certificates" {
   # re-emisiones) y después se purgan.
   lifecycle_rule {
     condition {
-      num_newer_versions = 3
+      num_newer_versions         = 3
       days_since_noncurrent_time = 90
     }
     action {


### PR DESCRIPTION
## Resumen
Dos cambios chicos y relacionados:
1. **fmt fix**: `terraform fmt storage.tf` — la regla `lifecycle_rule` de `google_storage_bucket.certificates` tenía los `=` desalineados (`num_newer_versions`/`days_since_noncurrent_time`). Solo alineación, cero cambio semántico. Vino de #449 (bucket de certificados).
2. **gate que faltaba**: job `terraform-fmt` nuevo en `ci.yml` (`terraform fmt -check -recursive infrastructure/`) + cableado a `ci-success`. El drift de #449 llegó a main porque **ningún check de CI corría `terraform fmt`**. No necesita GCP/WIF (puro formateo), corre en cada PR. El drift de ESTADO real (plan) lo cubre `terraform-drift.yml` (cron+WIF) por separado.

## Evidencia
- `terraform fmt -check -recursive infrastructure/` → **pasa** tras el fix (storage.tf era el único drift de todo el dir).
- `ci.yml` YAML válido (parse OK).
- diff atómico: storage.tf (2 líneas de alineación) + ci.yml (job nuevo + needs de ci-success).

🤖 Generated with [Claude Code](https://claude.com/claude-code)