### PR TITLE
fix(infra): ignorar template.revision en Cloud Run (drift vs Cloud Build)

### DIFF
--- a/infrastructure/modules/cloud-run-service/main.tf
+++ b/infrastructure/modules/cloud-run-service/main.tf
@@ -130,6 +130,12 @@ resource "google_cloud_run_v2_service" "service" {
     ignore_changes = [
       # Dejar que Cloud Build gestione las revisions/traffic después del primer apply
       template[0].containers[0].image,
+      # El nombre de la revisión lo asigna Cloud Build en cada deploy (gcloud run
+      # update / canary sequence). Terraform no lo gestiona, pero al refrescar el
+      # estado lo veía seteado y quería desclavarlo (`revision -> null`), drift que
+      # un apply convertía en una revisión nueva del service en vivo. Igual que
+      # `image` arriba: lo gestiona el pipeline, no Terraform (audit 2026-06-14).
+      template[0].revision,
       # GCP/gcloud auto-injectan labels (commit, goog-terraform-provisioned) y
       # annotations (operation-id, run.googleapis.com/*) durante deploys que TF
       # no controla. Sin ignore_changes acá, cada `terraform plan` mostraba


### PR DESCRIPTION
## Contexto

Parte de **destrabar el drift preexistente** (el `terraform-drift` check lleva 6+ días en rojo) antes de aplicar las alertas Wave 2 (#470). Al correr el plan autoritativo apareció, además de las 4 alertas a crear, un cambio **no relacionado y riesgoso** sobre producción:

```
~ module.service_api…google_cloud_run_v2_service.service
    ~ template {
        - revision = "booster-ai-api-00391-xuw" -> null
```

## Causa

El nombre de la revisión lo asigna **Cloud Build** en cada deploy (`gcloud run services update` / la secuencia canary). El módulo `cloud-run-service` ya ignora `template.containers[0].image`, `labels`, `annotations`, `traffic`, etc., pero **no** `template.revision`. Al refrescar el estado, TF veía la revisión real y quería desclavarla — y un `apply` lo habría convertido en una **revisión nueva del API en vivo** (riesgo de rolar prod a la config de Terraform, deshaciendo el último deploy del pipeline).

## Cambio

Agrego `template[0].revision` al `ignore_changes` del módulo (mismo tratamiento que `image`). Aplica a los 8 services del módulo — todos despliegan revisiones vía Cloud Build, no Terraform.

## Evidencia

```
$ terraform fmt -check   → OK
$ terraform plan (antes): Plan: 4 to add, 21 to change, 1 to destroy   (incluía service_api)
$ terraform plan (después): Plan: 4 to add, 20 to change, 1 to destroy  (service_api desaparece)
```

El residuo (`20 change, 1 destroy`) es **otro** foco de drift —el canal `sre_webhook`— que se resuelve aparte (decisión de ops: mantener el canal seteando `var.sre_webhook_url`, o aceptar su remoción). No se incluye acá.

## Nota
Solo `ignore_changes` (comportamiento de plan); no requiere apply para surtir efecto en el diff. Mergearlo deja el drift-check más limpio y previene el riesgo a futuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)