### PR TITLE
feat(safety): fan-out de eventos de seguridad al transportista (P0-G)

### DIFF
--- a/.specs/safety-event-fanout/apply-checklist.md
+++ b/.specs/safety-event-fanout/apply-checklist.md
@@ -1,0 +1,74 @@
+# Checklist — `terraform apply` safety fan-out (P0-G)
+
+Activa la infra del safety fan-out (push subscription + envs). Ejecutar **post-merge + post-deploy** de #473.
+
+> El **apply (paso 4) es gate del PO**. Los pasos 1-3 (plan) son read-only y los puede correr el agente para revisión.
+
+## 0. Precondiciones
+- [ ] **#473 mergeado** a `main`.
+- [ ] **Release desplegado**: `release.yml` desplegó las imágenes nuevas de `api` + `telemetry-processor` (con el endpoint + los producers); revisiones nuevas al 100% de tráfico.
+  - *Por qué el orden*: hasta el apply el código es **inerte y safe** (sin `SAFETY_EVENTS_TOPIC` el processor no publica; sin `SAFETY_PUSH_CALLER_SA` el endpoint rechaza todo). El apply **activa** la pipeline. Aplicar antes del deploy → push da 404.
+
+## 1. Posicionarse en main actualizado
+```
+cd /Users/felipevicencio/booster-ai
+git checkout main && git pull --ff-only
+git log --oneline -1   # debe incluir el merge de #473
+```
+
+## 2. Reautenticar GCP si hace falta
+La ADC caduca (`invalid_rapt`). Si el plan falla con error de auth:
+```
+gcloud auth application-default login    # cuenta dev@boosterchile.com
+```
+
+## 3. Plan completo y revisión (NO `-target` — lección prod-drift)
+```
+cd infrastructure
+terraform plan -out=safety.tfplan
+```
+Confirmar que el plan diga EXACTAMENTE:
+- [ ] `Plan: 3 to add, 3 to change, 0 to destroy`
+- [ ] **3 add**: `google_service_account.safety_push_invoker`, `google_service_account_iam_member.pubsub_safety_push_token_creator`, `google_cloud_run_v2_service_iam_member.safety_push_invoker_api`
+- [ ] **3 change (in-place)**: subscription `telemetry_events_safety_p0_notification` (suma `push_config`), `service_api` (env `SAFETY_PUSH_CALLER_SA`), `service_telemetry_processor` (env `SAFETY_EVENTS_TOPIC`)
+- [ ] **0 destroy**, y ningún recurso inesperado (si aparece drift ajeno → parar y triagear).
+
+## 4. Aplicar (gate del PO)
+```
+terraform apply safety.tfplan
+```
+Crea el SA + bindings, cambia la subscription a push, dispara revisiones nuevas de `api` + `telemetry-processor` (imagen ya desplegada por el release + el env nuevo; `image`/`revision` están en `ignore_changes`).
+
+## 5. Verificación post-apply
+- [ ] Subscription en push:
+```
+gcloud pubsub subscriptions describe telemetry-events-safety-p0-notification-sub \
+  --project=booster-ai-494222 \
+  --format="value(pushConfig.pushEndpoint, pushConfig.oidcToken.serviceAccountEmail, pushConfig.oidcToken.audience)"
+```
+Esperado: `https://api.boosterchile.com/internal/safety-events` · `safety-push-invoker@booster-ai-494222.iam.gserviceaccount.com` · `https://api.boosterchile.com`
+
+- [ ] Smoke test end-to-end (device demo, IMEI `863238075489155`):
+```
+gcloud pubsub topics publish telemetry-events-safety-p0 --project=booster-ai-494222 \
+  --message='{"eventType":"unplug","imei":"863238075489155","occurredAt":"2026-06-15T18:00:00.000Z","rawValue":1}'
+```
+Luego en logs del api:
+```
+gcloud logging read 'resource.labels.service_name="booster-ai-api" AND jsonPayload.message=~"safety"' \
+  --project=booster-ai-494222 --freshness=10m --limit=5 \
+  --format="value(timestamp,jsonPayload.message,jsonPayload.outcome)"
+```
+Esperado: outcome `notified` (o `unknown_vehicle` si el device aún no está mapeado a un vehículo real — ahí entra el de-demo). **NO** esperar `401`/`403`.
+
+- [ ] Sin acumulación en DLQ ni backlog: la alerta P1-A (`oldest_unacked_message_age` de la sub) NO debe dispararse. Si los push dan 401/403/404, los mensajes van a DLQ tras 5 intentos → revisar audience / SA / endpoint.
+
+## 6. Rollback
+Revertir el commit de infra + `terraform apply`, **o** en caliente (vuelve a pull, detiene el fan-out sin romper nada):
+```
+gcloud pubsub subscriptions modify-push-config telemetry-events-safety-p0-notification-sub \
+  --project=booster-ai-494222 --push-endpoint=""
+```
+
+## 7. Follow-up WhatsApp (separado, cuando Meta apruebe)
+Agregar `CONTENT_SID_SAFETY_ALERT` al bloque `secrets` de `compute.tf` (con su secret en Secret Manager). Hasta entonces el fan-out sale solo por push — sin cambio de código.

