### PR TITLE
docs(safety): script + spec v2 del template WhatsApp safety_alert

### DIFF
--- a/.specs/safety-event-fanout/whatsapp-template.md
+++ b/.specs/safety-event-fanout/whatsapp-template.md
@@ -1,74 +1,85 @@
-# WhatsApp template — `safety_alert_v1`
+# WhatsApp template — `safety_alert_v2`
 
-Listo para submitear en **Twilio Content Editor** (Content Template Builder) → se aprueba vía Meta. Categoría **UTILITY** (notificación transaccional, no marketing → aprobación más rápida y enviable fuera de la ventana de 24h).
+Template del fan-out de seguridad (P0-G): notifica al transportista ante eventos crash/unplug/jamming. Categoría **UTILITY** (notificación transaccional, no marketing → aprobación más rápida y enviable fuera de la ventana de 24h).
+
+**Forma de submit recomendada**: `scripts/create-safety-alert-template.sh` (crea el content vía Twilio Content API y lo submitea a Meta en un paso, sin hardcodear credenciales). El Content Editor de la consola también sirve, pero el script es reproducible.
 
 ---
+
+## Historial de rechazo (por qué v2)
+
+| Template | Content SID | Estado |
+|---|---|---|
+| `safety_alert_v1` | `HX0d6363fd0162c2d71519ed4e3afe2e3d` | **rejected** por Meta |
+| `copy_of_safety_alert_v1` | `HX80819b02ce9a546b855d09ada1aac944` | **rejected** por Meta |
+
+Razón de Meta (`subCode 2388293`):
+
+> *"This template has too many variables for its length. Reduce the number of variables or increase the message length."*
+
+El body de v1 era demasiado corto para 4 variables (ratio variables/texto muy alto). **v2 mantiene las mismas 4 variables** (para no tocar `dispatch-safety-notification.ts`) pero **alarga el texto fijo** que las rodea, lo que resuelve el ratio. Las variables además quedan cada una precedida por una etiqueta estática (nunca adyacentes entre sí ni al inicio/fin del body), otra regla que Meta valida.
+
+> El código referencia el template por **Content SID**, no por nombre — por eso el nombre nuevo (`safety_alert_v2`) no impacta nada. Se usa nombre nuevo porque Meta a veces bloquea reusar un nombre rechazado.
 
 ## Metadatos
 
 | Campo | Valor |
 |---|---|
-| **Template name** | `safety_alert_v1` (Twilio exige snake_case minúscula) |
+| **Template name** | `safety_alert_v2` (Twilio exige snake_case minúscula) |
 | **Category** | UTILITY |
-| **Language** | Spanish (es) |
+| **Language** | Spanish (`es`) |
 | **Content type** | `twilio/text` (body-only) — ver abajo variante con botón |
 
-## Header (opcional, texto estático)
+## Body (v2 — el que va a producción)
 
 ```
-🚨 Alerta de seguridad — Booster
-```
+🚨 Alerta de seguridad Booster AI
 
-## Body
+Detectamos un evento en uno de tus vehículos que requiere tu atención.
 
-```
-Detectamos un evento de seguridad en un vehículo de tu flota.
+🚚 Vehículo (patente): {{1}}
+⚠️ Evento detectado: {{2}}
+🕐 Hora (Chile): {{3}}
+📍 Viaje asociado: {{4}}
 
-Vehículo: {{1}}
-Evento: {{2}}
-Hora: {{3}}
-Viaje: {{4}}
-
-Revisá el estado del vehículo y contactá al conductor si es necesario.
-```
-
-## Footer (opcional, estático)
-
-```
-Booster · Logística sostenible
+Por favor verifica cuanto antes el estado del conductor y de la carga. Si se trata de una emergencia, llama a los servicios de emergencia (131 ambulancia · 133 Carabineros) y luego avísanos por este mismo chat. Si fue una falsa alarma, responde OK para que quede registrado.
 ```
 
 ## Variables — sample values (Meta los exige para aprobar)
 
