### PR TITLE
fix(web): SSE stream-ticket manda X-Empresa-Id (multi-empresa)

### DIFF
--- a/.specs/_followups/use-chat-stream-hardening.md
+++ b/.specs/_followups/use-chat-stream-hardening.md
@@ -1,0 +1,24 @@
+# Follow-up: endurecer use-chat-stream (reconnect policy + empresa-change + consolidación)
+
+**Origen**: review devils-advocate de `fix-sse-ticket-x-empresa` (2026-06-14). Tres hallazgos NO bloqueantes, ninguno regresión del cambio de `X-Empresa-Id`; todos pre-existentes en el hook.
+**Severidad**: BAJA (realtime es no-crítico; degrada a polling/refetch).
+**Archivo**: `apps/web/src/hooks/use-chat-stream.ts`.
+
+## 1. Política de reconnect: cortar en errores permanentes (FUERTE en el review)
+
+Hoy el hook trata todo `!res.ok` del mint igual (`use-chat-stream.ts` branch del catch): un 403 (empresa stale/revocada o user sin acceso real) entra en reconnect loop con backoff ≤30s **indefinidamente**, reintentando el mismo request que no puede tener éxito. Un 503 (Redis) sí es transitorio y debe reintentarse.
+
+**Acción propuesta**: distinguir error permanente (401/403) de transitorio (5xx / network / abort). En permanente: log + `onDisconnect` + **NO** reagendar reconnect (el realtime queda off; el polling/useQuery cubre la lectura). En transitorio: mantener el backoff actual. Test: 403 del mint → no se agenda reconnect; 503 → sí.
+
+## 2. Cambio de empresa activa en stream vivo no re-mintea (MENOR)
+
+El `useEffect` depende de `[enabled, opts.assignmentId]`, no de la empresa activa. Si el user cambia de empresa con un stream abierto, el ticket vigente no se re-emite hasta el próximo reconnect natural. Inocuo para seguridad (la empresa se fija en el mint + re-autorización server-side), pero el realtime puede quedar atado a la empresa anterior hasta reconnect.
+
+**Acción propuesta**: o agregar la empresa activa a las deps del effect (re-mintea al cambiar), o exponer un mecanismo de "refrescar stream" cuando `setActiveEmpresaId` cambia. Evaluar junto con (1).
+
+## 3. Consolidar el fetch del ticket con el api-client (MENOR, de spec §8)
+
+El fetch del mint duplica lo que `api-client.ts` ya hace (Bearer + X-Empresa-Id). Migrar a `api.post(...)` unificaría la inyección de headers (incluida cualquier futura: trace headers, etc.). Cuidar: el api-client arma su propio Content-Type/AbortController; el hook tiene un timeout de 10s y manejo de error específico que no debe perderse.
+
+## Estado
+Pendiente (BAJA). Los tres se pueden abordar en un solo ciclo corto (todo en `use-chat-stream.ts` + su test).

