### PR TITLE
perf(matching): índice compuesto en asignaciones para histórico 7d v2 (audit P1-K)

### DIFF
--- a/apps/api/drizzle/0042_matching_asignaciones_index.sql
+++ b/apps/api/drizzle/0042_matching_asignaciones_index.sql
@@ -1,0 +1,25 @@
+-- 0042 — Índice compuesto para el histórico 7d de matching v2 (audit P1-K)
+-- lookupCarriersForV2 (apps/api/src/services/matching-v2-lookups.ts) agrega por
+-- empresa el histórico de los últimos 7 días:
+--   SELECT empresa_id, count(*), sum(case ...)
+--   FROM asignaciones
+--   JOIN viajes ON viajes.id = asignaciones.viaje_id
+--   WHERE empresa_id IN (...) AND entregado_en >= now() - interval '7 days'
+--   GROUP BY empresa_id
+-- El índice (empresa_id, entregado_en) sirve esa forma: igualdad sobre
+-- empresa_id (IN) + rango sobre entregado_en → index range scan por empresa,
+-- sin escanear asignaciones antiguas. Con histórico grande la query pasa de
+-- seq scan O(n) a O(filas de las empresas candidatas en la ventana).
+--
+-- Idempotente (IF NOT EXISTS / IF EXISTS). Rollback: ver al final.
+CREATE INDEX IF NOT EXISTS "idx_asignaciones_empresa_entregado"
+  ON "asignaciones" ("empresa_id", "entregado_en");
+--> statement-breakpoint
+
+-- idx_asignaciones_empresa (single-column sobre empresa_id) queda redundante: el
+-- compuesto de arriba lo cubre como prefijo (empresa_id es su columna líder),
+-- así que toda query por empresa_id solo —incluido el check del FK
+-- asignaciones.empresa_id → empresas(id)— sigue indexada por el prefijo. Mismo
+-- criterio anti-redundancia que 0040/0041. Rollback: recrear con
+--   CREATE INDEX "idx_asignaciones_empresa" ON "asignaciones" ("empresa_id");
+DROP INDEX IF EXISTS "idx_asignaciones_empresa";

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1780876800005,
       "tag": "0041_matching_vehiculos_index",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1780876800006,
+      "tag": "0042_matching_asignaciones_index",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1225,7 +1225,18 @@ export const assignments = pgTable(
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => ({
-    empresaIdx: index('idx_asignaciones_empresa').on(table.empresaId),
+    // Índice compuesto del histórico 7d de matching v2 (lookupCarriersForV2 →
+    // agregación por empresa, matching-v2-lookups.ts): WHERE empresa_id IN (...)
+    // AND entregado_en >= now() - interval '7 days' GROUP BY empresa_id.
+    // empresa_id (igualdad/IN) + entregado_en (rango) → index range scan por
+    // empresa sin escanear asignaciones viejas. Creado en 0042 (audit P1-K).
+    empresaEntregadoIdx: index('idx_asignaciones_empresa_entregado').on(
+      table.empresaId,
+      table.deliveredAt,
+    ),
+    // idx_asignaciones_empresa (single-column) dropeado en 0042: el compuesto
+    // de arriba lo cubre como prefijo (empresa_id es su columna líder), incl.
+    // el check del FK a empresas. Mismo criterio anti-redundancia que 0040/0041.
     statusIdx: index('idx_asignaciones_estado').on(table.status),
     driverIdx: index('idx_asignaciones_conductor').on(table.driverUserId),
   }),

--- a/apps/api/test/integration/matching-asignaciones-index.integration.test.ts
+++ b/apps/api/test/integration/matching-asignaciones-index.integration.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { type TestDbHandle, createTestDb } from '../helpers/test-db.js';
+
+/**
+ * Audit P1-K — migración 0042.
+ *
+ * Igual que 0041 (índice de vehículos), un índice no cambia la corrección de
+ * la query sino el plan; el rigor es assertar el ESTADO DEL ESQUEMA que deja la
+ * migración y que el PLANNER honra la decisión de diseño:
+ *
+ *   1. idx_asignaciones_empresa_entregado existe sobre `asignaciones` con las
+ *      columnas en el orden (empresa_id, entregado_en).
+ *   2. idx_asignaciones_empresa (single-column, redundante) ya NO existe.
+ *   3. La query del histórico 7d de matching v2 usa el índice compuesto.
+ *   4. Una query por empresa_id solo TAMBIÉN lo usa (prueba que el prefijo
+ *      cubre al standalone dropeado → justifica el drop, no es regresión).
+ *
+ * Migraciones aplicadas por el globalSetup (runMigrations real de prod).
+ */
+describe('integration: índice de matching v2 de asignaciones (migración 0042)', () => {
+  let handle: TestDbHandle;
+
+  beforeAll(() => {
+    handle = createTestDb();
+  });
+
+  afterAll(async () => {
+    await handle.pool.end();
+  });
+
+  test('1: idx_asignaciones_empresa_entregado existe con las columnas en orden', async () => {
+    const res = await handle.pool.query<{ indexdef: string }>(
+      `SELECT indexdef FROM pg_indexes
+       WHERE schemaname = 'public'
+         AND tablename = 'asignaciones'
+         AND indexname = 'idx_asignaciones_empresa_entregado'`,
+    );
+    expect(res.rowCount).toBe(1);
+    expect(res.rows[0].indexdef).toContain('(empresa_id, entregado_en)');
+  });
+
+  test('2: idx_asignaciones_empresa (single-column redundante) ya no existe', async () => {
+    const res = await handle.pool.query(
+      `SELECT 1 FROM pg_indexes
+       WHERE schemaname = 'public'
+         AND tablename = 'asignaciones'
+         AND indexname = 'idx_asignaciones_empresa'`,
+    );
+    expect(res.rowCount).toBe(0);
+  });
+
+  test('3: la query del histórico 7d usa el índice compuesto', async () => {
+    // enable_seqscan=off aísla "¿este índice es usable para esta forma de
+    // query?" sin depender del volumen de datos (en tabla chica el planner
+    // elegiría seqscan por costo, lo que NO es evidencia contra el índice).
+    const client = await handle.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query('SET LOCAL enable_seqscan = off');
+      const explain = await client.query<{ 'QUERY PLAN': unknown }>(
+        `EXPLAIN (FORMAT JSON)
+         SELECT empresa_id, count(*)
+         FROM asignaciones
+         WHERE empresa_id IN ('00000000-0000-0000-0000-000000000001'::uuid)
+           AND entregado_en >= now() - interval '7 days'
+         GROUP BY empresa_id`,
+      );
+      const plan = JSON.stringify(explain.rows[0]['QUERY PLAN']);
+      expect(plan).toContain('idx_asignaciones_empresa_entregado');
+      expect(plan).toMatch(/Index (Only )?Scan|Bitmap Index Scan/);
+    } finally {
+      await client.query('ROLLBACK');
+      client.release();
+    }
+  });
+
+  test('4: una query por empresa_id solo usa el prefijo del compuesto (justifica el drop)', async () => {
+    const client = await handle.pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query('SET LOCAL enable_seqscan = off');
+      const explain = await client.query<{ 'QUERY PLAN': unknown }>(
+        `EXPLAIN (FORMAT JSON)
+         SELECT * FROM asignaciones
+         WHERE empresa_id = '00000000-0000-0000-0000-000000000001'::uuid`,
+      );
+      const plan = JSON.stringify(explain.rows[0]['QUERY PLAN']);
+      expect(plan).toContain('idx_asignaciones_empresa_entregado');
+    } finally {
+      await client.query('ROLLBACK');
+      client.release();
+    }
+  });
+});


