### PR TITLE
fix(test): serializar integration tests con fileParallelism (Vitest 4)

### DIFF
--- a/apps/api/vitest.integration.config.ts
+++ b/apps/api/vitest.integration.config.ts
@@ -5,9 +5,11 @@ import { defineConfig } from 'vitest/config';
  * no participa del `pnpm test` default (que cubre solo unit con BD stubbeada).
  *
  * Decisiones del plan v2 `2026-05-17-test-integration-infra-apps-api.md` §D2/D3:
- *   - `pool: 'forks'` + `poolOptions.forks.singleFork: true` — un único worker
- *     vitest para que las suites compartan globalSetup (que se introduce en
- *     T1b) y no compitan por advisory locks de Drizzle.
+ *   - `fileParallelism: false` — un único worker vitest, archivos uno-a-uno,
+ *     para que las suites compartan globalSetup, no compitan por advisory
+ *     locks de Drizzle y no se pisen los DELETE de `beforeEach` sobre la BD
+ *     compartida. (En Vitest 4 reemplaza al difunto `poolOptions.forks.
+ *     singleFork`; ver nota en el bloque `test` abajo.)
  *   - `sequence.concurrent: false` — refuerza serial; un test que use
  *     `test.concurrent` rompería el aislamiento de la BD compartida.
  *   - `include: ['test/integration/**']` — no toca `src/` ni `test/unit/`.
@@ -25,14 +27,25 @@ export default defineConfig({
     setupFiles: ['./test/setup.integration.ts'],
     globalSetup: ['./test/integration/setup-global.ts'],
     include: ['test/integration/**/*.{test,spec}.ts'],
-    // Vitest 4: poolOptions se movieron a top-level. `pool: 'forks'` +
-    // `forks.singleFork: true` garantiza un único worker para serializar
-    // el acceso a la BD compartida.
+    // Serializa la ejecución a un único worker, archivos uno-a-uno. Es
+    // IMPRESCINDIBLE: todas las suites integration comparten UNA Postgres
+    // (TEST_DATABASE_URL) y varios `beforeEach` hacen DELETE global sobre
+    // tablas compartidas (p.ej. `DELETE FROM solicitudes_registro`). Con
+    // archivos en paralelo, el `beforeEach` de un archivo borra filas recién
+    // insertadas por otro → flaky (count=0). Ver el caso real en
+    // signup-request-fail-closed > Scenario 1.
+    //
+    // OJO Vitest 4: `poolOptions.forks.singleFork` YA NO EXISTE (poolOptions se
+    // eliminó). La key `forks: { singleFork: true }` se ignora en silencio. El
+    // control correcto de serialización entre archivos es `fileParallelism:
+    // false` (fuerza maxWorkers=1 → un solo worker). `pool: 'forks'` es el
+    // default; se deja explícito por claridad (forks aísla mejor el driver pg).
     pool: 'forks',
-    forks: {
-      singleFork: true,
-    },
+    fileParallelism: false,
     sequence: {
+      // Refuerza serial DENTRO de cada archivo (no entre archivos: eso lo da
+      // fileParallelism). Un `test.concurrent` rompería el aislamiento de la
+      // BD compartida.
       concurrent: false,
     },
     testTimeout: 30_000,


### PR DESCRIPTION
## Causa raíz

`signup-request-fail-closed > Scenario 1` fallaba de forma intermitente en CI (`expect(rows[0].c).toBe(1)` → `0`), bloqueando merges (p.ej. #476 falló 3 re-runs seguidos mientras `main` estaba verde).

**No era flakiness del test ni un bug de producto** — el endpoint `POST /api/v1/signup-request` `await`ea el INSERT antes del `202` (`routes/signup-request.ts:43`). Era un **bug de aislamiento causado por una config rota en la migración Vitest 3→4**:

- `vitest.integration.config.ts` tenía `pool: 'forks'` + `forks: { singleFork: true }`.
- En **Vitest 4 `poolOptions` fue eliminado** y `singleFork` **ya no existe** como opción (verificado contra los `.d.ts` de `vitest@4.1.5`: ni `singleFork` ni `forks`/`threads` top-level existen). → la key se **ignora en silencio**.
- Sin serialización efectiva, vitest usa el default `fileParallelism: true` con varios workers → **los archivos de integración corren en paralelo**.
- Las suites comparten **una** Postgres (`TEST_DATABASE_URL`) y varios `beforeEach` hacen DELETE global (3 archivos tocan `solicitudes_registro`; dos con `DELETE FROM solicitudes_registro` sin `WHERE`). En paralelo, el `beforeEach` de un archivo **borra la fila recién insertada por otro** antes de su `SELECT count` → `0`.
- Escala con la contención del runner → explica por qué `main` pasaba y los runs de PR bajo carga fallaban consistentemente.

## Fix

Restaurar el worker único con la idiom correcta de Vitest 4: **`fileParallelism: false`** (fuerza `maxWorkers=1`, archivos uno-a-uno). Es la **causa raíz** (config), no el síntoma: el test es correcto *dado* el contrato serial que el diseño siempre asumió (globalSetup compartido + advisory locks Drizzle). También se corrige el comentario engañoso (`"poolOptions se movieron a top-level"`).

```diff
-    pool: 'forks',
-    forks: {
-      singleFork: true,
-    },
+    pool: 'forks',
+    fileParallelism: false,
```

## Evidencia

- **Biome**: `Checked 1 file. No fixes applied.` (exit 0)
- **`tsc --noEmit`** (apps/api): exit 0, 0 errores — confirma que `fileParallelism` es key válida de `InlineConfig` y que quitar `forks` no rompe tipos.
- **Integración local**: requiere Docker (testcontainers Redis + Postgres), **no disponible en este entorno** → la estabilidad se verifica en CI (es donde el flaky se manifestaba). Antes del fix: 3/3 runs fallidos. Tras el fix: se espera CI verde y estable across re-runs.
- **Tipos Vitest 4** (prueba de que `singleFork` era no-op):
  - `poolOptions` no aparece en ningún `.d.ts` de `vitest@4.1.5`.
  - `fileParallelism?: boolean` sí existe en `InlineConfig` (con doc: *"Setting this to false will override maxWorkers to 1"*).

## Por qué un PR aparte

Bloqueaba el merge de #476 (cableado `content-sid-safety-alert`), pero es un problema **independiente y preexistente** del tooling de tests. Una vez en `main`, #476 (y cualquier PR) deja de chocar con este flaky.

## Nota de seguimiento (no en este PR)

Defense-in-depth opcional: acotar los `DELETE FROM solicitudes_registro` de los `beforeEach` a emails propios de cada suite. No es necesario con ejecución serial, pero daría robustez si algún día se quiere volver a paralelizar. Lo dejo como follow-up para no mezclar scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)