### PR TITLE
feat(deploy): automatizar deploy GKE del gateway vía DNS endpoint (audit P0-I, ADR-065)

### DIFF
--- a/.specs/_followups/P0-I-gke-deploy-manual.md
+++ b/.specs/_followups/P0-I-gke-deploy-manual.md
@@ -1,5 +1,7 @@
 # P0-I — Deploy del telemetry-tcp-gateway (GKE) es manual
 
+> ✅ **RESUELTO (2026-06-16)** — [ADR-065](../../docs/adr/065-automate-gke-gateway-deploy-via-dns-endpoint.md). Se automatizó el deploy (Opción B, no el gate de la Opción A): el step `gke-deploy` de `cloudbuild.production.yaml` hace `kubectl set image` + `rollout status` vía DNS endpoint (ADR-059), gateado por IAM (SA `github-deployer` con `roles/container.developer`, ambos validados live). Corre tras `deploy-api` (API a salvo al 100%) y falla-ruidoso si el rollout no converge → fin del drift silencioso. Validación de reachability del worker pool → DNS endpoint pendiente del primer release real (residual documentado en el ADR; break-glass = script manual).
+
 **Dimensión**: sre · **Esfuerzo**: M (gate corto plazo) / L (VPC largo plazo)
 **Fuente**: audit 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ packages/
 
 infrastructure/              # Terraform (GCP)
 .claude/                     # Plugins config + ledger + worktrees (post-ADR-049/060)