-| Var | Significado (app) | Sample para el submit |
-|---|---|---|
-| `{{1}}` | Patente o alias del vehículo | `RJXK-42` |
-| `{{2}}` | Tipo de evento (label es) | `Posible colisión` |
-| `{{3}}` | Hora local del evento | `14:32 (15 jun)` |
-| `{{4}}` | tracking_code del viaje, o "Sin viaje activo" | `BOO-7F3A2C` |
+| Var | Significado (app) | Origen en código | Sample para el submit |
+|---|---|---|---|
+| `{{1}}` | Patente del vehículo | `routing.vehicleLabel` (= `vehicle.plate`) | `RJXK-42` |
+| `{{2}}` | Tipo de evento (label es) | `safetyEventLabel(eventType)` | `Posible colisión` |
+| `{{3}}` | Hora local del evento | `formatHoraLocal(occurredAt)` | `15 jun, 10:00` |
+| `{{4}}` | tracking_code del viaje, o fallback | `routing.trackingCode ?? 'Sin viaje activo'` | `BOO-7F3A2C` |
 
-**Labels de `{{2}}` que usará el código** (para que el sample sea representativo):
+**Labels de `{{2}}` que usa el código** (`apps/api/src/services/safety-event-labels.ts`):
 - `crash` → `Posible colisión`
 - `unplug` → `Desconexión de energía (manipulación)`
 - `jamming` → `Interferencia de señal GPS`
 
-## Variante con botón (opcional — si querés CTA directo)
+> El orden 1→4 y el mapping están fijados en `apps/api/src/services/dispatch-safety-notification.ts:121-126`. Si se cambia el body, NO reordenar ni agregar variables sin tocar también ese servicio (y sus tests).
 
-Agregar un **botón URL dinámico**:
-- Texto del botón: `Ver vehículo`
-- URL: `https://app.boosterchile.com/app/flota?v={{1}}`
-- Sample para `{{1}}` del botón: `6487dac2`
+## Variante con botón (opcional — no en v2)
 
-> Nota: el botón con URL dinámica agrega una variable extra y a veces alarga la revisión de Meta. Si querés la aprobación más rápida, submití **body-only** primero; el deep-link igual va por push. El botón se puede agregar en `safety_alert_v2` después.
+Se podría agregar un **botón URL dinámico** (`Ver vehículo` → `https://app.boosterchile.com/app/flota?v={{1}}`), pero agrega una variable extra y alarga la revisión de Meta. El deep-link igual sale por push, así que v2 va **body-only** para maximizar probabilidad de aprobación. El botón se evalúa en una v3 si se decide.
 
 ## Después de aprobar
 
