### PR TITLE
perf(matching): elimina N+1 + índice compuesto en el hot path de runMatching

### DIFF
--- a/apps/api/drizzle/0041_matching_vehiculos_index.sql
+++ b/apps/api/drizzle/0041_matching_vehiculos_index.sql
@@ -1,0 +1,25 @@
+-- 0041 — Índice compuesto para el hot path de matching (best-fit de vehículos)
+-- Rama perf/matching-n1-and-index — complementa la eliminación del N+1 en
+-- runMatching (apps/api/src/services/matching.ts): tras batchear el SELECT de
+-- vehículos a una sola query, ésta filtra por
+--   empresa_id IN (...) AND estado_vehiculo = 'activo' AND capacidad_kg >= X
+--   ORDER BY capacidad_kg, id
+-- El índice (empresa_id, estado_vehiculo, capacidad_kg, id) sirve esa forma
+-- exacta: igualdad en empresa_id (IN) + estado_vehiculo, rango en capacidad_kg,
+-- y entrega el orden (capacidad_kg, id) del best-fit determinista
+-- (skill empty-leg-matching §7) sin sort adicional por empresa.
+--
+-- Idempotente (IF NOT EXISTS / IF EXISTS) por consistencia con el reset de
+-- integration tests y reaplicaciones manuales. Rollback: ver al final.
+CREATE INDEX IF NOT EXISTS "idx_vehiculos_empresa_estado_capacidad"
+  ON "vehiculos" ("empresa_id", "estado_vehiculo", "capacidad_kg", "id");
+--> statement-breakpoint
+
+-- idx_vehiculos_empresa (single-column sobre empresa_id) queda redundante: el
+-- compuesto de arriba lo cubre como prefijo (empresa_id es su columna líder),
+-- así que toda query por empresa_id solo —incluido el check del FK
+-- vehiculos.empresa_id → empresas(id)— sigue indexada por el prefijo. Mismo
+-- criterio anti-redundancia que 0040 (índices redundantes pagan escritura sin
+-- aportar lecturas no cubiertas). Rollback: recrear con
+--   CREATE INDEX "idx_vehiculos_empresa" ON "vehiculos" ("empresa_id");
+DROP INDEX IF EXISTS "idx_vehiculos_empresa";

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1780876800004,
       "tag": "0040_integridad_indices",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1780876800005,
