### PR TITLE
docs(safety): registrar SID real de safety_alert_v2 y corregir estado en runbook

### DIFF
--- a/.specs/safety-event-fanout/whatsapp-template.md
+++ b/.specs/safety-event-fanout/whatsapp-template.md
@@ -12,6 +12,7 @@ Template del fan-out de seguridad (P0-G): notifica al transportista ante eventos
 |---|---|---|
 | `safety_alert_v1` | `HX0d6363fd0162c2d71519ed4e3afe2e3d` | **rejected** por Meta |
 | `copy_of_safety_alert_v1` | `HX80819b02ce9a546b855d09ada1aac944` | **rejected** por Meta |
+| `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` | **pending** (creado y submiteado 2026-06-15T23:01Z; en revisión Meta) |
 
 Razón de Meta (`subCode 2388293`):
 
@@ -70,7 +71,7 @@ Se podría agregar un **botón URL dinámico** (`Ver vehículo` → `https://app
 Meta devuelve (vía Twilio) el estado `approved` para el Content SID. Cargarlo en el secret `content-sid-safety-alert` (wiring de infra ya existe desde #476) y redeploy del api:
 
 ```bash
-echo -n "HX<sid-de-v2>" | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=booster-ai-494222
+echo -n "HX48d541ad8f2cab4e4f65165cb26489b1" | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=booster-ai-494222
 gcloud run services update booster-ai-api --region=southamerica-west1 \
   --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest --project=booster-ai-494222
 ```
@@ -79,7 +80,7 @@ Hasta entonces el código skipea WhatsApp y notifica **solo por push** (sin romp
 
 ## Checklist de submit
 
-- [ ] Correr `scripts/create-safety-alert-template.sh` (o crear a mano en Content Editor con name `safety_alert_v2`, category UTILITY, language `es`, body de arriba, 4 sample values).
-- [ ] Anotar el Content SID nuevo (`HX...`).
-- [ ] Vigilar aprobación (`ApprovalRequests`, típico 24-48h).
+- [x] Correr `scripts/create-safety-alert-template.sh` (o crear a mano en Content Editor con name `safety_alert_v2`, category UTILITY, language `es`, body de arriba, 4 sample values). — hecho 2026-06-15.
+- [x] Anotar el Content SID nuevo: `HX48d541ad8f2cab4e4f65165cb26489b1`.
+- [ ] Vigilar aprobación (`ApprovalRequests`, típico 24-48h). — en curso; status `pending` al 2026-06-16.
 - [ ] Al aprobar: cargar el SID en `content-sid-safety-alert` + redeploy (comandos arriba).

--- a/docs/runbooks/load-content-sids.md
+++ b/docs/runbooks/load-content-sids.md
@@ -8,7 +8,7 @@ WhatsApp aprobados por Meta. Los secrets viven en Secret Manager:
 | `content-sid-offer-new` | Notificar carrier de nueva oferta (B.8) | `offer_new_v1` | `HXa30e82ea818a72d08bb12a4214610a86` |
 | `content-sid-chat-unread` | Fallback WhatsApp para chat no leído (P3.d) | `chat_unread_v1` | _pending Meta_ |
 | `content-sid-tracking` | Link público de tracking al shipper al asignar (Phase 5 PR-L3) | `tracking_link_v1` | `HXac1ef21ed9423258a2c38dad02f31e41` (submitted Meta 2026-05-10) |
-| `content-sid-safety-alert` | Alerta de seguridad al transportista (crash/unplug/jamming, P0-G) | `copy_of_safety_alert_v1` | `HX80819b02ce9a546b855d09ada1aac944` (en revisión Meta 2026-06-15; `safety_alert_v1` `HX0d6363fd0162c2d71519ed4e3afe2e3d` fue rechazado) |
+| `content-sid-safety-alert` | Alerta de seguridad al transportista (crash/unplug/jamming, P0-G) | `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` (en revisión Meta desde 2026-06-15; `safety_alert_v1` `HX0d6363fd0162c2d71519ed4e3afe2e3d` y `copy_of_safety_alert_v1` `HX80819b02ce9a546b855d09ada1aac944` fueron **rechazados** por subCode 2388293) |
 
 ### Body de `tracking_link_v1` (creado vía Twilio Content API 2026-05-10)
 
@@ -88,8 +88,8 @@ echo -n "HXabcdef0123456789abcdef0123456789" \
       --data-file=- \
       --project=booster-ai-494222
 
-# Para safety_alert (cuando Meta apruebe copy_of_safety_alert_v1):
-echo -n "HX80819b02ce9a546b855d09ada1aac944" \
+# Para safety_alert (cuando Meta apruebe safety_alert_v2):
+echo -n "HX48d541ad8f2cab4e4f65165cb26489b1" \
   | gcloud secrets versions add content-sid-safety-alert \
       --data-file=- \
       --project=booster-ai-494222


### PR DESCRIPTION
## Qué

Corrige dos brechas de documentación del template WhatsApp de safety (P0-G), detectadas al verificar el estado real contra Twilio Content API.

- `.specs/safety-event-fanout/whatsapp-template.md`: reemplaza el placeholder `HX<sid-de-v2>` por el SID real, agrega `safety_alert_v2` al historial, y marca los pasos del checklist ya hechos (creación + submit del 2026-06-15).
- `docs/runbooks/load-content-sids.md`: el template vigente es `safety_alert_v2` (no `copy_of_safety_alert_v1`, que está **rejected**, no "en revisión").

Solo docs. **Sin cambios de código ni infra**: el secret `content-sid-safety-alert` sigue sin versión cargada y el fan-out de safety se mantiene en solo-push hasta que Meta apruebe.

## Evidencia

Verificación en vivo vía Twilio Content API (`GET /v1/Content/{SID}/ApprovalRequests`), 2026-06-16:

| Template | Content SID | Estado Meta |
|---|---|---|
| `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` | `pending` (creado 2026-06-15T23:01Z) |
| `copy_of_safety_alert_v1` | `HX80819b02ce9a546b855d09ada1aac944` | `rejected` (subCode 2388293) |
| `safety_alert_v1` | `HX0d6363fd0162c2d71519ed4e3afe2e3d` | `rejected` (subCode 2388293) |

- Secret `content-sid-safety-alert`: sin versión cargada → canal WhatsApp en solo-push (correcto mientras no haya `approved`).
- Pre-commit: gitleaks (0 leaks), Biome lint-staged OK, check-adr-numbering OK, spec-canonical-drift OK.
- Cambio docs-only → no corre tests/build; `release.yml` no despliega (paths-ignore docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)