### PR TITLE
docs(claude-md): regla permanente de commit + push post-tarea

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,17 @@ Al cerrar una tarea, genero un bloque de evidencia con:
 
 Esto es coherente con `superpowers:verification-before-completion`: no declaro nada "terminado" sin evidencia fresca de la verificación corrida en el momento.
 
+## Punto de control post-tarea: commit + push (regla permanente)
+
+Al terminar CADA tarea (cuando se cumple la Definición de Terminado de `booster-skills:definicion-de-terminado`), antes de pasar a la siguiente o de cerrar la sesión, el agente DEBE:
+
+1. Identificar explícitamente que la tarea quedó terminada y que hay cambios sin persistir.
+2. Commitear con Conventional Commits con scope, incluyendo los cambios en `.specs/` (el spec/plan es parte del entregable, no solo el código).
+3. Hacer `git push` de la rama feature — respaldo en GitHub; commit local ≠ guardado.
+4. NUNCA pushear directo a `main` — `main` exige PR + squash merge (ver §Deploy).
+
+Si al cerrar el turno hay cambios sin commitear o commits sin pushear, el agente debe decirlo explícitamente y proponer el commit/push — no dejarlo pendiente en silencio. "Lo commiteo después" es drift (ver `definicion-de-terminado`).
+
 ## Escalation
 
 Si encuentro un problema que no puedo resolver con skills + principios:


### PR DESCRIPTION
## Contexto

Agrega a `CLAUDE.md` una sección nueva **"## Punto de control post-tarea: commit + push (regla permanente)"** (entre §"Cómo genero evidencia para cada tarea" y §"Escalation"). Codifica la disciplina de persistir el trabajo al cerrar cada tarea.

## Cambio

Único archivo: `CLAUDE.md` (+15 líneas, una sección nueva). La regla:
1. Al cumplir la DoD de `booster-skills:definicion-de-terminado`, identificar que hay cambios sin persistir.
2. Commit Conventional con scope, **incluyendo `.specs/`** (el spec/plan es entregable).
3. `git push` de la rama feature (commit local ≠ guardado).
4. Nunca push directo a `main` (PR + squash merge).
5. Cambios sin commitear/pushear al cerrar turno se declaran explícitamente — no se dejan en silencio ("lo commiteo después" = drift).

No se tocó ninguna otra sección.

## Evidencia
```
$ git diff --stat   → CLAUDE.md | 15 ++++++++++
pre-commit: gitleaks OK, biome OK, ADR-check OK
```
Solo documentación/governance — sin cambios de código/runtime/CI/deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)