+      "tag": "0041_matching_vehiculos_index",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -803,7 +803,22 @@ export const vehicles = pgTable(
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
-    empresaIdx: index('idx_vehiculos_empresa').on(table.empresaId),
+    // Índice compuesto del hot path de matching (runMatching → best-fit de
+    // vehículos aptos): WHERE empresa_id IN (...) AND estado_vehiculo='activo'
+    // AND capacidad_kg >= X  ORDER BY capacidad_kg, id. Las columnas en este
+    // orden permiten: igualdad sobre empresa_id (IN) + estado_vehiculo, rango
+    // sobre capacidad_kg, y entregan el orden (capacidad_kg, id) que hace el
+    // best-fit determinista (skill empty-leg-matching §7). Creado en 0041.
+    empresaEstadoCapacidadIdx: index('idx_vehiculos_empresa_estado_capacidad').on(
+      table.empresaId,
+      table.vehicleStatus,
+      table.capacityKg,
+      table.id,
+    ),
+    // idx_vehiculos_empresa (single-column) dropeado en 0041: el compuesto de
+    // arriba lo cubre como prefijo (empresa_id es su columna líder), así que
+    // toda query por empresa_id solo —incl. el check del FK a empresas— sigue
+    // indexada. Mismo criterio anti-redundancia que 0040.
     typeIdx: index('idx_vehiculos_tipo').on(table.vehicleType),
     statusIdx: index('idx_vehiculos_estado').on(table.vehicleStatus),
     // idx_vehiculos_teltonika_imei dropeado en 0040: duplicaba el UNIQUE

--- a/apps/api/src/services/matching.ts
+++ b/apps/api/src/services/matching.ts
@@ -188,20 +188,35 @@ export async function runMatching(opts: RunMatchingOptions): Promise<MatchingRes
       const candidatesV1: ScoredCandidate[] = [];
       const candidatesV2: ScoredCandidateV2[] = [];
 
-      for (const emp of candidateEmpresas) {
-        const vehs = await tx
-          .select()
-          .from(vehicles)
-          .where(
-            and(
-              eq(vehicles.empresaId, emp.id),
-              eq(vehicles.vehicleStatus, 'activo'),
-              gte(vehicles.capacityKg, cargoWeight),
+      // Vehículos aptos de TODAS las empresas candidatas en una sola query
+      // (evita N+1: antes era 1 SELECT por empresa en el loop). El orden
+      // (capacityKg, id) hace el best-fit determinista ante empates de
+      // capacidad — requerimiento de auditabilidad del matching
+      // (skill empty-leg-matching §7). Se agrupa quedándose con el primero
+      // por empresa = menor capacidad apta (best-fit), desempate estable por id.
+      const aptVehicles = await tx
+        .select()
+        .from(vehicles)
+        .where(
+          and(
+            inArray(
+              vehicles.empresaId,
+              candidateEmpresas.map((e) => e.id),
             ),
-          )
-          .orderBy(vehicles.capacityKg)
-          .limit(1);
-        const veh = vehs[0];
+            eq(vehicles.vehicleStatus, 'activo'),
+            gte(vehicles.capacityKg, cargoWeight),
+          ),
+        )
+        .orderBy(vehicles.capacityKg, vehicles.id);
+      const bestVehicleByEmpresa = new Map<string, (typeof aptVehicles)[number]>();
+      for (const veh of aptVehicles) {
+        if (!bestVehicleByEmpresa.has(veh.empresaId)) {
+          bestVehicleByEmpresa.set(veh.empresaId, veh);
+        }
+      }
+
+      for (const emp of candidateEmpresas) {
+        const veh = bestVehicleByEmpresa.get(emp.id);
         if (!veh) {
           continue;
         }

--- a/apps/api/test/integration/matching-vehiculos-index.integration.test.ts
+++ b/apps/api/test/integration/matching-vehiculos-index.integration.test.ts
@@ -1,0 +1,102 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { type TestDbHandle, createTestDb } from '../helpers/test-db.js';
+
+/**
+ * Rama perf/matching-n1-and-index — migración 0041.
+ *
+ * Un índice no cambia la corrección de la query, solo el plan de ejecución;
+ * por eso el rigor acá NO es un test funcional (pasaría con y sin índice) sino
+ * assertar el ESTADO DEL ESQUEMA que deja la migración y que el PLANNER honra
+ * la decisión de diseño:
+ *
+ *   1. idx_vehiculos_empresa_estado_capacidad existe sobre `vehiculos` con las
+ *      columnas en el orden (empresa_id, estado_vehiculo, capacidad_kg, id).
+ *   2. idx_vehiculos_empresa (single-column, redundante) ya NO existe.
+ *   3. La query objetivo del hot path usa el índice compuesto.
+ *   4. Una query por empresa_id solo TAMBIÉN lo usa (prueba que el prefijo
+ *      cubre al standalone dropeado → justifica el drop, no es regresión).
+ *
+ * Las migraciones ya están aplicadas por el globalSetup (runMigrations real de
+ * prod) antes del primer test.
+ */
+describe('integration: índice de matching de vehículos (migración 0041)', () => {
+  let handle: TestDbHandle;
+
+  beforeAll(() => {
+    handle = createTestDb();
+  });
+
+  afterAll(async () => {
+    await handle.pool.end();
+  });
+
+  test('1: idx_vehiculos_empresa_estado_capacidad existe con las columnas en orden', async () => {
+    const res = await handle.pool.query<{ indexdef: string }>(
+      `SELECT indexdef FROM pg_indexes
+       WHERE schemaname = 'public'
+         AND tablename = 'vehiculos'
+         AND indexname = 'idx_vehiculos_empresa_estado_capacidad'`,
+    );
+    expect(res.rowCount).toBe(1);
+    // El orden de columnas es parte del contrato: habilita igualdad sobre
+    // empresa_id + estado_vehiculo, rango sobre capacidad_kg y el orden
+    // (capacidad_kg, id) del best-fit. pg_get_indexdef las emite en orden.
+    expect(res.rows[0].indexdef).toContain('(empresa_id, estado_vehiculo, capacidad_kg, id)');
+  });
+
+  test('2: idx_vehiculos_empresa (single-column redundante) ya no existe', async () => {
+    const res = await handle.pool.query(
+      `SELECT 1 FROM pg_indexes
+       WHERE schemaname = 'public'
+         AND tablename = 'vehiculos'
+         AND indexname = 'idx_vehiculos_empresa'`,
+    );
+    expect(res.rowCount).toBe(0);
+  });
+
+  test('3: la query del hot path usa el índice compuesto', async () => {
+    // enable_seqscan=off aísla "¿este índice es usable para esta forma de
+    // query?" sin depender del volumen de datos: en una tabla chica el planner
+    // elegiría seqscan por costo, lo que NO es evidencia contra el índice.
+    // Probamos que, descartado el seqscan, el plan se apoya en el compuesto.
+    const client = await handle.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query('SET LOCAL enable_seqscan = off');
+      const explain = await client.query<{ 'QUERY PLAN': unknown }>(
+        `EXPLAIN (FORMAT JSON)
+         SELECT * FROM vehiculos
+         WHERE empresa_id IN ('00000000-0000-0000-0000-000000000001'::uuid)
+           AND estado_vehiculo = 'activo'
+           AND capacidad_kg >= 1000
+         ORDER BY capacidad_kg, id`,
+      );
+      const plan = JSON.stringify(explain.rows[0]['QUERY PLAN']);
+      expect(plan).toContain('idx_vehiculos_empresa_estado_capacidad');
+      expect(plan).toMatch(/Index (Only )?Scan|Bitmap Index Scan/);
+    } finally {
+      await client.query('ROLLBACK');
+      client.release();
+    }
+  });
+
+  test('4: una query por empresa_id solo usa el prefijo del compuesto (justifica el drop)', async () => {
+    const client = await handle.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query('SET LOCAL enable_seqscan = off');
+      const explain = await client.query<{ 'QUERY PLAN': unknown }>(
+        `EXPLAIN (FORMAT JSON)
+         SELECT * FROM vehiculos
+         WHERE empresa_id = '00000000-0000-0000-0000-000000000001'::uuid`,
+      );
+      const plan = JSON.stringify(explain.rows[0]['QUERY PLAN']);
+      // El standalone idx_vehiculos_empresa fue dropeado; el prefijo del
+      // compuesto debe seguir cubriendo el acceso por empresa_id solo.
+      expect(plan).toContain('idx_vehiculos_empresa_estado_capacidad');
+    } finally {
+      await client.query('ROLLBACK');
+      client.release();
+    }
+  });
+});

--- a/apps/api/test/unit/matching-service-v2.test.ts
+++ b/apps/api/test/unit/matching-service-v2.test.ts
@@ -415,9 +415,12 @@ describe('runMatching — wire v2 (ADR-033)', () => {
             { id: 'emp-B', isTransportista: true, status: 'activa' },
             { id: 'emp-C', isTransportista: true, status: 'activa' },
           ],
-          [{ id: 'vA', empresaId: 'emp-A', capacityKg: 5100 }],
-          [{ id: 'vB', empresaId: 'emp-B', capacityKg: 5100 }],
-          [{ id: 'vC', empresaId: 'emp-C', capacityKg: 5100 }],
+          // Batch único de vehículos para las 3 empresas (post N+1 fix).
+          [
+            { id: 'vA', empresaId: 'emp-A', capacityKg: 5100 },
+            { id: 'vB', empresaId: 'emp-B', capacityKg: 5100 },
+            { id: 'vC', empresaId: 'emp-C', capacityKg: 5100 },
+          ],
         ],
         inserts: [
           [],
@@ -453,8 +456,12 @@ describe('runMatching — wire v2 (ADR-033)', () => {
             { id: 'emp-1', isTransportista: true, status: 'activa' },
             { id: 'emp-2', isTransportista: true, status: 'activa' },
           ],
-          [{ id: 'v1', empresaId: 'emp-1', capacityKg: 6000 }],
-          [{ id: 'v2', empresaId: 'emp-2', capacityKg: 6000 }],
+          // emp-2 SÍ tiene vehículo apto (batch único) — así el skip se da
+          // en el check de lookup faltante, no por falta de vehículo.
+          [
+            { id: 'v1', empresaId: 'emp-1', capacityKg: 6000 },
+            { id: 'v2', empresaId: 'emp-2', capacityKg: 6000 },
+          ],
         ],
         inserts: [[], [{ id: 'o1', empresaId: 'emp-1' }], []],
       });
@@ -464,7 +471,7 @@ describe('runMatching — wire v2 (ADR-033)', () => {
         logger: noopLogger,
         tripId: TRIP_ID,
       });
-      // emp-2 skipeada → solo 1 candidato evaluado.
+      // emp-2 skipeada (no está en el Map de lookups) → solo 1 candidato.
       expect(result.candidatesEvaluated).toBe(1);
       expect(result.offersCreated).toBe(1);
     });

