### PR TITLE
docs(repo): refs stale CLAUDE.md + gate real del retention lock

### DIFF
--- a/.specs/_followups/claude-md-referencias-stale.md
+++ b/.specs/_followups/claude-md-referencias-stale.md
@@ -14,4 +14,5 @@
 
 ## Estado
 
-Pendiente de aprobación del PO para los puntos 1-3; el punto técnico es ejecutable en cualquier ciclo.
+- **Puntos 1-3 RESUELTOS 2026-06-14** (PR `docs/followups-stale-refs-y-retention-gate`, aprobación PO explícita en sesión): §Deploy corregida (cloudbuild.staging.yaml eliminado en #445; e2e nightly pega a PRODUCCIÓN documentado); §Estructura packages 21 exacto + lista al día; comentario de `e2e-staging.yml` corregido. **Sub-decisión abierta del punto 3**: la re-firma del PO de "e2e nightly contra producción" vs priorizar `#STAGING-ENV` sigue siendo decisión del PO (ahora documentada en CLAUDE.md, no resuelta).
+- **Ítem técnico (`booleanFlag` en `apps/api/src/config.ts`)**: PENDIENTE — ejecutable en cualquier ciclo (sin tocar CLAUDE.md). Incluye la decisión de contrato fail-closed (error Zod al startup) vs default silencioso.

--- a/.specs/sec-h3-dte-retention-lock/spec.md
+++ b/.specs/sec-h3-dte-retention-lock/spec.md
@@ -173,3 +173,20 @@ La auditoría propuso inicialmente lockear también el bucket forense `{project}
 ## 14bis. Estado del prerequisito 14.1 (2026-06-11)
 
 **RESUELTO con la opción (b)** — decisión PO 2026-06-11 vía AskUserQuestion: bucket propio `{project}-certificates-{env}` sin retention policy (PR del ciclo `feat-certificados-bucket-propio`; migración operativa en `docs/runbooks/migracion-bucket-certificados.md`). Tras ejecutar esa migración, `documents` queda 100% DTE/mandato SII y el plan §14.3 continúa en el paso 2 (validación SC-4) — la decisión del lock sigue siendo del PO en sesión dedicada.
+
+## 15. Estado 2026-06-14 — lock DIFERIDO (SC-4 insatisfacible hoy)
+
+Verificación read-only en prod (gcloud, credenciales vivas):
+
+- Bucket `gs://booster-ai-494222-documents-prod`: `retentionPeriod=189216000` (6 años) ✓, **`isLocked` ausente (= false)** — sin cambios desde 2026-06-02.
+- **El bucket está VACÍO (0 objetos)** y **no hay actividad DTE en prod** (0 writes en logs de 7 días). El producto aún no emite DTEs reales; `document-service` deployado pero ocioso.
+
+**Conclusión**: **SC-4 (corrida 48h del write/read/lifecycle de DTEs reales) es insatisfacible hoy** — no hay DTEs que validar. Aplicar `is_locked=true` ahora sería exactamente el peor escenario que §0 advierte: lock irreversible de 6 años sobre un write path **nunca ejercido en prod**, sin la validación no-negociable. **El lock se DIFIERE.**
+
+**Trigger para retomar** (todas las condiciones): (1) emisión real de DTEs en prod operando; (2) SC-4 ejecutada 48h contra ese tráfico real con evidencia en `validation-48h-evidence.md`; (3) decisión PO en frío. Mientras tanto `is_locked=false` es **deliberado, no postergación** — el comentario de `infrastructure/storage.tf` se actualizó para reflejar este gate (antes decía "CAMBIAR A true MANUALMENTE", stale).
+
+Pendiente de readiness (opcional, no urgente; se puede preparar antes del trigger): smoke script `scripts/dte-write-read-smoke.ts` (T1) y el ADR de SC-3 (lock documents / no-lock crash-traces). No se escriben aún para no anticipar una decisión diferida.
+
+## 14ter. Decision log (continuación)
+
+- 2026-06-14 — Lock DIFERIDO. Evidencia prod read-only: bucket `documents-prod` vacío, 0 tráfico DTE → SC-4 insatisfacible. No se toca el bucket ni el Terraform funcional (solo el comentario stale de storage.tf). Sigue Draft; la decisión irreversible queda gateada por la emisión real de DTEs + SC-4 + decisión PO en frío.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Todo input externo pasa por Zod **antes** de tocar lógica:
 
 ### Deploy
 
-- **No existe entorno staging** (backlog `#STAGING-ENV`: requiere un 2º GCP project con infra paralela). El `cloudbuild.staging.yaml` está inactivo; `release.yml` removió el job `deploy-staging`.
+- **No existe entorno staging** (backlog `#STAGING-ENV`: requiere un 2º GCP project con infra paralela). El `cloudbuild.staging.yaml` fue eliminado (#445, higiene tooling); `release.yml` removió el job `deploy-staging`. El nightly `e2e-staging.yml` corre Playwright contra **producción** (`PRODUCTION_URL`; `STAGING_URL` solo aplicaría en PR, que no existe) por falta de staging — decisión deliberada **pendiente de re-firma del PO** o de priorizar `#STAGING-ENV`.
 - **Producción**: merge a `main` → `release.yml` (GitHub Actions vía Workload Identity Federation) → **requiere aprobación humana** en el GitHub Environment `production` (`required_reviewers`, enforced desde 2026-05-29) → Cloud Build `cloudbuild.production.yaml` canary (1% tráfico → 30 min → 100%). El step `canary-verify` es placeholder (`exit 0`): la promoción a 100% se observa/decide humanamente, no por verificación automática. Ver inventario `.specs/adr-vs-prod-inventory/inventory.md` finding #1.
 - **Monitoreo 2h post-deploy**: error rate, latency P95, logs limpios.
 - **Regla de horario de deploy eliminada 2026-05-29 por decisión del PO**: el control de riesgo de deploy se ejerce vía gate de aprobación (`required_reviewers` en el GitHub Environment `production`) + observación humana del canary, no vía restricción de calendario.
@@ -217,12 +217,13 @@ Booster-AI/
 │   ├── whatsapp-bot/           # Webhook Meta + NLU
 │   └── document-service/       # DTE + Carta Porte + OCR
 │
-├── packages/                   # ~21 packages compartidos
-│   # shared-schemas, logger, ai-provider, config,
-│   # trip-state-machine, codec8-parser, pricing-engine,
-│   # matching-algorithm, carbon-calculator, whatsapp-client,
-│   # dte-provider, carta-porte-generator, document-indexer,
-│   # notification-fan-out, ui-tokens, ui-components, etc.
+├── packages/                   # 21 packages compartidos
+│   # ai-provider, carbon-calculator, carta-porte-generator,
+│   # certificate-generator, coaching-generator, codec8-parser, config,
+│   # document-indexer, driver-scoring, dte-provider, factoring-engine,
+│   # logger, matching-algorithm, notification-fan-out, otel-bootstrap,
+│   # pricing-engine, shared-schemas, trip-state-machine, ui-components,
+│   # ui-tokens, whatsapp-client
 │
 ├── infrastructure/             # Terraform 100% IaC (incluye IAM humana)
 │   ├── main.tf
@@ -233,7 +234,7 @@ Booster-AI/
     ├── ci.yml                  # lint + test + coverage + build
     ├── security.yml            # gitleaks + npm audit + CodeQL
     ├── release.yml             # Changesets + Cloud Build
-    └── e2e-staging.yml         # Playwright contra staging
+    └── e2e-staging.yml         # Playwright; nightly pega a PRODUCCIÓN (no hay staging, #STAGING-ENV)
 ```
 
 Cambios v2→v3 (post-PR-2 / ADR-049):

--- a/infrastructure/storage.tf
+++ b/infrastructure/storage.tf
@@ -139,10 +139,15 @@ resource "google_storage_bucket" "documents" {
     log_object_prefix = "documents/"
   }
 
-  # Retention Lock 6 años (SII Chile)
+  # Retention Lock 6 años (SII Chile). is_locked se mantiene FALSE de forma
+  # DELIBERADA: el lock es IRREVERSIBLE (6 años por objeto, sin des-lock).
+  # Gate para pasarlo a true (.specs/sec-h3-dte-retention-lock §3):
+  #   (a) emisión real de DTEs en prod, (b) validación SC-4 (48h write/read sin
+  #   issues), (c) decisión PO en frío. 2026-06-14: bucket vacío / 0 tráfico DTE
+  #   → SC-4 insatisfacible; se mantiene false. NO cambiar sin cumplir el gate.
   retention_policy {
     retention_period = 189216000 # 6 años en segundos = 6 * 365.25 * 24 * 3600
-    is_locked        = false     # CAMBIAR A true MANUALMENTE después de validar
+    is_locked        = false
   }
 
   lifecycle_rule {


### PR DESCRIPTION
## Qué

Cierra dos follow-ups **documentales** (aprobación PO explícita en sesión 2026-06-14). Sin cambios funcionales: solo docs, specs y un comentario de Terraform.

### 1. `claude-md-referencias-stale` (puntos 1-3)
- **§Deploy**: `cloudbuild.staging.yaml` fue **eliminado** en #445 (CLAUDE.md decía "está inactivo"). Además se documenta que el nightly `e2e-staging.yml` corre Playwright contra **producción** (`PRODUCTION_URL`) por falta de staging — decisión deliberada, **re-firma del PO pendiente** o priorizar `#STAGING-ENV`.
- **§Estructura**: `~21 packages` → **21 exacto** + lista completa al día (faltaban `certificate-generator`, `coaching-generator`, `driver-scoring`, `factoring-engine`, `otel-bootstrap`).
- Comentario de `e2e-staging.yml` en el árbol: "contra staging" → "contra PRODUCCIÓN".

### 2. `sec-h3-dte-retention-lock` (gate real del lock)
- `infrastructure/storage.tf:145` decía `# CAMBIAR A true MANUALMENTE después de validar` (stale desde el commit inicial). Reemplazado por el **gate real**: el lock es IRREVERSIBLE y se **difiere** hasta (a) emisión real de DTEs en prod, (b) validación SC-4 (48h), (c) decisión PO en frío.
- **Verificación prod 2026-06-14** (read-only): bucket `documents-prod` **vacío (0 objetos)**, **0 tráfico DTE** en 7 días → SC-4 insatisfacible hoy. `is_locked` permanece `false` **deliberadamente** (no postergación).
- `spec.md`: §15 + decision log con la decisión de diferimiento y el trigger para retomar.

## Evidencia

- `terraform fmt -check infrastructure/storage.tf` → OK (exit 0).
- `is_locked = false` sin cambio funcional → **terraform plan = no changes** sobre el recurso (solo comentario).
- gitleaks (pre-commit) → 0 leaks. Biome (lint-staged) → OK. check-adr-numbering → OK. spec-canonical-drift → OK.
- Conteo de packages verificado: `ls -d packages/*/ | wc -l` = 21.
- `cloudbuild.staging.yaml` ausente: `git ls-files` vacío; borrado en #445 (`dc3d539`).
- `e2e-staging.yml:47` usa `PRODUCTION_URL` salvo en `pull_request`.

## Decisión que queda al PO

Re-firma de "e2e nightly contra producción" vs priorizar `#STAGING-ENV` (ahora **documentada** en CLAUDE.md, no resuelta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)