### PR TITLE
fix(deploy): timeout 3600s para el canary + corregir header stale

### DIFF
--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -1,8 +1,12 @@
 # Cloud Build pipeline — production
 #
 # Triggered desde GitHub Actions release.yml tras manual approval en el environment
-# `production`. Sin canary/split traffic por ahora (post-staging environment real,
-# task backlog #43). Al desplegar, el tráfico va 100% a la nueva revisión.
+# `production`. El deploy de apps/api usa canary: despliega la nueva revisión
+# con tag canary-signup-<sha> al 1% del tráfico, observa 30 min (step
+# canary-sleep) + verifica error_rate/p95 (canary-verify) y recién entonces
+# promueve a 100% (step deploy-api: update-traffic --to-latest). Ver T13
+# SEC-001 más abajo (~línea 154) y el runbook docs/qa/signup-canary-rollback.md.
+# El timeout global debe cubrir el sleep de 30 min — ver `timeout` al final.
 #
 # Scope:
 #   - Build + deploy de apps/api, apps/whatsapp-bot, apps/web (PWA),

--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -621,4 +621,11 @@ options:
   pool:
     name: projects/booster-ai-494222/locations/southamerica-west1/workerPools/booster-production-pool
 
-timeout: 2400s
+# Timeout global del build. DEBE acomodar el `canary-sleep` de 1800s (30 min,
+# step id: canary-sleep) MÁS el build+push de las 6 imágenes Docker + deploy
+# canary + verify + promoción. Con 2400s el presupuesto no-sleep era de solo
+# 600s (10 min) y un build frío (~11 min hasta route-canary) lo excedía →
+# TIMEOUT durante el sleep, la promoción a 100% nunca corría y el canary
+# quedaba stuck al 1% (incidente 2026-06-16, build aca4641f, deploy de a6bf14a).
+# 3600s deja ~1800s (30 min) de presupuesto no-sleep = ~3x el build observado.
+timeout: 3600s


### PR DESCRIPTION
## Problema

El deploy de prod (`cloudbuild.production.yaml`) hace un canary con un step **`canary-sleep` fijo de 1800s (30 min)**. El timeout global estaba en **2400s (40 min)**, dejando solo **600s (10 min)** de presupuesto para todo lo demás: build+push de **6 imágenes Docker** + `deploy-canary` + `route-canary` + `canary-verify` + promoción (`deploy-api`) + deploy de los otros 5 servicios.

Un build en frío consume ~11 min solo hasta `route-canary` → **excede los 2400s durante el `sleep 1800`** → el build hace **TIMEOUT** → la promoción a 100% (`deploy-api`: `update-traffic --to-latest`) **nunca corre** → el canary queda **stuck al 1%** y el 99% del tráfico en la revisión vieja.

### Incidente que lo destapó (2026-06-16)

- Merge de #483 (`a6bf14a`, perf matching) → `release.yml` → Cloud Build **`aca4641f`**.
- Build submitted 20:23:37Z → **TIMEOUT 21:04:45Z** (`build exceed the duration(seconds:2400)`).
- La revisión canary `booster-ai-api-00398-goj` se creó y sirvió 1% sin errores >30 min, pero **no promovió**.
- **Resuelto manualmente** con `gcloud run services update-traffic booster-ai-api --region southamerica-west1 --to-latest` → 100% a `00398-goj`, health 200, 0 errores. (Esto también resolvió el drift del split 1% vs Terraform.)

## Cambios

1. **`timeout: 2400s` → `timeout: 3600s`**. Deja **~1800s (30 min)** de presupuesto no-sleep = ~3x el build observado (~11 min), con headroom para builds fríos/lentos.
2. **Header stale corregido**: el comentario de cabecera decía *"Sin canary/split traffic por ahora… el tráfico va 100% a la nueva revisión"*, contradiciendo los steps de canary reales (T13 SEC-001). Reescrito para describir el flujo real (1% → 30 min → 100%) y apuntar al `timeout`.

Fix acotado al síntoma. El rediseño de fondo —**desacoplar la ventana de observación del canary del build** (p.ej. Cloud Deploy, o un job async que observe y promueva fuera del wall-clock del build)— queda como follow-up: bloquear un Cloud Build 30 min en un `sleep` es frágil por diseño.

## Evidencia

- **Cambios**: `cloudbuild.production.yaml` — `timeout` (2400s→3600s) + comentario justificando el cálculo, y reescritura del header (2 commits: `d6fced7` timeout, `ce59a57` header).
- **YAML válido**: `yaml.safe_load` OK, `timeout = 3600s`, 23 steps (intactos).
- **Pre-commit**: gitleaks (no leaks), check-adr-numbering OK.
- **Verificación del comportamiento corregido**: se observará en el **próximo deploy real** — el build deberá completar el canary (1% → 30 min → 100%) dentro de los 3600s sin timeout. No reproducible en CI (es config del runtime de Cloud Build).

### ADR compliance
- Sin nuevas dependencias ni cambio de patrón → no requiere ADR.
- No toca quality gates de CI ni IAM/Billing; solo el timeout del build de deploy + un comentario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)