--- a/.specs/safety-event-fanout/plan.md
+++ b/.specs/safety-event-fanout/plan.md
@@ -1,0 +1,576 @@
+# Safety Event Fan-out — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Dominio crítico (safety) → TDD es ley (`booster-skills:tdd-dominio-critico`).
+
+**Goal:** Cuando un Teltonika reporta crash/unplug/jamming, el dueño del transportista recibe push (+ WhatsApp si el template está aprobado), deduplicado y auditable.
+
+**Architecture:** `telemetry-processor` publica un `SafetyEvent` al topic Pub/Sub `safety-p0` → push subscription entrega a `POST /internal/safety-events` en `apps/api` (OIDC del SA) → routing `vehicleId → empresa transportista → dueños` → dedupe Redis → fan-out push + WhatsApp.
+
+**Tech Stack:** TypeScript, Hono, Drizzle, Zod, `@google-cloud/pubsub`, `google-auth-library` (OIDC), ioredis, web-push (VAPID), Twilio Content API, Terraform.
+
+**Convención de commits:** Conventional Commits con scope (`feat(safety): ...`). Commit por task (al final de cada uno).
+
+---
+
+## File Structure
+
+| Archivo | Responsabilidad |
+|---|---|
+| `packages/shared-schemas/src/domain/safety-event.ts` (crear) | Zod `safetyEventSchema` + tipo `SafetyEvent`. Contrato producer↔consumer. |
+| `apps/telemetry-processor/src/config.ts` (modificar) | Env `SAFETY_EVENTS_TOPIC`. |
+| `apps/telemetry-processor/src/publish-safety-events.ts` (crear) | `publishSafetyEvent()` — wrapper Pub/Sub fire-and-forget. |
+| `apps/telemetry-processor/src/panic-events.ts` (modificar) | Tras `logPanicEvents`, publicar unplug/jamming. |
+| `apps/telemetry-processor/src/persist-crash-trace.ts` (modificar) | Tras persistir, publicar `crash`. |
+| `apps/api/src/config.ts` (modificar) | Env `CONTENT_SID_SAFETY_ALERT` (opt), `SAFETY_PUSH_CALLER_SA`. |
+| `apps/api/src/services/route-safety-recipients.ts` (crear) | `vehicleId → recipients[]` (dueños activos + tracking_code del viaje activo). |
+| `apps/api/src/services/dispatch-safety-notification.ts` (crear) | dedupe Redis + fan-out push + WhatsApp. |
+| `apps/api/src/services/safety-event-labels.ts` (crear) | Labels es de eventType (puro, compartible con test). |
+| `apps/api/src/routes/internal-safety-events.ts` (crear) | `POST /internal/safety-events`: OIDC + Zod envelope + dispatch. |
+| `apps/api/src/server.ts` (modificar) | Montar la ruta interna. |
+| `infrastructure/messaging.tf` (modificar) | `telemetry-events-safety-p0-notification-sub` → push a `apps/api` con OIDC. |
+
+---
+
+## Task 1: SafetyEvent schema (shared-schemas)
+
+**Files:**
+- Create: `packages/shared-schemas/src/domain/safety-event.ts`
+- Modify: `packages/shared-schemas/src/index.ts`
+- Test: `packages/shared-schemas/src/domain/safety-event.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { safetyEventSchema } from './safety-event.js';
+
+describe('safetyEventSchema', () => {
+  it('parsea un evento válido', () => {
+    const parsed = safetyEventSchema.parse({
+      eventType: 'crash',
+      imei: '863238075489155',
+      vehicleId: '6487dac2-600e-4655-a20e-2ea77a6b1017',
+      occurredAt: '2026-06-15T14:32:00.000Z',
+      rawValue: 2,
+    });
+    expect(parsed.eventType).toBe('crash');
+  });
+
+  it('rechaza eventType desconocido', () => {
+    expect(() => safetyEventSchema.parse({ eventType: 'foo', imei: '1', occurredAt: '2026-06-15T14:32:00.000Z' })).toThrow();
+  });
+
+  it('imei es obligatorio; vehicleId es opcional', () => {
+    const parsed = safetyEventSchema.parse({ eventType: 'unplug', imei: '863238075489155', occurredAt: '2026-06-15T14:32:00.000Z' });
+    expect(parsed.vehicleId).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL** (`Cannot find module './safety-event.js'`)
+
+```
+pnpm --filter @booster-ai/shared-schemas exec vitest run src/domain/safety-event.test.ts
+```
+
+- [ ] **Step 3: Implement**
+
+```ts
+// packages/shared-schemas/src/domain/safety-event.ts
+import { z } from 'zod';
+
+/** Evento de seguridad física emitido por telemetry-processor al topic safety-p0. */
+export const safetyEventSchema = z.object({
+  eventType: z.enum(['crash', 'unplug', 'jamming']),
+  /** IMEI del device que emitió. Siempre presente (clave de routing). */
+  imei: z.string().min(1),
+  /** UUID del vehículo si el processor lo resolvió; el consumer hace fallback por IMEI si falta. */
+  vehicleId: z.string().uuid().optional(),
+  /** ISO-8601 UTC del evento. */
+  occurredAt: z.string().datetime(),
+  /** Valor crudo del IO (ej. jamming: 1 warning, 2 crítico). */
+  rawValue: z.number().int().optional(),
+});
+
+export type SafetyEvent = z.infer<typeof safetyEventSchema>;
+```
+
+- [ ] **Step 4: Export desde el barrel** — añadir a `packages/shared-schemas/src/index.ts`:
+
+```ts
+export { safetyEventSchema, type SafetyEvent } from './domain/safety-event.js';
+```
+
+- [ ] **Step 5: Run test — expect PASS**
+
+```
+pnpm --filter @booster-ai/shared-schemas exec vitest run src/domain/safety-event.test.ts
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/shared-schemas/src/domain/safety-event.ts packages/shared-schemas/src/domain/safety-event.test.ts packages/shared-schemas/src/index.ts
+git commit -m "feat(safety): schema SafetyEvent en shared-schemas"
+```
+
+---
+
+## Task 2: Config del topic en telemetry-processor
+
+**Files:**
+- Modify: `apps/telemetry-processor/src/config.ts`
+
+- [ ] **Step 1: Añadir la env al schema Zod** (junto a las otras `PUBSUB_*`):
+
+```ts
+/** Topic Pub/Sub de eventos de seguridad (safety-p0). Vacío = no publica (dev/test). */
+SAFETY_EVENTS_TOPIC: z.string().default(''),
+```
+
+- [ ] **Step 2: Typecheck**
+
+```
+pnpm --filter @booster-ai/telemetry-processor typecheck
+```
+
+Expected: 0 errores.
+
+- [ ] **Step 3: Commit**
+
+```
+git add apps/telemetry-processor/src/config.ts
+git commit -m "feat(safety): env SAFETY_EVENTS_TOPIC en telemetry-processor"
+```
+
+---
+
+## Task 3: Publisher Pub/Sub (telemetry-processor)
+
+**Files:**
+- Create: `apps/telemetry-processor/src/publish-safety-events.ts`
+- Test: `apps/telemetry-processor/src/publish-safety-events.test.ts`
+
+- [ ] **Step 1: Write the failing test** (publisher inyectable, fire-and-forget):
+
+```ts
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+import { describe, expect, it, vi } from 'vitest';
+import { publishSafetyEvent } from './publish-safety-events.js';
+
+function fakeLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never;
+}
+const ev: SafetyEvent = { eventType: 'unplug', imei: '863238075489155', occurredAt: '2026-06-15T14:32:00.000Z' };
+
+describe('publishSafetyEvent', () => {
+  it('publica con data JSON + attribute imei', async () => {
+    const publishMessage = vi.fn().mockResolvedValue('msg-1');
+    const topic = vi.fn().mockReturnValue({ publishMessage });
+    await publishSafetyEvent({ topicName: 'safety-p0', event: ev, logger: fakeLogger(), pubsub: { topic } as never });
+    expect(topic).toHaveBeenCalledWith('safety-p0');
+    const arg = publishMessage.mock.calls[0][0];
+    expect(JSON.parse(arg.data.toString())).toMatchObject({ eventType: 'unplug', imei: '863238075489155' });
+    expect(arg.attributes).toEqual({ imei: '863238075489155', event_type: 'unplug' });
+  });
+
+  it('no lanza si Pub/Sub falla (fire-and-forget)', async () => {
+    const publishMessage = vi.fn().mockRejectedValue(new Error('pubsub down'));
+    const topic = vi.fn().mockReturnValue({ publishMessage });
+    const logger = fakeLogger();
+    await expect(publishSafetyEvent({ topicName: 'safety-p0', event: ev, logger, pubsub: { topic } as never })).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('no publica si topicName está vacío', async () => {
+    const topic = vi.fn();
+    await publishSafetyEvent({ topicName: '', event: ev, logger: fakeLogger(), pubsub: { topic } as never });
+    expect(topic).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect FAIL**
+
+```
+pnpm --filter @booster-ai/telemetry-processor exec vitest run src/publish-safety-events.test.ts
+```
+
+- [ ] **Step 3: Implement** (patrón de `apps/api/src/services/chat-pubsub.ts`):
+
+```ts
+// apps/telemetry-processor/src/publish-safety-events.ts
+import type { Logger } from '@booster-ai/logger';
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+import { PubSub } from '@google-cloud/pubsub';
+
+let cached: PubSub | null = null;
+function defaultClient(): PubSub {
+  if (!cached) cached = new PubSub();
+  return cached;
+}
+
+/** Publica un SafetyEvent al topic. Fire-and-forget: nunca lanza ni bloquea el ack del record. */
+export async function publishSafetyEvent(opts: {
+  topicName: string;
+  event: SafetyEvent;
+  logger: Logger;
+  pubsub?: Pick<PubSub, 'topic'>;
+}): Promise<void> {
+  const { topicName, event, logger } = opts;
+  if (!topicName) return; // dev/test sin topic configurado
+  const pubsub = opts.pubsub ?? defaultClient();
+  try {
+    await pubsub.topic(topicName).publishMessage({
+      data: Buffer.from(JSON.stringify(event)),
+      attributes: { imei: event.imei, event_type: event.eventType },
+    });
+  } catch (err) {
+    logger.error({ err, imei: event.imei, eventType: event.eventType }, 'publishSafetyEvent falló (evento ya logueado para on-call)');
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect PASS**
+- [ ] **Step 5: Commit**
+
+```
+git add apps/telemetry-processor/src/publish-safety-events.ts apps/telemetry-processor/src/publish-safety-events.test.ts
+git commit -m "feat(safety): publisher Pub/Sub de SafetyEvent (fire-and-forget)"
+```
+
+---
+
+## Task 4: Producer unplug/jamming en panic-events
+
+**Files:**
+- Modify: `apps/telemetry-processor/src/panic-events.ts` (la función que orquesta detección, hoy `logPanicEvents`)
+- Modify: `apps/telemetry-processor/src/main.ts:97` (pasar topic + publisher al call)
+- Test: extender `apps/telemetry-processor/src/panic-events.test.ts` (o crear si no existe)
+
+- [ ] **Step 1: Write failing test** — al detectar unplug, se publica un SafetyEvent `unplug` con el imei del record:
+
+```ts
+it('publishPanicEvents publica un SafetyEvent por cada evento detectado', async () => {
+  const published: unknown[] = [];
+  const msg = makeRecordMessage({ imei: '863238075489155', io: [{ id: 252, value: 1 }] }); // helper existente o inline
+  await publishPanicEvents({
+    msg, messageId: 'm1', topicName: 'safety-p0', logger: fakeLogger(),
+    publish: async ({ event }) => { published.push(event); },
+  });
+  expect(published).toEqual([
+    expect.objectContaining({ eventType: 'unplug', imei: '863238075489155' }),
+  ]);
+});
+```
+
+> Nota: reusar `detectPanicEvents(msg)` (ya existe). Mapear `eventName 'Unplug'→'unplug'`, `'GnssJamming'→'jamming'`.
+
+- [ ] **Step 2: Run — expect FAIL**
+- [ ] **Step 3: Implement** — añadir junto a `logPanicEvents` (no reemplazarla):
+
+```ts
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+
+const EVENT_NAME_TO_TYPE: Record<'Unplug' | 'GnssJamming', SafetyEvent['eventType']> = {
+  Unplug: 'unplug',
+  GnssJamming: 'jamming',
+};
+
+/** Publica un SafetyEvent por cada panic detectado. `publish` inyectable para tests. */
+export async function publishPanicEvents(opts: {
+  msg: RecordMessage;
+  messageId: string;
+  topicName: string;
+  logger: Logger;
+  publish: (a: { topicName: string; event: SafetyEvent; logger: Logger }) => Promise<void>;
+}): Promise<void> {
+  const events = detectPanicEvents(opts.msg);
+  for (const e of events) {
+    const event: SafetyEvent = {
+      eventType: EVENT_NAME_TO_TYPE[e.eventName],
+      imei: opts.msg.record.imei, // confirmar el path real del imei en RecordMessage
+      occurredAt: new Date().toISOString(), // o el timestamp del record si está disponible
+      rawValue: e.rawValue,
+    };
+    await opts.publish({ topicName: opts.topicName, event, logger: opts.logger });
+  }
+}
+```
+
+> ⚠️ Verificar el path del `imei` y del timestamp en `RecordMessage` (ver `persist.ts`); ajustar si difiere. `new Date().toISOString()` está prohibido en workflows pero acá es código de runtime normal — OK.
+
+- [ ] **Step 4: Wire en `main.ts`** (junto a la línea 97 `logPanicEvents(...)`):
+
+```ts
+logPanicEvents({ logger, msg: parsed.data, messageId: message.id });
+void publishPanicEvents({
+  msg: parsed.data, messageId: message.id, topicName: config.SAFETY_EVENTS_TOPIC, logger,
+  publish: (a) => publishSafetyEvent(a),
+});
+```
+
+- [ ] **Step 5: Run unit + typecheck — expect PASS**
+- [ ] **Step 6: Commit**
+
+```
+git add apps/telemetry-processor/src/panic-events.ts apps/telemetry-processor/src/panic-events.test.ts apps/telemetry-processor/src/main.ts
+git commit -m "feat(safety): publicar unplug/jamming al topic safety-p0"
+```
+
+---
+
+## Task 5: Producer crash
+
+**Files:**
+- Modify: `apps/telemetry-processor/src/persist-crash-trace.ts` (tras persistir el crash trace OK)
+- Test: extender el test de persist-crash-trace
+
+- [ ] **Step 1: Write failing test** — tras `persistCrashTrace`, se publica un SafetyEvent `crash` con el imei del trace. (Inyectar el `publish` como dependencia, igual que Task 4.)
+- [ ] **Step 2: Run — expect FAIL**
+- [ ] **Step 3: Implement** — al final del happy-path de `persistCrashTrace`, construir `{ eventType: 'crash', imei, vehicleId?, occurredAt }` y `await publishSafetyEvent(...)` (fire-and-forget; el crash ya está en GCS+BQ). Pasar `topicName` y `publish` desde el wiring en `main.ts` (CONSUMER 2).
+- [ ] **Step 4: Run — expect PASS**
+- [ ] **Step 5: Commit** `feat(safety): publicar crash al topic safety-p0`
+
+---
+
+## Task 6: Config en apps/api
+
+**Files:**
+- Modify: `apps/api/src/config.ts`
+
+- [ ] **Step 1: Añadir al schema** (zona de templates Twilio + SAs internos):
+
+```ts
+/** Content SID Twilio del template safety_alert_v1. Vacío → WhatsApp se skipea (solo push). */
+CONTENT_SID_SAFETY_ALERT: z.preprocess(
+  (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+  z.string().regex(/^HX[a-fA-F0-9]+$/, 'Debe empezar con HX').optional(),
+),
+/** Email del SA que firma el OIDC de la push subscription de safety-events. */
+SAFETY_PUSH_CALLER_SA: z
+  .string()
+  .regex(/^[a-z0-9-]+@[a-z0-9-]+\.iam\.gserviceaccount\.com$/, 'SA email inválido')
+  .optional(),
+```
+
+- [ ] **Step 2: Typecheck** → `pnpm --filter @booster-ai/api typecheck`
+- [ ] **Step 3: Commit** `feat(safety): env CONTENT_SID_SAFETY_ALERT + SAFETY_PUSH_CALLER_SA`
+
+---
+
+## Task 7: Labels de evento (puro)
+
+**Files:**
+- Create: `apps/api/src/services/safety-event-labels.ts`
+- Test: `apps/api/src/services/safety-event-labels.test.ts`
+
+- [ ] **Step 1: Failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { safetyEventLabel } from './safety-event-labels.js';
+
+describe('safetyEventLabel', () => {
+  it('mapea cada tipo a su label es', () => {
+    expect(safetyEventLabel('crash')).toBe('Posible colisión');
+    expect(safetyEventLabel('unplug')).toBe('Desconexión de energía (manipulación)');
+    expect(safetyEventLabel('jamming')).toBe('Interferencia de señal GPS');
+  });
+});
+```
+
+- [ ] **Step 2: Run — FAIL**
+- [ ] **Step 3: Implement**
+
+```ts
+// apps/api/src/services/safety-event-labels.ts
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+
+const LABELS: Record<SafetyEvent['eventType'], string> = {
+  crash: 'Posible colisión',
+  unplug: 'Desconexión de energía (manipulación)',
+  jamming: 'Interferencia de señal GPS',
+};
+
+export function safetyEventLabel(t: SafetyEvent['eventType']): string {
+  return LABELS[t];
+}
+```
+
+- [ ] **Step 4: Run — PASS** · **Step 5: Commit** `feat(safety): labels es de eventos de seguridad`
+
+---
+
+## Task 8: Routing — vehicleId → destinatarios
+
+**Files:**
+- Create: `apps/api/src/services/route-safety-recipients.ts`
+- Test: `apps/api/src/services/route-safety-recipients.test.ts`
+
+**Contrato:**
+
+```ts
+export interface SafetyRecipient { userId: string; phoneE164: string | null; }
+export interface SafetyRouting { empresaId: string; vehicleLabel: string; trackingCode: string | null; recipients: SafetyRecipient[]; }
+export async function routeSafetyRecipients(opts: { db: Db; imei: string; vehicleId?: string }): Promise<SafetyRouting | null>;
+```
+
+**Lógica:**
+1. Resolver el vehículo: por `vehicleId` si viene, si no por `vehicles.teltonikaImei === imei` (NO el espejo). Si no existe → `return null`.
+2. `empresaId = vehicle.empresaId`. `vehicleLabel` = patente/alias del vehículo (campo existente, ej. `vehicles.patente`).
+3. `trackingCode`: buscar asignación activa del vehículo (estado en-curso) → su `trips.trackingCode`. Si no hay → `null` (camión parado).
+4. `recipients`: `memberships` WHERE `empresaId`, `role='dueno'`, `status='activa'` JOIN `users` → `{ userId, phoneE164: users.telefono }`.
+
+- [ ] **Step 1: Failing test** (mock `db` con builder encadenable; cubrir: con vehicleId; por imei; vehículo inexistente→null; con viaje activo→trackingCode; sin viaje→null; múltiples dueños). Ejemplo del caso núcleo:
+
+```ts
+it('resuelve dueños por empresa del vehículo (fallback sin viaje)', async () => {
+  const db = makeDbStub({
+    vehicle: { id: 'v1', empresaId: 'e1', patente: 'RJXK-42', teltonikaImei: '863238075489155' },
+    activeAssignment: null,
+    duenos: [{ userId: 'u1', telefono: '+56911111111' }],
+  });
+  const r = await routeSafetyRecipients({ db, imei: '863238075489155' });
+  expect(r).toEqual({ empresaId: 'e1', vehicleLabel: 'RJXK-42', trackingCode: null, recipients: [{ userId: 'u1', phoneE164: '+56911111111' }] });
+});
+```
+
+- [ ] **Step 2: Run — FAIL**
+- [ ] **Step 3: Implement** con Drizzle (`eq`, `and`). Patrón de la query de dueños: copiar de `apps/api/src/services/notify-offer.ts:72-81` (`memberships` innerJoin `users`, `role='dueno'`, `status='activa'`). Confirmar el nombre real de la columna teléfono en `users` (ej. `telefono`) y de patente en `vehicles`.
+- [ ] **Step 4: Run — PASS** · **Step 5: Commit** `feat(safety): routing vehicleId→dueños del transportista`
+
+---
+
+## Task 9: Dispatch — dedupe + fan-out
+
+**Files:**
+- Create: `apps/api/src/services/dispatch-safety-notification.ts`
+- Test: `apps/api/src/services/dispatch-safety-notification.test.ts`
+
+**Contrato:**
+
+```ts
+export type DispatchOutcome = 'notified' | 'deduped' | 'no_recipient';
+export async function dispatchSafetyNotification(opts: {
+  db: Db; redis: Redis; logger: Logger; event: SafetyEvent; routing: SafetyRouting;
+  contentSidSafety?: string;
+  sendPush: typeof sendPushToUser;
+  sendWhatsapp: (p: { to: string; contentSid: string; contentVariables: Record<string,string> }) => Promise<void>;
+}): Promise<DispatchOutcome>;
+```
+
+**Lógica:**
+1. **Dedupe**: `key = safety:dedupe:${event.imei}:${event.eventType}`. `redis.set(key, '1', 'EX', 600, 'NX')`. Si devuelve `null` (ya existe) → `return 'deduped'`.
+2. Si `routing.recipients.length === 0` → `return 'no_recipient'`.
+3. Construir mensaje: `label = safetyEventLabel(event.eventType)`, `hora = formato local de occurredAt`, `viaje = routing.trackingCode ?? 'Sin viaje activo'`.
+4. **Push** a cada `userId` (best-effort): `sendPush({ db, logger, userId, payload: { title: '🚨 Alerta de seguridad', body: \`${routing.vehicleLabel}: ${label}\`, tag: \`safety-${event.imei}-${event.eventType}\`, data: { url: \`/app/flota\` } } })`. Cada falla → log + sigue.
+5. **WhatsApp** (si `contentSidSafety` y `phoneE164`): `sendWhatsapp({ to: phoneE164, contentSid: contentSidSafety, contentVariables: { '1': routing.vehicleLabel, '2': label, '3': hora, '4': viaje } })`. Best-effort.
+6. `return 'notified'`.
+
+- [ ] **Step 1: Failing test** — casos:
+  - segundo evento dentro de ventana → `'deduped'`, no llama sendPush/sendWhatsapp;
+  - `recipients` vacío → `'no_recipient'`;
+  - con CONTENT_SID → push + whatsapp llamados con las variables correctas;
+  - sin CONTENT_SID → push llamado, whatsapp NO;
+  - push falla pero whatsapp ok → `'notified'` (no throw).
+
+Mock `redis.set` devolviendo `'OK'` la 1ª vez y `null` la 2ª.
+
+- [ ] **Step 2: Run — FAIL**
+- [ ] **Step 3: Implement** según el contrato. Usar `sendPushToUser` (firma real: `{ db, logger, userId, payload }`). `payload` shape: `{ title, body, tag, data: { url } }` (ver `web-push.ts:51`).
+- [ ] **Step 4: Run — PASS** · **Step 5: Commit** `feat(safety): dispatch con dedupe + push + WhatsApp`
+
+---
+
+## Task 10: Endpoint interno con OIDC
+
+**Files:**
+- Create: `apps/api/src/routes/internal-safety-events.ts`
+- Modify: `apps/api/src/server.ts` (montar la ruta)
+- Test: `apps/api/src/routes/internal-safety-events.test.ts`
+
+**Contrato:** `POST /internal/safety-events`. Body = envelope de Pub/Sub push:
+```json
+{ "message": { "data": "<base64 del SafetyEvent JSON>", "attributes": {...}, "messageId": "..." }, "subscription": "..." }
+```
+Auth: header `Authorization: Bearer <OIDC>`; `verifyIdToken` (audience = la URL del endpoint o config), `payload.email === SAFETY_PUSH_CALLER_SA`. Patrón: `apps/api/src/middleware/auth.ts` (OAuth2Client inyectable para test).
+
+- [ ] **Step 1: Failing test** (Hono app + OAuth2Client stub):
+  - OIDC válido + envelope con SafetyEvent → 200, `dispatchSafetyNotification` llamado;
+  - sin/again OIDC inválido → 403, dispatch NO llamado;
+  - `data` no decodifica a SafetyEvent válido → 400;
+  - dispatch lanza → 500 (para que Pub/Sub reintente → DLQ).
+
+- [ ] **Step 2: Run — FAIL**
+- [ ] **Step 3: Implement**:
+
+```ts
+// pseudo-estructura — auth con OAuth2Client.verifyIdToken, luego:
+const envelope = pubsubEnvelopeSchema.parse(await c.req.json());
+const raw = JSON.parse(Buffer.from(envelope.message.data, 'base64').toString('utf8'));
+const event = safetyEventSchema.parse(raw); // 400 si falla
+const routing = await routeSafetyRecipients({ db, imei: event.imei, vehicleId: event.vehicleId });
+if (!routing) { logger.warn(...); return c.json({ outcome: 'unknown_vehicle' }, 200); } // ack: no es transitorio
+const outcome = await dispatchSafetyNotification({ ...deps, event, routing, contentSidSafety: config.CONTENT_SID_SAFETY_ALERT });
+// span OTel + métrica safety_notifications_total{event_type, outcome}
+return c.json({ outcome }, 200);
+```
+Definir `pubsubEnvelopeSchema` (Zod) inline: `{ message: { data: z.string(), attributes: z.record(z.string()).optional(), messageId: z.string() }, subscription: z.string() }`.
+
+- [ ] **Step 4: Montar en `server.ts`** — junto a las otras rutas internas, SIN `firebaseAuthMiddleware` (usa su propia OIDC):
+
+```ts
+app.route('/internal/safety-events', createInternalSafetyEventsRoutes({ db: opts.db, redis, logger, config }));
+```
+
+> El gate de CI `is-demo-wire-completeness` exige que rutas con `firebaseAuthMiddleware` tengan también los middlewares demo. Esta ruta NO usa `firebaseAuthMiddleware` → no la afecta. Verificar que el check no la marque (su parser busca `firebaseAuthMiddleware` en el `app.use`).
+
+- [ ] **Step 5: Run unit + typecheck — PASS**
+- [ ] **Step 6: Commit** `feat(safety): endpoint interno /internal/safety-events con OIDC`
+
+---
+
+## Task 11: Infra — push subscription
+
+**Files:**
+- Modify: `infrastructure/messaging.tf` (recurso `telemetry_events_safety_p0_notification`)
+
+- [ ] **Step 1:** Cambiar la subscription de pull a **push** hacia `apps/api`:
+
+```hcl
+push_config {
+  push_endpoint = "${<url del cloud run api>}/internal/safety-events"
+  oidc_token {
+    service_account_email = google_service_account.safety_push_invoker.email # SA dedicado o reusar uno existente
+  }
+}
+```
+Mantener `dead_letter_policy` + `retry_policy` ya presentes. Crear el SA `safety_push_invoker` (o reusar uno con permiso de invocar el api) y exponer su email como `SAFETY_PUSH_CALLER_SA` en la env del Cloud Run api (`compute.tf`).
+
+- [ ] **Step 2:** `terraform fmt` + `terraform validate`.
+
+```
+cd infrastructure && terraform fmt messaging.tf && terraform validate
+```
+
+- [ ] **Step 3:** `terraform plan` (NO apply) — revisar que solo cambie la subscription + el SA. **Apply gateado** (revisar plan con el PO; ver lección de [[prod-drift]] — plan completo, no -target).
+- [ ] **Step 4: Commit** `feat(safety): push subscription safety-p0 → apps/api (OIDC)`
+
+---
+
+## Task 12: Integración + evidencia
+
+- [ ] **Step 1:** Integration test `apps/api/test/integration/safety-events.integration.test.ts`: POST envelope real (con OIDC stub) → verifica que con un vehículo+dueño+push-sub seedeado, se intenta el push y la métrica se emite; evento duplicado → segundo POST `'deduped'`.
+- [ ] **Step 2:** `pnpm --filter @booster-ai/api test` + `pnpm --filter @booster-ai/telemetry-processor test` + `pnpm --filter @booster-ai/shared-schemas test` — todo verde, coverage ≥80/75.
+- [ ] **Step 3:** `pnpm ci` (lint + typecheck + test + build).
+- [ ] **Step 4:** PR con sección `## Evidencia`: output tests + coverage, `curl` del endpoint con OIDC (401 sin token, 200 con), `terraform plan` de la subscription, checklist ADR-compliance.
+
+---
+
+## Notas de integración / dependencias
+
+- **WhatsApp**: hasta que Meta apruebe `safety_alert_v1`, `CONTENT_SID_SAFETY_ALERT` queda vacío → solo push. El código no rompe (Task 9 step skip).
+- **Onboarding push**: los dueños de los 10 carriers deben tener la PWA + push aceptado, o el push devuelve `sent:0`. Acción operativa al instalar.
+- **No tocar el subsistema demo** acá; el `notification-service` skeleton se retira en el cleanup aparte (esta feature lo deja sin uso, lo cual es correcto).
+- **Verificaciones pendientes durante implementación** (confirmar contra el schema/código real, no asumir): path exacto de `imei`/timestamp en `RecordMessage`; nombre de columna teléfono en `users` y patente en `vehicles`; estados que cuentan como "asignación activa".

--- a/.specs/safety-event-fanout/spec.md
+++ b/.specs/safety-event-fanout/spec.md
@@ -1,0 +1,100 @@
+# Spec — Safety event fan-out (P0-G)
+
+**Fecha**: 2026-06-14
+**Estado**: DISEÑO (pendiente aprobación PO)
+**Origen**: auditoría 2026-06-14 hallazgo P0-G; go-live de 10 Teltonika en carriers reales (sem. del 2026-06-15 + siguiente).
+**Dominio crítico**: sí (seguridad física) → TDD obligatorio (`booster-skills:tdd-dominio-critico`).
+
+---
+
+## 1. Objetivo
+
+Cuando un Teltonika real reporta un evento de **seguridad física** (crash, unplug/tamper, jamming GNSS), el **transportista dueño del camión** recibe una notificación (push + WhatsApp). Hoy esos eventos solo disparan alertas a on-call; **nadie del lado del cliente se entera**. Con camiones reales en ruta, ese gap es inaceptable.
+
+Éxito = un evento panic de un vehículo real produce, en < ~30 s, una notificación entregada al dueño del transportista, de forma idempotente (sin spam) y auditable.
+
+## 2. Decisiones fijadas (confirmadas por el PO)
+
+1. **Consumer en `apps/api`** (no construir `notification-service`). Reusa `web-push`, `whatsapp-client`, el patrón `notify-incident-shipper`. El skeleton `notification-service` se retira en el cleanup de demo (spec aparte).
+2. **Eventos**: crash + unplug + jamming. **Destinatario**: transportista (dueño del camión). Generador de carga = fase 2 (fuera de scope).
+3. **Canal**: push (PWA) primario + WhatsApp fallback (mismo patrón que el chat). ⚠️ El template WhatsApp requiere aprobación de Meta (24-48 h) → **iniciar hoy**.
+
+**Decisión derivada**: transporte del consumer = **Pub/Sub push subscription → endpoint HTTP en `apps/api`**, autenticado por OIDC del SA (patrón `INTERNAL_CRON_CALLER_SA` ya existente). Evita un worker pull nuevo.
+
+## 3. Arquitectura y data flow
+
+```
+telemetry-processor                     apps/api
+┌────────────────────────┐             ┌─────────────────────────────────────┐
+│ CONSUMER 1 (telemetry) │             │ POST /internal/safety-events        │
+│  logPanicEvents()      │  publish    │  (OIDC SA auth + Zod)               │
+│   detecta Unplug/Jam ──┼──► topic ──►│   1. routeSafetyRecipients(vehId)   │
+│                        │ safety-p0   │      → asignación activa | vehículo  │
+│ CONSUMER 2 (crash)     │  (push sub) │      → empresa transportista        │
+│  persistCrashTrace ────┼──► topic ──►│      → memberships dueno/activa      │
+└────────────────────────┘             │   2. dedupe (vehId+tipo, ventana)   │
+                                        │   3. fan-out:                        │
+                                        │      sendPushToUser (web-push)       │
+                                        │      + WhatsApp (CONTENT_SID safety) │
+                                        │   4. log estructurado + métrica      │
+                                        └─────────────────────────────────────┘
+                                                   │ falla → DLQ (existente)
+```
+
+**Routing (núcleo)**: dado `vehicleId` (o `imei`):
+1. Buscar **asignación activa** del vehículo (`asignaciones` en estado en-curso) → da contexto de viaje (tracking_code, origen/destino) para el mensaje.
+2. **Fallback sin viaje**: si no hay asignación activa (camión parado/tamper fuera de ruta), resolver la empresa por `vehicles.empresaId` directo. Un crash/unplug debe avisar igual.
+3. Empresa transportista → `memberships` con `role='dueno'` y `status='activa'` → `users` → push subscriptions + teléfono E.164.
+
+## 4. Componentes (archivos)
+
+| # | Componente | Archivo | Qué hace |
+|---|---|---|---|
+| 1 | **Schema del evento** | `packages/shared-schemas/src/domain/safety-event.ts` (nuevo) | Zod `safetyEventSchema`: `{ eventType: 'crash'|'unplug'|'jamming', imei, vehicleId?, occurredAt, rawValue?, severity }`. `z.infer` para el tipo. Export en index. |
+| 2 | **Producer unplug/jamming** | `apps/telemetry-processor/src/panic-events.ts` | Añadir `publishSafetyEvents()` (junto a `logPanicEvents`, no en vez de): publica cada PanicEvent al topic safety-p0 vía `@google-cloud/pubsub` (patrón `chat-pubsub.ts`). Fire-and-forget, nunca bloquea el ack del record. Gated por env (topic configurable). |
+| 3 | **Producer crash** | `apps/telemetry-processor/src/persist-crash-trace.ts` (o el adapter) | Tras persistir el crash trace, publicar un safety-event `crash` al mismo topic. |
+| 4 | **Infra: push subscription** | `infrastructure/messaging.tf` | Cambiar `telemetry-events-safety-p0-notification-sub` de pull(notification-service) a **push** → `https://<api>/internal/safety-events` con OIDC (`push_config.oidc_token`, SA dedicado). Mantener DLQ + retry ya configurados. |
+| 5 | **Endpoint consumer** | `apps/api/src/routes/internal-safety-events.ts` (nuevo) | `POST /internal/safety-events`. Auth: OIDC del SA de push (mismo patrón que `/admin/jobs/*` con `INTERNAL_CRON_CALLER_SA`). Valida el envelope Pub/Sub + el `safetyEventSchema` con Zod. Llama al service. 200 = ack; 5xx = nack→retry→DLQ. |
+| 6 | **Routing** | `apps/api/src/services/route-safety-recipients.ts` (nuevo) | `vehicleId/imei → recipients[]` (users dueño + sus push subs + teléfono). Función pura sobre la query; testeable. Maneja el fallback sin viaje. |
+| 7 | **Fan-out** | `apps/api/src/services/dispatch-safety-notification.ts` (nuevo) | Orquesta: dedupe (tag `safety-${vehId}-${tipo}`, ventana configurable, Redis como el chat) → `sendPushToUser` (web-push existente) + WhatsApp (`whatsapp-client` + `CONTENT_SID_SAFETY_ALERT`). Cada canal best-effort, loguea y sigue (no swallow silencioso: log + métrica). |
+| 8 | **WhatsApp template** | (Twilio Content Editor + Meta) | Nuevo template `safety_alert_v1` (categoría UTILITY, es). Variables: {{1}} patente/alias del vehículo, {{2}} tipo de evento, {{3}} hora local, {{4}} tracking_code o "Sin viaje activo". Contenido en `.specs/safety-event-fanout/whatsapp-template.md`. **Submit a Meta hoy** (24-48h). Env `CONTENT_SID_SAFETY_ALERT` (optional hasta aprobación; sin él, WhatsApp se skipea y push igual sale). |
+| 9 | **Config** | `apps/api/src/config.ts`, `telemetry-processor/src/config.ts` | `SAFETY_EVENTS_TOPIC`, `CONTENT_SID_SAFETY_ALERT` (optional), SA de push permitido en el endpoint. Zod en boundary. |
+| 10 | **Métrica + OTel** | en el endpoint/service | `safety_notifications_total{event_type,channel,outcome}`, span OTel, log con `trace_id`, `vehicle_id`, `empresa_id`, `event_type`. |
+
+## 5. Manejo de errores
+
+- **Idempotencia/dedupe**: jamming sostenido emite muchos records → dedupe por `(vehicleId, eventType)` en ventana (ej. 10 min) vía Redis SET NX EX. Sin esto, spam al transportista.
+- **Sin destinatario** (empresa sin dueño activo / sin push sub / sin teléfono): log WARN + métrica `outcome=no_recipient`, ack igual (no reintentar — no es transitorio).
+- **Falla de canal**: push o WhatsApp fallan → log + métrica `outcome=channel_error`, **no** re-throw si el otro canal salió; si ambos fallan, 5xx → Pub/Sub reintenta → DLQ tras max-attempts (ya configurado, 5).
+- **Producer**: el publish nunca bloquea ni lanza en el path de telemetría (fire-and-forget; el evento ya se logueó para on-call aunque el publish falle).
+- **Auth del endpoint**: rechaza si el OIDC no es del SA de push (403). Nunca procesa un POST no autenticado.
+
+## 6. Testing (TDD obligatorio — dominio safety)
+
+Tests escritos **antes** del código (red→green):
+- **`route-safety-recipients`** (unit): con viaje activo; sin viaje (fallback a `vehicles.empresaId`); empresa sin dueño; múltiples dueños.
+- **`dispatch-safety-notification`** (unit): dedupe dentro de ventana (segundo evento no notifica); push ok + WhatsApp skip (sin CONTENT_SID); ambos canales fallan → propaga para nack; un canal falla → ack.
+- **`panic-events` publish** (unit): publica N eventos; no lanza si el publisher falla.
+- **endpoint** (integration): envelope Pub/Sub válido → 200 + notificación; OIDC inválido → 403; payload malformado → 400; evento duplicado → 200 sin segunda notif.
+- Coverage ≥ 80% líneas / ≥ 75% branches en lo nuevo.
+
+## 7. Fuera de scope (specs/fases aparte)
+
+- **Gateway hardening** (rate-limit + IP allowlist de IMEIs, P1-3) — spec separada, también go-live-blocking, se diseña después de esta.
+- **Generador de carga** como segundo destinatario — fase 2.
+- **Retiro del subsistema demo** (incl. `notification-service` skeleton, mirror, middlewares) — proyecto en fases aparte.
+- **De-demo del device 863…** — operativo y trivial (asignar `teltonika_imei` al vehículo real vía `/admin/dispositivos-pendientes`); no requiere código nuevo.
+
+## 8. Riesgos y dependencias
+
+- **WhatsApp/Meta lead-time (24-48h)**: el template `safety_alert_v1` debe submitearse hoy o el canal WhatsApp no estará para la instalación. Push no depende de Meta → la feature funciona con push aunque el template no esté aprobado aún.
+- **Push requiere PWA instalada + suscripción**: los dueños de los carriers reales deben tener la PWA y haber aceptado push. Acción operativa de onboarding (verificar al instalar los devices).
+- **Cambiar la subscription a push**: toca `messaging.tf` (infra) + requiere el SA de push con permiso de invocar el endpoint. Apply gateado (revisar plan, como el resto de infra).
+- **El endpoint es internet-facing** (Pub/Sub push llega por HTTPS): la auth OIDC del SA es la única barrera → test de auth es P0.
+
+## 9. Criterio de terminado
+
+- Un evento panic real (o simulado en test) de un vehículo con dueño activo → push entregado (+ WhatsApp si template aprobado), deduplicado, con métrica y log con `trace_id`.
+- TDD verde, coverage en umbral, `pnpm ci` ok.
+- Infra: subscription push aplicada con plan revisado; endpoint rechaza no-OIDC.
+- PR con sección Evidencia (tests + trace del endpoint + plan de infra).

--- a/.specs/safety-event-fanout/whatsapp-template.md
+++ b/.specs/safety-event-fanout/whatsapp-template.md
@@ -1,0 +1,74 @@
+# WhatsApp template — `safety_alert_v1`
+
+Listo para submitear en **Twilio Content Editor** (Content Template Builder) → se aprueba vía Meta. Categoría **UTILITY** (notificación transaccional, no marketing → aprobación más rápida y enviable fuera de la ventana de 24h).
+
+---
+
+## Metadatos
+
+| Campo | Valor |
+|---|---|
+| **Template name** | `safety_alert_v1` (Twilio exige snake_case minúscula) |
+| **Category** | UTILITY |
+| **Language** | Spanish (es) |
+| **Content type** | `twilio/text` (body-only) — ver abajo variante con botón |
+
+## Header (opcional, texto estático)
+
+```
+🚨 Alerta de seguridad — Booster
+```
+
+## Body
+
+```
+Detectamos un evento de seguridad en un vehículo de tu flota.
+
+Vehículo: {{1}}
+Evento: {{2}}
+Hora: {{3}}
+Viaje: {{4}}
+
+Revisá el estado del vehículo y contactá al conductor si es necesario.
+```
+
+## Footer (opcional, estático)
+
+```
+Booster · Logística sostenible
+```
+
+## Variables — sample values (Meta los exige para aprobar)
+
+| Var | Significado (app) | Sample para el submit |
+|---|---|---|
+| `{{1}}` | Patente o alias del vehículo | `RJXK-42` |
+| `{{2}}` | Tipo de evento (label es) | `Posible colisión` |
+| `{{3}}` | Hora local del evento | `14:32 (15 jun)` |
+| `{{4}}` | tracking_code del viaje, o "Sin viaje activo" | `BOO-7F3A2C` |
+
+**Labels de `{{2}}` que usará el código** (para que el sample sea representativo):
+- `crash` → `Posible colisión`
+- `unplug` → `Desconexión de energía (manipulación)`
+- `jamming` → `Interferencia de señal GPS`
+
+## Variante con botón (opcional — si querés CTA directo)
+
+Agregar un **botón URL dinámico**:
+- Texto del botón: `Ver vehículo`
+- URL: `https://app.boosterchile.com/app/flota?v={{1}}`
+- Sample para `{{1}}` del botón: `6487dac2`
+
+> Nota: el botón con URL dinámica agrega una variable extra y a veces alarga la revisión de Meta. Si querés la aprobación más rápida, submití **body-only** primero; el deep-link igual va por push. El botón se puede agregar en `safety_alert_v2` después.
+
+## Después de aprobar
+
+Meta devuelve el Content SID (`HX...`). Setealo en la env del Cloud Run del api como `CONTENT_SID_SAFETY_ALERT`. Hasta entonces, el código skipea WhatsApp y notifica solo por push (sin romper nada).
+
+## Checklist de submit
+
+- [ ] Crear template en Twilio Content Editor, name `safety_alert_v1`, category UTILITY, language Spanish.
+- [ ] Pegar header / body / footer de arriba.
+- [ ] Cargar los 4 sample values.
+- [ ] Submit a Meta.
+- [ ] Al aprobar (24-48h): copiar el `HX...` → `CONTENT_SID_SAFETY_ALERT` en Cloud Run.

--- a/apps/api/scripts/check-route-default-deny.ts
+++ b/apps/api/scripts/check-route-default-deny.ts
@@ -182,6 +182,11 @@ export const ROUTE_CLASSIFICATION: Record<string, RouteClassificationEntry> = {
     category: 'INTERNAL',
     rationale: 'cron: Cloud Scheduler OIDC (cronAuthMiddleware, INTERNAL_CRON_CALLER_SA).',
   },
+  createInternalSafetyEventsRoutes: {
+    category: 'INTERNAL',
+    rationale:
+      'Pub/Sub push: OIDC SA auth inline (SAFETY_PUSH_CALLER_SA); fail-closed si SA no configurado. No usa firebaseAuthMiddleware ni userContext.',
+  },
 };
 
 /**

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -268,6 +268,30 @@ const apiEnvSchema = commonEnvSchema
       .optional(),
 
     /**
+     * Content SID del template Twilio `safety_alert_v1` (fan-out de eventos de
+     * seguridad al transportista). Vacío → WhatsApp se skipea y la alerta sale
+     * solo por push (la feature no depende de la aprobación de Meta).
+     */
+    CONTENT_SID_SAFETY_ALERT: z.preprocess(
+      (v) => (typeof v === 'string' && v.trim() === '' ? undefined : v),
+      z
+        .string()
+        .regex(/^HX[a-fA-F0-9]+$/, 'Debe empezar con HX seguido de hex chars')
+        .optional(),
+    ),
+
+    /**
+     * SA email que firma el OIDC de la push subscription de safety-events
+     * (Pub/Sub → POST /internal/safety-events). El endpoint valida
+     * claims.email === este valor. Optional en dev (sin él, el endpoint
+     * rechaza todo por falta de caller autorizado).
+     */
+    SAFETY_PUSH_CALLER_SA: z
+      .string()
+      .regex(/^[a-z0-9-]+@[a-z0-9-]+\.iam\.gserviceaccount\.com$/, 'SA email inválido')
+      .optional(),
+
+    /**
      * GCP project ID — Cloud Run lo setea automáticamente en runtime.
      * Usado para:
      *   - Vertex AI Gemini endpoint (ADR-037, coaching IA post-entrega).

--- a/apps/api/src/routes/internal-safety-events.test.ts
+++ b/apps/api/src/routes/internal-safety-events.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests del endpoint POST /internal/safety-events (Task 10).
+ *
+ * Cubre:
+ *   - Auth: token ausente → 401.
+ *   - Auth: JWT inválido/expirado → 401.
+ *   - Auth: email mismatch → 403.
+ *   - Auth: SAFETY_PUSH_CALLER_SA no configurado → 403 (fail-closed).
+ *   - Envelope inválido → 400.
+ *   - SafetyEvent inválido → 400.
+ *   - Vehículo desconocido (routing null) → 200 outcome:unknown_vehicle.
+ *   - Dispatch exitoso → 200 outcome.
+ *   - Dispatch throws → 500.
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+import type { LoginTicket, OAuth2Client, TokenPayload } from 'google-auth-library';
+import type { Redis } from 'ioredis';
+import { describe, expect, it, vi } from 'vitest';
+import type { Db } from '../db/client.js';
+import type { DispatchOutcome } from '../services/dispatch-safety-notification.js';
+import type { SafetyRouting } from '../services/route-safety-recipients.js';
+import {
+  type InternalSafetyEventsConfig,
+  createInternalSafetyEventsRoutes,
+} from './internal-safety-events.js';
+
+// ── Logger stub ──────────────────────────────────────────────────────────────
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as Logger;
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const CALLER_SA = 'safety-pubsub@booster-ai.iam.gserviceaccount.com';
+const API_AUDIENCE = ['https://api.boosterchile.com'];
+
+const VALID_EVENT = {
+  eventType: 'crash' as const,
+  imei: '123456789012345',
+  vehicleId: '00000000-0000-0000-0000-000000000001',
+  occurredAt: '2026-06-15T10:00:00Z',
+};
+
+const VALID_ROUTING: SafetyRouting = {
+  empresaId: 'empresa-1',
+  vehicleLabel: 'ABC-123',
+  trackingCode: 'TRK-001',
+  recipients: [{ userId: 'user-1', phoneE164: '+56912345678' }],
+};
+
+function makeEnvelopeBody(event: unknown): Record<string, unknown> {
+  return {
+    message: {
+      data: Buffer.from(JSON.stringify(event)).toString('base64'),
+      messageId: 'msg-001',
+    },
+    subscription: 'projects/booster-ai/subscriptions/safety-events-sub',
+  };
+}
+
+// ── OAuth2Client stub factory ─────────────────────────────────────────────────
+
+function makeOAuthClient(opts: {
+  shouldThrow?: boolean;
+  email?: string;
+}): OAuth2Client {
+  const verifyIdToken = vi.fn(async () => {
+    if (opts.shouldThrow) {
+      throw new Error('Token verification failed');
+    }
+    const payload: Partial<TokenPayload> = {
+      ...(opts.email !== undefined ? { email: opts.email } : {}),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    };
+    const ticket = {
+      getPayload: () => payload as TokenPayload,
+    } as LoginTicket;
+    return ticket;
+  });
+  return { verifyIdToken } as unknown as OAuth2Client;
+}
+
+// ── App factory ───────────────────────────────────────────────────────────────
+
+/**
+ * `callerSa` uses a sentinel to distinguish "not provided" (default to CALLER_SA)
+ * from "explicitly undefined" (SAFETY_PUSH_CALLER_SA not configured).
+ */
+const UNSET = Symbol('UNSET');
+
+type DispatchFn = (o: {
+  redis: Redis;
+  db: Db;
+  logger: Logger;
+  event: SafetyEvent;
+  routing: SafetyRouting;
+  contentSidSafety?: string;
+  sendPush: (a: {
+    db: Db;
+    logger: Logger;
+    userId: string;
+    payload: {
+      title: string;
+      body: string;
+      tag: string;
+      data: { assignment_id: string; message_id: string; url: string };
+    };
+  }) => Promise<unknown>;
+  sendWhatsapp: (a: {
+    to: string;
+    contentSid: string;
+    contentVariables: Record<string, string>;
+  }) => Promise<unknown>;
+}) => Promise<DispatchOutcome>;
+
+function makeApp(opts: {
+  callerSa?: string | typeof UNSET;
+  oauthClient: OAuth2Client;
+  routeRecipients?: (o: {
+    db: Db;
+    imei: string;
+    vehicleId?: string;
+  }) => Promise<SafetyRouting | null>;
+  dispatch?: DispatchFn;
+  sendWhatsapp?: () => Promise<unknown>;
+}) {
+  const config: InternalSafetyEventsConfig = {
+    safetyPushCallerSa: opts.callerSa === UNSET ? undefined : (opts.callerSa ?? CALLER_SA),
+    apiAudience: API_AUDIENCE,
+    contentSidSafetyAlert: undefined,
+  };
+
+  const db = {} as unknown as Db;
+  const redis = {} as unknown as Redis;
+
+  return createInternalSafetyEventsRoutes({
+    db,
+    redis,
+    logger: noopLogger,
+    config,
+    sendWhatsapp: opts.sendWhatsapp ?? vi.fn().mockResolvedValue(undefined),
+    oauthClient: opts.oauthClient,
+    ...(opts.routeRecipients !== undefined ? { routeRecipients: opts.routeRecipients } : {}),
+    ...(opts.dispatch !== undefined ? { dispatch: opts.dispatch } : {}),
+  });
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function makeRequest(opts: {
+  app: ReturnType<typeof makeApp>;
+  authorization?: string;
+  body?: unknown;
+}): Promise<Response> {
+  const body = opts.body !== undefined ? opts.body : makeEnvelopeBody(VALID_EVENT);
+  return await opts.app.request('/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(opts.authorization !== undefined ? { Authorization: opts.authorization } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('POST /internal/safety-events', () => {
+  describe('Auth', () => {
+    it('returns 401 when Authorization header is missing', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const dispatch = vi.fn();
+      const app = makeApp({ oauthClient, dispatch: dispatch as unknown as DispatchFn });
+
+      const res = await app.request('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(makeEnvelopeBody(VALID_EVENT)),
+      });
+
+      expect(res.status).toBe(401);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when JWT verification throws', async () => {
+      const oauthClient = makeOAuthClient({ shouldThrow: true });
+      const dispatch = vi.fn();
+      const app = makeApp({ oauthClient, dispatch: dispatch as unknown as DispatchFn });
+
+      const res = await makeRequest({ app, authorization: 'Bearer invalid-token' });
+
+      expect(res.status).toBe(401);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when JWT email does not match SAFETY_PUSH_CALLER_SA', async () => {
+      const oauthClient = makeOAuthClient({ email: 'other-sa@booster-ai.iam.gserviceaccount.com' });
+      const dispatch = vi.fn();
+      const app = makeApp({ oauthClient, dispatch: dispatch as unknown as DispatchFn });
+
+      const res = await makeRequest({ app, authorization: 'Bearer valid-token' });
+
+      expect(res.status).toBe(403);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('returns 403 when SAFETY_PUSH_CALLER_SA is not configured (fail-closed)', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const dispatch = vi.fn();
+      const app = makeApp({
+        callerSa: UNSET,
+        oauthClient,
+        dispatch: dispatch as unknown as DispatchFn,
+      });
+
+      const res = await makeRequest({ app, authorization: 'Bearer valid-token' });
+
+      expect(res.status).toBe(403);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Envelope and event validation', () => {
+    it('returns 400 when Pub/Sub envelope is malformed (missing message field)', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const app = makeApp({ oauthClient });
+
+      const res = await makeRequest({
+        app,
+        authorization: 'Bearer valid-token',
+        body: { subscription: 'some-sub' }, // missing message
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when message.data is not a valid SafetyEvent', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const dispatch = vi.fn();
+      const app = makeApp({ oauthClient, dispatch: dispatch as unknown as DispatchFn });
+
+      const invalidEvent = { eventType: 'crash', imei: 'NOT-A-VALID-IMEI' }; // missing occurredAt, bad imei
+      const res = await makeRequest({
+        app,
+        authorization: 'Bearer valid-token',
+        body: makeEnvelopeBody(invalidEvent),
+      });
+
+      expect(res.status).toBe(400);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when message.data is not valid JSON after base64 decode', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const app = makeApp({ oauthClient });
+
+      const res = await makeRequest({
+        app,
+        authorization: 'Bearer valid-token',
+        body: {
+          message: {
+            data: Buffer.from('not-json-at-all').toString('base64'),
+            messageId: 'msg-001',
+          },
+          subscription: 'projects/booster-ai/subscriptions/safety-events-sub',
+        },
+      });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('Routing', () => {
+    it('returns 200 with outcome:unknown_vehicle when vehicle is not found, without dispatching', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const dispatch = vi.fn();
+      const routeRecipients = vi.fn().mockResolvedValue(null);
+
+      const app = makeApp({
+        oauthClient,
+        routeRecipients,
+        dispatch: dispatch as unknown as DispatchFn,
+      });
+
+      const res = await makeRequest({ app, authorization: 'Bearer valid-token' });
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toEqual({ outcome: 'unknown_vehicle' });
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Dispatch', () => {
+    it('returns 200 with dispatch outcome when valid event is received for a known vehicle', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const routeRecipients = vi.fn().mockResolvedValue(VALID_ROUTING);
+      const dispatch = vi.fn().mockResolvedValue('notified' as DispatchOutcome);
+
+      const app = makeApp({
+        oauthClient,
+        routeRecipients,
+        dispatch: dispatch as unknown as DispatchFn,
+      });
+
+      const res = await makeRequest({ app, authorization: 'Bearer valid-token' });
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toEqual({ outcome: 'notified' });
+      expect(dispatch).toHaveBeenCalledOnce();
+    });
+
+    it('returns 200 with outcome:deduped when dispatch returns deduped', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const routeRecipients = vi.fn().mockResolvedValue(VALID_ROUTING);
+      const dispatch = vi.fn().mockResolvedValue('deduped' as DispatchOutcome);
+
+      const app = makeApp({
+        oauthClient,
+        routeRecipients,
+        dispatch: dispatch as unknown as DispatchFn,
+      });
+
+      const res = await makeRequest({ app, authorization: 'Bearer valid-token' });
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toEqual({ outcome: 'deduped' });
+    });
+
+    it('returns 500 when dispatch throws unexpectedly (so Pub/Sub retries)', async () => {
+      const oauthClient = makeOAuthClient({ email: CALLER_SA });
+      const routeRecipients = vi.fn().mockResolvedValue(VALID_ROUTING);
+      const dispatch = vi.fn().mockRejectedValue(new Error('Redis connection lost'));
+
+      const app = makeApp({
+        oauthClient,
+        routeRecipients,
+        dispatch: dispatch as unknown as DispatchFn,
+      });
+
+      const res = await makeRequest({ app, authorization: 'Bearer valid-token' });
+
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/apps/api/src/routes/internal-safety-events.ts
+++ b/apps/api/src/routes/internal-safety-events.ts
@@ -1,0 +1,269 @@
+/**
+ * Endpoint interno: POST /internal/safety-events
+ *
+ * Recibe un Pub/Sub PUSH envelope desde la suscripción del topic safety-p0,
+ * autentica al caller via OIDC (service account email claim), valida el
+ * SafetyEvent y despacha la notificación de seguridad.
+ *
+ * Auth: OIDC token con `email` claim == SAFETY_PUSH_CALLER_SA.
+ * Audience: config.API_AUDIENCE (idéntico al patrón admin-jobs).
+ * Fail-closed: si SAFETY_PUSH_CALLER_SA no está configurado, rechaza todo (403).
+ *
+ * Códigos de estado:
+ *   200  — éxito o ACK deliberado (vehicle desconocido, deduplicado).
+ *   400  — envelope o evento malformado → Pub/Sub NO reintenta.
+ *   401  — token Authorization ausente o JWT inválido.
+ *   403  — JWT válido pero SA no autorizado, o SAFETY_PUSH_CALLER_SA no configurado.
+ *   500  — error inesperado en routing o dispatch → Pub/Sub reintenta (→ DLQ).
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import { safetyEventSchema } from '@booster-ai/shared-schemas';
+import { OAuth2Client, type TokenPayload } from 'google-auth-library';
+import { Hono } from 'hono';
+import type { Redis } from 'ioredis';
+import { z } from 'zod';
+import type { Db } from '../db/client.js';
+import type { DispatchOutcome } from '../services/dispatch-safety-notification.js';
+import { dispatchSafetyNotification } from '../services/dispatch-safety-notification.js';
+import type { SafetyRouting } from '../services/route-safety-recipients.js';
+import { routeSafetyRecipients } from '../services/route-safety-recipients.js';
+import { sendPushToUser } from '../services/web-push.js';
+
+/**
+ * Schema del envelope de push de Pub/Sub.
+ * Ref: https://cloud.google.com/pubsub/docs/push#receive_push
+ */
+const pubsubPushEnvelopeSchema = z.object({
+  message: z.object({
+    data: z.string(),
+    attributes: z.record(z.string()).optional(),
+    messageId: z.string(),
+  }),
+  subscription: z.string(),
+});
+
+export interface InternalSafetyEventsConfig {
+  /** Email del SA autorizado a invocar este endpoint (SAFETY_PUSH_CALLER_SA). */
+  safetyPushCallerSa: string | undefined;
+  /** Audiences aceptadas para verifyIdToken (config.API_AUDIENCE). */
+  apiAudience: readonly string[];
+  /** Content SID del template Twilio safety_alert_v1 (CONTENT_SID_SAFETY_ALERT). */
+  contentSidSafetyAlert: string | undefined;
+}
+
+export function createInternalSafetyEventsRoutes(opts: {
+  db: Db;
+  redis: Redis;
+  logger: Logger;
+  config: InternalSafetyEventsConfig;
+  sendWhatsapp: (a: {
+    to: string;
+    contentSid: string;
+    contentVariables: Record<string, string>;
+  }) => Promise<unknown>;
+  /**
+   * OAuth2Client inyectable para tests (permite stubbear verifyIdToken sin
+   * pegarle a la red). En producción se crea una instancia por default.
+   */
+  oauthClient?: OAuth2Client;
+  /**
+   * Función de routing inyectable para tests. Por default usa la implementación real.
+   */
+  routeRecipients?: (opts: {
+    db: Db;
+    imei: string;
+    vehicleId?: string;
+  }) => Promise<SafetyRouting | null>;
+  /**
+   * Función de dispatch inyectable para tests. Por default usa la implementación real.
+   */
+  dispatch?: (opts: {
+    redis: Redis;
+    db: Db;
+    logger: Logger;
+    event: z.infer<typeof safetyEventSchema>;
+    routing: SafetyRouting;
+    contentSidSafety?: string;
+    sendPush: (a: {
+      db: Db;
+      logger: Logger;
+      userId: string;
+      payload: {
+        title: string;
+        body: string;
+        tag: string;
+        data: { assignment_id: string; message_id: string; url: string };
+      };
+    }) => Promise<unknown>;
+    sendWhatsapp: (a: {
+      to: string;
+      contentSid: string;
+      contentVariables: Record<string, string>;
+    }) => Promise<unknown>;
+  }) => Promise<DispatchOutcome>;
+}) {
+  const app = new Hono();
+
+  const oauthClient = opts.oauthClient ?? new OAuth2Client();
+  const apiAudienceMutable = [...opts.config.apiAudience];
+
+  const routeRecipientsFn = opts.routeRecipients ?? routeSafetyRecipients;
+  const dispatchFn = opts.dispatch ?? dispatchSafetyNotification;
+
+  app.post('/', async (c) => {
+    // ── 1. Auth: fail-closed si SA no configurado ─────────────────────────
+    const { safetyPushCallerSa } = opts.config;
+    if (!safetyPushCallerSa) {
+      opts.logger.warn('internal-safety-events: SAFETY_PUSH_CALLER_SA no configurado, rechazando');
+      return c.json({ error: 'Caller not allowed' }, 403);
+    }
+
+    // ── 2. Extraer Bearer token ───────────────────────────────────────────
+    const authHeader = c.req.header('authorization');
+    if (!authHeader?.startsWith('Bearer ')) {
+      opts.logger.warn('internal-safety-events: Authorization header ausente');
+      return c.json({ error: 'Unauthorized' }, 401);
+    }
+
+    const token = authHeader.slice('Bearer '.length).trim();
+
+    // ── 3. Verificar JWT (firma + aud + exp via google-auth-library) ──────
+    let payload: TokenPayload | undefined;
+    try {
+      const ticket = await oauthClient.verifyIdToken({
+        idToken: token,
+        audience: apiAudienceMutable,
+      });
+      payload = ticket.getPayload();
+    } catch (err: unknown) {
+      opts.logger.warn(
+        { err: err instanceof Error ? err.message : String(err) },
+        'internal-safety-events: JWT verification failed',
+      );
+      return c.json({ error: 'Invalid token' }, 401);
+    }
+
+    if (!payload) {
+      opts.logger.warn('internal-safety-events: JWT payload vacío tras verificación');
+      return c.json({ error: 'Invalid token' }, 401);
+    }
+
+    // ── 4. Whitelist del email del SA caller ──────────────────────────────
+    if (payload.email !== safetyPushCallerSa) {
+      opts.logger.warn(
+        { email: payload.email, expected: safetyPushCallerSa },
+        'internal-safety-events: SA caller no permitido',
+      );
+      return c.json({ error: 'Caller not allowed' }, 403);
+    }
+
+    // ── 5. Parsear envelope Pub/Sub ───────────────────────────────────────
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      opts.logger.warn('internal-safety-events: body no es JSON válido');
+      return c.json({ error: 'Invalid request body' }, 400);
+    }
+
+    const envelopeResult = pubsubPushEnvelopeSchema.safeParse(body);
+    if (!envelopeResult.success) {
+      opts.logger.warn(
+        { issues: envelopeResult.error.issues },
+        'internal-safety-events: envelope Pub/Sub inválido',
+      );
+      return c.json(
+        { error: 'Invalid Pub/Sub envelope', details: envelopeResult.error.issues },
+        400,
+      );
+    }
+
+    const envelope = envelopeResult.data;
+
+    // ── 6. Decodificar y validar el SafetyEvent ───────────────────────────
+    let rawEvent: unknown;
+    try {
+      rawEvent = JSON.parse(Buffer.from(envelope.message.data, 'base64').toString('utf8'));
+    } catch {
+      opts.logger.warn(
+        { messageId: envelope.message.messageId },
+        'internal-safety-events: message.data no es JSON válido tras base64 decode',
+      );
+      return c.json({ error: 'Invalid event data' }, 400);
+    }
+
+    const eventResult = safetyEventSchema.safeParse(rawEvent);
+    if (!eventResult.success) {
+      opts.logger.warn(
+        { issues: eventResult.error.issues, messageId: envelope.message.messageId },
+        'internal-safety-events: SafetyEvent inválido',
+      );
+      return c.json({ error: 'Invalid SafetyEvent', details: eventResult.error.issues }, 400);
+    }
+
+    const event = eventResult.data;
+
+    // ── 7. Routing ────────────────────────────────────────────────────────
+    let routing: SafetyRouting | null;
+    try {
+      routing = await routeRecipientsFn({
+        db: opts.db,
+        imei: event.imei,
+        ...(event.vehicleId !== undefined ? { vehicleId: event.vehicleId } : {}),
+      });
+    } catch (err: unknown) {
+      opts.logger.error(
+        { err, imei: event.imei, eventType: event.eventType },
+        'internal-safety-events: error inesperado en routeSafetyRecipients',
+      );
+      return c.json({ error: 'internal_error' }, 500);
+    }
+
+    if (routing === null) {
+      opts.logger.warn(
+        { imei: event.imei, eventType: event.eventType },
+        'internal-safety-events: vehículo desconocido, ACK sin notificación',
+      );
+      return c.json({ outcome: 'unknown_vehicle' }, 200);
+    }
+
+    // ── 8. Dispatch ───────────────────────────────────────────────────────
+    let outcome: DispatchOutcome;
+    try {
+      outcome = await dispatchFn({
+        redis: opts.redis,
+        db: opts.db,
+        logger: opts.logger,
+        event,
+        routing,
+        ...(opts.config.contentSidSafetyAlert !== undefined
+          ? { contentSidSafety: opts.config.contentSidSafetyAlert }
+          : {}),
+        sendPush: sendPushToUser,
+        sendWhatsapp: opts.sendWhatsapp,
+      });
+    } catch (err: unknown) {
+      opts.logger.error(
+        { err, imei: event.imei, eventType: event.eventType },
+        'internal-safety-events: error inesperado en dispatchSafetyNotification',
+      );
+      return c.json({ error: 'internal_error' }, 500);
+    }
+
+    // ── 9. Structured log final ───────────────────────────────────────────
+    opts.logger.info(
+      {
+        imei: event.imei,
+        eventType: event.eventType,
+        outcome,
+        messageId: envelope.message.messageId,
+      },
+      'internal-safety-events: procesado',
+    );
+
+    return c.json({ outcome }, 200);
+  });
+
+  return app;
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -40,6 +40,7 @@ import { createEmpresaRoutes } from './routes/empresas.js';
 import { createFeatureFlagsRoutes } from './routes/feature-flags.js';
 import { createHealthSignupFlowRouter } from './routes/health-signup-flow.js';
 import { createHealthRouter } from './routes/health.js';
+import { createInternalSafetyEventsRoutes } from './routes/internal-safety-events.js';
 import { createMeClaveNumericaRoutes } from './routes/me-clave-numerica.js';
 import { createMeConsentsRoutes } from './routes/me-consents.js';
 import { createMeLiquidacionesRoutes } from './routes/me-liquidaciones.js';
@@ -260,6 +261,29 @@ export function createServer(opts: CreateServerOptions): Hono {
 
   app.use('/trip-requests/*', authMiddleware);
   app.route('/trip-requests', createTripRequestsRoutes({ db: opts.db, logger }));
+
+  // Endpoint interno: POST /internal/safety-events (Task 10).
+  // Auth propia vía OIDC (Pub/Sub push SA). NO usa firebaseAuthMiddleware.
+  // Excluido del CI gate `check-is-demo-wire-completeness` (no requiere is_demo).
+  const safetyTwilioClient = opts.notify?.twilioClient ?? null;
+  app.route(
+    '/internal/safety-events',
+    createInternalSafetyEventsRoutes({
+      db: opts.db,
+      redis: redisForRateLimit,
+      logger,
+      config: {
+        safetyPushCallerSa: config.SAFETY_PUSH_CALLER_SA,
+        apiAudience: config.API_AUDIENCE,
+        contentSidSafetyAlert: config.CONTENT_SID_SAFETY_ALERT,
+      },
+      sendWhatsapp: safetyTwilioClient
+        ? (a) => safetyTwilioClient.sendContent(a)
+        : async (a) => {
+            logger.warn({ to: a.to }, 'internal-safety-events: whatsapp no configurado, skip');
+          },
+    }),
+  );
 
   // End-user routes (Firebase ID token required). /me es especial: no usa
   // userContext middleware porque el user puede no existir aún en la DB

--- a/apps/api/src/services/dispatch-safety-notification.test.ts
+++ b/apps/api/src/services/dispatch-safety-notification.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests de dispatchSafetyNotification (Task 9 — dedupe + push + WhatsApp).
+ *
+ * Cubre:
+ *   1. deduped: redis.set devuelve null → 'deduped', sendPush/sendWhatsapp NO llamados.
+ *   2. no_recipient: redis.set devuelve 'OK', recipients=[] → 'no_recipient'.
+ *   3. notified con WhatsApp: 'OK', 1 recipient con phone, contentSidSafety set
+ *      → sendPush llamado 1x, sendWhatsapp llamado 1x con contentVariables correctas.
+ *   4. sin contentSid → WhatsApp saltado: sendPush llamado, sendWhatsapp NO.
+ *   5. push throws → best-effort: resultado sigue 'notified', sendWhatsapp aún llamado.
+ *   6. recipient con phone null → WhatsApp saltado para ese recipient, push intentado.
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+import { describe, expect, it, vi } from 'vitest';
+import type { Db } from '../db/client.js';
+import { dispatchSafetyNotification } from './dispatch-safety-notification.js';
+import type { SafetyRouting } from './route-safety-recipients.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const safetyEvent: SafetyEvent = {
+  eventType: 'crash',
+  imei: '351756051523010',
+  occurredAt: '2026-06-15T10:00:00.000Z',
+  vehicleId: 'v-uuid',
+};
+
+const routingWithRecipient: SafetyRouting = {
+  empresaId: 'emp-uuid',
+  vehicleLabel: 'ABCD12',
+  trackingCode: 'TRK-001',
+  recipients: [{ userId: 'user-1', phoneE164: '+56912345678' }],
+};
+
+const routingNoRecipients: SafetyRouting = {
+  empresaId: 'emp-uuid',
+  vehicleLabel: 'ABCD12',
+  trackingCode: null,
+  recipients: [],
+};
+
+// ---------------------------------------------------------------------------
+// Logger stub
+// ---------------------------------------------------------------------------
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger;
+}
+
+// ---------------------------------------------------------------------------
+// DB stub (not used by dispatchSafetyNotification directly, just passed through)
+// ---------------------------------------------------------------------------
+const dbStub = {} as unknown as Db;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('dispatchSafetyNotification', () => {
+  it('deduped: redis.set devuelve null → retorna deduped, sendPush/sendWhatsapp NO llamados', async () => {
+    const redis = { set: vi.fn().mockResolvedValue(null) } as never;
+    const sendPush = vi.fn();
+    const sendWhatsapp = vi.fn();
+    const logger = makeLogger();
+
+    const outcome = await dispatchSafetyNotification({
+      redis,
+      db: dbStub,
+      logger,
+      event: safetyEvent,
+      routing: routingWithRecipient,
+      contentSidSafety: 'HX123',
+      sendPush,
+      sendWhatsapp,
+    });
+
+    expect(outcome).toBe('deduped');
+    expect(sendPush).not.toHaveBeenCalled();
+    expect(sendWhatsapp).not.toHaveBeenCalled();
+  });
+
+  it('no_recipient: redis.set devuelve OK, recipients=[] → retorna no_recipient', async () => {
+    const redis = { set: vi.fn().mockResolvedValue('OK') } as never;
+    const sendPush = vi.fn();
+    const sendWhatsapp = vi.fn();
+    const logger = makeLogger();
+
+    const outcome = await dispatchSafetyNotification({
+      redis,
+      db: dbStub,
+      logger,
+      event: safetyEvent,
+      routing: routingNoRecipients,
+      contentSidSafety: 'HX123',
+      sendPush,
+      sendWhatsapp,
+    });
+
+    expect(outcome).toBe('no_recipient');
+    expect(sendPush).not.toHaveBeenCalled();
+    expect(sendWhatsapp).not.toHaveBeenCalled();
+  });
+
+  it('notified con whatsapp: sendPush 1x, sendWhatsapp 1x con contentVariables correctas', async () => {
+    const redis = { set: vi.fn().mockResolvedValue('OK') } as never;
+    const sendPush = vi.fn().mockResolvedValue(undefined);
+    const sendWhatsapp = vi.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
+
+    const outcome = await dispatchSafetyNotification({
+      redis,
+      db: dbStub,
+      logger,
+      event: safetyEvent,
+      routing: routingWithRecipient,
+      contentSidSafety: 'HX123',
+      sendPush,
+      sendWhatsapp,
+    });
+
+    expect(outcome).toBe('notified');
+
+    // Push llamado una vez con el userId correcto
+    expect(sendPush).toHaveBeenCalledTimes(1);
+    const pushCall = sendPush.mock.calls[0]?.[0];
+    expect(pushCall.userId).toBe('user-1');
+    expect(pushCall.payload.title).toBe('🚨 Alerta de seguridad');
+    expect(pushCall.payload.body).toBe('ABCD12: Posible colisión');
+    expect(pushCall.payload.tag).toBe(`safety-${safetyEvent.imei}-${safetyEvent.eventType}`);
+    expect(pushCall.payload.data.url).toBe('/app/flota');
+
+    // WhatsApp llamado una vez
+    expect(sendWhatsapp).toHaveBeenCalledTimes(1);
+    const waCall = sendWhatsapp.mock.calls[0]?.[0];
+    expect(waCall.to).toBe('+56912345678');
+    expect(waCall.contentSid).toBe('HX123');
+    // Variable 1: vehicleLabel
+    expect(waCall.contentVariables['1']).toBe('ABCD12');
+    // Variable 2: label del evento
+    expect(waCall.contentVariables['2']).toBe('Posible colisión');
+    // Variable 3: hora (non-empty string)
+    expect(typeof waCall.contentVariables['3']).toBe('string');
+    expect(waCall.contentVariables['3'].length).toBeGreaterThan(0);
+    // Variable 4: viaje = trackingCode
+    expect(waCall.contentVariables['4']).toBe('TRK-001');
+  });
+
+  it('sin contentSid → sendWhatsapp NO llamado, sendPush sí', async () => {
+    const redis = { set: vi.fn().mockResolvedValue('OK') } as never;
+    const sendPush = vi.fn().mockResolvedValue(undefined);
+    const sendWhatsapp = vi.fn();
+    const logger = makeLogger();
+
+    const outcome = await dispatchSafetyNotification({
+      redis,
+      db: dbStub,
+      logger,
+      event: safetyEvent,
+      routing: routingWithRecipient,
+      // contentSidSafety: undefined
+      sendPush,
+      sendWhatsapp,
+    });
+
+    expect(outcome).toBe('notified');
+    expect(sendPush).toHaveBeenCalledTimes(1);
+    expect(sendWhatsapp).not.toHaveBeenCalled();
+  });
+
+  it('push throws → best-effort: resultado es notified, sendWhatsapp igual se llama', async () => {
+    const redis = { set: vi.fn().mockResolvedValue('OK') } as never;
+    const sendPush = vi.fn().mockRejectedValue(new Error('push timeout'));
+    const sendWhatsapp = vi.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
+
+    const outcome = await dispatchSafetyNotification({
+      redis,
+      db: dbStub,
+      logger,
+      event: safetyEvent,
+      routing: routingWithRecipient,
+      contentSidSafety: 'HX123',
+      sendPush,
+      sendWhatsapp,
+    });
+
+    // A pesar del fallo en push, se retorna 'notified' y se intentó WhatsApp
+    expect(outcome).toBe('notified');
+    expect(sendWhatsapp).toHaveBeenCalledTimes(1);
+    // El error fue logueado
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('recipient con phone null → WhatsApp saltado para ese recipient, push sí intentado', async () => {
+    const routingNullPhone: SafetyRouting = {
+      empresaId: 'emp-uuid',
+      vehicleLabel: 'ABCD12',
+      trackingCode: null,
+      recipients: [{ userId: 'user-no-phone', phoneE164: null }],
+    };
+
+    const redis = { set: vi.fn().mockResolvedValue('OK') } as never;
+    const sendPush = vi.fn().mockResolvedValue(undefined);
+    const sendWhatsapp = vi.fn();
+    const logger = makeLogger();
+
+    const outcome = await dispatchSafetyNotification({
+      redis,
+      db: dbStub,
+      logger,
+      event: safetyEvent,
+      routing: routingNullPhone,
+      contentSidSafety: 'HX123',
+      sendPush,
+      sendWhatsapp,
+    });
+
+    expect(outcome).toBe('notified');
+    // Push intentado a pesar de no tener phone
+    expect(sendPush).toHaveBeenCalledTimes(1);
+    expect(sendPush.mock.calls[0]?.[0].userId).toBe('user-no-phone');
+    // WhatsApp NO llamado porque phoneE164 es null
+    expect(sendWhatsapp).not.toHaveBeenCalled();
+  });
+
+  it('viaje null → variable 4 dice "Sin viaje activo"', async () => {
+    const routingNoViaje: SafetyRouting = {
+      empresaId: 'emp-uuid',
+      vehicleLabel: 'ABCD12',
+      trackingCode: null,
+      recipients: [{ userId: 'user-1', phoneE164: '+56912345678' }],
+    };
+
+    const redis = { set: vi.fn().mockResolvedValue('OK') } as never;
+    const sendPush = vi.fn().mockResolvedValue(undefined);
+    const sendWhatsapp = vi.fn().mockResolvedValue(undefined);
+    const logger = makeLogger();
+
+    await dispatchSafetyNotification({
+      redis,
+      db: dbStub,
+      logger,
+      event: safetyEvent,
+      routing: routingNoViaje,
+      contentSidSafety: 'HX123',
+      sendPush,
+      sendWhatsapp,
+    });
+
+    const waCall = sendWhatsapp.mock.calls[0]?.[0];
+    expect(waCall.contentVariables['4']).toBe('Sin viaje activo');
+  });
+});

--- a/apps/api/src/services/dispatch-safety-notification.ts
+++ b/apps/api/src/services/dispatch-safety-notification.ts
@@ -1,0 +1,150 @@
+/**
+ * dispatchSafetyNotification — Task 9
+ *
+ * Envía notificaciones de seguridad física (push + WhatsApp) a los dueños
+ * del transportista cuando ocurre un evento safety-p0 (crash/unplug/jamming).
+ *
+ * Garantías:
+ *   - Dedupe por IMEI+eventType con TTL 600s en Redis (SET NX EX).
+ *   - Best-effort en push y WhatsApp: el fallo de un canal no impide el otro.
+ *   - La función NUNCA lanza. Si el dedupe pasa y hay recipients, retorna 'notified'.
+ *   - Zero console.* — logging 100% vía logger inyectado.
+ */
+
+import type { Logger } from '@booster-ai/logger';
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+import type { Redis } from 'ioredis';
+import type { Db } from '../db/client.js';
+import type { SafetyRouting } from './route-safety-recipients.js';
+import { safetyEventLabel } from './safety-event-labels.js';
+import type { ChatPushPayload } from './web-push.js';
+
+export type DispatchOutcome = 'notified' | 'deduped' | 'no_recipient';
+
+/**
+ * Formatea el timestamp UTC del evento como hora local en Chile (America/Santiago).
+ * Produce una cadena corta y legible para el mensaje de WhatsApp.
+ *
+ * Ejemplo: "15 jun, 10:00"
+ */
+function formatHoraLocal(occurredAt: string): string {
+  return new Date(occurredAt).toLocaleString('es-CL', {
+    timeZone: 'America/Santiago',
+    hour: '2-digit',
+    minute: '2-digit',
+    day: '2-digit',
+    month: 'short',
+  });
+}
+
+export async function dispatchSafetyNotification(opts: {
+  redis: Redis;
+  db: Db;
+  logger: Logger;
+  event: SafetyEvent;
+  routing: SafetyRouting;
+  contentSidSafety?: string;
+  sendPush: (a: {
+    db: Db;
+    logger: Logger;
+    userId: string;
+    payload: ChatPushPayload;
+  }) => Promise<unknown>;
+  sendWhatsapp: (a: {
+    to: string;
+    contentSid: string;
+    contentVariables: Record<string, string>;
+  }) => Promise<unknown>;
+}): Promise<DispatchOutcome> {
+  const { redis, db, logger, event, routing, contentSidSafety, sendPush, sendWhatsapp } = opts;
+
+  // 1. Dedupe: clave por IMEI + tipo de evento, TTL 600s, solo si no existe.
+  const dedupeKey = `safety:dedupe:${event.imei}:${event.eventType}`;
+  const setResult = await redis.set(dedupeKey, '1', 'EX', 600, 'NX');
+
+  if (setResult !== 'OK') {
+    logger.info(
+      { imei: event.imei, eventType: event.eventType },
+      'dispatchSafetyNotification: evento duplicado, omitido',
+    );
+    return 'deduped';
+  }
+
+  // 2. Verificar que hay destinatarios.
+  if (routing.recipients.length === 0) {
+    logger.warn(
+      { imei: event.imei, eventType: event.eventType, empresaId: routing.empresaId },
+      'dispatchSafetyNotification: no hay destinatarios para el evento',
+    );
+    return 'no_recipient';
+  }
+
+  // 3. Construir partes del mensaje.
+  const label = safetyEventLabel(event.eventType);
+  const viaje = routing.trackingCode ?? 'Sin viaje activo';
+  const hora = formatHoraLocal(event.occurredAt);
+
+  // 4. Push a cada destinatario (best-effort: wrap en try/catch).
+  for (const recipient of routing.recipients) {
+    const pushPayload: ChatPushPayload = {
+      title: '🚨 Alerta de seguridad',
+      body: `${routing.vehicleLabel}: ${label}`,
+      tag: `safety-${event.imei}-${event.eventType}`,
+      data: {
+        assignment_id: '',
+        message_id: '',
+        url: '/app/flota',
+      },
+    };
+
+    try {
+      await sendPush({ db, logger, userId: recipient.userId, payload: pushPayload });
+    } catch (err: unknown) {
+      logger.error(
+        { err, userId: recipient.userId, imei: event.imei, eventType: event.eventType },
+        'dispatchSafetyNotification: push falló (best-effort, continuando)',
+      );
+    }
+  }
+
+  // 5. WhatsApp (solo si contentSidSafety está configurado).
+  if (contentSidSafety !== undefined) {
+    for (const recipient of routing.recipients) {
+      if (recipient.phoneE164 === null) {
+        continue;
+      }
+
+      try {
+        await sendWhatsapp({
+          to: recipient.phoneE164,
+          contentSid: contentSidSafety,
+          contentVariables: {
+            '1': routing.vehicleLabel,
+            '2': label,
+            '3': hora,
+            '4': viaje,
+          },
+        });
+      } catch (err: unknown) {
+        logger.error(
+          { err, userId: recipient.userId, imei: event.imei, eventType: event.eventType },
+          'dispatchSafetyNotification: whatsapp falló (best-effort, continuando)',
+        );
+      }
+    }
+  }
+
+  // 6. Log estructurado del despacho.
+  logger.info(
+    {
+      imei: event.imei,
+      empresaId: routing.empresaId,
+      eventType: event.eventType,
+      recipientCount: routing.recipients.length,
+      whatsappEnabled: contentSidSafety !== undefined,
+    },
+    'dispatchSafetyNotification: notificaciones despachadas',
+  );
+
+  return 'notified';
+}

--- a/apps/api/src/services/route-safety-recipients.test.ts
+++ b/apps/api/src/services/route-safety-recipients.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests de routeSafetyRecipients (Task 8 — safety notification routing).
+ *
+ * Cubre:
+ *   1. Vehicle found by vehicleId, active assignment → returns trackingCode + dueños.
+ *   2. Vehicle found by imei (no vehicleId), no active assignment → trackingCode null, dueños returned.
+ *   3. Vehicle not found → returns null.
+ *   4. Empresa with multiple dueños → all returned.
+ *   5. Dueño with null phone → phoneE164: null (still included as recipient).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Db } from '../db/client.js';
+import {
+  type SafetyRecipient,
+  type SafetyRouting,
+  routeSafetyRecipients,
+} from './route-safety-recipients.js';
+
+// ---------------------------------------------------------------------------
+// Helpers para construir el stub de Drizzle.
+//
+// La función hace DOS queries independientes con `.select().from().where()`:
+//   Q1 — vehicle lookup
+//   Q2 — active assignment + trip (joined)
+//   Q3 — memberships innerJoin users (dueños)
+//
+// Cada query usa la misma cadena pero devuelve datos distintos.
+// Usamos una queue de resultados: la primera llamada a `where` (o `on` / `limit`)
+// devuelve el primer elemento de la cola, la segunda el segundo, etc.
+// ---------------------------------------------------------------------------
+
+type SelectResult = Record<string, unknown>[];
+
+function makeDbStub(queue: SelectResult[]) {
+  let callIndex = 0;
+
+  const limit = vi.fn(async () => {
+    const result = queue[callIndex] ?? [];
+    callIndex += 1;
+    return result;
+  });
+
+  // Para las queries sin .limit() al final (la de dueños no tiene limit)
+  // necesitamos que .where() también resuelva. Creamos un objeto que tanto
+  // es thenable (si se await directamente) como tiene .limit().
+  function makeWhere(): Promise<SelectResult> & { limit: typeof limit } {
+    const idx = callIndex;
+    callIndex += 1;
+    const p = Promise.resolve(queue[idx] ?? []) as Promise<SelectResult> & { limit: typeof limit };
+    p.limit = vi.fn(async () => queue[idx] ?? []);
+    return p;
+  }
+
+  // innerJoin devuelve un objeto con .where()
+  const innerJoin = vi.fn(() => ({ where: vi.fn(makeWhere) }));
+
+  // from devuelve objeto con .where() e .innerJoin()
+  const from = vi.fn(() => ({
+    where: vi.fn(makeWhere),
+    innerJoin,
+  }));
+
+  const select = vi.fn(() => ({ from }));
+
+  return {
+    db: { select } as unknown as Db,
+  };
+}
+
+// Filas de vehículo de ejemplo
+const vehicleRow = {
+  id: 'v-uuid',
+  empresaId: 'emp-uuid',
+  plate: 'ABCD12',
+  teltonikaImei: '351756051523010',
+};
+
+// Fila de assignment + trip (active: status 'asignado')
+const assignmentRow = {
+  status: 'asignado' as const,
+  trackingCode: 'TRK-001',
+};
+
+// Fila de dueño
+function makeDuenoRow(userId: string, phone: string | null) {
+  return { userId, phoneE164: phone };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('routeSafetyRecipients', () => {
+  it('vehicle found by vehicleId, active assignment → returns trackingCode + dueños', async () => {
+    // Q1: vehicle lookup by id → 1 row
+    // Q2: active assignment+trip → 1 row (status asignado)
+    // Q3: dueños → 1 row
+    const { db } = makeDbStub([
+      [vehicleRow],
+      [assignmentRow],
+      [makeDuenoRow('user-1', '+56912345678')],
+    ]);
+
+    const result = await routeSafetyRecipients({
+      db,
+      imei: '351756051523010',
+      vehicleId: 'v-uuid',
+    });
+
+    expect(result).not.toBeNull();
+    const r = result as SafetyRouting;
+    expect(r.empresaId).toBe('emp-uuid');
+    expect(r.vehicleLabel).toBe('ABCD12');
+    expect(r.trackingCode).toBe('TRK-001');
+    expect(r.recipients).toHaveLength(1);
+    expect(r.recipients[0]).toEqual<SafetyRecipient>({
+      userId: 'user-1',
+      phoneE164: '+56912345678',
+    });
+  });
+
+  it('vehicle found by imei (no vehicleId), no active assignment → trackingCode null, dueños returned', async () => {
+    // Q1: vehicle lookup by imei → 1 row
+    // Q2: active assignment+trip → empty (parked)
+    // Q3: dueños → 1 row
+    const { db } = makeDbStub([[vehicleRow], [], [makeDuenoRow('user-1', '+56912345678')]]);
+
+    const result = await routeSafetyRecipients({
+      db,
+      imei: '351756051523010',
+      // vehicleId NOT passed
+    });
+
+    expect(result).not.toBeNull();
+    const r = result as SafetyRouting;
+    expect(r.trackingCode).toBeNull();
+    expect(r.recipients).toHaveLength(1);
+    expect(r.recipients[0]?.userId).toBe('user-1');
+  });
+
+  it('vehicle not found → returns null', async () => {
+    // Q1: vehicle lookup → empty
+    const { db } = makeDbStub([[]]);
+
+    const result = await routeSafetyRecipients({
+      db,
+      imei: 'not-in-db',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('empresa with multiple dueños → all returned', async () => {
+    // Q1: vehicle → found
+    // Q2: active assignment → found with trackingCode
+    // Q3: dueños → 2 rows
+    const { db } = makeDbStub([
+      [vehicleRow],
+      [assignmentRow],
+      [makeDuenoRow('user-1', '+56911111111'), makeDuenoRow('user-2', '+56922222222')],
+    ]);
+
+    const result = await routeSafetyRecipients({
+      db,
+      imei: '351756051523010',
+      vehicleId: 'v-uuid',
+    });
+
+    expect(result).not.toBeNull();
+    const r = result as SafetyRouting;
+    expect(r.recipients).toHaveLength(2);
+    expect(r.recipients.map((rec) => rec.userId)).toEqual(['user-1', 'user-2']);
+  });
+
+  it('dueño with null phone → phoneE164: null (still a recipient)', async () => {
+    // Q1: vehicle → found
+    // Q2: active assignment → empty (parked)
+    // Q3: dueño with null phone
+    const { db } = makeDbStub([[vehicleRow], [], [makeDuenoRow('user-no-phone', null)]]);
+
+    const result = await routeSafetyRecipients({
+      db,
+      imei: '351756051523010',
+    });
+
+    expect(result).not.toBeNull();
+    const r = result as SafetyRouting;
+    expect(r.recipients).toHaveLength(1);
+    expect(r.recipients[0]).toEqual<SafetyRecipient>({
+      userId: 'user-no-phone',
+      phoneE164: null,
+    });
+  });
+});

--- a/apps/api/src/services/route-safety-recipients.ts
+++ b/apps/api/src/services/route-safety-recipients.ts
@@ -1,0 +1,110 @@
+/**
+ * Safety notification routing (Task 8).
+ *
+ * Resuelve un vehicleId/imei de telemetría a los dueños del transportista
+ * que deben recibir una notificación de seguridad, junto con el tracking
+ * code del viaje activo (si lo hay) y los datos de la empresa.
+ *
+ * Active-assignment: status IN ('asignado', 'recogido') — alineado con la
+ * lógica de apps/api/src/routes/assignments.ts:428 que define un viaje
+ * activo para Teltonika como aquél en estado 'asignado' o 'recogido'.
+ */
+
+import { and, eq, inArray } from 'drizzle-orm';
+import type { Db } from '../db/client.js';
+import { assignments, memberships, trips, users, vehicles } from '../db/schema.js';
+
+export interface SafetyRecipient {
+  userId: string;
+  phoneE164: string | null;
+}
+
+export interface SafetyRouting {
+  empresaId: string;
+  vehicleLabel: string;
+  trackingCode: string | null;
+  recipients: SafetyRecipient[];
+}
+
+/**
+ * Resuelve los destinatarios de una notificación de seguridad a partir de
+ * un vehículo identificado por telemetría (imei o vehicleId).
+ *
+ * @returns SafetyRouting con empresa, label del vehículo, código de
+ *   seguimiento del viaje activo (o null si está estacionado) y lista de
+ *   dueños activos del transportista.
+ *   Retorna null si el vehículo no se encuentra en la BD.
+ */
+export async function routeSafetyRecipients(opts: {
+  db: Db;
+  imei: string;
+  vehicleId?: string;
+}): Promise<SafetyRouting | null> {
+  const { db, imei, vehicleId } = opts;
+
+  // 1. Resolver el vehículo: por vehicleId si se provee, si no por imei.
+  //    NOT teltonikaImeiEspejo — solo el IMEI real ('teltonika_imei').
+  const vehicleRows = await db
+    .select({
+      id: vehicles.id,
+      empresaId: vehicles.empresaId,
+      plate: vehicles.plate,
+    })
+    .from(vehicles)
+    .where(vehicleId !== undefined ? eq(vehicles.id, vehicleId) : eq(vehicles.teltonikaImei, imei))
+    .limit(1);
+
+  const vehicle = vehicleRows[0];
+  if (!vehicle) {
+    return null;
+  }
+
+  // 2. Buscar la asignación activa del vehículo (si hay una).
+  //    Activa = status IN ('asignado', 'recogido') — el vehículo está en ruta.
+  //    Si no hay asignación activa el camión está estacionado; se notifica igual
+  //    pero sin trackingCode.
+  const activeAssignmentRows = await db
+    .select({ trackingCode: trips.trackingCode })
+    .from(assignments)
+    .innerJoin(trips, eq(trips.id, assignments.tripId))
+    .where(
+      and(
+        eq(assignments.vehicleId, vehicle.id),
+        inArray(assignments.status, ['asignado', 'recogido']),
+      ),
+    )
+    .limit(1);
+
+  const trackingCode = activeAssignmentRows[0]?.trackingCode ?? null;
+
+  // 3. Resolver los dueños activos del transportista.
+  //    Patrón copiado de notify-offer.ts:72-81 (memberships innerJoin users,
+  //    role='dueno', status='activa') con la diferencia de que acá devolvemos
+  //    TODOS los dueños (sin .limit(1)) porque safety notifications van a todos.
+  const duenoRows = await db
+    .select({
+      userId: memberships.userId,
+      phoneE164: users.phone,
+    })
+    .from(memberships)
+    .innerJoin(users, eq(users.id, memberships.userId))
+    .where(
+      and(
+        eq(memberships.empresaId, vehicle.empresaId),
+        eq(memberships.role, 'dueno'),
+        eq(memberships.status, 'activa'),
+      ),
+    );
+
+  const recipients: SafetyRecipient[] = duenoRows.map((row) => ({
+    userId: row.userId,
+    phoneE164: row.phoneE164 ?? null,
+  }));
+
+  return {
+    empresaId: vehicle.empresaId,
+    vehicleLabel: vehicle.plate,
+    trackingCode,
+    recipients,
+  };
+}

--- a/apps/api/src/services/safety-event-labels.test.ts
+++ b/apps/api/src/services/safety-event-labels.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { safetyEventLabel } from './safety-event-labels.js';
+
+describe('safetyEventLabel', () => {
+  it('mapea cada tipo a su label en español', () => {
+    expect(safetyEventLabel('crash')).toBe('Posible colisión');
+    expect(safetyEventLabel('unplug')).toBe('Desconexión de energía (manipulación)');
+    expect(safetyEventLabel('jamming')).toBe('Interferencia de señal GPS');
+  });
+});

--- a/apps/api/src/services/safety-event-labels.ts
+++ b/apps/api/src/services/safety-event-labels.ts
@@ -1,0 +1,16 @@
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+
+/**
+ * Labels en español de cada tipo de evento de seguridad, para mostrar al
+ * transportista en la notificación (push + WhatsApp). Mapping de presentación
+ * (los valores del enum son códigos técnicos en inglés).
+ */
+const LABELS: Record<SafetyEvent['eventType'], string> = {
+  crash: 'Posible colisión',
+  unplug: 'Desconexión de energía (manipulación)',
+  jamming: 'Interferencia de señal GPS',
+};
+
+export function safetyEventLabel(eventType: SafetyEvent['eventType']): string {
+  return LABELS[eventType];
+}

--- a/apps/api/test/integration/safety-events.integration.test.ts
+++ b/apps/api/test/integration/safety-events.integration.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Task 12 — Integration test: POST /internal/safety-events
+ *
+ * Smoke-test end-to-end contra:
+ *   - Postgres real (routing query vía Drizzle ORM)
+ *   - Redis real (dedupe SET NX EX vía @testcontainers/redis)
+ *   - OIDC client stubbeado (verifyIdToken no pega a la red)
+ *   - sendWhatsapp espiado (verifica que no se llama cuando contentSid=undefined)
+ *
+ * Casos:
+ *   1. notified   — empresa+vehículo+dueño activo → 200 { outcome: 'notified' }
+ *                   + clave Redis safety:dedupe:<imei>:crash existe.
+ *   2. deduped    — misma llamada inmediata → 200 { outcome: 'deduped' }
+ *                   + sendWhatsapp NO llamado (contentSid undefined).
+ *   3. 403        — email del SA stub no coincide con config → 403.
+ *   4. unknown_vehicle — IMEI sin vehículo seedeado → 200 { outcome: 'unknown_vehicle' }.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { createLogger } from '@booster-ai/logger';
+import { RedisContainer, type StartedRedisContainer } from '@testcontainers/redis';
+import type { LoginTicket, OAuth2Client, TokenPayload } from 'google-auth-library';
+import { Hono } from 'hono';
+import Redis from 'ioredis';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as schema from '../../src/db/schema.js';
+import { createInternalSafetyEventsRoutes } from '../../src/routes/internal-safety-events.js';
+import { type TestDbHandle, createTestDb } from '../helpers/test-db.js';
+
+// ── Logger ────────────────────────────────────────────────────────────────────
+
+const logger = createLogger({
+  service: 'safety-events-integration',
+  version: '0',
+  level: 'silent',
+  pretty: false,
+});
+
+// ── Constantes ────────────────────────────────────────────────────────────────
+
+const CALLER_SA = 'safety-integration-test@booster-ai.iam.gserviceaccount.com';
+const API_AUDIENCE = ['https://api.boosterchile.com'] as const;
+/** IMEI de 15 dígitos único para este suite; lo compartimos entre tests que sí
+ *  tienen vehículo seedeado. El IMEI desconocido usa un valor distinto. */
+const TEST_IMEI = '123456700000001';
+const UNKNOWN_IMEI = '999999999999999';
+
+// ── OAuth2Client stub ─────────────────────────────────────────────────────────
+
+function makeOAuthClient(email: string): OAuth2Client {
+  const verifyIdToken = vi.fn(async () => {
+    const payload: Partial<TokenPayload> = {
+      email,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    };
+    const ticket = {
+      getPayload: () => payload as TokenPayload,
+    } as LoginTicket;
+    return ticket;
+  });
+  return { verifyIdToken } as unknown as OAuth2Client;
+}
+
+// ── Envelope builder ─────────────────────────────────────────────────────────
+
+function makeEnvelope(event: unknown): Record<string, unknown> {
+  return {
+    message: {
+      data: Buffer.from(JSON.stringify(event)).toString('base64'),
+      messageId: 'test-1',
+    },
+    subscription: 'test-sub',
+  };
+}
+
+const VALID_EVENT = {
+  eventType: 'crash' as const,
+  imei: TEST_IMEI,
+  occurredAt: '2026-06-15T14:32:00.000Z',
+};
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe('integration: POST /internal/safety-events', () => {
+  let dbHandle: TestDbHandle;
+  let container: StartedRedisContainer;
+  let redis: Redis;
+
+  // IDs del seed — rellenados en beforeEach para limpiar FK en orden correcto.
+  let seedEmpresaId: string;
+  let seedUserId: string;
+  let _seedVehicleId: string;
+  let seedMembershipId: string;
+
+  beforeAll(async () => {
+    dbHandle = createTestDb();
+
+    container = await new RedisContainer('redis:7-alpine').start();
+    redis = new Redis({
+      host: container.getHost(),
+      port: container.getMappedPort(6379),
+      maxRetriesPerRequest: 1,
+      enableOfflineQueue: false,
+      commandTimeout: 1500,
+      lazyConnect: true,
+    });
+    redis.on('error', () => undefined);
+    await redis.connect();
+    await redis.ping();
+  }, 120_000);
+
+  afterAll(async () => {
+    redis?.disconnect();
+    await container?.stop().catch(() => undefined);
+    await dbHandle?.pool.end();
+  });
+
+  beforeEach(async () => {
+    // ── cleanup previo (FK order: memberships → vehicles → users → empresas) ──
+    await dbHandle.pool.query('DELETE FROM membresias WHERE id = $1', [
+      seedMembershipId ?? '00000000-0000-0000-0000-000000000000',
+    ]);
+    await dbHandle.pool.query('DELETE FROM vehiculos WHERE empresa_id = $1', [
+      seedEmpresaId ?? '00000000-0000-0000-0000-000000000000',
+    ]);
+    await dbHandle.pool.query("DELETE FROM usuarios WHERE email LIKE 'safety-integration-%'");
+    await dbHandle.pool.query(
+      "DELETE FROM empresas WHERE email_contacto LIKE 'safety-integration-%'",
+    );
+    await redis.flushdb();
+
+    // ── Seed plan (gratis, onConflictDoNothing) ───────────────────────────────
+    const { db } = dbHandle;
+    const suffix = randomUUID().slice(0, 8);
+
+    const [planRow] = await db
+      .insert(schema.plans)
+      .values({
+        slug: 'gratis',
+        name: 'Plan Gratis (integration)',
+        description: 'Plan de fixture para integration tests',
+        monthlyPriceClp: 0,
+        features: {},
+      })
+      .onConflictDoNothing({ target: schema.plans.slug })
+      .returning({ id: schema.plans.id });
+
+    const planId =
+      planRow?.id ??
+      (await db.select({ id: schema.plans.id }).from(schema.plans).limit(1)).at(0)?.id;
+
+    if (!planId) {
+      throw new Error('safety-events integration: no se pudo obtener un planId');
+    }
+
+    // ── Empresa transportista ─────────────────────────────────────────────────
+    const [empresaRow] = await db
+      .insert(schema.empresas)
+      .values({
+        legalName: `Safety Integration SpA ${suffix}`,
+        rut: `${Math.floor(10_000_000 + Math.random() * 89_999_999)}-K`,
+        contactEmail: `safety-integration-empresa-${suffix}@test.invalid`,
+        contactPhone: '+56911111111',
+        addressStreet: 'Av. Integración 100',
+        addressCity: 'Santiago',
+        addressRegion: 'RM',
+        isTransportista: true,
+        planId,
+      })
+      .returning({ id: schema.empresas.id });
+
+    if (!empresaRow) {
+      throw new Error('safety-events integration: empresa no creada');
+    }
+    seedEmpresaId = empresaRow.id;
+
+    // ── Vehículo con IMEI fijo ────────────────────────────────────────────────
+    const [vehicleRow] = await db
+      .insert(schema.vehicles)
+      .values({
+        empresaId: seedEmpresaId,
+        plate: `SI${suffix.slice(0, 4).toUpperCase()}`,
+        vehicleType: 'camion_mediano',
+        capacityKg: 5000,
+        teltonikaImei: TEST_IMEI,
+      })
+      .returning({ id: schema.vehicles.id });
+
+    if (!vehicleRow) {
+      throw new Error('safety-events integration: vehicle no creado');
+    }
+    _seedVehicleId = vehicleRow.id;
+
+    // ── Usuario (dueño) ───────────────────────────────────────────────────────
+    const [userRow] = await db
+      .insert(schema.users)
+      .values({
+        firebaseUid: `fb-safety-integration-${suffix}`,
+        email: `safety-integration-owner-${suffix}@test.invalid`,
+        fullName: 'Safety Integration Dueño',
+        status: 'activo',
+      })
+      .returning({ id: schema.users.id });
+
+    if (!userRow) {
+      throw new Error('safety-events integration: usuario no creado');
+    }
+    seedUserId = userRow.id;
+
+    // ── Membership dueño activa ───────────────────────────────────────────────
+    const [membershipRow] = await db
+      .insert(schema.memberships)
+      .values({
+        userId: seedUserId,
+        empresaId: seedEmpresaId,
+        role: 'dueno',
+        status: 'activa',
+      })
+      .returning({ id: schema.memberships.id });
+
+    if (!membershipRow) {
+      throw new Error('safety-events integration: membership no creada');
+    }
+    seedMembershipId = membershipRow.id;
+  });
+
+  // ── Helper: construye la app con el stub de OIDC indicado ────────────────
+
+  function makeApp(callerSaEmail: string, sendWhatsappSpy = vi.fn().mockResolvedValue(undefined)) {
+    const app = new Hono();
+    app.route(
+      '/internal/safety-events',
+      createInternalSafetyEventsRoutes({
+        db: dbHandle.db,
+        redis,
+        logger,
+        config: {
+          safetyPushCallerSa: CALLER_SA,
+          apiAudience: API_AUDIENCE,
+          contentSidSafetyAlert: undefined,
+        },
+        sendWhatsapp: sendWhatsappSpy,
+        oauthClient: makeOAuthClient(callerSaEmail),
+        // routeRecipients y dispatch NO inyectados → usa los reales (integration point)
+      }),
+    );
+    return { app, sendWhatsappSpy };
+  }
+
+  // ── Test 1: notified ──────────────────────────────────────────────────────
+
+  it('notified: empresa+vehículo+dueño activo → 200 { outcome: "notified" } + clave Redis', async () => {
+    const { app } = makeApp(CALLER_SA);
+
+    const res = await app.request('/internal/safety-events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer faketoken',
+      },
+      body: JSON.stringify(makeEnvelope(VALID_EVENT)),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { outcome: string };
+    expect(body.outcome).toBe('notified');
+
+    // Verificar clave de dedupe en Redis
+    const dedupeKey = `safety:dedupe:${TEST_IMEI}:crash`;
+    const redisVal = await redis.get(dedupeKey);
+    expect(redisVal).toBeTruthy();
+  });
+
+  // ── Test 2: deduped ───────────────────────────────────────────────────────
+
+  it('deduped: segunda llamada inmediata → 200 { outcome: "deduped" } + sendWhatsapp no llamado', async () => {
+    const sendWhatsappSpy = vi.fn().mockResolvedValue(undefined);
+    const { app } = makeApp(CALLER_SA, sendWhatsappSpy);
+
+    const envelope = makeEnvelope(VALID_EVENT);
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer faketoken',
+    };
+
+    // Primera llamada → notified (setea la clave Redis)
+    const first = await app.request('/internal/safety-events', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(envelope),
+    });
+    expect(first.status).toBe(200);
+    expect(((await first.json()) as { outcome: string }).outcome).toBe('notified');
+
+    // Segunda llamada → deduped (la clave ya existe)
+    const second = await app.request('/internal/safety-events', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(envelope),
+    });
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as { outcome: string };
+    expect(secondBody.outcome).toBe('deduped');
+
+    // contentSidSafetyAlert = undefined → sendWhatsapp NUNCA debe llamarse
+    expect(sendWhatsappSpy).not.toHaveBeenCalled();
+  });
+
+  // ── Test 3: 403 por SA incorrecto ─────────────────────────────────────────
+
+  it('403: email del SA stub no coincide con config → 403', async () => {
+    const { app } = makeApp('attacker@evil.iam.gserviceaccount.com');
+
+    const res = await app.request('/internal/safety-events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer faketoken',
+      },
+      body: JSON.stringify(makeEnvelope(VALID_EVENT)),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  // ── Test 4: unknown_vehicle ───────────────────────────────────────────────
+
+  it('unknown_vehicle: IMEI sin vehículo seedeado → 200 { outcome: "unknown_vehicle" }', async () => {
+    const { app } = makeApp(CALLER_SA);
+
+    const unknownEvent = {
+      eventType: 'crash' as const,
+      imei: UNKNOWN_IMEI,
+      occurredAt: '2026-06-15T14:32:00.000Z',
+    };
+
+    const res = await app.request('/internal/safety-events', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer faketoken',
+      },
+      body: JSON.stringify(makeEnvelope(unknownEvent)),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { outcome: string };
+    expect(body.outcome).toBe('unknown_vehicle');
+  });
+});

--- a/apps/telemetry-processor/src/build-crash-safety-event.test.ts
+++ b/apps/telemetry-processor/src/build-crash-safety-event.test.ts
@@ -1,0 +1,53 @@
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+import { describe, expect, it } from 'vitest';
+import { buildCrashSafetyEvent } from './build-crash-safety-event.js';
+
+describe('buildCrashSafetyEvent', () => {
+  it('construye un SafetyEvent crash con vehicleId cuando está presente', () => {
+    const vehicleId = '123e4567-e89b-12d3-a456-426614174000';
+    const result: SafetyEvent = buildCrashSafetyEvent({
+      imei: '863238075489155',
+      vehicleId,
+      occurredAtMs: 1749998520000,
+    });
+
+    expect(result.eventType).toBe('crash');
+    expect(result.imei).toBe('863238075489155');
+    expect(result.vehicleId).toBe(vehicleId);
+    expect(result.occurredAt).toBe(new Date(1749998520000).toISOString());
+    expect(result.rawValue).toBeUndefined();
+  });
+
+  it('omite vehicleId del output cuando el input es null', () => {
+    const result: SafetyEvent = buildCrashSafetyEvent({
+      imei: '863238075489155',
+      vehicleId: null,
+      occurredAtMs: 1749998520000,
+    });
+
+    expect(result.eventType).toBe('crash');
+    expect(result.vehicleId).toBeUndefined();
+    expect('vehicleId' in result).toBe(false);
+  });
+
+  it('convierte occurredAtMs como number a ISO string correcto', () => {
+    const tsMs = 1749998520000;
+    const result = buildCrashSafetyEvent({
+      imei: '863238075489155',
+      vehicleId: null,
+      occurredAtMs: tsMs,
+    });
+
+    expect(result.occurredAt).toBe(new Date(1749998520000).toISOString());
+  });
+
+  it('convierte occurredAtMs como string numérico a ISO string correcto', () => {
+    const result = buildCrashSafetyEvent({
+      imei: '863238075489155',
+      vehicleId: null,
+      occurredAtMs: '1749998520000',
+    });
+
+    expect(result.occurredAt).toBe(new Date(1749998520000).toISOString());
+  });
+});

--- a/apps/telemetry-processor/src/build-crash-safety-event.ts
+++ b/apps/telemetry-processor/src/build-crash-safety-event.ts
@@ -1,0 +1,22 @@
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+
+/**
+ * Construye el SafetyEvent 'crash' a partir de los datos del crash trace.
+ *
+ * Función pura: no tiene efectos secundarios ni dependencias de módulo.
+ * El timestamp proviene de `trace.crashTimestampMs` (BigInt serializado a
+ * number por el caller) — es el mismo valor que usa `persistCrashTrace`
+ * para el campo `timestamp` de BigQuery.
+ */
+export function buildCrashSafetyEvent(opts: {
+  imei: string;
+  vehicleId: string | null;
+  occurredAtMs: number | string;
+}): SafetyEvent {
+  return {
+    eventType: 'crash',
+    imei: opts.imei,
+    ...(opts.vehicleId ? { vehicleId: opts.vehicleId } : {}),
+    occurredAt: new Date(Number(opts.occurredAtMs)).toISOString(),
+  };
+}

--- a/apps/telemetry-processor/src/config.ts
+++ b/apps/telemetry-processor/src/config.ts
@@ -28,6 +28,13 @@ const envSchema = z.object({
   BIGQUERY_CRASH_TABLE: z.string().default('crash_events'),
 
   /**
+   * Topic Pub/Sub de eventos de seguridad (safety-p0). El processor publica
+   * crash/unplug/jamming acá para el fan-out al transportista. Vacío = no
+   * publica (dev/test sin topic configurado).
+   */
+  SAFETY_EVENTS_TOPIC: z.string().default(''),
+
+  /**
    * Mensajes a procesar en paralelo. Pub/Sub flow control. Más alto
    * = más throughput pero más memoria y carga DB. 50-100 es balance OK
    * para piloto.

--- a/apps/telemetry-processor/src/main.ts
+++ b/apps/telemetry-processor/src/main.ts
@@ -11,10 +11,11 @@ import {
   createBigQueryCrashTraceIndexer,
   createGcsCrashTraceUploader,
 } from './crash-trace-adapters.js';
-import { logPanicEvents } from './panic-events.js';
+import { logPanicEvents, publishPanicEvents } from './panic-events.js';
 import { crashTraceMessageSchema, persistCrashTrace } from './persist-crash-trace.js';
 import { persistGreenDrivingFromRecord } from './persist-green-driving.js';
 import { persistRecord, recordMessageSchema } from './persist.js';
+import { publishSafetyEvent } from './publish-safety-events.js';
 
 /**
  * telemetry-processor: consumer Pub/Sub de dos topics:
@@ -95,6 +96,12 @@ async function main(): Promise<void> {
       // ANTES del persist a propósito: el evento alerta aunque el device
       // esté pendiente o el insert falle (spec fix-telemetry-panic-event-alerts).
       logPanicEvents({ logger, msg: parsed.data, messageId: message.id });
+      void publishPanicEvents({
+        msg: parsed.data,
+        topicName: config.SAFETY_EVENTS_TOPIC,
+        logger,
+        publish: (a) => publishSafetyEvent(a),
+      });
 
       const result = await persistRecord({ db, logger, msg: parsed.data });
 

--- a/apps/telemetry-processor/src/main.ts
+++ b/apps/telemetry-processor/src/main.ts
@@ -6,6 +6,7 @@ import { type Message, PubSub, type Subscription } from '@google-cloud/pubsub';
 import { Storage } from '@google-cloud/storage';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import pg from 'pg';
+import { buildCrashSafetyEvent } from './build-crash-safety-event.js';
 import { loadConfig } from './config.js';
 import {
   createBigQueryCrashTraceIndexer,
@@ -222,6 +223,16 @@ async function main(): Promise<void> {
           bucketName: config.GCS_CRASH_TRACES_BUCKET,
           bigQueryDatasetId: config.BIGQUERY_CRASH_DATASET,
           bigQueryTableId: config.BIGQUERY_CRASH_TABLE,
+          logger,
+        });
+
+        void publishSafetyEvent({
+          topicName: config.SAFETY_EVENTS_TOPIC,
+          event: buildCrashSafetyEvent({
+            imei: parsed.data.imei,
+            vehicleId: parsed.data.vehicleId,
+            occurredAtMs: Number(trace.crashTimestampMs),
+          }),
           logger,
         });
 

--- a/apps/telemetry-processor/src/panic-events.test.ts
+++ b/apps/telemetry-processor/src/panic-events.test.ts
@@ -1,0 +1,110 @@
+import type { Logger } from '@booster-ai/logger';
+import type { SafetyEvent, TelemetryRecordMessage } from '@booster-ai/shared-schemas';
+import { describe, expect, it, vi } from 'vitest';
+import { publishPanicEvents } from './panic-events.js';
+
+type PublishFn = (a: { topicName: string; event: SafetyEvent; logger: Logger }) => Promise<void>;
+
+function fakeLogger(): Logger {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger;
+}
+
+function makeMsg(
+  entries: { id: number; value: number | string; byteSize?: 1 | 2 | 4 | 8 | null }[],
+): TelemetryRecordMessage {
+  return {
+    imei: '863238075489155',
+    vehicleId: null,
+    record: {
+      timestampMs: '1749998520000', // 2025-06-15T14:22:00.000Z
+      priority: 1,
+      gps: {
+        longitude: -70.6506,
+        latitude: -33.437,
+        altitude: 567,
+        angle: 45,
+        satellites: 8,
+        speedKmh: 60,
+      },
+      io: {
+        eventIoId: 252,
+        totalIo: entries.length,
+        entries: entries.map((e) => ({ id: e.id, value: e.value, byteSize: e.byteSize ?? 1 })),
+      },
+    },
+  };
+}
+
+describe('publishPanicEvents', () => {
+  it('llama publish una vez con SafetyEvent unplug cuando AVL 252 = 1', async () => {
+    const msg = makeMsg([{ id: 252, value: 1 }]);
+    const publish = vi.fn<PublishFn>().mockResolvedValue(undefined);
+
+    await publishPanicEvents({
+      msg,
+      topicName: 'safety-p0',
+      logger: fakeLogger(),
+      publish,
+    });
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    const called = publish.mock.calls[0]?.[0];
+    expect(called?.topicName).toBe('safety-p0');
+    expect(called?.event.eventType).toBe('unplug');
+    expect(called?.event.imei).toBe('863238075489155');
+    expect(called?.event.occurredAt).toBe(new Date(1749998520000).toISOString());
+    expect(called?.event.rawValue).toBe(1);
+  });
+
+  it('no llama publish cuando no hay IO de pánico', async () => {
+    // AVL 66 (velocidad) — no es pánico
+    const msg = makeMsg([{ id: 66, value: 80 }]);
+    const publish = vi.fn<PublishFn>().mockResolvedValue(undefined);
+
+    await publishPanicEvents({
+      msg,
+      topicName: 'safety-p0',
+      logger: fakeLogger(),
+      publish,
+    });
+
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('llama publish una vez con SafetyEvent jamming cuando AVL 318 = 2', async () => {
+    const msg = makeMsg([{ id: 318, value: 2 }]);
+    const publish = vi.fn<PublishFn>().mockResolvedValue(undefined);
+
+    await publishPanicEvents({
+      msg,
+      topicName: 'safety-p0',
+      logger: fakeLogger(),
+      publish,
+    });
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    const event = publish.mock.calls[0]?.[0]?.event;
+    expect(event?.eventType).toBe('jamming');
+    expect(event?.rawValue).toBe(2);
+  });
+
+  it('llama publish dos veces cuando hay Unplug Y GnssJamming en el mismo record', async () => {
+    const msg = makeMsg([
+      { id: 252, value: 1 },
+      { id: 318, value: 1 },
+    ]);
+    const publish = vi.fn<PublishFn>().mockResolvedValue(undefined);
+
+    await publishPanicEvents({
+      msg,
+      topicName: 'safety-p0',
+      logger: fakeLogger(),
+      publish,
+    });
+
+    expect(publish).toHaveBeenCalledTimes(2);
+    const types = publish.mock.calls.map((c) => c[0]?.event.eventType);
+    expect(types).toContain('unplug');
+    expect(types).toContain('jamming');
+  });
+});

--- a/apps/telemetry-processor/src/panic-events.ts
+++ b/apps/telemetry-processor/src/panic-events.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@booster-ai/logger';
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
 import type { RecordMessage } from './persist.js';
 
 /**
@@ -43,6 +44,30 @@ export function detectPanicEvents(msg: RecordMessage): PanicEvent[] {
     }
   }
   return events;
+}
+
+const EVENT_NAME_TO_TYPE: Record<'Unplug' | 'GnssJamming', SafetyEvent['eventType']> = {
+  Unplug: 'unplug',
+  GnssJamming: 'jamming',
+};
+
+/** Publica un SafetyEvent por cada panic detectado. `publish` inyectable para tests. */
+export async function publishPanicEvents(opts: {
+  msg: RecordMessage;
+  topicName: string;
+  logger: Logger;
+  publish: (a: { topicName: string; event: SafetyEvent; logger: Logger }) => Promise<void>;
+}): Promise<void> {
+  const events = detectPanicEvents(opts.msg);
+  for (const e of events) {
+    const event: SafetyEvent = {
+      eventType: EVENT_NAME_TO_TYPE[e.eventName],
+      imei: opts.msg.imei,
+      occurredAt: new Date(Number(opts.msg.record.timestampMs)).toISOString(),
+      rawValue: e.rawValue,
+    };
+    await opts.publish({ topicName: opts.topicName, event, logger: opts.logger });
+  }
 }
 
 /**

--- a/apps/telemetry-processor/src/publish-safety-events.test.ts
+++ b/apps/telemetry-processor/src/publish-safety-events.test.ts
@@ -1,0 +1,54 @@
+import type { Logger } from '@booster-ai/logger';
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+import { describe, expect, it, vi } from 'vitest';
+import { publishSafetyEvent } from './publish-safety-events.js';
+
+function fakeLogger(): Logger {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger;
+}
+const ev: SafetyEvent = {
+  eventType: 'unplug',
+  imei: '863238075489155',
+  occurredAt: '2026-06-15T14:32:00.000Z',
+};
+
+describe('publishSafetyEvent', () => {
+  it('publica con data JSON + attributes imei/event_type', async () => {
+    const publishMessage = vi.fn().mockResolvedValue('msg-1');
+    const topic = vi.fn().mockReturnValue({ publishMessage });
+    await publishSafetyEvent({
+      topicName: 'safety-p0',
+      event: ev,
+      logger: fakeLogger(),
+      pubsub: { topic } as never,
+    });
+    expect(topic).toHaveBeenCalledWith('safety-p0');
+    const arg = publishMessage.mock.calls[0]?.[0];
+    expect(JSON.parse(arg.data.toString())).toMatchObject({
+      eventType: 'unplug',
+      imei: '863238075489155',
+    });
+    expect(arg.attributes).toEqual({ imei: '863238075489155', event_type: 'unplug' });
+  });
+
+  it('no lanza si Pub/Sub falla (fire-and-forget) y loguea error', async () => {
+    const publishMessage = vi.fn().mockRejectedValue(new Error('pubsub down'));
+    const topic = vi.fn().mockReturnValue({ publishMessage });
+    const logger = fakeLogger();
+    await expect(
+      publishSafetyEvent({ topicName: 'safety-p0', event: ev, logger, pubsub: { topic } as never }),
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('no publica si topicName está vacío', async () => {
+    const topic = vi.fn();
+    await publishSafetyEvent({
+      topicName: '',
+      event: ev,
+      logger: fakeLogger(),
+      pubsub: { topic } as never,
+    });
+    expect(topic).not.toHaveBeenCalled();
+  });
+});

--- a/apps/telemetry-processor/src/publish-safety-events.ts
+++ b/apps/telemetry-processor/src/publish-safety-events.ts
@@ -1,0 +1,36 @@
+import type { Logger } from '@booster-ai/logger';
+import type { SafetyEvent } from '@booster-ai/shared-schemas';
+import { PubSub } from '@google-cloud/pubsub';
+
+let cached: PubSub | null = null;
+function defaultClient(): PubSub {
+  if (!cached) {
+    cached = new PubSub();
+  }
+  return cached;
+}
+
+/** Publica un SafetyEvent al topic. Fire-and-forget: nunca lanza ni bloquea el ack del record. */
+export async function publishSafetyEvent(opts: {
+  topicName: string;
+  event: SafetyEvent;
+  logger: Logger;
+  pubsub?: Pick<PubSub, 'topic'>;
+}): Promise<void> {
+  const { topicName, event, logger } = opts;
+  if (!topicName) {
+    return; // dev/test sin topic configurado
+  }
+  const pubsub = opts.pubsub ?? defaultClient();
+  try {
+    await pubsub.topic(topicName).publishMessage({
+      data: Buffer.from(JSON.stringify(event)),
+      attributes: { imei: event.imei, event_type: event.eventType },
+    });
+  } catch (err) {
+    logger.error(
+      { err, imei: event.imei, eventType: event.eventType },
+      'publishSafetyEvent falló (evento ya logueado para on-call)',
+    );
+  }
+}

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -93,6 +93,9 @@ module "service_api" {
     # Ambas se mantienen aceptadas; su costo es 0.
     API_AUDIENCE      = "${local.public_api_url},${local.cloud_run_api_url}"
     ALLOWED_CALLER_SA = google_service_account.cloud_run_runtime.email
+    # Safety fan-out (P0-G): el endpoint /internal/safety-events valida que el
+    # OIDC entrante (push subscription safety-p0) venga de este SA.
+    SAFETY_PUSH_CALLER_SA = google_service_account.safety_push_invoker.email
     # Origins permitidos al api. La PWA nueva corre en https://app.${var.domain}
     # — sin esto el browser bloquea preflight OPTIONS y todas las requests
     # cross-origin desde el frontend fallan con "Failed to fetch".
@@ -447,6 +450,8 @@ module "service_telemetry_processor" {
     BIGQUERY_CRASH_DATASET           = google_bigquery_dataset.telemetry.dataset_id
     BIGQUERY_CRASH_TABLE             = google_bigquery_table.crash_events.table_id
     PUBSUB_SUBSCRIPTION_CRASH_TRACES = google_pubsub_subscription.crash_traces_processor.name
+    # Safety fan-out (P0-G): topic al que el processor publica crash/unplug/jamming.
+    SAFETY_EVENTS_TOPIC = google_pubsub_topic.telemetry_events_safety_p0.name
   })
   secrets = local.common_secrets
 

--- a/infrastructure/messaging.tf
+++ b/infrastructure/messaging.tf
@@ -249,12 +249,24 @@ resource "google_pubsub_subscription" "telemetry_events_safety_p0_notification" 
   # deberían disparar en < 5s, ack en < 30s con margen.
   ack_deadline_seconds = 30
 
-  # 7 días: si el notification-service está caído, no perdemos eventos
-  # críticos por retención corta.
+  # 7 días: si el consumer está caído, no perdemos eventos críticos por
+  # retención corta.
   message_retention_duration = "604800s"
 
-  expiration_policy {
-    ttl = ""
+  # PUSH → apps/api (safety fan-out P0-G). El consumer NO es notification-service
+  # (skeleton, se retira en el cleanup de demo) sino el endpoint OIDC en el api.
+  #
+  # Endpoint = public_api_url (api.boosterchile.com), NO el run.app: el api corre
+  # con ingress=INTERNAL_LOAD_BALANCER (ADR-062), así que el push entra por el LB.
+  # audience DEBE coincidir con una entrada de API_AUDIENCE (compute.tf) o el
+  # endpoint da 401 a cada mensaje — acá usamos public_api_url, que está en
+  # API_AUDIENCE. El endpoint además valida email==SAFETY_PUSH_CALLER_SA.
+  push_config {
+    push_endpoint = "${local.public_api_url}/internal/safety-events"
+    oidc_token {
+      service_account_email = google_service_account.safety_push_invoker.email
+      audience              = local.public_api_url
+    }
   }
 
   dead_letter_policy {
@@ -271,10 +283,44 @@ resource "google_pubsub_subscription" "telemetry_events_safety_p0_notification" 
   labels = {
     env        = var.environment
     managed_by = "terraform"
-    consumer   = "notification-service"
+    consumer   = "api-safety-fanout"
     wave       = "2"
     priority   = "panic"
   }
+
+  depends_on = [google_service_account_iam_member.pubsub_safety_push_token_creator]
+}
+
+# SA dedicado con el que Pub/Sub firma el OIDC token de la push subscription
+# safety-p0. Identidad distinta y de mínimo privilegio (least privilege): el
+# endpoint del api valida `claims.email == SAFETY_PUSH_CALLER_SA` (= este email,
+# inyectado en compute.tf).
+resource "google_service_account" "safety_push_invoker" {
+  account_id   = "safety-push-invoker"
+  display_name = "Safety events push invoker"
+  description  = "SA con el que Pub/Sub firma el OIDC de la push subscription telemetry-events-safety-p0 → POST /internal/safety-events del api (safety fan-out P0-G)."
+  project      = google_project.booster_ai.project_id
+  depends_on   = [google_project_service.apis]
+}
+
+# Para emitir tokens OIDC como `safety_push_invoker`, el service agent de Pub/Sub
+# necesita Token Creator sobre ese SA. Requisito de GCP para push + oidc_token.
+resource "google_service_account_iam_member" "pubsub_safety_push_token_creator" {
+  service_account_id = google_service_account.safety_push_invoker.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:service-${google_project.booster_ai.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+# Permitir que el SA invoque booster-ai-api. El api ya es public=true (allUsers
+# para CORS preflight); este binding explícito documenta la intención y protege
+# si en el futuro se restringe el invoker. Mismo patrón que scheduler_invoker_api.
+resource "google_cloud_run_v2_service_iam_member" "safety_push_invoker_api" {
+  project    = google_project.booster_ai.project_id
+  location   = var.region
+  name       = "booster-ai-api"
+  role       = "roles/run.invoker"
+  member     = "serviceAccount:${google_service_account.safety_push_invoker.email}"
+  depends_on = [module.service_api]
 }
 
 resource "google_pubsub_subscription" "telemetry_events_security_p1_notification" {

--- a/packages/shared-schemas/src/domain/safety-event.test.ts
+++ b/packages/shared-schemas/src/domain/safety-event.test.ts
@@ -17,10 +17,22 @@ describe('safetyEventSchema', () => {
     expect(() =>
       safetyEventSchema.parse({
         eventType: 'foo',
-        imei: '1',
+        imei: '863238075489155',
         occurredAt: '2026-06-15T14:32:00.000Z',
       }),
     ).toThrow();
+  });
+
+  it('rechaza imei no-numérico o de largo inválido', () => {
+    for (const imei of ['x', '1', '12345678901234567', 'abc']) {
+      expect(() =>
+        safetyEventSchema.parse({
+          eventType: 'crash',
+          imei,
+          occurredAt: '2026-06-15T14:32:00.000Z',
+        }),
+      ).toThrow();
+    }
   });
 
   it('imei es obligatorio; vehicleId es opcional', () => {

--- a/packages/shared-schemas/src/domain/safety-event.test.ts
+++ b/packages/shared-schemas/src/domain/safety-event.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { safetyEventSchema } from './safety-event.js';
+
+describe('safetyEventSchema', () => {
+  it('parsea un evento válido', () => {
+    const parsed = safetyEventSchema.parse({
+      eventType: 'crash',
+      imei: '863238075489155',
+      vehicleId: '6487dac2-600e-4655-a20e-2ea77a6b1017',
+      occurredAt: '2026-06-15T14:32:00.000Z',
+      rawValue: 2,
+    });
+    expect(parsed.eventType).toBe('crash');
+  });
+
+  it('rechaza eventType desconocido', () => {
+    expect(() =>
+      safetyEventSchema.parse({
+        eventType: 'foo',
+        imei: '1',
+        occurredAt: '2026-06-15T14:32:00.000Z',
+      }),
+    ).toThrow();
+  });
+
+  it('imei es obligatorio; vehicleId es opcional', () => {
+    const parsed = safetyEventSchema.parse({
+      eventType: 'unplug',
+      imei: '863238075489155',
+      occurredAt: '2026-06-15T14:32:00.000Z',
+    });
+    expect(parsed.vehicleId).toBeUndefined();
+  });
+});

--- a/packages/shared-schemas/src/domain/safety-event.ts
+++ b/packages/shared-schemas/src/domain/safety-event.ts
@@ -3,8 +3,13 @@ import { z } from 'zod';
 /** Evento de seguridad física emitido por telemetry-processor al topic safety-p0. */
 export const safetyEventSchema = z.object({
   eventType: z.enum(['crash', 'unplug', 'jamming']),
-  /** IMEI del device que emitió. Siempre presente (clave de routing). */
-  imei: z.string().min(1),
+  /**
+   * IMEI del device que emitió. Siempre presente (clave de routing).
+   * 14-16 dígitos: cubre IMEI (15) e IMEISV (16); rango laxo a propósito
+   * para no descartar un evento de seguridad por un identificador atípico,
+   * pero rechaza basura no-numérica en el boundary.
+   */
+  imei: z.string().regex(/^\d{14,16}$/, 'IMEI debe ser 14-16 dígitos'),
   /** UUID del vehículo si el processor lo resolvió; el consumer hace fallback por IMEI si falta. */
   vehicleId: z.string().uuid().optional(),
   /** ISO-8601 UTC del evento. */

--- a/packages/shared-schemas/src/domain/safety-event.ts
+++ b/packages/shared-schemas/src/domain/safety-event.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+/** Evento de seguridad física emitido por telemetry-processor al topic safety-p0. */
+export const safetyEventSchema = z.object({
+  eventType: z.enum(['crash', 'unplug', 'jamming']),
+  /** IMEI del device que emitió. Siempre presente (clave de routing). */
+  imei: z.string().min(1),
+  /** UUID del vehículo si el processor lo resolvió; el consumer hace fallback por IMEI si falta. */
+  vehicleId: z.string().uuid().optional(),
+  /** ISO-8601 UTC del evento. */
+  occurredAt: z.string().datetime(),
+  /** Valor crudo del IO (ej. jamming: 1 warning, 2 crítico). */
+  rawValue: z.number().int().optional(),
+});
+
+export type SafetyEvent = z.infer<typeof safetyEventSchema>;

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -65,3 +65,6 @@ export * from './domain/cuentas-demo.js';
 
 // SEC-001 Sprint 2b H1.2 — solicitudes de registro signup gate (ADR-052)
 export * from './domain/signup-request.js';
+
+// Safety events — Pub/Sub payload para topic safety-p0 (feat/safety-event-fanout)
+export * from './domain/safety-event.js';


### PR DESCRIPTION
## ⚠️ DRAFT — no merge-ready (faltan 2 gates + integración, ver abajo)

## Contexto

Implementa el **fan-out de eventos de seguridad física** (crash / unplug / jamming) al transportista, para el go-live de **10 Teltonika reales** en clientes. Cierra el hallazgo **P0-G** de la auditoría 2026-06-14: hoy esos eventos solo alertan a on-call; **nadie del lado del cliente se entera** cuando un camión real reporta un incidente.

Spec + plan + template en `.specs/safety-event-fanout/`. Construido con **subagent-driven development + TDD** (dominio crítico safety), 10 commits.

## Arquitectura

```
telemetry-processor                          apps/api
 detecta crash/unplug/jamming                 POST /internal/safety-events (OIDC)
   → publishSafetyEvent ──► topic safety-p0 ──(push sub)──► routeSafetyRecipients(vehId→dueños)
                                                            → dispatchSafetyNotification
                                                               (dedupe Redis → push + WhatsApp)
```

- **Consumer en apps/api** (reusa `web-push`, `whatsapp-client`, patrón `notify-incident-shipper`) — el `notification-service` skeleton queda sin uso (se retira en el cleanup de demo aparte).
- **Transport** = Pub/Sub **push subscription → endpoint OIDC** (fail-closed, verifica `email === SAFETY_PUSH_CALLER_SA`, `verifyIdToken` cripto, no decode).
- **Routing**: `vehicleId`/`imei` → empresa transportista → **todos los dueños activos**; fallback a empresa directa si el camión está parado (sin viaje). Usa el IMEI real, **no** el espejo demo.
- **Dedupe** Redis `NX EX 600` por `(imei, eventType)` — anti-spam en jamming sostenido.
- **WhatsApp opcional**: sin `CONTENT_SID_SAFETY_ALERT` aprobado, sale solo push (no rompe).

## Evidencia (unit, TDD)

```
shared-schemas:      214 tests ✓   (SafetyEvent schema + IMEI boundary validation)
telemetry-processor:  56 tests ✓   (publisher fire-and-forget, producers unplug/jamming + crash)
apps/api:           1498 tests ✓   (labels, routing, dispatch+dedupe, endpoint OIDC con 11 tests de auth)
typecheck:           0 errores en los 3 paquetes
```

Reviews: routing y endpoint-OIDC pasaron review adversarial dedicado (vehículo real no espejo, fan-out a todos los dueños, auth fail-closed verificada). Producers/dispatch verificados por el controller.

## ⛔ Pendiente antes de merge (gates)

1. **Task 11 — Infra** (`messaging.tf`): cambiar `telemetry-events-safety-p0-notification-sub` de pull(notification-service) a **push → apps/api** con `oidc_token { service_account_email, audience = API_AUDIENCE }`. ⚠️ El `audience` DEBE coincidir con `config.API_AUDIENCE` o todo da 401. Apply gateado (plan revisado por PO).
2. **Template WhatsApp** → submit a Meta (`safety_alert_v1`, contenido en `.specs/.../whatsapp-template.md`); al aprobar, setear `CONTENT_SID_SAFETY_ALERT`. Lead-time 24-48h.
3. **Task 12 — Integration test** (DB+Redis end-to-end) — diferido explícitamente; unit coverage es exhaustivo.
4. **Onboarding push**: los dueños de los 10 carriers necesitan la PWA + push aceptado (acción operativa al instalar).

## ADR compliance
- [x] Zod en boundaries (envelope Pub/Sub + SafetyEvent), zero `any`/`console.*`, logger estructurado.
- [x] Auth fail-closed, `verifyIdToken` cripto (no decode), Zero-Trust OIDC.
- [x] Domain en `shared-schemas`, algoritmos en packages, services orquestan.
- [x] Coverage por TDD; Conventional Commits con scope `safety`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)