--- a/apps/api/test/unit/matching-service.test.ts
+++ b/apps/api/test/unit/matching-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { vehicles } from '../../src/db/schema.js';
 import {
   TripRequestNotFoundError,
   TripRequestNotMatchableError,
@@ -31,11 +32,22 @@ function makeDb(queues: DbQueues = {}) {
   const updates = [...(queues.updates ?? [])];
   const inserts = [...(queues.inserts ?? [])];
 
+  // Trazas para aserciones de forma de acceso a DB (N+1, orden determinista).
+  const fromCalls: unknown[] = [];
+  const orderByCalls: unknown[][] = [];
+  const insertValues: unknown[] = [];
+
   const buildSelectChain = () => {
     const chain: Record<string, unknown> = {
-      from: vi.fn(() => chain),
+      from: vi.fn((table?: unknown) => {
+        fromCalls.push(table);
+        return chain;
+      }),
       where: vi.fn(() => chain),
-      orderBy: vi.fn(() => chain),
+      orderBy: vi.fn((...cols: unknown[]) => {
+        orderByCalls.push(cols);
+        return chain;
+      }),
       innerJoin: vi.fn(() => chain),
       limit: vi.fn(async () => selects.shift() ?? []),
     };
@@ -62,7 +74,10 @@ function makeDb(queues: DbQueues = {}) {
 
   const buildInsertChain = () => {
     const chain: Record<string, unknown> = {
-      values: vi.fn(() => chain),
+      values: vi.fn((rows?: unknown) => {
+        insertValues.push(rows);
+        return chain;
+      }),
       returning: vi.fn(async () => inserts.shift() ?? []),
     };
     chain.then = (resolve: (v: unknown) => unknown) => {
@@ -82,6 +97,9 @@ function makeDb(queues: DbQueues = {}) {
     select: tx.select,
     update: tx.update,
     insert: tx.insert,
+    __fromCalls: fromCalls,
+    __orderByCalls: orderByCalls,
+    __insertValues: insertValues,
   };
 }
 
@@ -247,9 +265,12 @@ describe('runMatching', () => {
           { id: 'emp-2', isTransportista: true, status: 'activa' },
           { id: 'emp-3', isTransportista: true, status: 'activa' },
         ],
-        [{ id: 'v1', empresaId: 'emp-1', capacityKg: 5200 }],
-        [{ id: 'v2', empresaId: 'emp-2', capacityKg: 5800 }],
-        [{ id: 'v3', empresaId: 'emp-3', capacityKg: 12000 }],
+        // Una sola query batch de vehículos para las 3 empresas (post N+1 fix).
+        [
+          { id: 'v1', empresaId: 'emp-1', capacityKg: 5200 },
+          { id: 'v2', empresaId: 'emp-2', capacityKg: 5800 },
+          { id: 'v3', empresaId: 'emp-3', capacityKg: 12000 },
+        ],
       ],
       inserts: [[], offers, []],
     });
@@ -260,6 +281,71 @@ describe('runMatching', () => {
     });
     expect(result.candidatesEvaluated).toBe(3);
     expect(result.offersCreated).toBe(3);
+  });
+
+  it('N+1 fix: consulta la tabla vehicles UNA sola vez para N empresas candidatas', async () => {
+    const offerRows = [
+      { id: 'o1', empresaId: 'emp-1' },
+      { id: 'o2', empresaId: 'emp-2' },
+    ];
+    const db = makeDb({
+      selects: [
+        [TRIP_BASE],
+        [{ empresaId: 'emp-1' }, { empresaId: 'emp-2' }], // zonas
+        [
+          { id: 'emp-1', isTransportista: true, status: 'activa' },
+          { id: 'emp-2', isTransportista: true, status: 'activa' },
+        ],
+        // Batch único: ambos vehículos en una sola respuesta.
+        [
+          { id: 'v1', empresaId: 'emp-1', capacityKg: 5200 },
+          { id: 'v2', empresaId: 'emp-2', capacityKg: 5800 },
+        ],
+      ],
+      inserts: [[], offerRows, []],
+    });
+    const result = await runMatching({ db: db as never, logger: noopLogger, tripId: TRIP_ID });
+
+    // Ambas empresas reciben oferta: el batch agrupa por empresa correctamente.
+    expect(result.candidatesEvaluated).toBe(2);
+    expect(result.offersCreated).toBe(2);
+
+    // El corazón del fix: la tabla vehicles se consulta EXACTAMENTE una vez,
+    // no una por empresa candidata (antes: N queries).
+    const vehicleQueries = (db.__fromCalls as unknown[]).filter((t) => t === vehicles);
+    expect(vehicleQueries).toHaveLength(1);
+
+    // Determinismo (skill empty-leg-matching §7): el batch ordena por
+    // (capacityKg, id) para que el best-fit sea estable ante empates.
+    const vehicleOrderBy = (db.__orderByCalls as unknown[][]).find(
+      (cols) => cols.includes(vehicles.capacityKg) && cols.includes(vehicles.id),
+    );
+    expect(vehicleOrderBy).toBeDefined();
+  });
+
+  it('best-fit por empresa: con 2 vehículos aptos elige el primero del orden SQL (menor capacidad)', async () => {
+    const db = makeDb({
+      selects: [
+        [TRIP_BASE],
+        [{ empresaId: 'emp-1' }],
+        [{ id: 'emp-1', isTransportista: true, status: 'activa' }],
+        // El orden lo garantiza el orderBy(capacityKg, id) en SQL; el mock
+        // lo respeta entregando el menor primero. El grouping toma el primero.
+        [
+          { id: 'veh-small', empresaId: 'emp-1', capacityKg: 5200 },
+          { id: 'veh-big', empresaId: 'emp-1', capacityKg: 9000 },
+        ],
+      ],
+      inserts: [[], [{ id: 'o1', empresaId: 'emp-1' }], []],
+    });
+    await runMatching({ db: db as never, logger: noopLogger, tripId: TRIP_ID });
+
+    // La offer insertada sugiere el vehículo best-fit (menor capacidad apta).
+    const offerInsert = (db.__insertValues as unknown[]).find(
+      (rows): rows is Array<{ suggestedVehicleId?: string }> =>
+        Array.isArray(rows) && rows.length > 0 && 'suggestedVehicleId' in (rows[0] ?? {}),
+    );
+    expect(offerInsert?.[0]?.suggestedVehicleId).toBe('veh-small');
   });
 
   it('cargo_weight null → trata como 0, sigue matching', async () => {
@@ -308,8 +394,11 @@ describe('runMatching', () => {
           { id: 'emp-1', isTransportista: true, status: 'activa' },
           { id: 'emp-2', isTransportista: true, status: 'activa' },
         ],
-        [{ id: 'v1', empresaId: 'emp-1', capacityKg: 6000 }],
-        [{ id: 'v2', empresaId: 'emp-2', capacityKg: 7000 }],
+        // Batch único de vehículos para ambas empresas (post N+1 fix).
+        [
+          { id: 'v1', empresaId: 'emp-1', capacityKg: 6000 },
+          { id: 'v2', empresaId: 'emp-2', capacityKg: 7000 },
+        ],
       ],
       inserts: [
         [],


### PR DESCRIPTION
## Qué

`runMatching` (`apps/api/src/services/matching.ts`) tenía un **N+1** en su hot path: un `SELECT` de vehículos por cada empresa candidata dentro del loop. Esta rama lo elimina y añade el **índice compuesto** que sirve la query resultante.

| Commit | Entregable |
|---|---|
| `9d1457d` | N+1: un solo `SELECT` con `inArray` para todas las empresas candidatas; best-fit por empresa resuelto en memoria (orden `capacidad_kg, id` → desempate estable, determinista — skill empty-leg-matching §7) |
| `c0ba7fc` | Índice compuesto `idx_vehiculos_empresa_estado_capacidad` + drop del redundante `idx_vehiculos_empresa` |

La query batcheada filtra por `empresa_id IN (...) AND estado_vehiculo='activo' AND capacidad_kg >= X ORDER BY capacidad_kg, id`. El índice `(empresa_id, estado_vehiculo, capacidad_kg, id)` la sirve exacta: igualdad sobre `empresa_id` (IN) + `estado_vehiculo`, rango sobre `capacidad_kg`, y entrega el orden `(capacidad_kg, id)` del best-fit sin Sort por empresa.

## Decisiones de diseño

- **Drop de `idx_vehiculos_empresa` (single-column)**: el compuesto lo cubre como prefijo (`empresa_id` es su columna líder), incl. el check del FK `vehiculos.empresa_id → empresas(id)`. Mismo criterio anti-redundancia que la migración `0040`. Neto: menos costo de escritura, cero regresión.
- **Migración `0041` idempotente** (`CREATE INDEX IF NOT EXISTS` / `DROP INDEX IF EXISTS`), rollback documentado en el `.sql`.
- **Rigor de verificación para un índice**: un índice no cambia la corrección, solo el plan; un test funcional pasaría con y sin él. Por eso el integration test assertA el **estado del esquema** (índice existe con columnas en orden; el redundante no) y que el **planner honra el diseño** vía `EXPLAIN (FORMAT JSON)` — el compuesto para la query objetivo y para acceso por `empresa_id` solo (prueba que el prefijo cubre al standalone dropeado).

## Evidencia

- **Cambios**: `apps/api/src/services/matching.ts` (N+1), `apps/api/src/db/schema.ts` (metadata ORM en sync), `apps/api/drizzle/0041_matching_vehiculos_index.sql` (nueva), `apps/api/drizzle/meta/_journal.json` (entrada idx 41), `apps/api/test/unit/matching-service*.test.ts` (N+1), `apps/api/test/integration/matching-vehiculos-index.integration.test.ts` (nueva).
- **Unit**: suite completa de `@booster-ai/api` → **1500 passed | 2 skipped (126 files)**. Incluye `migration-journal-integrity` (valida la 0041) y `matching-service` / `matching-service-v2`.
- **Typecheck**: `tsc --noEmit` → 0 errores.
- **Lint**: `biome check` → limpio.
- **Pre-commit**: gitleaks (no leaks), Biome, check-adr-numbering OK, spec-drift OK.
- **Integration (CI)**: `matching-vehiculos-index.integration.test.ts` corre en el job `integration-tests` con `postgres:15-alpine` (migraciones aplicadas inline por el migrator real de prod). Verifica los 4 asserts arriba.

### ADR compliance
- Sin nuevas dependencias ni cambios de patrón cross-módulo → no requiere ADR.
- Naming bilingüe respetado (SQL español snake_case, código inglés camelCase).
- Algoritmo de matching sin cambios de lógica; solo se optimiza el acceso a datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)