### PR TITLE
fix(whatsapp): validar HMAC del status callback contra URL configurable (audit P1-6)

### DIFF
--- a/apps/whatsapp-bot/src/config.ts
+++ b/apps/whatsapp-bot/src/config.ts
@@ -35,6 +35,15 @@ const whatsAppBotEnvSchema = commonEnvSchema
      */
     TWILIO_WEBHOOK_URL: z.string().url(),
 
+    /**
+     * URL pública EXACTA del status callback (Twilio Console → Status callback
+     * URL). El HMAC del status callback se firma sobre ESTA url (P1-6). Opcional:
+     * si se omite, se deriva de `TWILIO_WEBHOOK_URL` cambiando el path a
+     * `/webhooks/twilio-status`. Cablear cuando la Console use un dominio/path
+     * distinto al del inbound webhook, o el HMAC del status callback se rechaza.
+     */
+    TWILIO_STATUS_CALLBACK_URL: z.string().url().optional(),
+
     /** URL del apps/api — para llamar POST /trip-requests */
     API_URL: z.string().url(),
 

--- a/apps/whatsapp-bot/src/main.ts
+++ b/apps/whatsapp-bot/src/main.ts
@@ -96,6 +96,7 @@ app.route(
     redis,
     authToken: config.TWILIO_AUTH_TOKEN,
     webhookUrl: config.TWILIO_WEBHOOK_URL,
+    statusWebhookUrl: config.TWILIO_STATUS_CALLBACK_URL,
     logger,
   }),
 );

--- a/apps/whatsapp-bot/src/routes/webhook.test.ts
+++ b/apps/whatsapp-bot/src/routes/webhook.test.ts
@@ -1,4 +1,4 @@
-import type { TwilioWhatsAppClient } from '@booster-ai/whatsapp-client';
+import { type TwilioWhatsAppClient, verifyTwilioSignature } from '@booster-ai/whatsapp-client';
 import type Redis from 'ioredis';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConversationStore } from '../conversation/store.js';
@@ -55,6 +55,7 @@ function makeApp(opts?: {
   whatsAppClient?: TwilioWhatsAppClient;
   apiClient?: ApiClient;
   redis?: RedisStub;
+  statusWebhookUrl?: string;
 }) {
   const redis = opts?.redis ?? makeRedisStub();
   const store =
@@ -72,6 +73,7 @@ function makeApp(opts?: {
     redis: redis as unknown as Redis,
     authToken: 'test_token',
     webhookUrl: 'https://example.test/webhooks/whatsapp',
+    statusWebhookUrl: opts?.statusWebhookUrl,
     logger: noopLogger,
   });
 
@@ -294,5 +296,44 @@ describe('POST /webhooks/twilio-status', () => {
     });
     expect(res.status).toBe(200);
     expect(noopLogger.error).toHaveBeenCalled();
+  });
+
+  // P1-6: el HMAC del status callback debe validarse contra la URL EXACTA con
+  // la que Twilio firma (la configurada en su Console → Status callback URL),
+  // no contra una derivada del inbound webhook que puede no coincidir.
+  it('valida la firma contra TWILIO_STATUS_CALLBACK_URL cuando está configurada', async () => {
+    const { app } = makeApp({ statusWebhookUrl: 'https://callbacks.test/twilio/status' });
+    await app.request('/webhooks/twilio-status', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-twilio-signature': 'fakesig',
+      },
+      body: form({ MessageSid: 'SMd', MessageStatus: 'delivered' }),
+    });
+    expect(vi.mocked(verifyTwilioSignature)).toHaveBeenCalledWith(
+      'test_token',
+      'fakesig',
+      'https://callbacks.test/twilio/status',
+      expect.anything(),
+    );
+  });
+
+  it('sin TWILIO_STATUS_CALLBACK_URL deriva la URL del status callback desde webhookUrl', async () => {
+    const { app } = makeApp();
+    await app.request('/webhooks/twilio-status', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/x-www-form-urlencoded',
+        'x-twilio-signature': 'fakesig',
+      },
+      body: form({ MessageSid: 'SMe', MessageStatus: 'delivered' }),
+    });
+    expect(vi.mocked(verifyTwilioSignature)).toHaveBeenCalledWith(
+      'test_token',
+      'fakesig',
+      'https://example.test/webhooks/twilio-status',
+      expect.anything(),
+    );
   });
 });