--- a/.specs/fix-sse-ticket-x-empresa/review.md
+++ b/.specs/fix-sse-ticket-x-empresa/review.md
@@ -1,0 +1,45 @@
+# Devils-advocate review — fix-sse-ticket-x-empresa — 2026-06-14T10:31:00Z
+
+## Premise
+- Assumed: el server valida la membership de `X-Empresa-Id` antes de mintear el ticket. CONFIRMADO — `resolveUserContext` (user-context.ts:69-77) hace `.find(m => m.empresa.id === requestedEmpresaId)` y lanza `EmpresaNotInMembershipsError` -> 403 si no hay match. El header NO concede acceso de mas.
+- Asumido implicito y NO verificado por el spec: que `getActiveEmpresaId()` (raw `localStorage.getItem`, api-client.ts:31-33) nunca lanza en el contexto del hook. Es la asuncion mas fragil (ver Failure F1).
+- Mas doloroso si falso: si `localStorage.getItem` lanzara (Safari modo privado viejo / storage deshabilitado), la excepcion cae DENTRO del try del mint (use-chat-stream.ts:99, dentro del try de la linea 89) -> se trata como fallo de ticket -> backoff/reconnect infinito sin stream. Degradacion silenciosa, no crash. El api-client YA usa el mismo patron sin guard y no ha sido problema, pero el spec lo declara L/L sin evidencia.
+
+## Scope and second-order effects
+- El cambio toca SOLO el header del POST del ticket. El `EventSource` sigue sin header (correcto: la empresa queda fijada en el mint). Sin cambios server.
+- Segundo orden no mencionado en el spec: la empresa con la que se mintea el ticket es la `activeMembership` AL MOMENTO DEL MINT. Si el user cambia de empresa activa (setActiveEmpresaId) mientras el stream esta vivo, el stream existente NO se reabre — el `useEffect` depende de `[enabled, opts.assignmentId]` (use-chat-stream.ts:188), NO de la empresa activa. El stream sigue corriendo con el ticket viejo hasta el proximo reconnect. Funcionalmente correcto (el ticket scoped al assignment+uid sigue valido; resolveChatAccess re-autoriza por assignment, no por empresa-en-vivo) pero NADIE lo documento. Hyrum: si algun consumidor asume que cambiar empresa activa re-evalua el chat en vivo, se sorprende.
+- El docblock del archivo (use-chat-stream.ts:13-21) sigue diciendo "el auth viaja en la URL" / "NO mandamos el Firebase ID token". Sigue siendo cierto, pero el bloque NO menciona X-Empresa-Id. Drift documental menor.
+
+## Alternatives discarded
+- Considerada y rechazada en spec section 8: migrar el fetch a `api.post()` del api-client (auto-inyectaria el header). Rechazo razonable (el api-client arma su propio AbortController/Content-Type y el hook ya tiene timeout de 10s). Trade-off: se DUPLICA la logica de "construir headers auth + empresa" que ya vive en `buildHeaders` (api-client.ts:43-62). Hoy son dos copias de la misma regla "Bearer + X-Empresa-Id condicional". Si manana se agrega un tercer header comun (ej. trace), hay que tocar dos sitios.
+- NO considerada: fix server-side en vez de client-side. El server YA sabe que empresas son parte del assignment (carrierEmpresaId/shipperEmpresaId, chat.ts:177-181) — podria auto-seleccionar la membership del user que matchee el assignment sin depender del header del cliente. Esa alternativa elimina la clase entera de bug "empresa activa equivocada" pero no se discutio. Spec section 5 solo dice "no cambiar userContextMiddleware" sin argumentar por que el cliente debe ser la fuente de verdad.
+
+## Failure modes
+- F1 (localStorage lanza / deteccion: no hay / recovery: ninguna, cae en reconnect loop / costo: el user multi-empresa no obtiene realtime, degrada a polling — el mismo sintoma que el bug que esto arregla). Mismo riesgo preexistia en el api-client; el cambio lo extiende al hook. No bloqueante.
+- F2 (empresa activa stale en localStorage apunta a una membership ya revocada / deteccion: server responde 403 empresa_forbidden en el mint / recovery: el hook trata 403 como fallo de ticket -> backoff/reconnect, reintentando el MISMO header malo indefinidamente cada <=30s / costo: reconnect loop silencioso + carga al api). El hook NO distingue 403-empresa de 503-redis (use-chat-stream.ts:113-128 trata todo `!res.ok` igual). No es regresion, pero el manejo de error es indiscriminado.
+- F3 (race empresa-cambia-durante-stream / deteccion: ninguna / recovery: solo al proximo reconnect natural / costo: ventana donde el ticket se emitio con empresa A y el user ya esta en empresa B en la UI). Inocuo para seguridad (el assignment y el uid mandan), pero comportamiento no especificado.
+
+## Reversibility
+- Costo de deshacer en 30 dias: trivial. `git revert` de 2 archivos, sin migracion, sin flag, sin estado persistido (spec section 11). El ticket es efimero (TTL 60s) asi que no hay datos que limpiar.
+- Mecanismo de reversa: revert del commit. Sin coordinacion server (el server ya acepta el header desde siempre via userContextMiddleware). Es lo mas limpio del cambio.
+
+## Drift signals
+- Escaneo del vocabulario anti-drift sobre el diff y el spec: sin coincidencias. No hay marcadores de deuda provisional ni de minimo-viable ni de atajo en el codigo nuevo.
+- Si hay un follow-up explicito y razonado (consolidar fetch del ticket con api-client) — mencionado en spec section 8 pero SIN stub en `.specs/_followups/`. Eso es deuda no-ticketeada segun el contrato Booster: el follow-up que ORIGINO este cambio (sse-realtime-multi-empresa.md) si tiene stub; el que este cambio GENERA no. Objecion menor.
+
+## Evidence quality
+- Claim "el server valida la membership server-side, no concede acceso de mas" -> Evidencia: user-context.ts:69-77 + chat.ts:177-188 (rol derivado de empresaActivaId vs carrier/shipper del assignment) -> Veredicto: SUFICIENTE. Un user que pone una empresa a la que no pertenece recibe 403 en el mint (EmpresaNotInMembershipsError). Un user que pone una empresa a la que SI pertenece pero que NO es parte del assignment recibe 403 forbidden_not_party (chat.ts:183-188). No hay IDOR.
+- Claim "el token NUNCA va en la URL / ticket single-use scoped" -> Evidencia: sse-ticket.ts:79 (GETDEL atomico = single-use), :95 (scope por assignmentId), use-chat-stream.ts:102 (token solo en header `authorization`), test :123-126 y :154-155 (URL no contiene token ni empresa) -> Veredicto: SUFICIENTE. El fix anterior NO se regresa.
+- Claim "el header llega / spread condicional correcto" -> Evidencia: 13/13 tests verdes (corrido localmente), test :143-156 verifica presencia, :158-171 verifica ausencia -> Veredicto: SUFICIENTE para presencia/ausencia.
+- Claim del test "headers EXACTAMENTE {authorization} prueba la ausencia de X-Empresa-Id" (test:162-163) -> Evidencia: usa `expect.objectContaining({ headers: { authorization: ... } })`. El `objectContaining` es shallow en su primer nivel, pero el valor anidado `headers` se compara por IGUALDAD ESTRICTA (no es otro `objectContaining`). Por eso un `headers` con una key extra SI falla el match -> Veredicto: SUFICIENTE, el comentario del test es correcto. Verificado: T2 pasa con el mock devolviendo null y fallaria si el header se colara.
+- Claim spec section 9 "localStorage no disponible: L/L, tests stubean getActiveEmpresaId" -> Veredicto: DEBIL. El test stubea la funcion entera, asi que NUNCA ejercita el `localStorage.getItem` real. El riesgo de que `getActiveEmpresaId` lance en runtime queda SIN cobertura por construccion. La mitigacion citada no mitiga el riesgo que dice mitigar.
+
+## Verdict
+- Strong objections (must address): NINGUNA bloqueante. No hay IDOR, no hay regresion del fix anterior, el cambio es correcto y los tests pasan.
+- Residual risks (accept and document):
+  1. (FUERTE) Manejo de error indiscriminado: un 403 por empresa stale/revocada (F2) entra en reconnect loop identico a un 503 transitorio. No es regresion, pero vale un short-circuit (no reintentar en 403). Decidir explicitamente: se acepta el loop silencioso?
+  2. (MENOR) Comportamiento no especificado: cambiar empresa activa durante un stream vivo NO re-mintea (dep array no incluye empresa). Documentar en spec section 4 que es esperado.
+  3. (MENOR) Deuda no-ticketeada: el follow-up "consolidar fetch del ticket con api-client" (spec section 8) no tiene stub en `.specs/_followups/`. Crearlo o borrar la mencion.
+  4. (MENOR) Spec section 9 sobre-vende la mitigacion de "localStorage no disponible": los tests stubean la funcion, asi que el riesgo real (getItem lanza) queda sin cobertura. Corregir el texto del riesgo.
+  5. (MENOR) El docblock del hook (use-chat-stream.ts:13-21) no menciona X-Empresa-Id. Actualizar para que el por-que del header quede en el archivo, no solo en el spec.
+- Out of scope for this review: el diseno de la resolucion de membership default (userContextMiddleware), el fix-sse-ticket-auth ya mergeado (#461), la arquitectura de Pub/Sub del stream.

--- a/.specs/fix-sse-ticket-x-empresa/spec.md
+++ b/.specs/fix-sse-ticket-x-empresa/spec.md
@@ -1,0 +1,69 @@
+# Spec: fix-sse-ticket-x-empresa
+
+- Author: Felipe Vicencio (with agent-rigor)
+- Date: 2026-06-14
+- Status: Approved
+- Linked: `.specs/_followups/sse-realtime-multi-empresa.md` (QUESTION del review de seguridad de `fix-sse-ticket-auth`, severidad BAJA) + `.specs/fix-sse-ticket-auth/spec.md`.
+
+## 1. Objective
+
+El fetch del cliente a `POST /assignments/:id/messages/stream-ticket` (`apps/web/src/hooks/use-chat-stream.ts`) usa `fetch` crudo con SOLO el header `authorization: Bearer`, sin `X-Empresa-Id`. Para un user **multi-empresa** cuya empresa activa NO es la primera membership, `userContextMiddleware` resuelve la empresa default → `resolveChatAccess` da 403 → no se emite el ticket → el chat realtime no conecta (degrada a polling). Objetivo: que el fetch del ticket mande `X-Empresa-Id` con la empresa activa de la PWA, igual que el `api-client`.
+
+## 2. Why now
+
+No es regresión (comportamiento idéntico al `?auth=` previo) pero quedó como QUESTION abierta del review de `fix-sse-ticket-auth`. Es un cambio acotado y cierra el follow-up. Seguridad intacta: el binding ticket↔uid↔assignment + la re-autorización del stream no cambian; mandar la empresa activa solo corrige la resolución funcional del contexto.
+
+## 3. Success criteria
+
+- [ ] SC-1: el fetch de `/stream-ticket` incluye `X-Empresa-Id: <empresa activa>` cuando hay una seteada (`getActiveEmpresaId()` de `api-client.ts`, fuente única de verdad — localStorage `booster.activeEmpresaId`). Si no hay empresa activa, no se manda el header (idéntico al api-client).
+- [ ] SC-2: el `authorization: Bearer` sigue yendo (sin cambios). El token NUNCA va en la URL (no se regresa el fix anterior).
+- [ ] SC-3: test del hook: el POST de mint se llama con `X-Empresa-Id` cuando hay empresa activa, y SIN el header cuando no la hay.
+- [ ] SC-4: cero `any`; lint/typecheck/test verdes; coverage del hook no baja.
+
+## 4. User-visible behaviour
+
+Para users multi-empresa con chat en empresa no-default: el chat realtime ahora **conecta** en vez de caer a polling. Para el resto: sin cambio.
+
+## 5. Out of scope
+
+- El `EventSource` del stream no manda headers (no puede) y no lo necesita: la identidad + empresa quedan fijadas en el mint (en el ticket). Sin cambios en el server (`chat.ts` / `firebase-auth.ts` / `sse-ticket.ts`).
+- Cambiar `userContextMiddleware` o la resolución de membership default.
+
+## 6. Constraints
+
+- Reusar `getActiveEmpresaId()` (no duplicar la key de localStorage).
+- El header se llama `X-Empresa-Id` (igual que api-client, case-insensitive en HTTP).
+
+## 7. Approach
+
+`use-chat-stream.ts`: importar `getActiveEmpresaId` de `../lib/api-client.js`; construir los headers del POST como `{ authorization: 'Bearer <token>', ...(empresa ? { 'X-Empresa-Id': empresa } : {}) }`.
+
+## 8. Alternatives considered
+
+- Migrar el fetch del ticket a `api.post(...)` (api-client), que auto-inyectaría el header. Rechazada para este cambio: el api-client arma su propio `AbortController`/headers/Content-Type y el hook ya tiene su timeout de 10s + manejo de error específico; añadir un solo header es menos invasivo y no arriesga el flujo del fix anterior. La unificación del fetch del ticket con el api-client se registra como follow-up separado si se quiere consolidar.
+
+## 9. Risks and mitigations
+
+| Risk | L | I | Mitigation |
+|---|---|---|---|
+| `localStorage.getItem` lanza (modo privado / storage deshabilitado) | L | L | La llamada a `getActiveEmpresaId()` ocurre DENTRO del `try` del mint; si lanzara, el `catch` degrada a reconnect/polling sin crash. Mismo riesgo que el api-client, que ya usa `localStorage`. (Los tests stubean la función, así que NO ejercitan el `getItem` real — no es mitigación, es aislamiento de test.) |
+| Header mal nombrado → server lo ignora | L | M | Mismo nombre exacto que api-client (`X-Empresa-Id`), cubierto por test |
+| 403 por empresa stale/revocada → reconnect loop indefinido | L | L | **Pre-existente** (el hook reintenta todo `!res.ok` por igual, no es regresión de este cambio). Ticketeado en follow-up `use-chat-stream-hardening` (política de reconnect: cortar en errores permanentes). |
+
+## 10. Test list
+
+- T1: con empresa activa seteada → el POST `/stream-ticket` se llama con `X-Empresa-Id: <id>`.
+- T2: sin empresa activa → el POST NO lleva `X-Empresa-Id`.
+- T3 (regresión): el token sigue solo en el header `authorization`, nunca en la URL.
+
+## 11. Rollout
+
+- Deploy normal (web) por el pipeline. Sin migraciones, sin flag. Rollback = revert.
+
+## 12. Open questions
+
+None.
+
+## 13. Decision log
+
+- 2026-06-14 — Draft + approved. Cambio mínimo (un header), sin tocar el server. Cierra el follow-up `sse-realtime-multi-empresa`.

--- a/apps/web/src/hooks/use-chat-stream.test.tsx
+++ b/apps/web/src/hooks/use-chat-stream.test.tsx
@@ -13,6 +13,15 @@ vi.mock('../lib/firebase.js', () => ({
   },
 }));
 