-Meta devuelve el Content SID (`HX...`). Setealo en la env del Cloud Run del api como `CONTENT_SID_SAFETY_ALERT`. Hasta entonces, el código skipea WhatsApp y notifica solo por push (sin romper nada).
+Meta devuelve (vía Twilio) el estado `approved` para el Content SID. Cargarlo en el secret `content-sid-safety-alert` (wiring de infra ya existe desde #476) y redeploy del api:
+
+```bash
+echo -n "HX<sid-de-v2>" | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=booster-ai-494222
+gcloud run services update booster-ai-api --region=southamerica-west1 \
+  --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest --project=booster-ai-494222
+```
+
+Hasta entonces el código skipea WhatsApp y notifica **solo por push** (sin romper nada). Detalle completo en `docs/runbooks/load-content-sids.md`.
 
 ## Checklist de submit
 
-- [ ] Crear template en Twilio Content Editor, name `safety_alert_v1`, category UTILITY, language Spanish.
-- [ ] Pegar header / body / footer de arriba.
-- [ ] Cargar los 4 sample values.
-- [ ] Submit a Meta.
-- [ ] Al aprobar (24-48h): copiar el `HX...` → `CONTENT_SID_SAFETY_ALERT` en Cloud Run.
+- [ ] Correr `scripts/create-safety-alert-template.sh` (o crear a mano en Content Editor con name `safety_alert_v2`, category UTILITY, language `es`, body de arriba, 4 sample values).
+- [ ] Anotar el Content SID nuevo (`HX...`).
+- [ ] Vigilar aprobación (`ApprovalRequests`, típico 24-48h).
+- [ ] Al aprobar: cargar el SID en `content-sid-safety-alert` + redeploy (comandos arriba).

--- a/scripts/create-safety-alert-template.sh
+++ b/scripts/create-safety-alert-template.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# create-safety-alert-template.sh — crea el template WhatsApp `safety_alert_v2`
+# vía Twilio Content API y lo submitea a Meta para aprobación.
+#
+# CONTEXTO
+#   El fan-out de seguridad (P0-G) notifica al transportista ante eventos
+#   crash/unplug/jamming. El canal WhatsApp usa un template Twilio cuyo Content
+#   SID se carga en el secret `content-sid-safety-alert` (ver
+#   docs/runbooks/load-content-sids.md). El wiring de infra ya existe (#476);
+#   este script genera el template que falta.
+#
+#   Historia: `safety_alert_v1` (HX0d6363fd0162c2d71519ed4e3afe2e3d) y su copia
+#   `copy_of_safety_alert_v1` (HX80819b02ce9a546b855d09ada1aac944) fueron
+#   RECHAZADOS por Meta con subCode 2388293: "This template has too many
+#   variables for its length. Reduce the number of variables or increase the
+#   message length." Este script usa un body MÁS LARGO (más texto fijo por
+#   variable) manteniendo las mismas 4 variables {{1}}..{{4}} en el mismo orden,
+#   así `apps/api/src/services/dispatch-safety-notification.ts` no cambia.
+#
+# VARIABLES (las arma el código, ver dispatch-safety-notification.ts:121-126)
+#   {{1}} patente del vehículo        (vehicleLabel = vehicle.plate)
+#   {{2}} tipo de evento (label es)   (safetyEventLabel: Posible colisión, etc.)
+#   {{3}} hora local Chile            (formatHoraLocal: "15 jun, 10:00")
+#   {{4}} tracking_code del viaje      (o "Sin viaje activo")
+#
+# USO
+#   ./scripts/create-safety-alert-template.sh
+#
+#   Requiere: gcloud autenticado con acceso a los secrets twilio-account-sid y
+#   twilio-auth-token del proyecto, python3, curl. NO recibe ni hardcodea
+#   credenciales — las lee de Secret Manager en runtime.
+#
+set -euo pipefail
+
+PROJ="booster-ai-494222"
+NAME="safety_alert_v2"
+
+echo "→ Leyendo credenciales Twilio desde Secret Manager (proyecto $PROJ)…"
+TW_SID="$(gcloud secrets versions access latest --secret=twilio-account-sid --project="$PROJ")"
+TW_TOK="$(gcloud secrets versions access latest --secret=twilio-auth-token  --project="$PROJ")"
+
+# Payload de creación: python3 arma el JSON para escapar bien newlines, emoji y
+# acentos del body. El body es body-only (twilio/text); el deep-link al vehículo
+# va por push, no por el template (evita una variable extra que alarga la
+# revisión de Meta — ver la nota "variante con botón" en el spec).
+CREATE_PAYLOAD="$(python3 - "$NAME" <<'PY'
+import json, sys
+name = sys.argv[1]
+body = (
+    "🚨 Alerta de seguridad Booster AI\n\n"
+    "Detectamos un evento en uno de tus vehículos que requiere tu atención.\n\n"
+    "🚚 Vehículo (patente): {{1}}\n"
+    "⚠️ Evento detectado: {{2}}\n"
+    "🕐 Hora (Chile): {{3}}\n"
+    "📍 Viaje asociado: {{4}}\n\n"
+    "Por favor verifica cuanto antes el estado del conductor y de la carga. "
+    "Si se trata de una emergencia, llama a los servicios de emergencia "
+    "(131 ambulancia · 133 Carabineros) y luego avísanos por este mismo chat. "
+    "Si fue una falsa alarma, responde OK para que quede registrado."
+)
+print(json.dumps({
+    "friendly_name": name,
+    "language": "es",
+    # Sample values: Meta los exige para renderizar el template en la revisión.
+    "variables": {
+        "1": "RJXK-42",
+        "2": "Posible colisión",
+        "3": "15 jun, 10:00",
+        "4": "BOO-7F3A2C",
+    },
+    "types": {"twilio/text": {"body": body}},
+}))
+PY
+)"
+
+echo "→ Creando content '$NAME' vía Content API…"
+CREATE_RESP="$(curl -sS -u "$TW_SID:$TW_TOK" \
+  -H 'Content-Type: application/json' \
+  -X POST "https://content.twilio.com/v1/Content" \
+  -d "$CREATE_PAYLOAD")"
+
+CONTENT_SID="$(printf '%s' "$CREATE_RESP" | python3 -c 'import sys,json; print(json.load(sys.stdin)["sid"])')"
+echo "✅ Content creado: $CONTENT_SID"
+
+echo "→ Submiteando a Meta para aprobación WhatsApp (categoría UTILITY)…"
+curl -sS -u "$TW_SID:$TW_TOK" \
+  -H 'Content-Type: application/json' \
+  -X POST "https://content.twilio.com/v1/Content/${CONTENT_SID}/ApprovalRequests/whatsapp" \
+  -d "{\"name\": \"${NAME}\", \"category\": \"UTILITY\"}" | python3 -m json.tool
+
+cat <<EOF
+
+────────────────────────────────────────────────────────────────────────────
+Content SID nuevo: ${CONTENT_SID}
+
+Próximos pasos (detalle completo en docs/runbooks/load-content-sids.md):
+
+  1. Vigilar la aprobación de Meta: consultar el endpoint ApprovalRequests de
+     este Content SID (${CONTENT_SID}) hasta que whatsapp.status == "approved".
+     El comando exacto (curl autenticado) está en el runbook.
+
+  2. Al aprobar, cargar el SID en el secret + redeploy del api:
+       echo -n "${CONTENT_SID}" | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=${PROJ}
+       gcloud run services update booster-ai-api --region=southamerica-west1 \\
+         --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest --project=${PROJ}
+────────────────────────────────────────────────────────────────────────────
+EOF