--- a/apps/whatsapp-bot/src/routes/webhook.ts
+++ b/apps/whatsapp-bot/src/routes/webhook.ts
@@ -34,9 +34,27 @@ export function createWebhookRoutes(opts: {
   redis: Redis;
   authToken: string;
   webhookUrl: string;
+  /**
+   * URL exacta con la que Twilio firma el **status callback** (P1-6). Twilio
+   * calcula el HMAC sobre la URL configurada en su Console → Status callback
+   * URL, que puede diferir del inbound webhook (otro dominio/path/trailing
+   * slash). Si se omite, se deriva de `webhookUrl` cambiando el path a
+   * `/webhooks/twilio-status` (default backwards-compat). Cablear vía
+   * `TWILIO_STATUS_CALLBACK_URL` cuando la Console use una URL distinta.
+   */
+  statusWebhookUrl?: string | undefined;
   logger: Logger;
 }) {
-  const { store, whatsAppClient, apiClient, redis, authToken, webhookUrl, logger } = opts;
+  const {
+    store,
+    whatsAppClient,
+    apiClient,
+    redis,
+    authToken,
+    webhookUrl,
+    statusWebhookUrl,
+    logger,
+  } = opts;
   const app = new Hono();
 
   // Twilio no usa GET handshake. Si pinguean GET, devolvemos 200 vacío para health-check
@@ -146,14 +164,19 @@ export function createWebhookRoutes(opts: {
       params[key] = value;
     }
 
-    // Twilio firma con la URL configurada en Twilio console — necesita ser la
-    // URL del status callback, no la del inbound webhook. Aceptamos ambas
-    // para flexibilidad (si admin configura status callback en una URL
-    // distinta, debe setear STATUS_WEBHOOK_URL env var; default = webhookUrl
-    // con path /twilio-status).
-    const statusWebhookUrl = `${webhookUrl.replace(/\/webhooks\/whatsapp$/, '')}/webhooks/twilio-status`;
+    // Twilio firma con la URL EXACTA configurada en su Console → Status
+    // callback URL, que puede no coincidir con el inbound webhook (otro
+    // dominio/path/trailing slash). P1-6: si está cableada
+    // `TWILIO_STATUS_CALLBACK_URL` (→ opts.statusWebhookUrl) se usa esa;
+    // si no, se deriva de `webhookUrl` cambiando el path (default
+    // backwards-compat). Antes la env var se documentaba pero NUNCA se leía:
+    // el HMAC se validaba siempre contra la derivada → rechazaba callbacks
+    // legítimos cuando la Console usaba otra URL.
+    const resolvedStatusUrl =
+      statusWebhookUrl ??
+      `${webhookUrl.replace(/\/webhooks\/whatsapp$/, '')}/webhooks/twilio-status`;
 
-    if (!verifyTwilioSignature(authToken, signatureHeader, statusWebhookUrl, params)) {
+    if (!verifyTwilioSignature(authToken, signatureHeader, resolvedStatusUrl, params)) {
       logger.warn(
         { signatureProvided: !!signatureHeader },
         'Twilio status callback signature invalid',


### PR DESCRIPTION
## Qué

Resuelve **P1-6** de la auditoría 2026-06-14. El handler `POST /webhooks/twilio-status` (`apps/whatsapp-bot/src/routes/webhook.ts`) derivaba la URL del HMAC string-replaceando el path del inbound webhook:

```ts
const statusWebhookUrl = `${webhookUrl.replace(/\/webhooks\/whatsapp$/, '')}/webhooks/twilio-status`;
```

El comentario decía que el admin *"debe setear `STATUS_WEBHOOK_URL` env var"* — pero **esa env var nunca se leía**: el HMAC se validaba siempre contra la URL derivada. Twilio firma el callback sobre la URL **exacta** configurada en su Console → *Status callback URL*; si esa difiere de la derivada (otro dominio, path, o trailing slash), el callback legítimo se rechaza con **403** (delivery receipts perdidos).

## Fix

- Añade `TWILIO_STATUS_CALLBACK_URL` (Zod, **opcional**) al config del bot.
- `createWebhookRoutes` acepta `statusWebhookUrl`; el handler usa `statusWebhookUrl ?? <derivado>`.
- **Backwards-compat**: si la env var no se setea, el comportamiento es idéntico al anterior (deriva del inbound). Sin cambio de infra requerido — es opt-in.

## TDD

- **RED**: test que assertA la URL exacta pasada a `verifyTwilioSignature` cuando `TWILIO_STATUS_CALLBACK_URL` está configurada → falla (el handler ignoraba el param, usaba la derivada).
- **GREEN**: el handler usa el override → pasa.
- **Guard**: test que confirma que sin la env var se sigue derivando la URL (no rompe el default).

## Evidencia

- **Cambios**: `webhook.ts` (handler + factory param), `webhook.test.ts` (2 tests nuevos), `config.ts` (Zod), `main.ts` (wiring). `git diff`: 4 files, +84/-10.
- **Tests**: `@booster-ai/whatsapp-bot` → **44 passed (6 files)**, incl. los 2 nuevos de P1-6.
- **Typecheck**: `tsc --noEmit` → 0 errores (incl. `exactOptionalPropertyTypes`).
- **Lint**: `biome check` → limpio.
- **Pre-commit**: gitleaks (no leaks), check-adr-numbering OK, spec-drift OK.

### ADR compliance
- Sin nuevas dependencias ni cambio de patrón → no requiere ADR.
- Validación en boundary con Zod (env var nueva en el schema del config). HMAC sin cambios; solo la URL canónica ahora es configurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)