+// fix-sse-ticket-x-empresa: el hook lee la empresa activa de api-client para
+// mandarla como X-Empresa-Id en el POST del ticket (users multi-empresa).
+const { getActiveEmpresaIdMock } = vi.hoisted(() => ({
+  getActiveEmpresaIdMock: vi.fn((): string | null => null),
+}));
+vi.mock('../lib/api-client.js', () => ({
+  getActiveEmpresaId: getActiveEmpresaIdMock,
+}));
+
 const { useChatStream } = await import('./use-chat-stream.js');
 
 interface FakeEventSource {
@@ -68,6 +77,8 @@ beforeEach(() => {
   currentUserState.value = { getIdToken: getIdTokenMock };
   getIdTokenMock.mockClear();
   fetchMock.mockClear();
+  getActiveEmpresaIdMock.mockReset();
+  getActiveEmpresaIdMock.mockReturnValue(null);
   (globalThis as any).EventSource = StubEventSource;
   (globalThis as any).fetch = fetchMock;
 });
@@ -127,6 +138,36 @@ describe('useChatStream', () => {
 
     lastEventSource?.emit('message', { message_id: 'm1', assignment_id: 'a1' });
     expect(onMessage).toHaveBeenCalledWith({ message_id: 'm1', assignment_id: 'a1' });
+  });
+
+  it('multi-empresa: manda X-Empresa-Id (empresa activa) en el POST del ticket — SC-1', async () => {
+    getActiveEmpresaIdMock.mockReturnValue('emp-no-default');
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn() }));
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/assignments/a1/messages/stream-ticket'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: { authorization: 'Bearer firebase-id-token', 'X-Empresa-Id': 'emp-no-default' },
+      }),
+    );
+    // El id de empresa NO viaja en la URL del stream (solo el ticket efímero).
+    expect(lastEventSource?.url).not.toContain('emp-no-default');
+  });
+
+  it('sin empresa activa → el POST del ticket NO lleva X-Empresa-Id — SC-1', async () => {
+    getActiveEmpresaIdMock.mockReturnValue(null);
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn() }));
+    await waitFor(() => expect(lastEventSource).not.toBeNull());
+    // headers EXACTAMENTE { authorization } → la deep-equality falla si
+    // X-Empresa-Id estuviera presente, así que esto prueba su ausencia.
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/assignments/a1/messages/stream-ticket'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: { authorization: 'Bearer firebase-id-token' },
+      }),
+    );
   });
 
   it('fallo al obtener el ticket → no abre EventSource + onDisconnect (reconnect)', async () => {

--- a/apps/web/src/hooks/use-chat-stream.ts
+++ b/apps/web/src/hooks/use-chat-stream.ts
@@ -16,12 +16,16 @@
  * Cloud Run que ningún scrubbing de app alcanza). En su lugar:
  *   1. POST /assignments/:id/messages/stream-ticket con el Bearer header
  *      (autenticación normal, sin exponer el token en la URL) → {ticket}.
+ *      El POST también manda `X-Empresa-Id` (empresa activa de la PWA, misma
+ *      fuente que el api-client) para que `resolveChatAccess` resuelva la
+ *      empresa correcta en users multi-empresa (fix-sse-ticket-x-empresa).
  *   2. EventSource a `...?ticket=<ticket>`. El ticket es de UN SOLO USO,
  *      TTL ~60s, scoped al assignment → su filtrado post-consumo es inocuo.
  * Cada reconnect pide un ticket nuevo (son single-use).
  */
 
 import { useEffect, useRef } from 'react';
+import { getActiveEmpresaId } from '../lib/api-client.js';
 import { env } from '../lib/env.js';
 import { firebaseAuth } from '../lib/firebase.js';
 import { logger } from '../lib/logger.js';
@@ -91,11 +95,20 @@ export function useChatStream(opts: UseChatStreamOptions): void {
         // sin caer al backoff de reconnect.
         const abort = new AbortController();
         const timeout = setTimeout(() => abort.abort(), 10_000);
+        // X-Empresa-Id: la empresa activa de la PWA (misma fuente que el
+        // api-client). Necesario para users multi-empresa cuyo chat NO está en
+        // su membership default — sin esto resolveChatAccess da 403 y el ticket
+        // no se emite (follow-up sse-realtime-multi-empresa).
+        const activeEmpresaId = getActiveEmpresaId();
+        const ticketHeaders: Record<string, string> = {
+          authorization: `Bearer ${token}`,
+          ...(activeEmpresaId ? { 'X-Empresa-Id': activeEmpresaId } : {}),
+        };
         let res: Response;
         try {
           res = await fetch(
             `${env.VITE_API_URL}/assignments/${opts.assignmentId}/messages/stream-ticket`,
-            { method: 'POST', headers: { authorization: `Bearer ${token}` }, signal: abort.signal },
+            { method: 'POST', headers: ticketHeaders, signal: abort.signal },
           );
         } finally {
           clearTimeout(timeout);


### PR DESCRIPTION
## Qué

El fetch del cliente a `POST /assignments/:id/messages/stream-ticket` (`apps/web/src/hooks/use-chat-stream.ts`) mandaba **solo** `authorization: Bearer`. Para users **multi-empresa** cuyo chat NO está en su membership default, `userContextMiddleware` resolvía la empresa default → `resolveChatAccess` daba **403** → no se emitía el ticket → el chat realtime **no conectaba** (degradaba a polling/refetch). Ahora el POST manda `X-Empresa-Id` con la empresa activa de la PWA (`getActiveEmpresaId`, misma fuente que el `api-client`).

Cierra el follow-up `sse-realtime-multi-empresa` (QUESTION del review de seguridad de #461).

## Seguridad (review devils-advocate — sin hallazgos IDOR)

Mandar `X-Empresa-Id` desde el cliente **no** abre acceso indebido. La membership se valida server-side en dos capas:
- `resolveUserContext` (`apps/api/src/services/user-context.ts:69-77`): 403 si el user no pertenece a la empresa pedida.
- `resolveChatAccess` (`apps/api/src/routes/chat.ts:177-188`): 403 `forbidden_not_party` si esa empresa no es `shipper`/`carrier` del assignment.

El header solo elige entre las memberships **legítimas del propio user**. El token sigue solo en el header (nunca en la URL); el ticket sigue single-use + scoped (sin regresión de #461). El `X-Empresa-Id` no entra al payload del ticket.

## Evidencia

- **Tests**: `apps/web/src/hooks/use-chat-stream.test.tsx` → **13/13** verdes (2 nuevos: T1 manda el header con empresa activa; T2 no lo manda sin empresa; + regresión "token/empresa nunca en la URL").
- **Lint** (Biome): 0 errores en los archivos tocados.
- **Typecheck** (`tsc --noEmit`, web): exit 0, 0 errores.
- gitleaks + lint-staged + check-adr-numbering + spec-canonical-drift (pre-commit): OK.

## Alcance / follow-ups

- Sin cambios en el server (`chat.ts` / `firebase-auth.ts` / `sse-ticket.ts`): el `EventSource` no manda headers y no los necesita (identidad+empresa fijadas en el mint + re-autorización aguas abajo).
- Hallazgos **pre-existentes** (no regresión) ticketeados en `.specs/_followups/use-chat-stream-hardening.md`: (1) reconnect loop en errores permanentes (403), (2) cambio de empresa en stream vivo no re-mintea, (3) consolidar el fetch con el api-client.

Spec: `.specs/fix-sse-ticket-x-empresa/spec.md`. Review: `.specs/fix-sse-ticket-x-empresa/review.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)