### PR DESCRIPTION
## Qué

Resuelve **P1-K** de la auditoría 2026-06-14. `lookupCarriersForV2` (`apps/api/src/services/matching-v2-lookups.ts`) agrega por empresa el histórico de asignaciones de los últimos 7 días:

```sql
SELECT empresa_id, count(*), sum(case when ... end)
FROM asignaciones
JOIN viajes ON viajes.id = asignaciones.viaje_id
WHERE empresa_id IN (...) AND entregado_en >= now() - interval '7 days'
GROUP BY empresa_id
```

`asignaciones` tenía índices sueltos (`empresa`, `estado`, `conductor`) pero **ninguno componía `empresa_id` + `entregado_en`**, así que el filtro de ventana hacía seq scan sobre toda la tabla.

- **Añade** `idx_asignaciones_empresa_entregado` sobre `(empresa_id, entregado_en)`: igualdad sobre `empresa_id` (IN) + rango sobre `entregado_en` → index range scan por empresa, sin escanear asignaciones antiguas. Con histórico grande pasa de O(n) a O(filas de las empresas candidatas en la ventana).
- **Dropea** `idx_asignaciones_empresa` (single-column): el compuesto lo cubre como prefijo (`empresa_id` es su columna líder), incl. el check del FK a `empresas`. Mismo criterio anti-redundancia que `0040`/`0041` (este último, #483).

## Decisión de diseño (consistente con #483)

Igual que el índice de vehículos de #483 (aprobado por el PO): añadir el compuesto + dropear el single-column redundante. El test 4 (EXPLAIN por `empresa_id` solo) prueba que el prefijo cubre al standalone → cero regresión.

## Evidencia

- **Cambios**: `apps/api/src/db/schema.ts` (índice ORM en sync), `apps/api/drizzle/0042_matching_asignaciones_index.sql` (nueva, idempotente + rollback), `apps/api/drizzle/meta/_journal.json` (idx 42), `apps/api/test/integration/matching-asignaciones-index.integration.test.ts` (nueva). `git diff`: 4 files, +138/-1.
- **Unit**: suite completa de `@booster-ai/api` → **1500 passed | 2 skipped (126 files)** (incl. `migration-journal-integrity` que valida la 0042).
- **Typecheck**: `tsc --noEmit` → 0 errores.
- **Lint**: `biome check` → limpio.
- **Pre-commit**: gitleaks (no leaks), check-adr-numbering OK, spec-drift OK.
- **Integration (CI)**: `matching-asignaciones-index.integration.test.ts` corre en el job `integration-tests` (`postgres:15-alpine`, migrator real). Verifica índice existe con columnas en orden, el redundante no, y EXPLAIN usa el compuesto (histórico 7d + acceso por empresa_id solo).

### ADR compliance
- Sin nuevas dependencias ni cambio de patrón → no requiere ADR.
- Naming bilingüe respetado (SQL español snake_case). Lógica de matching sin cambios; solo acceso a datos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)