### PR TITLE
feat(infra): cablear content-sid-safety-alert en Secret Manager (P0-G)

### DIFF
--- a/docs/runbooks/load-content-sids.md
+++ b/docs/runbooks/load-content-sids.md
@@ -8,6 +8,7 @@ WhatsApp aprobados por Meta. Los secrets viven en Secret Manager:
 | `content-sid-offer-new` | Notificar carrier de nueva oferta (B.8) | `offer_new_v1` | `HXa30e82ea818a72d08bb12a4214610a86` |
 | `content-sid-chat-unread` | Fallback WhatsApp para chat no leído (P3.d) | `chat_unread_v1` | _pending Meta_ |
 | `content-sid-tracking` | Link público de tracking al shipper al asignar (Phase 5 PR-L3) | `tracking_link_v1` | `HXac1ef21ed9423258a2c38dad02f31e41` (submitted Meta 2026-05-10) |
+| `content-sid-safety-alert` | Alerta de seguridad al transportista (crash/unplug/jamming, P0-G) | `copy_of_safety_alert_v1` | `HX80819b02ce9a546b855d09ada1aac944` (en revisión Meta 2026-06-15; `safety_alert_v1` `HX0d6363fd0162c2d71519ed4e3afe2e3d` fue rechazado) |
 
 ### Body de `tracking_link_v1` (creado vía Twilio Content API 2026-05-10)
 
@@ -86,6 +87,14 @@ echo -n "HXabcdef0123456789abcdef0123456789" \
   | gcloud secrets versions add content-sid-chat-unread \
       --data-file=- \
       --project=booster-ai-494222
+
+# Para safety_alert (cuando Meta apruebe copy_of_safety_alert_v1):
+echo -n "HX80819b02ce9a546b855d09ada1aac944" \
+  | gcloud secrets versions add content-sid-safety-alert \
+      --data-file=- \
+      --project=booster-ai-494222
+# Luego redeploy con --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest
+# Mientras esté en placeholder, el fan-out de safety sale solo por push (no bloquea).
 ```
 
 ### 3. Forzar re-deploy del api Cloud Run para tomar el nuevo valor

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -250,6 +250,12 @@ module "service_api" {
     # Meta apruebe (submitted 2026-05-10, SID HXac1ef21ed9423258a2c38dad02f31e41),
     # el secret mantiene placeholder y notify-tracking-link skipea con warn.
     CONTENT_SID_TRACKING = google_secret_manager_secret.secrets["content-sid-tracking"].secret_id
+    # Safety fan-out (P0-G) — template `safety_alert` al transportista ante
+    # crash/unplug/jamming. `safety_alert_v1` rechazado por Meta; reenviado
+    # como `copy_of_safety_alert_v1` (SID HX80819b02ce9a546b855d09ada1aac944,
+    # en revisión 2026-06-15). Mientras el secret esté en placeholder el
+    # fan-out sale solo por push (config.ts CONTENT_SID_SAFETY_ALERT opcional).
+    CONTENT_SID_SAFETY_ALERT = google_secret_manager_secret.secrets["content-sid-safety-alert"].secret_id
 
     # P3.c — Web Push VAPID. El api firma cada push con la privada (JWT
     # Authorization header al push service del browser). La pública se

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -235,6 +235,15 @@ locals {
     # usuario). SID Twilio creado: HXac1ef21ed9423258a2c38dad02f31e41
     # (submitted to Meta 2026-05-10, approval ~24-48h).
     "content-sid-tracking",
+    # Safety fan-out (P0-G) — template `safety_alert` para avisar al
+    # transportista de eventos crash/unplug/jamming detectados por el
+    # telemetry-processor. Categoría Meta: Utility. `safety_alert_v1`
+    # (HX0d6363fd0162c2d71519ed4e3afe2e3d) fue rechazado por Meta; se
+    # reenvió como `copy_of_safety_alert_v1`
+    # (HX80819b02ce9a546b855d09ada1aac944, en revisión 2026-06-15). El
+    # código degrada a solo-push si el secret está en placeholder, así
+    # que la feature no bloquea por la aprobación de Meta.
+    "content-sid-safety-alert",
 
     # Web Push VAPID (P3.c) — generadas con `npx web-push generate-vapid-keys`
     # post-deploy y subidas con `gcloud secrets versions add`. La pública se


### PR DESCRIPTION
## Contexto

El fan-out de eventos de seguridad (P0-G, #473) lee `CONTENT_SID_SAFETY_ALERT` (config.ts:275, server.ts:278) pero **el secret nunca se cableó en infra** — sí estaban `content-sid-offer-new`, `content-sid-chat-unread` y `content-sid-tracking`, pero no el de safety.

Detectado a raíz de que Meta rechazó `safety_alert_v1` (`HX0d6363fd0162c2d71519ed4e3afe2e3d`) y se reenvió como `copy_of_safety_alert_v1` (`HX80819b02ce9a546b855d09ada1aac944`, en revisión 2026-06-15). Sin este wiring, aunque Meta apruebe, el SID no tiene dónde cargarse y la alerta de seguridad al transportista seguiría saliendo **solo por push**.

## Cambios

- **`infrastructure/security.tf`**: `+ "content-sid-safety-alert"` a `local.secret_names`. Placeholder version (`ROTATE_ME_...`) e IAM accessor son automáticos (for_each + binding `secretAccessor` a nivel proyecto del runtime SA).
- **`infrastructure/compute.tf`**: `+ CONTENT_SID_SAFETY_ALERT` al bloque `secrets` del api, montado desde el secret.
- **`docs/runbooks/load-content-sids.md`**: fila en tabla + comando `gcloud secrets versions add` para cuando Meta apruebe.

El lado aplicación ya estaba completo y testeado (config.ts opcional, `safety-events.integration.test.ts`). El código degrada a solo-push si el secret está en placeholder, así que **la feature no bloquea por la aprobación de Meta** — esto solo prepara el camino para encender el canal WhatsApp el día que apruebe.

## Evidencia

**`terraform fmt -check -diff`** (compute.tf, security.tf):
```
exit 0  (sin diffs)
```

**`terraform validate`**:
```
Success! The configuration is valid.
```

**`terraform plan`** (targeted a los recursos nuevos):
```
google_secret_manager_secret.secrets["content-sid-safety-alert"]          will be created
google_secret_manager_secret_version.placeholder["content-sid-safety-alert"] will be created
Plan: 2 to add, 0 to change, 0 to destroy.
```
Cero recursos existentes tocados. La env var del api se suma en el apply completo (cambio aditivo idéntico a los otros 3 templates).

**pre-commit**: gitleaks 0 leaks · Biome ok · ADR numbering ok · spec-drift ok.

## Activación post-merge (cuando Meta apruebe)

```bash
echo -n "HX80819b02ce9a546b855d09ada1aac944" \
  | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=booster-ai-494222
gcloud run services update booster-ai-api --region=southamerica-west1 \
  --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest --project=booster-ai-494222
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)