-docs/adr/                    # Architecture Decision Records (001..064)
+docs/adr/                    # Architecture Decision Records (001..065)
 ```
 
 ## Desarrollo con agentes de IA

--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -473,35 +473,35 @@ steps:
 
   # apps/telemetry-tcp-gateway — GKE Autopilot. NO va a Cloud Run.
   #
-  # NOTA OPERACIONAL (2026-05-09): el deploy a GKE NO se hace desde Cloud
-  # Build private pool. El pool y el GKE control plane usan service
-  # networking peerings independientes que no propagan rutas entre si
-  # (limitacion VPC peering no-transitivo). kubectl desde el pool al
-  # master interno (172.16.0.2) hace timeout.
+  # ADR-065 (2026-06-16): deploy AUTOMÁTICO desde Cloud Build vía DNS endpoint
+  # del control plane (ADR-059), reemplaza el stdout-only manual (audit P0-I).
+  # El SA github-deployer (roles/container.developer) hace `kubectl set image`
+  # al SHA buildeado y verifica el rollout, gateado por IAM — sin depender del
+  # VPC peering (la NOTA stale 2026-05-09 era previa a ADR-059).
   #
-  # Cloud Build SOLO buildea + pushea la imagen :${_COMMIT_SHA} a
-  # Artifact Registry. El operador deploya manualmente desde su laptop
-  # (autorizado en master_authorized_networks_config) o via IAP TCP:
-  #
-  #   ./scripts/deploy-telemetry-gateway.sh ${_COMMIT_SHA}
-  #
-  # El script hace `kubectl set image` al SHA buildeado. Output del
-  # build incluye el SHA para facilitar copy-paste.
-  - id: gke-deploy-instructions
-    name: gcr.io/cloud-builders/curl
+  # Ordenamiento `waitFor: [deploy-api, ...]`: corre DESPUÉS de que el API se
+  # promovió a 100%. Si el rollout del gateway falla, el build falla SIN poner
+  # en riesgo el canary del API (que ya está a salvo). Fail-loud: un rollout
+  # fallido o que no converge alerta al operador → no más drift silencioso.
+  # Break-glass: scripts/deploy-telemetry-gateway.sh sigue disponible desde una
+  # laptop autorizada si la ruta de Cloud Build falla.
+  - id: gke-deploy
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
     entrypoint: bash
+    env:
+      - USE_GKE_GCLOUD_AUTH_PLUGIN=True
     args:
       - -c
       - |
-        echo "=========================================="
-        echo "  GKE deploy MANUAL pendiente"
-        echo "=========================================="
-        echo "  Imagen lista: ${_REGISTRY}/telemetry-tcp-gateway:${_COMMIT_SHA}"
-        echo ""
-        echo "  Para deployar al gateway, ejecutar desde laptop autorizado:"
-        echo "    ./scripts/deploy-telemetry-gateway.sh ${_COMMIT_SHA}"
-        echo "=========================================="
-    waitFor: [push-telemetry-tcp-gateway]
+        set -euo pipefail
+        gcloud container clusters get-credentials booster-ai-telemetry \
+          --region=${_REGION} --project=$PROJECT_ID --dns-endpoint
+        kubectl set image deployment/telemetry-tcp-gateway \
+          gateway=${_REGISTRY}/telemetry-tcp-gateway:${_COMMIT_SHA} \
+          -n telemetry
+        kubectl rollout status deployment/telemetry-tcp-gateway \
+          -n telemetry --timeout=300s
+    waitFor: [deploy-api, push-telemetry-tcp-gateway]
 
   # =========================================================================
   # Smoke test — ping al webhook Twilio via la URL pública canonical.

--- a/docs/adr/065-automate-gke-gateway-deploy-via-dns-endpoint.md
+++ b/docs/adr/065-automate-gke-gateway-deploy-via-dns-endpoint.md
@@ -1,0 +1,60 @@
+# ADR-065 — Automatizar el deploy del telemetry-tcp-gateway a GKE vía DNS endpoint
+
+**Estado**: Accepted
+**Fecha**: 2026-06-16
+**Decider**: Felipe Vicencio (Product Owner)
+**Related**: [ADR-059](./059-gke-dns-endpoint.md) (habilita la conectividad), `cloudbuild.production.yaml`, auditoría 2026-06-14 (P0-I)
+
+---
+
+## Contexto
+
+`apps/telemetry-tcp-gateway` corre en GKE Autopilot (no Cloud Run): es el servidor TCP que reciben los devices Teltonika. El resto de los servicios los deploya Cloud Build directamente, pero el gateway **no**: el step `gke-deploy-instructions` de `cloudbuild.production.yaml` solo **imprime instrucciones por stdout** y un humano corre `scripts/deploy-telemetry-gateway.sh` a mano desde una laptop autorizada.
+
+La auditoría 2026-06-14 lo marcó **P0-I**: en cada release el gateway queda en la versión anterior hasta que alguien corra el script, **sin alerta ni gate**. Los Teltonika hablan con código desactualizado en silencio — drift en el camino crítico de telemetría.
+
+El comentario del step (2026-05-09) justificaba el stdout-only con que el Cloud Build private pool y el GKE control plane usan VPC peerings no-transitivos → `kubectl` desde el pool al master interno hace timeout. **Ese comentario quedó stale**: [ADR-059](./059-gke-dns-endpoint.md) (2026-05-13) habilitó el **DNS endpoint** del control plane (`controlPlaneEndpointsConfig.dnsEndpointConfig.allowExternalTraffic = true`), que es alcanzable por IAM **sin** depender del peering de la VPC.
+
+### Validación de prerrequisitos (2026-06-16)
+
+| Prerrequisito | Estado |
+|---|---|
+| SA del build `github-deployer@` tiene permisos GKE | ✅ `roles/container.developer` (cubre `clusters.get`, `deployments.get/update`) |
+| DNS endpoint del cluster `booster-ai-telemetry` habilitado | ✅ `gke-ca908…gke.goog`, `allowExternalTraffic = True` |
+| Build corre como ese SA | ✅ `serviceAccount:` en `cloudbuild.production.yaml` |
+
+## Decisión
+
+Reemplazar el step `gke-deploy-instructions` (stdout) por un step `gke-deploy` que **ejecuta el deploy real** desde Cloud Build:
+
+```
+gcloud container clusters get-credentials booster-ai-telemetry \
+  --region=${_REGION} --project=${PROJECT_ID} --dns-endpoint
+kubectl set image deployment/telemetry-tcp-gateway gateway=${_REGISTRY}/telemetry-tcp-gateway:${_COMMIT_SHA} -n telemetry
+kubectl rollout status deployment/telemetry-tcp-gateway -n telemetry --timeout=300s
+```
+
+Decisiones de diseño:
+
+1. **Conectividad vía `--dns-endpoint`** (IAM-gated, no VPC). Desbloqueado por ADR-059. La autenticación es el WIF del SA `github-deployer`; no hay keys.
+
+2. **Ordenamiento: `waitFor: [deploy-api, push-telemetry-tcp-gateway]`.** El step corre **después** de que el API se promovió a 100% (step `deploy-api`). Razón: el `gke-deploy` puede fallar (rollout); si corriera en paralelo al canary del API, su fallo abortaría el build y dejaría el canary del API **sin promover** (el mismo mal estado del incidente de timeout, ADR del #484). Ejecutándolo tras la promoción, un fallo del gateway no pone en riesgo al API, que ya está a salvo al 100%.
+
+3. **Falla ruidosa (fail-loud).** `set -euo pipefail` + `kubectl rollout status --timeout=300s`. Si el rollout falla o no converge, el step falla → el build falla → el operador es alertado. Esto **es** el fix de P0-I: el drift silencioso ("alguien olvidó deployar") se vuelve imposible. `kubectl set image` es atómico: si falla, el deployment queda en la imagen anterior (sin estado parcial).
+
+4. **El script manual se conserva** como break-glass: si la ruta de Cloud Build falla (p.ej. el worker pool no tiene egress al DNS endpoint), el operador puede seguir corriendo `scripts/deploy-telemetry-gateway.sh` desde una laptop autorizada.
+
+5. **Presupuesto de timeout.** El step agrega ~2-5 min después de `deploy-api` (~42 min en el build). Total ~47 min < `timeout: 3600s` (60 min, #484). Holgura suficiente.
+
+## Consecuencias
+
+**Positivas**:
+- Elimina la clase de drift silencioso del gateway (riesgo P0). El gateway se deploya en cada release, automáticamente, con verificación de rollout.
+- Sin paso manual en el camino feliz; el operador solo interviene en break-glass.
+- Reusa la conectividad de ADR-059 sin infra nueva.
+
+**Negativas / riesgos**:
+- **Residual no testeable localmente**: el pipeline de Cloud Build no es ejecutable fuera de un release real. La reachability del worker pool privado → DNS endpoint (`*.gke.goog`, egress a internet) **se valida en el primer release** post-merge. Si el pool no tiene egress, el step falla ruidoso (no silencioso) y el operador cae al script manual; se itera con un follow-up de networking del pool.
+- Un fallo del gateway ahora **falla el release** (después de que el API ya está al 100%). Es el comportamiento deseado (fail-loud vs drift), pero exige atención del operador ante un build rojo cuyo API sí se desplegó.
+
+**Re-evaluar si**: el worker pool resulta sin egress al DNS endpoint (→ networking del pool o Cloud Deploy), o si se quiere auto-rollback (`kubectl rollout undo`) en vez de fail-loud.


### PR DESCRIPTION
## Qué

Resuelve **P0-I** de la auditoría 2026-06-14 ([ADR-065](docs/adr/065-automate-gke-gateway-deploy-via-dns-endpoint.md)). El step `gke-deploy-instructions` de `cloudbuild.production.yaml` solo **imprimía instrucciones por stdout**; el deploy del `telemetry-tcp-gateway` a GKE lo hacía un humano a mano. En cada release el gateway quedaba en la versión anterior hasta que alguien corriera el script, **sin alerta** → drift silencioso en el camino crítico de telemetría (los Teltonika hablando con código viejo).

## Por qué ahora se puede automatizar

El comentario que justificaba el stdout-only (2026-05-09: "VPC peering no-transitivo → kubectl timeout") quedó **stale**: **ADR-059** (2026-05-13) habilitó el **DNS endpoint** del control plane, alcanzable por IAM sin depender del peering.

**Validado live (read-only) antes de implementar:**
| Prerrequisito | Estado |
|---|---|
| SA `github-deployer@` tiene permisos GKE | ✅ `roles/container.developer` |
| DNS endpoint del cluster `booster-ai-telemetry` | ✅ `gke-ca908…gke.goog`, `allowExternalTraffic=True` |

## Cambio

Reemplaza el step por `gke-deploy` (Opción B = automatizar, no el gate de la Opción A):

```
gcloud container clusters get-credentials booster-ai-telemetry --region=${_REGION} --project=$PROJECT_ID --dns-endpoint
kubectl set image deployment/telemetry-tcp-gateway gateway=${_REGISTRY}/telemetry-tcp-gateway:${_COMMIT_SHA} -n telemetry
kubectl rollout status deployment/telemetry-tcp-gateway -n telemetry --timeout=300s
```

Decisiones de diseño (detalle en ADR-065):
- **`waitFor: [deploy-api, ...]`** — corre tras la promoción del API a 100%. Si el rollout del gateway falla, el build falla **sin** poner en riesgo el canary del API (evita repetir el mal estado del incidente de timeout #484).
- **Fail-loud** (`set -euo pipefail` + `rollout status --timeout`): un rollout que no converge alerta al operador → fin del drift silencioso. `kubectl set image` es atómico (sin estado parcial).
- **Break-glass**: `scripts/deploy-telemetry-gateway.sh` se conserva para deploy manual si la ruta de Cloud Build falla.

## Evidencia

- **Validación IAM/DNS endpoint**: `gcloud` read-only confirmó `container.developer` + DNS endpoint habilitado (arriba).
- **YAML válido**: `yaml.safe_load` OK, `timeout=3600s` intacto, 23 steps, step `gke-deploy` presente, 0 referencias colgantes al step viejo, `deploy-api` existe como dependencia.
- **Pre-commit**: gitleaks (no leaks), **check-adr-numbering OK** (065 libre), spec-drift OK.
- **Residual (documentado en ADR-065)**: la reachability del **worker pool privado → DNS endpoint** (`*.gke.goog`, egress) no es testeable fuera de un release real. **Se valida en el primer release post-merge**: si el pool no tiene egress, el step falla ruidoso (no silencioso) y el operador cae al script manual; se itera con follow-up de networking. El cambio es net-positivo en cualquier caso (fail-loud > drift silencioso).

Archivos: `docs/adr/065-*.md` (nuevo), `cloudbuild.production.yaml` (step), `.specs/_followups/P0-I-*.md` (resuelto), `README.md` (rango ADR → 065).

🤖 Generated with [Claude Code](https://claude.com/claude-code)