### PR TITLE
fix(infra): quitar template.revision de ignore_changes (revierte #472)

### DIFF
--- a/infrastructure/modules/cloud-run-service/main.tf
+++ b/infrastructure/modules/cloud-run-service/main.tf
@@ -130,12 +130,13 @@ resource "google_cloud_run_v2_service" "service" {
     ignore_changes = [
       # Dejar que Cloud Build gestione las revisions/traffic después del primer apply
       template[0].containers[0].image,
-      # El nombre de la revisión lo asigna Cloud Build en cada deploy (gcloud run
-      # update / canary sequence). Terraform no lo gestiona, pero al refrescar el
-      # estado lo veía seteado y quería desclavarlo (`revision -> null`), drift que
-      # un apply convertía en una revisión nueva del service en vivo. Igual que
-      # `image` arriba: lo gestiona el pipeline, no Terraform (audit 2026-06-14).
-      template[0].revision,
+      # NOTA: `template[0].revision` NO va en ignore_changes. Pinearlo (#472)
+      # hacía que terraform reusara el nombre de la revisión viva al actualizar
+      # config (ej. sumar un env) → Error 409 "revision already exists with
+      # different configuration". Sin pinearlo, terraform manda revision vacío y
+      # Cloud Run auto-nombra la nueva revisión (audit 2026-06-15, fix del apply
+      # de safety fan-out). El `revision` queda como computed; el nombre real lo
+      # pone Cloud Run/Cloud Build en cada deploy.
       # GCP/gcloud auto-injectan labels (commit, goog-terraform-provisioned) y
       # annotations (operation-id, run.googleapis.com/*) durante deploys que TF
       # no controla. Sin ignore_changes acá, cada `terraform plan` mostraba


### PR DESCRIPTION
## Contexto

#472 agregó `template[0].revision` al `ignore_changes` del módulo `cloud-run-service` (para suprimir el drift cosmético `revision -> null`). Eso introdujo un bug: al **actualizar config de un service vía terraform** (ej. sumar un env var), terraform reusaba el nombre de la revisión viva (pineada) → **`Error 409: Revision already exists with different configuration`**. Rompió el `terraform apply` del safety fan-out (el env `SAFETY_PUSH_CALLER_SA` en el api).

## Cambio

Quita `template[0].revision` del `ignore_changes` del módulo. Sin pinearlo, terraform manda `revision` vacío y **Cloud Run auto-nombra** la revisión nueva. El campo queda computed; el nombre lo asigna Cloud Run/Cloud Build en cada deploy.

## Evidencia

```
$ terraform plan (con el fix): Plan: 1 to add, 1 to change, 0 to destroy
  → solo afecta al api (el service con cambio de config); NO redeploy masivo de los 8.
  service_api: revision "00394-det" -> null (desclava) + env SAFETY_PUSH_CALLER_SA

$ terraform apply  → OK
$ terraform plan (post): No changes. Your infrastructure matches the configuration.
$ revisión nueva 00358-dnr al 100%, MISMA imagen del release (sha c5275121…), + el env.
$ smoke test e2e: POST /internal/safety-events → 200, outcome=notified. Pipeline LIVE.
```

**Aplicado a prod 2026-06-15** (apply desde esta rama tras validar el plan; este PR pone `main` en sync con lo aplicado — main = estado aplicado).

terraform fmt OK. Solo el módulo cloud-run (1 archivo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)