### PR DESCRIPTION
## Contexto

Meta rechazó `safety_alert_v1` (`HX0d6363fd0162c2d71519ed4e3afe2e3d`) y `copy_of_safety_alert_v1` (`HX80819b02ce9a546b855d09ada1aac944`) con `subCode 2388293`: *"too many variables for its length"*. El wiring de infra del secret ya está en `main` (#476); faltaba el template aprobable.

## Cambios

- **`scripts/create-safety-alert-template.sh`** (ejecutable): crea el content `safety_alert_v2` vía Twilio Content API con un **body más largo** y lo submitea a Meta (categoría UTILITY) en un paso. Credenciales leídas de Secret Manager en runtime (nunca hardcodeadas). Imprime el SID nuevo + próximos pasos (vigilar aprobación + cargar en `content-sid-safety-alert`).
- **`.specs/safety-event-fanout/whatsapp-template.md`**: actualizado a v2 — historial de rechazo, body nuevo, mapping de las 4 variables a su origen en el código, y checklist.

## Por qué v2 pasa el filtro que rechazó a v1

- **Mismas 4 variables** `{{1}}..{{4}}` en el mismo orden → `dispatch-safety-notification.ts:121-126` **no se toca**.
- **Más texto fijo** rodeando las variables → resuelve el ratio variables/largo (causa del `2388293`).
- Cada variable precedida por etiqueta estática → **ninguna adyacente ni al inicio/fin** del body.

## Evidencia

- **`bash -n`** del script: OK (0 errores de sintaxis).
- **Payload JSON validado** (round-trip `json.loads`): 4 variables, body empieza y termina en texto (no variable), 0 variables adyacentes — cumple las reglas estructurales de Meta.
- **gitleaks**: `no leaks found` (el help-text se ajustó para no duplicar el `curl -u` autenticado del runbook → además DRY).
- **Biome**: aplicado en pre-commit, sin cambios.

## Nota

Este PR **no envía nada a Meta** — solo versiona la herramienta y el spec. El submit real lo dispara el PO corriendo el script cuando decida (genera SID nuevo → cargar en el secret → redeploy). Hasta entonces, el fan-out de seguridad sigue saliendo por **push** (sin bloqueo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)