### PR TITLE
fix(api,web): SSE auth por ticket efímero — token Firebase fuera de la URL

### DIFF
--- a/.specs/_followups/sse-auth-token-en-url.md
+++ b/.specs/_followups/sse-auth-token-en-url.md
@@ -1,0 +1,33 @@
+# Follow-up: el Firebase ID token del SSE viaja en la URL (?auth=) y se filtra a Cloud Trace + Cloud Logging
+
+**Origen**: spot-check post-deploy del scrubbing de OTel (2026-06-14), validando el fix de #451 con un request sintético al SSE (`?auth=<centinela>`).
+**Severidad**: ALTO. Es el MISMO hallazgo que #451 intentó cerrar, ahora demostrado como cerrado solo PARCIALMENTE.
+
+## Evidencia (prueba sintética, token falso)
+
+Request: `GET https://api.boosterchile.com/assignments/scrub-test/messages/stream?auth=<centinela>` → 401.
+Dos superficies capturan el `?auth=` EN CRUDO (verificado en prod):
+1. **Cloud Trace** — span de PLATAFORMA de Cloud Run (`/component=AppServer`, sin `g.co/agent`): `/http/url = ...?auth=<centinela>`. Lo genera la infra de Cloud Run y se exporta directo a Cloud Trace, FUERA del `RedactingSpanExporter` de #451 (que sí scrubbea el span de la app — `g.co/agent=opentelemetry-js` → `auth=[REDACTED]`).
+2. **Cloud Logging** — el request log de Cloud Run (`httpRequest.requestUrl`) guarda la URL completa con el token. También lo genera la plataforma, fuera del mixin del logger.
+
+Retención: Cloud Trace ~30d, Cloud Logging según config. Audiencia: `cloudtrace.viewer` / `logging.viewer` (devs/SRE). Un Firebase ID token (bearer, ~1h, impersonación completa del usuario) es replayable dentro de su validez.
+
+## Por qué el scrubbing a nivel app NO basta
+
+El `RedactingSpanExporter` (#451) y el mixin de redacción del logger solo tocan telemetría GENERADA POR LA APP. Los spans de plataforma de Cloud Run y los access logs los emite la infraestructura con la URL cruda. No hay hook de app que los intercepte.
+
+## Fix real (lo que recomendó el security-auditor de #451)
+
+Sacar el token de la URL. EventSource del browser no soporta headers, así que el patrón estándar es:
+1. El cliente pide un **ticket de un solo uso, corta vida** a un endpoint autenticado normal (Authorization header): `POST /assignments/:id/messages/stream-ticket` → `{ticket}` (Redis, TTL ~30-60s, single-use, scoped al assignment+user).
+2. El cliente abre `EventSource('/assignments/:id/messages/stream?ticket=<ticket>')`.
+3. El SSE valida el ticket (lo consume de Redis) en vez del Firebase ID token.
+
+Así, lo que viaja en la URL es un ticket efímero de un solo uso — su filtrado a logs/trace es inocuo (ya consumido / expira en segundos).
+Tocaría: `apps/api` (mint + validate ticket, middleware del SSE), `apps/web` (`use-chat-stream.ts`). Ciclo agent-rigor completo (toca auth → security-auditor en review). El `RedactingSpanExporter` se mantiene como defensa en profundidad.
+
+## Mitigación parcial mientras tanto
+Ninguna a nivel app. Las palancas de infra (bajar sampling de Cloud Trace, desactivar request logging del path) son toscas y con pérdida — no se recomiendan; ir directo al fix real.
+
+## Estado
+Pendiente — decisión del PO sobre si se encara el ciclo del ticket SSE.

--- a/.specs/_followups/sse-realtime-multi-empresa.md
+++ b/.specs/_followups/sse-realtime-multi-empresa.md
@@ -1,0 +1,14 @@
+# Follow-up: el realtime de chat asume la empresa default (users multi-empresa)
+
+**Origen**: review de seguridad de fix-sse-ticket-auth (2026-06-14), QUESTION. NO es regresión — comportamiento idéntico al `?auth=` previo.
+**Severidad**: BAJA (funcional, no seguridad — jamás concede acceso de más).
+
+## Problema
+El POST `/stream-ticket` (y antes el SSE con `?auth=`) usa raw fetch/EventSource SIN header `X-Empresa-Id`, así que `userContextMiddleware` resuelve la PRIMERA membership activa (user-context.ts). Para un user multi-empresa cuyo chat pertenece a una empresa NO-default, `resolveChatAccess` da 403 → el ticket no se emite → el chat realtime no conecta (degrada a polling/refetch; los mensajes igual se leen). Seguridad intacta: el binding ticket↔uid↔assignment + la re-autorización del stream impiden cualquier acceso indebido.
+
+## Acción propuesta
+- El cliente manda `X-Empresa-Id` (la empresa activa de la PWA) en el POST `/stream-ticket` — el api-client ya lo hace para el resto de requests (api-client.ts); el fetch del ticket debería igualarlo.
+- (EventSource del stream no puede mandar header, pero ya no lo necesita: la identidad+empresa se fijan en el mint.)
+
+## Estado
+Pendiente (BAJA). Afecta solo a users multi-empresa con chat en empresa no-default.

--- a/.specs/fix-sse-ticket-auth/plan.md
+++ b/.specs/fix-sse-ticket-auth/plan.md
@@ -1,0 +1,35 @@
+# Plan: fix-sse-ticket-auth
+
+- Spec: .specs/fix-sse-ticket-auth/spec.md
+- Created: 2026-06-14
+- Status: Active
+
+## Tasks
+
+### T1: módulo del ticket store (TDD)
+- File: apps/api/src/services/sse-ticket.ts (+ sse-ticket.test.ts)
+- `mintStreamTicket({redis, uid, assignmentId})` → ticket (randomBytes hex), SET con TTL 60s, valor = `${uid}` keyed por assignment.
+- `consumeStreamTicket({redis, ticket, assignmentId})` → uid|null (GETDEL atómico, match assignment).
+- LOC ~60 + tests. Acceptance: T2 de la spec.
+
+### T2: endpoint mint en chat.ts
+- File: apps/api/src/routes/chat.ts (+ createChatRoutes recibe redis)
+- `POST /:id/messages/stream-ticket` tras resolveChatAccess → mint → {ticket, expiresInSec}.
+- Depends: T1. Acceptance: T1 de la spec.
+
+### T3: firebaseAuth — ticket en vez de token en el SSE
+- File: apps/api/src/middleware/firebase-auth.ts (+ server.ts wiring)
+- Inyectar `sseTicketStore?`; branch `/stream` GET: consumir `?ticket=` → set firebaseClaims → next(); ELIMINAR el path `?auth=` token. Sin ticket → 401.
+- Depends: T1. Acceptance: SC-2/SC-3, T3/T4.
+
+### T4: cliente web
+- File: apps/web/src/hooks/use-chat-stream.ts
+- POST stream-ticket (Bearer) → EventSource(?ticket=); reconnect = ticket nuevo. Actualizar el comentario de auth.
+- Acceptance: SC-4.
+
+### T5: VERIFY + REVIEW
+- Suite api verde, typecheck api+web, coverage; security-auditor + devils-advocate (toca auth). verify.md + review.md.
+
+## Notas
+- Redis: reutilizar el patrón de `redisForRateLimit` (server.ts). Fail-closed.
+- RedactingSpanExporter (#451) se mantiene.

--- a/.specs/fix-sse-ticket-auth/review.md
+++ b/.specs/fix-sse-ticket-auth/review.md
@@ -1,0 +1,79 @@
+# Devils-advocate review — fix-sse-ticket-auth — 2026-06-14T00:55:00Z
+
+Base: `git diff github/main..HEAD` (rama `fix/sse-ticket-auth`). Tests corridos: sse-ticket (5 ok), firebase-auth (11 ok), use-chat-stream (10 ok). Todos verdes.
+
+## Premise
+- Asumido: el ticket en la URL es "inocuo" tras consumo. Mayormente cierto, PERO el endpoint de mint `POST /:id/messages/stream-ticket` AHORA recibe el Firebase ID token en el header `Authorization` — y la spec 1 dice que el span de PLATAFORMA de Cloud Run (`/component=AppServer`) y el access log capturan la request "EN CRUDO". Los access logs de Cloud Run NO suelen registrar headers, asi que el token del header no se filtra por la misma via que el query. Pero esto NO esta verificado en la spec: el spot-check post-deploy (11, verify.md "Pendiente") solo planea revisar la URL del `/stream`, NO confirma que el header `Authorization` del nuevo POST `/stream-ticket` no aparezca en ningun sink (p.ej. si algun dia se habilita header-logging en Cloud Armor / LB). La premisa "sacar el token de la URL cierra el leak" es correcta para el query param; queda SIN evidencia que el header no abra una superficie equivalente.
+- Asumido: `userContextMiddleware` "solo necesita claims.uid" (spec 6.1, constraint "verificado"). Confirmado leyendo `user-context.ts:44` (resuelve por `firebaseUid`). Esta premisa SI se sostiene.
+- Mas doloroso si es falso: que el chain aguas abajo dependa de `claims.custom` para algo de SEGURIDAD y no solo de `uid`. ES FALSO — ver Failure modes F1. demo-expires e is-demo-enforcement dependen de `custom.is_demo`, que el ticket setea a `{}`.
+
+## Scope and second-order effects
+- El SSE GET pasa por la cadena COMPLETA montada en `server.ts:439-445`: `firebaseAuth -> demoExpires -> isDemoEnforcement -> userContext`. El cambio inserta una identidad SINTETICA (`firebase-auth.ts:76-83`, `custom:{}`) que NO es equivalente a la identidad real por-token para los middlewares que leen `custom`. Consumidor downstream no consultado: el sistema de enforcement de cuentas demo (SEC-001 Sprint 2a/2b). Hyrum: dos middlewares de seguridad ya dependen de la forma observable de `firebaseClaims.custom`.
+- `is-demo-enforcement` en modo `requireNotDemo` bloquea writes; el `/stream` es GET, asi que en la practica el bloqueo de writes no aplicaba al stream igual. Pero `demo-expires` SI bloquea cualquier metodo (incl. GET) si la cuenta expiro. Bajo ticket, ese bloqueo desaparece para el stream (F1).
+- Segundo orden no medido: cada reconnect del cliente hace `getIdToken()` + POST mint + nuevo `SET` en Redis + GETDEL. Un cliente en loop de reconnect (red mala) genera carga de tokens+Redis proporcional al backoff. El backoff (1s->30s) lo acota, pero N pestanas x M usuarios con red intermitente = trafico de mint no presupuestado. Sin metrica de rate del mint (no hay rate-limit en `/stream-ticket`, a diferencia de otros paths que si lo tienen).
+
+## Alternatives discarded
+- Considerados en spec 8: A (sampling/log off), B (cookie httpOnly), C (cifrar token), D (fetch-streaming). Rechazos razonables y documentados. D queda como follow-up legitimo.
+- NO considerada (debio estarlo): bind del ticket a la sesion/IP o a un nonce del cliente. El ticket actual es portador puro: cualquiera que lo intercepte ANTES del consumo (es de un solo uso pero hay una ventana de 60s) y llegue primero al `/stream` gana la conexion. Mitigado por HTTPS + single-use + TTL corto, pero no discutido.
+- NO considerada: re-validar la cuenta demo dentro del handler del stream (o re-correr demo-expires con el uid del ticket). Habria cerrado F1 sin reescribir el cliente. No aparece en alternativas.
+
+## Failure modes
+- F1 (demo/disabled evasion — STRONG): deteccion NULA, recovery NINGUNA, costo lo paga seguridad/compliance. Una cuenta `is_demo:true` con `expires_at` pasado, o `disabled:true`, que obtiene un ticket y abre el `/stream`, NO es bloqueada. Cadena: `demo-expires.ts:166` `isDemoClaim` lee `claims.custom.is_demo`; bajo ticket `custom={}` (`firebase-auth.ts:82`) -> `false` -> passthrough sin chequear expiracion/disabled. Igual `is-demo-enforcement.ts:126`. `resolveChatAccess` (`chat.ts:140-196`) NO mira demo — solo membership. NOTA: el ticket caduca a 60s y el mint SI corre demo-expires al emitirlo, asi que una cuenta que expira ENTRE mint y open tiene <=60s de ventana; pero una cuenta YA expirada que logra mint (p.ej. expires_at justo en el borde, o cache de 60s del snapshot de demo-expires sirviendo un estado viejo) abre un stream que vive HORAS (es long-lived, `chat.ts:515` espera onAbort) sin re-chequeo. El stream sobrevive a la expiracion de la cuenta. Esto NO esta en la spec 9 Risks.
+- F2 (Redis down -> contrato 503 documentado es falso): deteccion por 500, recovery cliente reintenta con backoff. La spec 6.2 y el comentario en `chat.ts:113-114` dicen mint->503. Falso: `mintStreamTicket` (`chat.ts:421-426`) llama `redis.set` SIN try/catch; si Redis tira (tras `maxRetriesPerRequest:2`), el throw sube a `app.onError` (`server.ts:789`) -> 500, no 503. El 503 solo ocurre si `opts.redis` es undefined (nunca en prod, siempre se inyecta `redisForRateLimit`). Lado consume: `consumeStreamTicket` tambien sin try/catch -> throw -> 500 en el `/stream`. Funcionalmente fail-closed (no hay stream), PERO: con `enableOfflineQueue` default=true en ioredis, los comandos pueden QUEDAR ENCOLADOS hasta reconexion en vez de rechazar rapido -> el POST mint puede colgar en vez de fallar limpio, y el cliente queda esperando el `fetch` (sin timeout en `use-chat-stream.ts:90`) en vez de caer al backoff. No hay AbortController/timeout en el fetch del ticket.
+- F3 (reconnect nativo de EventSource con ticket consumido — no testeado): deteccion por 401/onerror, recovery por reconnect manual con ticket nuevo. El "baile" descrito: EventSource reconecta nativo a la MISMA URL con el ticket ya consumido (GETDEL) -> server 401 -> onerror (`use-chat-stream.ts:145`) -> `close()` + reconnect manual con ticket fresco. En teoria funciona. PERO hay una ventana: entre el `connected` inicial y el primer reconnect nativo, si la conexion se cae, EventSource puede reintentar 1+ veces con el ticket muerto ANTES de que `onerror` dispare el cierre manual — cada reintento nativo es un 401 que NO refresca ticket. Como `onerror` SI cierra y reagenda, no hay loop infinito, pero hay reintentos nativos desperdiciados (401 ruidosos en logs/metricas) en cada caida. NINGUN test cubre esto: `StubEventSource` (`use-chat-stream.test.tsx:29`) no auto-reconecta; el "reconnect pide ticket nuevo" (SC-4) NO esta verificado por test — solo el `onerror`->onDisconnect. La asercion de SC-4 es por inspeccion de codigo, no por test.
+- F4 (loop de reconnect agresivo): parcialmente mitigado. Si el mint devuelve 503/500 persistente (Redis caido), el cliente entra en backoff exponencial hasta 30s (`use-chat-stream.ts:106`) — aceptable. Si devuelve 401 persistente (cuenta realmente sin acceso), MISMO backoff, reintenta indefinidamente cada 30s para siempre. No hay tope de reintentos ni circuit-breaker: una cuenta sin acceso al chat machaca `/stream-ticket` cada 30s eternamente mientras el componente este montado. Bajo, pero es ruido de auth perpetuo sin alerta.
+
+## Reversibility
+- Costo de deshacer en 30 dias: BAJO. Es revert de PR (sin migracion de datos, sin DDL). El estado en Redis (`sse-ticket:*`) es efimero (TTL 60s) -> se drena solo. Sin estado persistente. Confirmado: ningun archivo de migracion en el diff.
+- Mecanismo de reversa: revert. PERO ojo — revertir RE-INTRODUCE el leak del token en la URL (el `?auth=` vuelve). Si se revierte, hay que re-evaluar el riesgo de seguridad original, no es un revert "gratis". No hay feature flag (decision consciente, spec 11: cambio acoplado api+web).
+
+## Drift signals
+- "follow-up posible" / "queda como out-of-scope/follow-up" (spec 5, 8.D): justificado, fetch-streaming es legitimamente mayor. OK.
+- "aceptable: realtime no-critico" (spec 11, repetido en `use-chat-stream.ts:102`): ESTA es la racionalizacion load-bearing del rollout. Es la justificacion para NO reconocer honestamente el window de incompatibilidad de deploy. Ver Evidence.
+- "El step canary-verify es placeholder (exit 0)" (contexto CLAUDE.md, no de este PR): relevante porque este cambio acoplado api+web confia en que el canary humano detecte un chat roto — pero el canary NO verifica el chat realtime. No hay gate automatico que detecte "el chat dejo de conectar".
+- No hay marcadores de deuda inline sin ticket en el diff. Limpio en ese eje.
+
+## Evidence quality
+- "el chat sigue funcionando igual" (spec 4) -> Evidence: tests unitarios + verify.md "Pendiente: chat real conecta". Verdict: DEBIL. Ningun test integra mint->stream end-to-end; ningun test cubre el reconnect con ticket fresco (SC-4 sin cobertura real). El "funciona igual" descansa en verificacion manual post-deploy aun no hecha.
+- "El api acepta SOLO ticket tras el deploy -> el web debe deployar a la par... el deploy del monorepo es atomico por release" (spec 11) -> Evidence: ninguna. Verdict: ABSENTE / FALSO en el peor caso. El deploy NO es atomico: api y web son servicios Cloud Run SEPARADOS, se despliegan en pasos distintos del mismo release. Hay una ventana real (segundos a minutos) donde api-nuevo + web-viejo coexisten. Clientes con web-viejo (ya cargado en el browser del usuario, NO se actualiza al hacer redeploy — el usuario tiene la PWA abierta) mandan `?auth=<token>` -> 401 -> chat realtime cae hasta que el usuario recargue la PWA. La spec lo menciona como hipotesis ("Si el api deployara antes que el web") pero lo descarta con "atomico por release", que es incorrecto para Cloud Run. Y omite el caso MAS comun: PWA ya abierta en el browser del usuario con bundle viejo, independiente del orden de deploy. Eso NO se cubre con "deploy atomico".
+- "Fail-closed: mint y validacion -> error (503)" (spec 6.2) -> Evidence: codigo. Verdict: PARCIALMENTE FALSO. Es 500, no 503 (ver F2). Fail-closed si, pero el contrato HTTP documentado no matchea el codigo.
+- "ticket random >=128 bits, single-use, GETDEL atomico" (SC-1, SC-2) -> Evidence: `sse-ticket.ts:37` (32 bytes=256 bits), `:57` getdel, test `sse-ticket.test.ts:41-48`. Verdict: SUFICIENTE. Esta parte esta bien construida y bien testeada.
+- "el viejo ?auth= ya NO autentica -> 401" (SC-3) -> Evidence: `firebase-auth.test.ts:208-214` (asserta 401 + verifyIdToken NO llamado). Verdict: SUFICIENTE y robusta. El branch `?auth=` se elimino de verdad (no quedo dead code que un dia se reactive).
+- "token NUNCA en la URL" (test web) -> Evidence: `use-chat-stream.test.tsx:112-113` (`not.toContain('auth=')`, `not.toContain('firebase-id-token')`). Verdict: SUFICIENTE para el query. El token real (`getIdToken->'firebase-id-token'`) se asserta ausente de la URL. Robusta contra regresion del leak por query.
+
+## Verdict
+APROBADO CON OBSERVACIONES — el objetivo de seguridad (sacar el token bearer del query del SSE) se logra y esta bien testeado en su nucleo. Pero hay objeciones fuertes que deben resolverse o documentarse explicitamente como riesgo aceptado ANTES de ship.
+
+- Objeciones fuertes (resolver o documentar como waiver):
+  1. F1 demo/disabled evasion: el `/stream` por ticket NO ejecuta el enforcement de cuentas demo expiradas/disabled porque `firebaseClaims.custom={}`. Una cuenta demo expirada abre y mantiene un stream long-lived. Minimo: documentar el riesgo en spec 9; mejor: re-correr demo-expires con el uid del ticket en el handler del stream, o propagar `is_demo`/`expires_at` dentro del payload del ticket y re-chequear al consumir. `firebase-auth.ts:76-83`, `demo-expires.ts:166`, `is-demo-enforcement.ts:126`.
+  2. Ventana de deploy / PWA con bundle viejo: la spec afirma "deploy atomico por release" (11) — falso para Cloud Run y, sobre todo, no cubre la PWA ya cargada en el browser. El chat realtime de usuarios con bundle viejo cae a 401 hasta recargar. Reconocerlo honestamente en la spec y decidir mitigacion (p.ej. mantener el branch `?auth=` un release como deprecated, o forzar reload de la PWA por version) o aceptarlo por escrito.
+  3. Contrato 503 vs 500 en Redis caido (F2): el codigo tira 500, la spec/comentarios prometen 503. Corregir el codigo (try/catch -> 503) o corregir la doc. Y agregar timeout/AbortController al `fetch` del ticket en el cliente (`use-chat-stream.ts:90`) para no colgar si el offline-queue de ioredis demora.
+  4. SC-4 sin test real: "reconnect pide ticket nuevo" no esta cubierto por ningun test (el StubEventSource no reconecta). Es la afirmacion central de que el chat no se rompe en reconexion. Agregar un test que ejercite onerror->reconnect->nuevo mint con ticket distinto.
+
+- Riesgos residuales (aceptar y documentar):
+  - Reintentos nativos de EventSource con ticket muerto generan 401 ruidosos por cada caida (F3) — funcionalmente recupera, pero ensucia logs/metricas de auth. Considerar un label que distinga 401-por-ticket-consumido de 401-real.
+  - Sin rate-limit ni circuit-breaker en `/stream-ticket`: una cuenta sin acceso reintenta cada 30s para siempre (F4). Bajo impacto, pero perpetuo.
+  - Ticket portador puro (sin bind a IP/sesion): ventana de 60s de robo pre-consumo. Aceptable bajo HTTPS+single-use, pero no discutido en alternativas.
+  - El header `Authorization` del nuevo mint no fue verificado contra sinks de plataforma (solo el query). El spot-check post-deploy debe incluirlo.
+
+- Fuera de alcance de esta review:
+  - La calidad del `RedactingSpanExporter` de #451 (se mantiene, no se toca).
+  - Las ~70 fallas preexistentes de la suite web (verify.md las marca como ajenas; no verifique esa afirmacion).
+  - Migracion a fetch-streaming (follow-up D legitimo).
+
+---
+
+## Resolución del fix-round (2026-06-14, post-review)
+
+Veredictos: security-auditor APROBADO (0 bloqueantes, 2 QUESTIONS); devils-advocate APROBADO CON OBSERVACIONES (4 objeciones fuertes). Resueltas:
+
+| Hallazgo (ambos convergen en el #1) | Resolución |
+|---|---|
+| **Demo/disabled enforcement evadido** (custom={} → el stream se saltaba demoExpires) | RESUELTO: el ticket lleva `isDemo` (del claim real al mintear); el SSE lo restituye en `firebaseClaims.custom.is_demo` → demoExpires/isDemoEnforcement corren igual que por header (expires_at/disabled lo resuelve demoExpires por uid). Tests: sse-ticket round-trip isDemo + firebase-auth propaga is_demo. SC-7 nuevo. |
+| **503 vs 500 + fetch sin timeout** | RESUELTO: mint con try/catch → 503 (contrato §6.2); consumeStreamTicket atrapa error de Redis → null (fail-closed → 401); cliente con AbortController (10s). Tests: "Redis caído en consume → null". |
+| **SC-4 sin test** (reconnect → ticket nuevo) | RESUELTO: test "reconnect tras onerror pide un ticket NUEVO" (onerror → backoff → 2º mint). |
+| **Spec §11 "deploy atómico" falso** | RESUELTO: §11 reescrito — api/web son Cloud Run separados; una PWA ya abierta usa el bundle viejo (`?auth=`) → realtime cae a polling hasta recargar (mensajes NO se pierden); no se mantiene `?auth=` como compat (reintroduce el leak). |
+| **X-Empresa-Id ausente en el mint** (multi-empresa, PREEXISTENTE, no seguridad) | Follow-up `.specs/_followups/sse-realtime-multi-empresa.md` (BAJA). |
+| firebase-auth Redis outage → 500 (sugerencia) | Cubierto por el fail-closed de consume (→ 401 limpio). |
+
+Sin objeción que sobreviva. El núcleo (token fuera de la URL, ticket CSPRNG-256 single-use scoped, RedactingSpanExporter mantenido) confirmado por ambos.

--- a/.specs/fix-sse-ticket-auth/spec.md
+++ b/.specs/fix-sse-ticket-auth/spec.md
@@ -1,0 +1,86 @@
+# Spec: fix-sse-ticket-auth
+
+- Author: Felipe Vicencio (with agent-rigor)
+- Date: 2026-06-14
+- Status: Approved
+- Linked: `.specs/_followups/sse-auth-token-en-url.md` (hallazgo ALTO del spot-check 2026-06-14) + review de #451 (el security-auditor ya había señalado "sacar el token de la URL del SSE"). Es el cierre REAL de lo que #451 mitigó parcialmente.
+
+## 1. Objective
+
+El SSE de chat (`GET /assignments/:id/messages/stream`) autentica leyendo el **Firebase ID token** del query param `?auth=` (EventSource no soporta headers). El spot-check de prod (2026-06-14) confirmó que ese token se filtra EN CRUDO a dos sinks que ningún scrubbing de aplicación alcanza: el span de plataforma de Cloud Run (`/component=AppServer`) → Cloud Trace, y el access log de Cloud Run (`httpRequest.requestUrl`) → Cloud Logging. Un Firebase ID token es bearer (~1h, impersonación completa), replayable dentro de su validez por cualquiera con `cloudtrace.viewer`/`logging.viewer`. El objetivo es que **lo que viaje en la URL del SSE sea un ticket efímero de un solo uso**, no el token — de modo que su filtrado a telemetría sea inocuo.
+
+## 2. Why now
+
+Es un secreto bearer vivo filtrándose a logs/trazas en cada conexión de chat. El `RedactingSpanExporter` de #451 cubre los spans de la app pero NO la telemetría de plataforma (demostrado). El único cierre real es no poner el token en la URL.
+
+## 3. Success criteria
+
+- [ ] SC-1: nuevo endpoint `POST /assignments/:id/messages/stream-ticket` autenticado por el chain normal (Bearer header → firebaseAuth → userContext; NUNCA por query). Valida acceso al chat (resolveChatAccess) y emite un ticket: random ≥128 bits, guardado en Redis con TTL 60s, **single-use** (se borra al consumir), scoped a `{uid, assignmentId}`. Responde `{ticket, expiresInSec}`.
+- [ ] SC-2: el SSE acepta `?ticket=` en vez de `?auth=`: valida+consume el ticket de Redis, verifica que el `assignmentId` del ticket coincide con el de la URL, y resuelve la identidad (setea `firebaseClaims.uid` del ticket → `userContextMiddleware` resuelve el user como en cualquier request). resolveChatAccess queda SIN cambios.
+- [ ] SC-3: el fallback `?auth=<Firebase ID token>` se ELIMINA de `firebase-auth.ts`. Ningún Firebase ID token puede viajar más en una URL. Un `?auth=` ahora se ignora → 401.
+- [ ] SC-4: el cliente (`apps/web/src/hooks/use-chat-stream.ts`) pide el ticket (POST con Bearer) y abre `EventSource(...?ticket=<ticket>)`. En reconnect pide un ticket nuevo (son single-use).
+- [ ] SC-5: tests (api): mint requiere auth (401 sin Bearer); ticket single-use (segundo consumo → 401); TTL (expirado → 401); ticket de otro assignment → 401; SSE con ticket válido resuelve el user y conecta; SSE sin ticket ni Bearer → 401; `?auth=<jwt>` ya NO autentica. coverage ≥80 en el código nuevo.
+- [ ] SC-6: el `RedactingSpanExporter` (#451) se MANTIENE como defensa en profundidad (no se revierte).
+
+## 4. User-visible behaviour
+
+Ninguno para el usuario: el chat sigue funcionando igual (el cliente hace un POST extra de ~1 round-trip antes de abrir el stream). Observable solo en telemetría: la URL del SSE ahora lleva `?ticket=<efímero>` en vez de un token bearer.
+
+## 5. Out of scope
+
+- Migrar EventSource a fetch-streaming (permitiría headers, elimina el query param del todo) — más invasivo; el ticket efímero resuelve el riesgo. Follow-up posible.
+- Otros endpoints `?auth=` — solo el `/stream` lo usaba (firebase-auth ya restringía el fallback a paths `/stream`).
+- Cambiar el WhatsApp bot u otros flujos.
+
+## 6. Constraints
+
+1. `userContextMiddleware` solo necesita `claims.uid` (resuelve el user por `firebase_uid` contra DB) — verificado. El ticket guarda el `uid`; el resto del chain queda intacto.
+2. Redis ya está disponible en el api (`redisForRateLimit` ioredis, server.ts) — se reutiliza para el ticket store (o un cliente análogo). Fail-closed: si Redis está caído, mint y validación → error (sin ticket no hay stream; consistente con el patrón rate-limit del repo).
+3. El ticket es single-use y corto: su filtrado a logs/trace post-consumo es inocuo.
+4. Zero `any`; validación Zod del body/params donde aplique; logs estructurados (regla de stack Booster).
+
+## 7. Approach
+
+- `packages/...` o `apps/api/src/services/sse-ticket.ts`: `mintStreamTicket({redis, uid, assignmentId})` y `consumeStreamTicket({redis, ticket, assignmentId}) → uid | null` (GETDEL atómico + match de assignment).
+- `chat.ts`: ruta `POST /:id/messages/stream-ticket` (tras resolveChatAccess) que llama mint.
+- `firebase-auth.ts`: el branch `/stream` GET deja de leer `?auth=` como token; en su lugar, si hay `sseTicketStore` inyectado y `?ticket=`, consume el ticket → setea `firebaseClaims={uid,...}` → `next()` (sin verifyIdToken). Sin ticket → 401. Se elimina el path de token-en-query.
+- `use-chat-stream.ts`: `POST stream-ticket` con `Authorization: Bearer <idToken>` → `{ticket}` → `EventSource(stream?ticket=...)`; reconnect pide ticket nuevo.
+
+## 8. Alternatives considered
+
+- **A. Solo bajar sampling de Cloud Trace / desactivar request-logging del path** — Rechazada: toscas, con pérdida de observabilidad, y NO cierran el leak del access log/otros sinks. Mitigación, no fix.
+- **B. Cookie de sesión httpOnly para el SSE** — Rechazada: EventSource manda cookies same-origin, pero el api y la PWA están en dominios distintos (api.boosterchile.com vs app.boosterchile.com) → cookies cross-site con SameSite=None+Secure, más superficie CSRF y complejidad de set-cookie cross-domain. El ticket en query es más simple y acotado.
+- **C. Mantener el token pero cifrarlo/ofuscarlo en la URL** — Rechazada: sigue siendo un secreto reutilizable en la URL; ofuscar no es cerrar.
+- **D. fetch-streaming con header Authorization** — buena a futuro (elimina el query param), pero reescribe el cliente y el handler SSE; el ticket logra el objetivo de seguridad con cambio acotado. Queda como out-of-scope/follow-up.
+
+## 9. Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Romper el chat realtime en la migración | M | M | Tests api + verificación manual; el flujo del cliente cambia solo en use-chat-stream.ts; rollback = revert del PR |
+| Redis caído → no se puede abrir el stream | L | M | Fail-closed explícito (sin ticket no hay stream); el chat realtime es no-crítico (degrada a polling/refetch del cliente); mismo patrón que rate-limit |
+| Ticket replay si no es single-use | L | H | GETDEL atómico (un solo consumo); TTL 60s; scoped a assignment+uid |
+| Un caller abusa del mint para generar tickets | L | L | El mint requiere auth completa (Bearer + userContext + resolveChatAccess) — misma barrera que el resto del chat |
+
+## 10. Test list
+
+- T1: mint sin Bearer → 401; con Bearer + acceso al chat → 200 `{ticket}`.
+- T2: consumeStreamTicket: válido → uid; segundo consumo → null (single-use); ticket inexistente/expirado → null; assignment distinto → null.
+- T3: SSE `?ticket=` válido → resuelve user (firebaseClaims.uid seteado), conecta.
+- T4: SSE sin ticket ni Bearer → 401; SSE con `?auth=<jwt>` → 401 (fallback eliminado).
+- T5: coverage ≥80 del código nuevo (sse-ticket + branch nuevo).
+
+## 11. Rollout
+
+- Flag: no (cambio acoplado api+web; deben ir juntos). Deploy normal por el pipeline (merge a main → release). El api acepta SOLO ticket tras el deploy → el web debe deployar a la par (mismo release del monorepo).
+- Orden: como api y web se buildean/deployan del mismo release, no hay ventana de incompatibilidad si se mergea junto. (Si el api deployara antes que el web, los clientes viejos con `?auth=` romperían el chat realtime hasta que el web actualice — aceptable: realtime no-crítico, y el deploy del monorepo es atómico por release.)
+- Post-deploy: repetir el spot-check sintético (`?ticket=` aparece en la URL, NO un token; un `?auth=<jwt>` da 401) + un chat real conecta.
+- Rollback: revert del PR.
+
+## 12. Open questions
+
+None as of 2026-06-14.
+
+## 13. Decision log
+
+- 2026-06-14 — Draft + decisión del PO ("construir el fix ahora"). Ticket efímero single-use (no cookie, no ofuscación); elimina el `?auth=` token; RedactingSpanExporter se mantiene como defensa en profundidad.

--- a/.specs/fix-sse-ticket-auth/spec.md
+++ b/.specs/fix-sse-ticket-auth/spec.md
@@ -21,6 +21,7 @@ Es un secreto bearer vivo filtrándose a logs/trazas en cada conexión de chat. 
 - [ ] SC-4: el cliente (`apps/web/src/hooks/use-chat-stream.ts`) pide el ticket (POST con Bearer) y abre `EventSource(...?ticket=<ticket>)`. En reconnect pide un ticket nuevo (son single-use).
 - [ ] SC-5: tests (api): mint requiere auth (401 sin Bearer); ticket single-use (segundo consumo → 401); TTL (expirado → 401); ticket de otro assignment → 401; SSE con ticket válido resuelve el user y conecta; SSE sin ticket ni Bearer → 401; `?auth=<jwt>` ya NO autentica. coverage ≥80 en el código nuevo.
 - [ ] SC-6: el `RedactingSpanExporter` (#451) se MANTIENE como defensa en profundidad (no se revierte).
+- [ ] SC-7 (review 2026-06-14): la sesión por-ticket preserva el enforcement de demo — el ticket lleva `is_demo` y el SSE lo restituye en `firebaseClaims.custom` → demoExpires/isDemoEnforcement corren igual que por header.
 
 ## 4. User-visible behaviour
 
@@ -61,6 +62,8 @@ Ninguno para el usuario: el chat sigue funcionando igual (el cliente hace un POS
 | Redis caído → no se puede abrir el stream | L | M | Fail-closed explícito (sin ticket no hay stream); el chat realtime es no-crítico (degrada a polling/refetch del cliente); mismo patrón que rate-limit |
 | Ticket replay si no es single-use | L | H | GETDEL atómico (un solo consumo); TTL 60s; scoped a assignment+uid |
 | Un caller abusa del mint para generar tickets | L | L | El mint requiere auth completa (Bearer + userContext + resolveChatAccess) — misma barrera que el resto del chat |
+| La sesión por-ticket se salta demoExpires (custom vacío) | M | M | RESUELTO (review): el ticket lleva `is_demo`; el SSE lo restituye → demoExpires enforca por uid igual que por header. Además el mint ya pasa demoExpires (una demo expirada no mintea) |
+| Redis caído → mint 500 en vez del 503 documentado / fetch del cliente colgado | L | L | RESUELTO (review): mint con try/catch → 503; consume fail-closed → 401; el cliente usa AbortController (10s) |
 
 ## 10. Test list
 
@@ -73,7 +76,7 @@ Ninguno para el usuario: el chat sigue funcionando igual (el cliente hace un POS
 ## 11. Rollout
 
 - Flag: no (cambio acoplado api+web; deben ir juntos). Deploy normal por el pipeline (merge a main → release). El api acepta SOLO ticket tras el deploy → el web debe deployar a la par (mismo release del monorepo).
-- Orden: como api y web se buildean/deployan del mismo release, no hay ventana de incompatibilidad si se mergea junto. (Si el api deployara antes que el web, los clientes viejos con `?auth=` romperían el chat realtime hasta que el web actualice — aceptable: realtime no-crítico, y el deploy del monorepo es atómico por release.)
+- Orden / ventana (corregido en review 2026-06-14): api y web son Cloud Run SEPARADOS — el deploy NO es atómico. Además una PWA YA ABIERTA sigue con el bundle viejo (`?auth=`) hasta que el usuario recargue. En ambos casos el chat REALTIME de esas sesiones cae (401 al abrir el SSE) y degrada a polling/refetch hasta el reload — los mensajes NO se pierden (el POST/GET de mensajes va por header, sin cambio). Aceptable: realtime no-crítico, autocorrige al recargar. No se mantiene el `?auth=` como compat porque reintroduciría el leak (es el objetivo del cambio).
 - Post-deploy: repetir el spot-check sintético (`?ticket=` aparece en la URL, NO un token; un `?auth=<jwt>` da 401) + un chat real conecta.
 - Rollback: revert del PR.
 

--- a/.specs/fix-sse-ticket-auth/verify.md
+++ b/.specs/fix-sse-ticket-auth/verify.md
@@ -1,0 +1,15 @@
+# Verify: fix-sse-ticket-auth
+
+- Date: 2026-06-14
+
+## Resultados
+- **sse-ticket** (módulo store): 5 tests ✓ — mint hex 256-bit + TTL; consume single-use (GETDEL); inexistente/expirado → null; otro assignment → null; valor corrupto → null.
+- **firebase-auth** (branch ticket, T3/T4): 4 tests nuevos ✓ — ticket válido → resuelve uid sin llamar verifyIdToken; ticket inválido → 401; sin ticket ni Bearer → 401; **el viejo `?auth=<jwt>` ya NO autentica (401, sin verifyIdToken)**. + los 7 del header path siguen verdes (sin regresión).
+- **use-chat-stream** (cliente, T4): 10 tests ✓ — happy path ahora asserta `ticket=` en la URL y `NOT auth=`/`NOT firebase-id-token`, + POST al stream-ticket con Bearer header; caso nuevo: fallo del ticket → no abre EventSource + onDisconnect.
+- **api suite completa**: 120 files / 1453 tests ✓ (+ los nuevos), 0 regresiones. typecheck api + web OK. Lint OK.
+
+## Nota
+- Las ~70 fallas de la suite web son PREEXISTENTES (localStorage/indexedDB/jsdom polyfill + fetch ENOTFOUND a api.test.boosterchile.com), de branches fix/web-test-* sin mergear — ajenas a este cambio. use-chat-stream.test.tsx (lo tocado) pasa 10/10.
+
+## Pendiente (post-deploy)
+- Repetir el spot-check sintético en prod: la URL del SSE muestra `?ticket=` (no token); un `?auth=<jwt>` → 401; un chat real conecta vía ticket.

--- a/apps/api/src/middleware/firebase-auth.ts
+++ b/apps/api/src/middleware/firebase-auth.ts
@@ -38,7 +38,10 @@ export interface FirebaseClaims {
  * (consumeStreamTicket sobre Redis). Devuelve el uid si el ticket es válido,
  * de un solo uso, no expiró y coincide con el assignment del path; null si no.
  */
-export type SseTicketStore = (ticket: string, assignmentId: string) => Promise<string | null>;
+export type SseTicketStore = (
+  ticket: string,
+  assignmentId: string,
+) => Promise<{ uid: string; isDemo: boolean } | null>;
 
 const STREAM_PATH_RE = /^\/assignments\/([^/]+)\/messages\/stream$/;
 
@@ -65,21 +68,23 @@ export function createFirebaseAuthMiddleware(opts: {
     if (c.req.method === 'GET' && streamMatch && !c.req.header('authorization')) {
       const assignmentId = streamMatch[1] as string;
       const ticket = c.req.query('ticket');
-      const uid =
+      const consumed =
         ticket && opts.sseTicketStore ? await opts.sseTicketStore(ticket, assignmentId) : null;
-      if (!uid) {
+      if (!consumed) {
         opts.logger.warn({ path: c.req.path }, 'SSE ticket inválido/ausente');
         return c.json({ error: 'Unauthorized' }, 401);
       }
       // El ticket prueba la identidad; userContextMiddleware resuelve el user
-      // por uid (solo necesita claims.uid). El resto del chain queda intacto.
+      // por uid (solo necesita claims.uid). Restituimos `is_demo` para que
+      // demoExpires/isDemoEnforcement enforquen igual que en un request por
+      // header (sin esto, el stream se saltaba el demo-expiry — review 2026-06-14).
       c.set('firebaseClaims', {
-        uid,
+        uid: consumed.uid,
         email: undefined,
         emailVerified: false,
         name: undefined,
         picture: undefined,
-        custom: {},
+        custom: { is_demo: consumed.isDemo },
       } satisfies FirebaseClaims);
       await next();
       return;

--- a/apps/api/src/middleware/firebase-auth.ts
+++ b/apps/api/src/middleware/firebase-auth.ts
@@ -33,6 +33,15 @@ export interface FirebaseClaims {
  * Ambos usan Bearer token pero las claims son distintas (Firebase: uid +
  * email + custom; OIDC SA: aud + email-of-SA + iss=accounts.google.com).
  */
+/**
+ * Resuelve un ticket efímero del SSE → uid. Inyectado desde server.ts
+ * (consumeStreamTicket sobre Redis). Devuelve el uid si el ticket es válido,
+ * de un solo uso, no expiró y coincide con el assignment del path; null si no.
+ */
+export type SseTicketStore = (ticket: string, assignmentId: string) => Promise<string | null>;
+
+const STREAM_PATH_RE = /^\/assignments\/([^/]+)\/messages\/stream$/;
+
 export function createFirebaseAuthMiddleware(opts: {
   /**
    * Instancia de firebase-admin Auth. Inyectable para tests (stub
@@ -40,26 +49,47 @@ export function createFirebaseAuthMiddleware(opts: {
    */
   auth: Auth;
   logger: Logger;
+  /**
+   * Store de tickets del SSE (fix-sse-ticket-auth). Si está presente, el
+   * GET del stream se autentica con `?ticket=<efímero>` en vez de un Firebase
+   * ID token en la URL — que se filtraba a Cloud Trace/Logging. Sin store,
+   * el stream no tiene vía de auth por query (devuelve 401).
+   */
+  sseTicketStore?: SseTicketStore;
 }): MiddlewareHandler {
   return async (c, next) => {
-    // Path normal: token en header Authorization. Cubre 99% de los casos.
+    // SSE: EventSource no soporta headers. En vez del Firebase ID token en la
+    // URL (se filtraba EN CRUDO a Cloud Trace/Logging — fix-sse-ticket-auth),
+    // el GET del stream se autentica con un ticket efímero de un solo uso.
+    const streamMatch = STREAM_PATH_RE.exec(c.req.path);
+    if (c.req.method === 'GET' && streamMatch && !c.req.header('authorization')) {
+      const assignmentId = streamMatch[1] as string;
+      const ticket = c.req.query('ticket');
+      const uid =
+        ticket && opts.sseTicketStore ? await opts.sseTicketStore(ticket, assignmentId) : null;
+      if (!uid) {
+        opts.logger.warn({ path: c.req.path }, 'SSE ticket inválido/ausente');
+        return c.json({ error: 'Unauthorized' }, 401);
+      }
+      // El ticket prueba la identidad; userContextMiddleware resuelve el user
+      // por uid (solo necesita claims.uid). El resto del chain queda intacto.
+      c.set('firebaseClaims', {
+        uid,
+        email: undefined,
+        emailVerified: false,
+        name: undefined,
+        picture: undefined,
+        custom: {},
+      } satisfies FirebaseClaims);
+      await next();
+      return;
+    }
+
+    // Path normal: token en header Authorization.
     const authHeader = c.req.header('authorization');
     let token: string | null = null;
     if (authHeader?.startsWith('Bearer ')) {
       token = authHeader.slice('Bearer '.length).trim();
-    } else if (
-      // Fallback: token en query param `?auth=...`. Solo para endpoints
-      // SSE (EventSource del browser no soporta headers custom). Estricto:
-      // solo aceptamos query auth en paths que terminan en `/stream` y
-      // método GET. Cualquier otro endpoint con `?auth=` lo ignoramos —
-      // si no hay header, devolvemos 401.
-      c.req.method === 'GET' &&
-      c.req.path.endsWith('/stream')
-    ) {
-      const queryAuth = c.req.query('auth');
-      if (queryAuth) {
-        token = queryAuth;
-      }
     }
 
     if (!token) {

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -422,12 +422,25 @@ export function createChatRoutes(opts: {
       opts.logger.error({ path: c.req.path }, 'stream-ticket without userContext');
       return c.json({ error: 'Unauthorized' }, 401);
     }
-    const { ticket, expiresInSec } = await mintStreamTicket({
-      redis: opts.redis,
-      uid: userContext.user.firebaseUid,
-      assignmentId,
-    });
-    return c.json({ ticket, expires_in_sec: expiresInSec });
+    // Restituimos is_demo en el ticket para que el SSE corra demoExpires igual
+    // que un request por header (review 2026-06-14). Acá ya pasó demoExpires,
+    // así que una demo expirada ni siquiera llega a mintear.
+    const claims = c.get('firebaseClaims') as { custom?: Record<string, unknown> } | undefined;
+    const isDemo = claims?.custom?.is_demo === true;
+    try {
+      const { ticket, expiresInSec } = await mintStreamTicket({
+        redis: opts.redis,
+        uid: userContext.user.firebaseUid,
+        assignmentId,
+        isDemo,
+      });
+      return c.json({ ticket, expires_in_sec: expiresInSec });
+    } catch (err) {
+      // Redis caído al persistir → fail-closed 503 (sin ticket no hay stream;
+      // el realtime degrada a polling). Contrato documentado en spec §6.2.
+      opts.logger.warn({ err, assignmentId }, 'stream-ticket: Redis error al mintear');
+      return c.json({ error: 'realtime_disabled', code: 'realtime_disabled' }, 503);
+    }
   });
 
   // GET /:id/messages/stream — SSE realtime (P3.b)

--- a/apps/api/src/routes/chat.ts
+++ b/apps/api/src/routes/chat.ts
@@ -32,10 +32,12 @@ import { and, desc, eq, isNull, lt, ne } from 'drizzle-orm';
 import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { streamSSE } from 'hono/streaming';
+import type { Redis } from 'ioredis';
 import { z } from 'zod';
 import type { Db } from '../db/client.js';
 import { assignments, chatMessages, trips, users as usersTable } from '../db/schema.js';
 import { createEphemeralChatSubscription, publishChatMessage } from '../services/chat-pubsub.js';
+import { mintStreamTicket } from '../services/sse-ticket.js';
 import { notifyChatMessageViaPush } from '../services/web-push.js';
 
 let cachedStorage: Storage | null = null;
@@ -107,6 +109,13 @@ export function createChatRoutes(opts: {
    * payload de Web Push (P3.c). Sin esto, no se manda push.
    */
   webAppUrl?: string;
+  /**
+   * Redis para emitir tickets efímeros del SSE (fix-sse-ticket-auth). Sin
+   * esto, POST /:id/messages/stream-ticket responde 503: el cliente no puede
+   * abrir el stream (realtime degrada a polling). El SSE valida el ticket
+   * con el mismo Redis vía el sseTicketStore inyectado en firebaseAuth.
+   */
+  redis?: Redis;
 }) {
   const app = new Hono();
 
@@ -392,6 +401,35 @@ export function createChatRoutes(opts: {
   });
 
   // -------------------------------------------------------------------------
+  // POST /:id/messages/stream-ticket — emite un ticket efímero para el SSE
+  // -------------------------------------------------------------------------
+  // Autenticado por el chain normal (Bearer header → firebaseAuth →
+  // userContext) + resolveChatAccess. Devuelve un ticket de un solo uso que
+  // el cliente pone en la URL del EventSource (?ticket=) en vez del Firebase
+  // ID token — que se filtraba a Cloud Trace/Logging (fix-sse-ticket-auth).
+  // -------------------------------------------------------------------------
+  app.post('/:id/messages/stream-ticket', async (c) => {
+    const assignmentId = c.req.param('id');
+    const access = await resolveChatAccess(c, assignmentId);
+    if (!access.ok) {
+      return access.response;
+    }
+    if (!opts.redis) {
+      return c.json({ error: 'realtime_disabled', code: 'realtime_disabled' }, 503);
+    }
+    const userContext = c.get('userContext');
+    if (!userContext) {
+      opts.logger.error({ path: c.req.path }, 'stream-ticket without userContext');
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+    const { ticket, expiresInSec } = await mintStreamTicket({
+      redis: opts.redis,
+      uid: userContext.user.firebaseUid,
+      assignmentId,
+    });
+    return c.json({ ticket, expires_in_sec: expiresInSec });
+  });
+
   // GET /:id/messages/stream — SSE realtime (P3.b)
   // -------------------------------------------------------------------------
   // El cliente abre EventSource a este endpoint. El servidor:

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -60,6 +60,7 @@ import { LoggingSignupRequestNotifier } from './services/notifications/signup-re
 import type { NotifyOfferDeps } from './services/notify-offer.js';
 import type { NotifyTrackingLinkDeps } from './services/notify-tracking-link.js';
 import { buildObservabilityServices } from './services/observability/factory.js';
+import { consumeStreamTicket } from './services/sse-ticket.js';
 import { configureWebPush } from './services/web-push.js';
 
 export interface CreateServerOptions {
@@ -267,6 +268,10 @@ export function createServer(opts: CreateServerOptions): Hono {
     const firebaseAuthMiddleware = createFirebaseAuthMiddleware({
       auth: opts.firebaseAuth,
       logger,
+      // SSE de chat: se autentica con ticket efímero por query (no el Firebase
+      // ID token, que se filtraba a Cloud Trace/Logging — fix-sse-ticket-auth).
+      sseTicketStore: (ticket, assignmentId) =>
+        consumeStreamTicket({ redis: redisForRateLimit, ticket, assignmentId }),
     });
     // T5 SEC-001 Sprint 2a — demo-expires middleware. Aplicado DESPUÉS
     // de firebase-auth en cada path: lee firebaseClaims del context y
@@ -451,6 +456,8 @@ export function createServer(opts: CreateServerOptions): Hono {
       db: opts.db,
       logger,
       webAppUrl: config.WEB_APP_URL,
+      // Redis para emitir los tickets efímeros del SSE (fix-sse-ticket-auth).
+      redis: redisForRateLimit,
       ...(config.CHAT_ATTACHMENTS_BUCKET
         ? { attachmentsBucket: config.CHAT_ATTACHMENTS_BUCKET }
         : {}),

--- a/apps/api/src/services/sse-ticket.test.ts
+++ b/apps/api/src/services/sse-ticket.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { consumeStreamTicket, mintStreamTicket } from './sse-ticket.js';
+
+/**
+ * Spec fix-sse-ticket-auth §10 T2. Mock de Redis con la semántica real de
+ * SET EX + GETDEL (single-use atómico). El ticket NUNCA debe sobrevivir a un
+ * consumo, ni servir para otro assignment, ni tras expirar.
+ */
+function makeRedis() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    async set(key: string, value: string, _mode: string, _ttl: number) {
+      store.set(key, value);
+      return 'OK';
+    },
+    async getdel(key: string) {
+      const v = store.get(key) ?? null;
+      store.delete(key);
+      return v;
+    },
+  } as never;
+}
+
+const UID = 'firebase-uid-123';
+const ASSIGNMENT = 'a1111111-2222-3333-4444-555555555555';
+
+describe('sse-ticket', () => {
+  it('mint crea un ticket hex ≥128 bits y lo guarda con TTL', async () => {
+    const redis = makeRedis();
+    const { ticket, expiresInSec } = await mintStreamTicket({
+      redis,
+      uid: UID,
+      assignmentId: ASSIGNMENT,
+    });
+    expect(ticket).toMatch(/^[0-9a-f]{64}$/); // 32 bytes hex = 256 bits
+    expect(expiresInSec).toBe(60);
+    expect((redis as unknown as { store: Map<string, string> }).store.size).toBe(1);
+  });
+
+  it('consume válido → uid, y es SINGLE-USE (segundo consumo → null)', async () => {
+    const redis = makeRedis();
+    const { ticket } = await mintStreamTicket({ redis, uid: UID, assignmentId: ASSIGNMENT });
+
+    expect(await consumeStreamTicket({ redis, ticket, assignmentId: ASSIGNMENT })).toBe(UID);
+    // Segundo consumo: ya fue borrado (GETDEL) → replay imposible.
+    expect(await consumeStreamTicket({ redis, ticket, assignmentId: ASSIGNMENT })).toBeNull();
+  });
+
+  it('ticket inexistente/expirado → null', async () => {
+    const redis = makeRedis();
+    expect(
+      await consumeStreamTicket({ redis, ticket: 'nope', assignmentId: ASSIGNMENT }),
+    ).toBeNull();
+    expect(await consumeStreamTicket({ redis, ticket: '', assignmentId: ASSIGNMENT })).toBeNull();
+  });
+
+  it('ticket de OTRO assignment → null (y se consume igual, no queda colgado)', async () => {
+    const redis = makeRedis();
+    const { ticket } = await mintStreamTicket({ redis, uid: UID, assignmentId: ASSIGNMENT });
+    expect(
+      await consumeStreamTicket({ redis, ticket, assignmentId: 'otro-assignment' }),
+    ).toBeNull();
+  });
+
+  it('valor corrupto en Redis → null (no throw)', async () => {
+    const redis = makeRedis();
+    (redis as unknown as { store: Map<string, string> }).store.set('sse-ticket:bad', '{no-json');
+    expect(
+      await consumeStreamTicket({ redis, ticket: 'bad', assignmentId: ASSIGNMENT }),
+    ).toBeNull();
+  });
+});

--- a/apps/api/src/services/sse-ticket.test.ts
+++ b/apps/api/src/services/sse-ticket.test.ts
@@ -32,6 +32,7 @@ describe('sse-ticket', () => {
       redis,
       uid: UID,
       assignmentId: ASSIGNMENT,
+      isDemo: false,
     });
     expect(ticket).toMatch(/^[0-9a-f]{64}$/); // 32 bytes hex = 256 bits
     expect(expiresInSec).toBe(60);
@@ -40,9 +41,17 @@ describe('sse-ticket', () => {
 
   it('consume válido → uid, y es SINGLE-USE (segundo consumo → null)', async () => {
     const redis = makeRedis();
-    const { ticket } = await mintStreamTicket({ redis, uid: UID, assignmentId: ASSIGNMENT });
+    const { ticket } = await mintStreamTicket({
+      redis,
+      uid: UID,
+      assignmentId: ASSIGNMENT,
+      isDemo: false,
+    });
 
-    expect(await consumeStreamTicket({ redis, ticket, assignmentId: ASSIGNMENT })).toBe(UID);
+    expect(await consumeStreamTicket({ redis, ticket, assignmentId: ASSIGNMENT })).toEqual({
+      uid: UID,
+      isDemo: false,
+    });
     // Segundo consumo: ya fue borrado (GETDEL) → replay imposible.
     expect(await consumeStreamTicket({ redis, ticket, assignmentId: ASSIGNMENT })).toBeNull();
   });
@@ -57,10 +66,38 @@ describe('sse-ticket', () => {
 
   it('ticket de OTRO assignment → null (y se consume igual, no queda colgado)', async () => {
     const redis = makeRedis();
-    const { ticket } = await mintStreamTicket({ redis, uid: UID, assignmentId: ASSIGNMENT });
+    const { ticket } = await mintStreamTicket({
+      redis,
+      uid: UID,
+      assignmentId: ASSIGNMENT,
+      isDemo: false,
+    });
     expect(
       await consumeStreamTicket({ redis, ticket, assignmentId: 'otro-assignment' }),
     ).toBeNull();
+  });
+
+  it('preserva isDemo=true en el round-trip (demo enforcement del SSE)', async () => {
+    const redis = makeRedis();
+    const { ticket } = await mintStreamTicket({
+      redis,
+      uid: UID,
+      assignmentId: ASSIGNMENT,
+      isDemo: true,
+    });
+    expect(await consumeStreamTicket({ redis, ticket, assignmentId: ASSIGNMENT })).toEqual({
+      uid: UID,
+      isDemo: true,
+    });
+  });
+
+  it('Redis caído en consume → null (fail-closed, no throw)', async () => {
+    const redis = {
+      async getdel() {
+        throw new Error('ECONNREFUSED');
+      },
+    } as never;
+    expect(await consumeStreamTicket({ redis, ticket: 'x', assignmentId: ASSIGNMENT })).toBeNull();
   });
 
   it('valor corrupto en Redis → null (no throw)', async () => {

--- a/apps/api/src/services/sse-ticket.ts
+++ b/apps/api/src/services/sse-ticket.ts
@@ -1,0 +1,73 @@
+import { randomBytes } from 'node:crypto';
+import type { Redis } from 'ioredis';
+
+/**
+ * Tickets efímeros de un solo uso para autenticar el SSE de chat
+ * (`GET /assignments/:id/messages/stream`).
+ *
+ * Por qué (spec fix-sse-ticket-auth, hallazgo ALTO 2026-06-14): EventSource
+ * del browser no soporta headers, así que el auth viaja en la URL. Pasar el
+ * Firebase ID token por `?auth=` lo filtraba EN CRUDO a Cloud Trace (span de
+ * plataforma de Cloud Run) y a Cloud Logging (httpRequest.requestUrl) —
+ * telemetría de plataforma que ningún scrubbing de app alcanza. Solución: lo
+ * que viaja en la URL es ESTE ticket — random ≥128 bits, TTL corto, un solo
+ * uso, scoped al assignment — cuyo filtrado post-consumo es inocuo.
+ */
+
+const TICKET_PREFIX = 'sse-ticket:';
+const TICKET_TTL_SEC = 60;
+
+interface TicketPayload {
+  uid: string;
+  assignmentId: string;
+}
+
+/**
+ * Emite un ticket para abrir el SSE de `assignmentId` como `uid`. Lo guarda
+ * en Redis con TTL corto. Se llama desde un endpoint YA autenticado (Bearer
+ * header → firebaseAuth → userContext + resolveChatAccess), nunca por query.
+ */
+export async function mintStreamTicket(opts: {
+  redis: Redis;
+  uid: string;
+  assignmentId: string;
+  ttlSec?: number;
+}): Promise<{ ticket: string; expiresInSec: number }> {
+  const ttl = opts.ttlSec ?? TICKET_TTL_SEC;
+  const ticket = randomBytes(32).toString('hex');
+  const payload: TicketPayload = { uid: opts.uid, assignmentId: opts.assignmentId };
+  await opts.redis.set(`${TICKET_PREFIX}${ticket}`, JSON.stringify(payload), 'EX', ttl);
+  return { ticket, expiresInSec: ttl };
+}
+
+/**
+ * Valida y CONSUME (single-use) un ticket. Devuelve el `uid` si el ticket
+ * existe, no expiró, y su `assignmentId` coincide con el del stream; null en
+ * cualquier otro caso. El borrado es atómico (GETDEL) → un ticket no puede
+ * reutilizarse aunque dos requests lleguen a la vez.
+ */
+export async function consumeStreamTicket(opts: {
+  redis: Redis;
+  ticket: string;
+  assignmentId: string;
+}): Promise<string | null> {
+  if (!opts.ticket) {
+    return null;
+  }
+  const raw = await opts.redis.getdel(`${TICKET_PREFIX}${opts.ticket}`);
+  if (!raw) {
+    return null;
+  }
+  let payload: TicketPayload;
+  try {
+    payload = JSON.parse(raw) as TicketPayload;
+  } catch {
+    return null;
+  }
+  // Scope: un ticket emitido para el assignment A no sirve para el stream de
+  // B (defensa en profundidad; resolveChatAccess re-autoriza igual aguas abajo).
+  if (payload.assignmentId !== opts.assignmentId) {
+    return null;
+  }
+  return payload.uid;
+}

--- a/apps/api/src/services/sse-ticket.ts
+++ b/apps/api/src/services/sse-ticket.ts
@@ -20,41 +20,67 @@ const TICKET_TTL_SEC = 60;
 interface TicketPayload {
   uid: string;
   assignmentId: string;
+  /**
+   * Snapshot del claim `is_demo` al momento del mint. Se restituye en
+   * `firebaseClaims.custom` al consumir, para que el SSE corra el mismo
+   * enforcement de demo-expiry que un request por header (sin esto, una
+   * sesión por-ticket se veía como NO-demo y saltaba demoExpires — review
+   * 2026-06-14). El expires_at/disabled real lo resuelve demoExpires por uid.
+   */
+  isDemo: boolean;
+}
+
+export interface ConsumedTicket {
+  uid: string;
+  isDemo: boolean;
 }
 
 /**
  * Emite un ticket para abrir el SSE de `assignmentId` como `uid`. Lo guarda
  * en Redis con TTL corto. Se llama desde un endpoint YA autenticado (Bearer
  * header → firebaseAuth → userContext + resolveChatAccess), nunca por query.
+ * Fail-closed: si Redis falla al persistir, lanza (el caller responde 503).
  */
 export async function mintStreamTicket(opts: {
   redis: Redis;
   uid: string;
   assignmentId: string;
+  isDemo: boolean;
   ttlSec?: number;
 }): Promise<{ ticket: string; expiresInSec: number }> {
   const ttl = opts.ttlSec ?? TICKET_TTL_SEC;
   const ticket = randomBytes(32).toString('hex');
-  const payload: TicketPayload = { uid: opts.uid, assignmentId: opts.assignmentId };
+  const payload: TicketPayload = {
+    uid: opts.uid,
+    assignmentId: opts.assignmentId,
+    isDemo: opts.isDemo,
+  };
   await opts.redis.set(`${TICKET_PREFIX}${ticket}`, JSON.stringify(payload), 'EX', ttl);
   return { ticket, expiresInSec: ttl };
 }
 
 /**
- * Valida y CONSUME (single-use) un ticket. Devuelve el `uid` si el ticket
- * existe, no expiró, y su `assignmentId` coincide con el del stream; null en
- * cualquier otro caso. El borrado es atómico (GETDEL) → un ticket no puede
- * reutilizarse aunque dos requests lleguen a la vez.
+ * Valida y CONSUME (single-use) un ticket. Devuelve {uid, isDemo} si el
+ * ticket existe, no expiró, y su `assignmentId` coincide con el del stream;
+ * null en cualquier otro caso (incluido Redis caído → fail-closed). El
+ * borrado es atómico (GETDEL) → un ticket no puede reutilizarse aunque dos
+ * requests lleguen a la vez.
  */
 export async function consumeStreamTicket(opts: {
   redis: Redis;
   ticket: string;
   assignmentId: string;
-}): Promise<string | null> {
+}): Promise<ConsumedTicket | null> {
   if (!opts.ticket) {
     return null;
   }
-  const raw = await opts.redis.getdel(`${TICKET_PREFIX}${opts.ticket}`);
+  let raw: string | null;
+  try {
+    raw = await opts.redis.getdel(`${TICKET_PREFIX}${opts.ticket}`);
+  } catch {
+    // Redis caído → fail-closed (sin ticket válido → 401, no stream).
+    return null;
+  }
   if (!raw) {
     return null;
   }
@@ -69,5 +95,5 @@ export async function consumeStreamTicket(opts: {
   if (payload.assignmentId !== opts.assignmentId) {
     return null;
   }
-  return payload.uid;
+  return { uid: payload.uid, isDemo: payload.isDemo === true };
 }

--- a/apps/api/test/unit/firebase-auth.test.ts
+++ b/apps/api/test/unit/firebase-auth.test.ts
@@ -157,7 +157,10 @@ describe('firebase auth middleware — SSE ticket (fix-sse-ticket-auth)', () => 
 
   async function buildStreamApp(opts: {
     auth: Auth;
-    sseTicketStore?: (ticket: string, assignmentId: string) => Promise<string | null>;
+    sseTicketStore?: (
+      ticket: string,
+      assignmentId: string,
+    ) => Promise<{ uid: string; isDemo: boolean } | null>;
   }): Promise<Hono> {
     const { createFirebaseAuthMiddleware } = await import('../../src/middleware/firebase-auth.js');
     const app = new Hono();
@@ -170,21 +173,35 @@ describe('firebase auth middleware — SSE ticket (fix-sse-ticket-auth)', () => 
       }),
     );
     app.get('/assignments/:id/messages/stream', (c) => {
-      const claims = c.get('firebaseClaims') as { uid: string } | undefined;
-      return c.json({ ok: true, uid: claims?.uid });
+      const claims = c.get('firebaseClaims') as
+        | { uid: string; custom: Record<string, unknown> }
+        | undefined;
+      return c.json({ ok: true, uid: claims?.uid, isDemo: claims?.custom?.is_demo });
     });
     return app;
   }
 
   it('ticket válido → resuelve uid del store y NO llama verifyIdToken', async () => {
     const auth = stubFirebaseAuth({ succeed: {} });
-    const store = vi.fn(async () => 'uid-from-ticket');
+    const store = vi.fn(async () => ({ uid: 'uid-from-ticket', isDemo: false }));
     const app = await buildStreamApp({ auth, sseTicketStore: store });
     const res = await app.request(`${STREAM_PATH}?ticket=abc123`);
     expect(res.status).toBe(200);
-    expect((await res.json()).uid).toBe('uid-from-ticket');
+    const body = (await res.json()) as { uid: string; isDemo: boolean };
+    expect(body.uid).toBe('uid-from-ticket');
+    expect(body.isDemo).toBe(false);
     expect(store).toHaveBeenCalledWith('abc123', ASSIGNMENT);
     expect(auth.verifyIdToken).not.toHaveBeenCalled();
+  });
+
+  it('restituye is_demo del ticket en firebaseClaims.custom (demo enforcement del SSE)', async () => {
+    const app = await buildStreamApp({
+      auth: stubFirebaseAuth({ succeed: {} }),
+      sseTicketStore: async () => ({ uid: 'demo-uid', isDemo: true }),
+    });
+    const res = await app.request(`${STREAM_PATH}?ticket=demo-ticket`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).isDemo).toBe(true);
   });
 
   it('ticket inválido/expirado (store → null) → 401', async () => {

--- a/apps/api/test/unit/firebase-auth.test.ts
+++ b/apps/api/test/unit/firebase-auth.test.ts
@@ -147,3 +147,69 @@ describe('firebase auth middleware', () => {
     expect(auth.verifyIdToken).toHaveBeenCalledWith('t', true);
   });
 });
+
+// fix-sse-ticket-auth: el SSE del chat se autentica con un ticket efímero por
+// query (?ticket=), NO con el Firebase ID token (que se filtraba a Cloud
+// Trace/Logging). El fallback `?auth=<token>` quedó ELIMINADO.
+describe('firebase auth middleware — SSE ticket (fix-sse-ticket-auth)', () => {
+  const ASSIGNMENT = 'a1111111-2222-3333-4444-555555555555';
+  const STREAM_PATH = `/assignments/${ASSIGNMENT}/messages/stream`;
+
+  async function buildStreamApp(opts: {
+    auth: Auth;
+    sseTicketStore?: (ticket: string, assignmentId: string) => Promise<string | null>;
+  }): Promise<Hono> {
+    const { createFirebaseAuthMiddleware } = await import('../../src/middleware/firebase-auth.js');
+    const app = new Hono();
+    app.use(
+      '/assignments/*',
+      createFirebaseAuthMiddleware({
+        auth: opts.auth,
+        logger: noopLogger,
+        ...(opts.sseTicketStore ? { sseTicketStore: opts.sseTicketStore } : {}),
+      }),
+    );
+    app.get('/assignments/:id/messages/stream', (c) => {
+      const claims = c.get('firebaseClaims') as { uid: string } | undefined;
+      return c.json({ ok: true, uid: claims?.uid });
+    });
+    return app;
+  }
+
+  it('ticket válido → resuelve uid del store y NO llama verifyIdToken', async () => {
+    const auth = stubFirebaseAuth({ succeed: {} });
+    const store = vi.fn(async () => 'uid-from-ticket');
+    const app = await buildStreamApp({ auth, sseTicketStore: store });
+    const res = await app.request(`${STREAM_PATH}?ticket=abc123`);
+    expect(res.status).toBe(200);
+    expect((await res.json()).uid).toBe('uid-from-ticket');
+    expect(store).toHaveBeenCalledWith('abc123', ASSIGNMENT);
+    expect(auth.verifyIdToken).not.toHaveBeenCalled();
+  });
+
+  it('ticket inválido/expirado (store → null) → 401', async () => {
+    const app = await buildStreamApp({
+      auth: stubFirebaseAuth({ succeed: {} }),
+      sseTicketStore: async () => null,
+    });
+    const res = await app.request(`${STREAM_PATH}?ticket=expired`);
+    expect(res.status).toBe(401);
+  });
+
+  it('sin ticket ni Bearer → 401', async () => {
+    const app = await buildStreamApp({
+      auth: stubFirebaseAuth({ succeed: {} }),
+      sseTicketStore: async () => 'x',
+    });
+    const res = await app.request(STREAM_PATH);
+    expect(res.status).toBe(401);
+  });
+
+  it('el viejo ?auth=<jwt> ya NO autentica el stream (401, sin verifyIdToken)', async () => {
+    const auth = stubFirebaseAuth({ succeed: { uid: 'should-not-happen' } });
+    const app = await buildStreamApp({ auth, sseTicketStore: async () => null });
+    const res = await app.request(`${STREAM_PATH}?auth=eyJfake.jwt.token`);
+    expect(res.status).toBe(401);
+    expect(auth.verifyIdToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/use-chat-stream.test.tsx
+++ b/apps/web/src/hooks/use-chat-stream.test.tsx
@@ -55,11 +55,13 @@ class StubEventSource implements FakeEventSource {
 
 // fix-sse-ticket-auth: el hook ahora hace POST /stream-ticket (Bearer) y abre
 // el EventSource con ?ticket=. Mock del fetch del ticket.
-const fetchMock = vi.fn(async () => ({
-  ok: true,
-  status: 200,
-  json: async () => ({ ticket: 'ticket-xyz', expires_in_sec: 60 }),
-}));
+const fetchMock = vi.fn(
+  async (): Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }> => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ ticket: 'ticket-xyz', expires_in_sec: 60 }),
+  }),
+);
 
 beforeEach(() => {
   lastEventSource = null;
@@ -163,6 +165,16 @@ describe('useChatStream', () => {
     first?.onerror?.();
     expect(onDisconnect).toHaveBeenCalled();
     expect(first?.closed).toBe(true);
+  });
+
+  it('reconnect tras onerror pide un ticket NUEVO (single-use) — SC-4', async () => {
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn() }));
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    expect(fetchMock).toHaveBeenCalledTimes(1); // primer mint
+    lastEventSource?.onerror?.();
+    // El backoff reagenda connect → debe pedir OTRO ticket (el anterior ya se
+    // consumió). Esperamos a que el segundo mint ocurra.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), { timeout: 3000 });
   });
 
   it('cleanup en unmount → close + cancela reconnect timer', async () => {

--- a/apps/web/src/hooks/use-chat-stream.test.tsx
+++ b/apps/web/src/hooks/use-chat-stream.test.tsx
@@ -53,17 +53,28 @@ class StubEventSource implements FakeEventSource {
   }
 }
 
+// fix-sse-ticket-auth: el hook ahora hace POST /stream-ticket (Bearer) y abre
+// el EventSource con ?ticket=. Mock del fetch del ticket.
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ ticket: 'ticket-xyz', expires_in_sec: 60 }),
+}));
+
 beforeEach(() => {
   lastEventSource = null;
   currentUserState.value = { getIdToken: getIdTokenMock };
   getIdTokenMock.mockClear();
+  fetchMock.mockClear();
   (globalThis as any).EventSource = StubEventSource;
+  (globalThis as any).fetch = fetchMock;
 });
 
 afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   Reflect.deleteProperty(globalThis as any, 'EventSource');
+  Reflect.deleteProperty(globalThis as any, 'fetch');
 });
 
 async function flushPromises() {
@@ -96,13 +107,36 @@ describe('useChatStream', () => {
     renderHook(() => useChatStream({ assignmentId: 'a1', onMessage, onConnect }));
     await waitFor(() => expect(lastEventSource).not.toBeNull());
     expect(lastEventSource?.url).toContain('/assignments/a1/messages/stream');
-    expect(lastEventSource?.url).toContain('auth=firebase-id-token');
+    // El token NUNCA va en la URL — solo el ticket efímero (fix-sse-ticket-auth).
+    expect(lastEventSource?.url).toContain('ticket=ticket-xyz');
+    expect(lastEventSource?.url).not.toContain('auth=');
+    expect(lastEventSource?.url).not.toContain('firebase-id-token');
+    // El ticket se pidió por POST con Bearer header (token NO en la URL).
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/assignments/a1/messages/stream-ticket'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: { authorization: 'Bearer firebase-id-token' },
+      }),
+    );
 
     lastEventSource?.emit('connected');
     expect(onConnect).toHaveBeenCalled();
 
     lastEventSource?.emit('message', { message_id: 'm1', assignment_id: 'a1' });
     expect(onMessage).toHaveBeenCalledWith({ message_id: 'm1', assignment_id: 'a1' });
+  });
+
+  it('fallo al obtener el ticket → no abre EventSource + onDisconnect (reconnect)', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'realtime_disabled' }),
+    });
+    const onDisconnect = vi.fn();
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn(), onDisconnect }));
+    await waitFor(() => expect(onDisconnect).toHaveBeenCalled());
+    expect(lastEventSource).toBeNull();
   });
 
   it('payload no-JSON → log warn, no crash, no callback', async () => {

--- a/apps/web/src/hooks/use-chat-stream.ts
+++ b/apps/web/src/hooks/use-chat-stream.ts
@@ -10,17 +10,15 @@
  *     falla. EventSource ya hace reconnect nativo pero podemos perderlo
  *     en errores transitorios — agregamos backoff manual.
  *
- * Auth: el endpoint SSE requiere Firebase ID token. EventSource NO
- * soporta headers custom, así que el token va como query param. El
- * server lee ?auth=<token> en el middleware especial. Trade-off: el
- * token aparece en logs server. Mitigado por:
- *   - Tokens Firebase tienen TTL 1h.
- *   - URL es HTTPS only.
- *   - El uso es interno (no compartido).
- *
- * Si en el futuro queremos eliminar este trade-off, migrar a WebSocket
- * (donde sí podemos mandar headers en el handshake) o a fetch streaming
- * con ReadableStream (no soportado en todos los browsers).
+ * Auth (fix-sse-ticket-auth): EventSource NO soporta headers custom, así
+ * que el auth viaja en la URL. NO mandamos el Firebase ID token — se
+ * filtraba EN CRUDO a Cloud Trace/Logging (telemetría de plataforma de
+ * Cloud Run que ningún scrubbing de app alcanza). En su lugar:
+ *   1. POST /assignments/:id/messages/stream-ticket con el Bearer header
+ *      (autenticación normal, sin exponer el token en la URL) → {ticket}.
+ *   2. EventSource a `...?ticket=<ticket>`. El ticket es de UN SOLO USO,
+ *      TTL ~60s, scoped al assignment → su filtrado post-consumo es inocuo.
+ * Cada reconnect pide un ticket nuevo (son single-use).
  */
 
 import { useEffect, useRef } from 'react';
@@ -75,8 +73,6 @@ export function useChatStream(opts: UseChatStreamOptions): void {
         return;
       }
 
-      // Firebase token para auth — va como query param porque EventSource
-      // no soporta headers.
       const user = firebaseAuth.currentUser;
       if (!user) {
         // Sin user, no hay auth posible. Reintentamos en un rato (puede
@@ -84,10 +80,40 @@ export function useChatStream(opts: UseChatStreamOptions): void {
         reconnectTimer = setTimeout(connect, 2000);
         return;
       }
-      const token = await user.getIdToken();
 
+      // 1. Pedir un ticket efímero con el Bearer header (el token NO va en la
+      //    URL — fix-sse-ticket-auth). single-use, así que se pide en cada
+      //    connect/reconnect.
+      let ticket: string;
+      try {
+        const token = await user.getIdToken();
+        const res = await fetch(
+          `${env.VITE_API_URL}/assignments/${opts.assignmentId}/messages/stream-ticket`,
+          { method: 'POST', headers: { authorization: `Bearer ${token}` } },
+        );
+        if (!res.ok) {
+          throw new Error(`stream-ticket ${res.status}`);
+        }
+        ticket = ((await res.json()) as { ticket: string }).ticket;
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        // Sin ticket no hay stream — reconnect con backoff (el realtime es
+        // no-crítico; el cliente sigue refrescando por polling/useQuery).
+        logger.warn({ err }, 'useChatStream: no se pudo obtener stream-ticket');
+        onDisconnectRef.current?.();
+        backoff = Math.min(backoff * 2, MAX_BACKOFF_MS);
+        reconnectTimer = setTimeout(connect, backoff);
+        return;
+      }
+      if (cancelled) {
+        return;
+      }
+
+      // 2. Abrir el EventSource con el ticket en la URL.
       const url = new URL(`${env.VITE_API_URL}/assignments/${opts.assignmentId}/messages/stream`);
-      url.searchParams.set('auth', token);
+      url.searchParams.set('ticket', ticket);
 
       eventSource = new EventSource(url.toString());
 

--- a/apps/web/src/hooks/use-chat-stream.ts
+++ b/apps/web/src/hooks/use-chat-stream.ts
@@ -87,10 +87,19 @@ export function useChatStream(opts: UseChatStreamOptions): void {
       let ticket: string;
       try {
         const token = await user.getIdToken();
-        const res = await fetch(
-          `${env.VITE_API_URL}/assignments/${opts.assignmentId}/messages/stream-ticket`,
-          { method: 'POST', headers: { authorization: `Bearer ${token}` } },
-        );
+        // Timeout duro: si Redis/el api cuelga, no dejamos el connect colgado
+        // sin caer al backoff de reconnect.
+        const abort = new AbortController();
+        const timeout = setTimeout(() => abort.abort(), 10_000);
+        let res: Response;
+        try {
+          res = await fetch(
+            `${env.VITE_API_URL}/assignments/${opts.assignmentId}/messages/stream-ticket`,
+            { method: 'POST', headers: { authorization: `Bearer ${token}` }, signal: abort.signal },
+          );
+        } finally {
+          clearTimeout(timeout);
+        }
         if (!res.ok) {
           throw new Error(`stream-ticket ${res.status}`);
         }


### PR DESCRIPTION
## Resumen
Cierra el hallazgo **ALTO** del spot-check (2026-06-14): el SSE de chat (`GET /assignments/:id/messages/stream`) autenticaba con el **Firebase ID token en `?auth=`** de la URL, y ese token se filtraba EN CRUDO a **Cloud Trace** (span de plataforma de Cloud Run `/component=AppServer`) y **Cloud Logging** (`httpRequest.requestUrl`) — telemetría de plataforma que el RedactingSpanExporter de #451 NO alcanza. Un Firebase ID token es bearer (~1h, impersonación total). Fix: lo que viaja en la URL es un **ticket efímero de un solo uso**.

- **api**: `POST /:id/messages/stream-ticket` (autenticado por Bearer header + resolveChatAccess) emite el ticket (CSPRNG 256-bit, Redis TTL 60s, GETDEL single-use, scoped a {uid, assignmentId, is_demo}). El SSE consume `?ticket=` → resuelve identidad. **Eliminado el fallback `?auth=<token>`** — ningún token va más en una URL.
- **web**: `use-chat-stream.ts` pide el ticket por POST (Bearer, con AbortController 10s) → `EventSource(?ticket=)`; reconnect pide ticket nuevo.
- **#451 RedactingSpanExporter se mantiene** como defensa en profundidad.

Spec/plan/verify/review en `.specs/fix-sse-ticket-auth/`.

## Evidencia
- Tests: sse-ticket 7, firebase-auth 12 (incl. `?auth=<jwt>` ya NO autentica + is_demo propagado), use-chat-stream 11 (incl. token NO en la URL + reconnect pide ticket nuevo). **Suite api 1456 verde**, typecheck api+web OK, lint OK.
- **Review adversarial** (security-auditor + devils-advocate): ambos convergieron en un hallazgo que introduje — la sesión por-ticket se saltaba el enforcement de demo (`custom={}`). **Resuelto** (el ticket lleva is_demo, el SSE lo restituye) + fail-closed 503/AbortController + test de reconnect + spec corregida (deploy NO atómico). Detalle en review.md.

## Acción del PO (post-deploy)
- Repetir el spot-check sintético: la URL del SSE muestra `?ticket=` (no token); un `?auth=<jwt>` → 401; un chat real conecta vía ticket.
- Nota de deploy: una PWA ya abierta cae a polling hasta recargar (realtime no-crítico, mensajes no se pierden).

## Follow-up
- `.specs/_followups/sse-realtime-multi-empresa.md` (BAJA, preexistente): X-Empresa-Id en el mint para users multi-empresa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)