### PR TITLE
feat(telemetry): rate limiting del open enrollment del TCP gateway (audit P1-L)

### DIFF
--- a/apps/telemetry-tcp-gateway/src/config.ts
+++ b/apps/telemetry-tcp-gateway/src/config.ts
@@ -55,6 +55,42 @@ const envSchema = z.object({
     .pipe(z.number().int().min(30).max(3600)),
 
   // -------------------------------------------------------------------------
+  // Rate limiting (audit P1-L) — protección DoS del open enrollment.
+  // In-memory per-pod; no depende de IP cliente (el LB TCP la enmascara).
+  // -------------------------------------------------------------------------
+
+  /**
+   * Cap de conexiones TCP concurrentes por pod. Acota agotamiento de FDs/
+   * memoria ante un flood. Default 5000 = holgado para flota real (10 devices
+   * piloto, miles a escala) pero muy por debajo del límite de FDs del pod.
+   * Conexiones por encima del cap se rechazan inmediatamente (destroy).
+   */
+  MAX_CONCURRENT_CONNECTIONS: z
+    .string()
+    .default('5000')
+    .transform((s) => Number.parseInt(s, 10))
+    .pipe(z.number().int().min(10).max(100000)),
+
+  /**
+   * Máximo de IMEIs nuevos (enrollments) admitidos por ventana, por pod.
+   * Excedido → el IMEI desconocido se descarta sin escribir en
+   * dispositivos_pendientes (acota crecimiento de tabla por flood). Default 30
+   * por 60s: un instalador enrola un puñado; un atacante hace miles/seg.
+   */
+  ENROLLMENT_RATE_MAX: z
+    .string()
+    .default('30')
+    .transform((s) => Number.parseInt(s, 10))
+    .pipe(z.number().int().min(1).max(100000)),
+
+  /** Ventana del rate limit de enrollment, en segundos. */
+  ENROLLMENT_RATE_WINDOW_SEC: z
+    .string()
+    .default('60')
+    .transform((s) => Number.parseInt(s, 10))
+    .pipe(z.number().int().min(1).max(3600)),
+
+  // -------------------------------------------------------------------------
   // Wave 3 — TLS endpoint (Track D3)
   // -------------------------------------------------------------------------
 

--- a/apps/telemetry-tcp-gateway/src/connection-handler.ts
+++ b/apps/telemetry-tcp-gateway/src/connection-handler.ts
@@ -12,6 +12,7 @@ import type { Logger } from '@booster-ai/logger';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import { resolveImei } from './imei-auth.js';
 import type { CrashTracePublisher, TelemetryPublisher } from './pubsub-publisher.js';
+import type { RateLimiter } from './rate-limiter.js';
 
 /**
  * Lifecycle de una conexión TCP de un device Teltonika:
@@ -73,6 +74,8 @@ export interface ConnectionDeps {
   crashPublisher: CrashTracePublisher | null;
   logger: Logger;
   idleTimeoutSec: number;
+  /** Rate limiter del open enrollment (P1-L). Se pasa a resolveImei. */
+  enrollmentLimiter: RateLimiter;
 }
 
 interface ConnectionState {
@@ -86,7 +89,7 @@ interface ConnectionState {
 }
 
 export function handleConnection(socket: Socket, deps: ConnectionDeps): void {
-  const { db, publisher, crashPublisher, logger, idleTimeoutSec } = deps;
+  const { db, publisher, crashPublisher, logger, idleTimeoutSec, enrollmentLimiter } = deps;
   const sourceIp = socket.remoteAddress ?? null;
   const childLogger = logger.child({
     component: 'connection-handler',
@@ -133,6 +136,7 @@ export function handleConnection(socket: Socket, deps: ConnectionDeps): void {
       crashPublisher,
       logger: childLogger,
       sourceIp,
+      enrollmentLimiter,
     }).catch((err) => {
       childLogger.error({ err }, 'error procesando buffer, cerrando conexión');
       socket.destroy();
@@ -148,8 +152,10 @@ async function processBuffer(opts: {
   crashPublisher: CrashTracePublisher | null;
   logger: Logger;
   sourceIp: string | null;
+  enrollmentLimiter: RateLimiter;
 }): Promise<void> {
-  const { state, socket, db, publisher, crashPublisher, logger, sourceIp } = opts;
+  const { state, socket, db, publisher, crashPublisher, logger, sourceIp, enrollmentLimiter } =
+    opts;
 
   // Fase 1: handshake IMEI.
   if (!state.receivedFirstHandshake) {
@@ -166,7 +172,7 @@ async function processBuffer(opts: {
       state.imei = imei;
       state.buffer = state.buffer.subarray(2 + declaredLen);
 
-      const resolution = await resolveImei({ db, logger, imei, sourceIp });
+      const resolution = await resolveImei({ db, logger, imei, sourceIp, enrollmentLimiter });
       state.vehicleId = resolution.vehicleId;
       state.pendingDeviceId = resolution.pendingDeviceId;
       state.receivedFirstHandshake = true;

--- a/apps/telemetry-tcp-gateway/src/imei-auth.ts
+++ b/apps/telemetry-tcp-gateway/src/imei-auth.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@booster-ai/logger';
 import { sql } from 'drizzle-orm';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import type { RateLimiter } from './rate-limiter.js';
 
 /**
  * Resolución de IMEI → vehículo, con open enrollment fallback.
@@ -34,8 +35,16 @@ export async function resolveImei(opts: {
   logger: Logger;
   imei: string;
   sourceIp: string | null;
+  /**
+   * Rate limiter del enrollment (P1-L). Solo se consulta cuando el IMEI es
+   * DESCONOCIDO (a punto de enrollar) — los devices autorizados nunca se
+   * limitan. Si rechaza, se omite el upsert (no se escribe en
+   * `dispositivos_pendientes`): acota el crecimiento de la tabla ante un flood
+   * de IMEIs falsos. Opcional para backwards-compat / tests.
+   */
+  enrollmentLimiter?: RateLimiter;
 }): Promise<ImeiResolution> {
-  const { db, logger, imei, sourceIp } = opts;
+  const { db, logger, imei, sourceIp, enrollmentLimiter } = opts;
 
   // 1. Lookup en vehículos.
   const vehMatch = await db.execute<{ id: string }>(
@@ -44,6 +53,18 @@ export async function resolveImei(opts: {
   if (vehMatch.rows[0]) {
     logger.debug({ imei, vehicleId: vehMatch.rows[0].id }, 'imei autorizado');
     return { vehicleId: vehMatch.rows[0].id, pendingDeviceId: null };
+  }
+
+  // 1b. Rate limit del open enrollment (P1-L): si se excede la tasa de IMEIs
+  // nuevos, NO escribimos en dispositivos_pendientes (evita que un flood infle
+  // la tabla). El device autorizado ya retornó arriba, así que esto solo afecta
+  // a IMEIs desconocidos.
+  if (enrollmentLimiter && !enrollmentLimiter.tryConsume()) {
+    logger.warn(
+      { imei, sourceIp },
+      'enrollment rate limit excedido — IMEI desconocido descartado sin upsert (P1-L)',
+    );
+    return { vehicleId: null, pendingDeviceId: null };
   }
 
   // 2. Upsert en dispositivos_pendientes.

--- a/apps/telemetry-tcp-gateway/src/main.ts
+++ b/apps/telemetry-tcp-gateway/src/main.ts
@@ -8,6 +8,7 @@ import pg from 'pg';
 import { loadConfig } from './config.js';
 import { handleConnection } from './connection-handler.js';
 import { CrashTracePublisher, TelemetryPublisher } from './pubsub-publisher.js';
+import { createConnectionGuard, createSlidingWindowLimiter } from './rate-limiter.js';
 
 /**
  * Entry point del telemetry-tcp-gateway.
@@ -68,21 +69,49 @@ async function main(): Promise<void> {
     logger.warn('PUBSUB_TOPIC_CRASH_TRACES no configurado — Crash Trace publish DESHABILITADO');
   }
 
+  // Rate limiting in-memory per-pod (audit P1-L). El guard acota conexiones
+  // concurrentes (FDs/memoria); el limiter acota enrollments de IMEIs nuevos
+  // (crecimiento de dispositivos_pendientes).
+  const connectionGuard = createConnectionGuard(config.MAX_CONCURRENT_CONNECTIONS);
+  const enrollmentLimiter = createSlidingWindowLimiter({
+    maxEvents: config.ENROLLMENT_RATE_MAX,
+    windowMs: config.ENROLLMENT_RATE_WINDOW_SEC * 1000,
+  });
+
   const connectionDeps = {
     db,
     publisher,
     crashPublisher,
     logger,
     idleTimeoutSec: config.IDLE_TIMEOUT_SEC,
+    enrollmentLimiter,
+  };
+
+  // Acepta una conexión bajo el cap concurrente: si está lleno, rechaza
+  // inmediatamente (destroy) sin tocar la DB ni asignar buffers. Libera el slot
+  // al cerrarse el socket. Compartido por el plain y el TLS server.
+  const acceptConnection = (socket: net.Socket): void => {
+    if (!connectionGuard.tryAcquire()) {
+      logger.warn(
+        {
+          active: connectionGuard.active,
+          max: config.MAX_CONCURRENT_CONNECTIONS,
+          sourceIp: socket.remoteAddress ?? null,
+        },
+        'cap de conexiones concurrentes alcanzado — rechazando conexión (P1-L)',
+      );
+      socket.destroy();
+      return;
+    }
+    socket.once('close', () => connectionGuard.release());
+    handleConnection(socket, connectionDeps);
   };
 
   // -------------------------------------------------------------------------
   // SERVIDOR 1: TCP plain port 5027 (existente)
   // -------------------------------------------------------------------------
 
-  const plainServer = net.createServer((socket) => {
-    handleConnection(socket, connectionDeps);
-  });
+  const plainServer = net.createServer(acceptConnection);
   plainServer.on('error', (err) => {
     logger.error({ err, port: config.PORT }, 'plain server error');
   });
@@ -126,8 +155,8 @@ async function main(): Promise<void> {
       },
       (socket) => {
         // tls.TLSSocket extiende net.Socket — pasable directamente al
-        // handler que ya espera net.Socket.
-        handleConnection(socket, connectionDeps);
+        // acceptConnection (cap concurrente + handler).
+        acceptConnection(socket);
       },
     );
     tlsServer.on('error', (err) => {

--- a/apps/telemetry-tcp-gateway/src/rate-limiter.ts
+++ b/apps/telemetry-tcp-gateway/src/rate-limiter.ts
@@ -1,0 +1,76 @@
+/**
+ * Rate limiting in-memory (per-pod) para el TCP gateway (audit P1-L).
+ *
+ * El gateway expone puertos TCP a la red para los devices Teltonika y hace
+ * "open enrollment" de IMEIs desconocidos. Sin límites, un atacante en la red
+ * puede agotar FDs/memoria (muchas conexiones) o inflar `dispositivos_pendientes`
+ * (muchos IMEIs nuevos). Estas dos primitivas son la barrera:
+ *
+ *   - ConnectionGuard: cap de conexiones concurrentes (gauge) → FDs/memoria.
+ *   - SlidingWindowLimiter: cap de eventos por ventana → enrollment.
+ *
+ * In-memory y per-pod a propósito: el gateway no tiene Redis, y el control
+ * relevante para DoS es local al proceso (cada pod protege sus propios FDs).
+ * No depende de la IP cliente (el LB TCP puede enmascararla).
+ */
+
+/** Cap de conexiones concurrentes. `tryAcquire` toma un slot; `release` lo devuelve. */
+export interface ConnectionGuard {
+  /** Toma un slot. `false` si ya se alcanzó el máximo (rechazar la conexión). */
+  tryAcquire(): boolean;
+  /** Devuelve un slot al cerrarse la conexión. Idempotente bajo el piso 0. */
+  release(): void;
+  /** Conexiones activas actuales. */
+  readonly active: number;
+}
+
+export function createConnectionGuard(maxConcurrent: number): ConnectionGuard {
+  let active = 0;
+  return {
+    tryAcquire(): boolean {
+      if (active >= maxConcurrent) {
+        return false;
+      }
+      active += 1;
+      return true;
+    },
+    release(): void {
+      if (active > 0) {
+        active -= 1;
+      }
+    },
+    get active(): number {
+      return active;
+    },
+  };
+}
+
+/** Limita eventos a `maxEvents` dentro de una ventana deslizante de `windowMs`. */
+export interface RateLimiter {
+  /** Registra un evento y retorna `true` si está dentro del límite, `false` si lo excede. */
+  tryConsume(): boolean;
+}
+
+export function createSlidingWindowLimiter(opts: {
+  maxEvents: number;
+  windowMs: number;
+  /** Inyectable para tests; default `Date.now`. */
+  now?: () => number;
+}): RateLimiter {
+  const { maxEvents, windowMs } = opts;
+  const now = opts.now ?? Date.now;
+  let timestamps: number[] = [];
+
+  return {
+    tryConsume(): boolean {
+      const cutoff = now() - windowMs;
+      // Poda los eventos que ya salieron de la ventana (estrictamente viejos).
+      timestamps = timestamps.filter((ts) => ts > cutoff);
+      if (timestamps.length >= maxEvents) {
+        return false;
+      }
+      timestamps.push(now());
+      return true;
+    },
+  };
+}

--- a/apps/telemetry-tcp-gateway/test/connection-handler.test.ts
+++ b/apps/telemetry-tcp-gateway/test/connection-handler.test.ts
@@ -134,6 +134,8 @@ function makeDeps(opts?: { crashPublisher?: CrashStub | null }) {
     crashPublisher: opts?.crashPublisher === undefined ? null : opts.crashPublisher,
     logger: noopLogger,
     idleTimeoutSec: 60,
+    // Limiter permisivo: los tests del handler no ejercitan el rate limit (P1-L).
+    enrollmentLimiter: { tryConsume: () => true },
   };
 }
 

--- a/apps/telemetry-tcp-gateway/test/imei-auth.test.ts
+++ b/apps/telemetry-tcp-gateway/test/imei-auth.test.ts
@@ -59,4 +59,47 @@ describe('resolveImei', () => {
     });
     expect(result.pendingDeviceId).toBe('pending-uuid-789');
   });
+
+  // P1-L: open enrollment con rate limiting.
+  it('NO enrolla (skip del upsert) si el rate limiter de enrollment rechaza', async () => {
+    const db = makeMockDb({}); // sin match de vehículo → iría al enrollment
+    const enrollmentLimiter = { tryConsume: vi.fn(() => false) };
+    const result = await resolveImei({
+      db,
+      logger: noopLogger,
+      imei: '888888888888888',
+      sourceIp: '9.9.9.9',
+      enrollmentLimiter,
+    });
+    expect(result.vehicleId).toBeNull();
+    expect(result.pendingDeviceId).toBeNull();
+    expect(enrollmentLimiter.tryConsume).toHaveBeenCalledTimes(1);
+    // Solo corre la query de lookup de vehículo; el INSERT del upsert NO.
+    expect(db.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('un IMEI conocido nunca consulta el rate limiter de enrollment', async () => {
+    const db = makeMockDb({ vehicleRow: { id: 'veh-1' } });
+    const enrollmentLimiter = { tryConsume: vi.fn(() => false) };
+    const result = await resolveImei({
+      db,
+      logger: noopLogger,
+      imei: '356307042441013',
+      sourceIp: '1.2.3.4',
+      enrollmentLimiter,
+    });
+    expect(result.vehicleId).toBe('veh-1');
+    expect(enrollmentLimiter.tryConsume).not.toHaveBeenCalled();
+  });
+
+  it('sin enrollmentLimiter (opcional) enrolla normal — backwards-compat', async () => {
+    const db = makeMockDb({ upsertedRow: { id: 'pending-uuid-xyz' } });
+    const result = await resolveImei({
+      db,
+      logger: noopLogger,
+      imei: '222222222222222',
+      sourceIp: '8.8.8.8',
+    });
+    expect(result.pendingDeviceId).toBe('pending-uuid-xyz');
+  });
 });

--- a/apps/telemetry-tcp-gateway/test/rate-limiter.test.ts
+++ b/apps/telemetry-tcp-gateway/test/rate-limiter.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { createConnectionGuard, createSlidingWindowLimiter } from '../src/rate-limiter.js';
+
+describe('createConnectionGuard — cap de conexiones concurrentes', () => {
+  it('admite hasta maxConcurrent y rechaza el siguiente', () => {
+    const guard = createConnectionGuard(2);
+    expect(guard.tryAcquire()).toBe(true);
+    expect(guard.tryAcquire()).toBe(true);
+    expect(guard.tryAcquire()).toBe(false); // 3ra excede el cap
+    expect(guard.active).toBe(2);
+  });
+
+  it('release libera un slot para una nueva conexión', () => {
+    const guard = createConnectionGuard(1);
+    expect(guard.tryAcquire()).toBe(true);
+    expect(guard.tryAcquire()).toBe(false);
+    guard.release();
+    expect(guard.active).toBe(0);
+    expect(guard.tryAcquire()).toBe(true);
+  });
+
+  it('release nunca baja active por debajo de 0 (doble release defensivo)', () => {
+    const guard = createConnectionGuard(1);
+    guard.tryAcquire();
+    guard.release();
+    guard.release();
+    expect(guard.active).toBe(0);
+  });
+});
+
+describe('createSlidingWindowLimiter — rate limit de enrollment', () => {
+  it('admite maxEvents dentro de la ventana y rechaza el excedente', () => {
+    const nowMs = 1000;
+    const limiter = createSlidingWindowLimiter({ maxEvents: 3, windowMs: 1000, now: () => nowMs });
+    expect(limiter.tryConsume()).toBe(true);
+    expect(limiter.tryConsume()).toBe(true);
+    expect(limiter.tryConsume()).toBe(true);
+    expect(limiter.tryConsume()).toBe(false); // 4to en la misma ventana
+  });
+
+  it('vuelve a admitir cuando los eventos viejos salen de la ventana', () => {
+    let nowMs = 1000;
+    const limiter = createSlidingWindowLimiter({ maxEvents: 2, windowMs: 1000, now: () => nowMs });
+    expect(limiter.tryConsume()).toBe(true); // t=1000
+    expect(limiter.tryConsume()).toBe(true); // t=1000
+    expect(limiter.tryConsume()).toBe(false); // lleno
+    nowMs = 2001; // los dos eventos de t=1000 ya están fuera de la ventana [1001..2001]
+    expect(limiter.tryConsume()).toBe(true);
+  });
+
+  it('la ventana es deslizante, no fija: un evento viejo libera cupo parcial', () => {
+    let nowMs = 0;
+    const limiter = createSlidingWindowLimiter({ maxEvents: 1, windowMs: 100, now: () => nowMs });
+    expect(limiter.tryConsume()).toBe(true); // t=0
+    nowMs = 50;
+    expect(limiter.tryConsume()).toBe(false); // t=50, el de t=0 sigue dentro [−50..50]... no, dentro de (−50,50]? está en ventana
+    nowMs = 101;
+    expect(limiter.tryConsume()).toBe(true); // t=101, el de t=0 salió de (1,101]
+  });
+});

--- a/infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
+++ b/infrastructure/k8s/telemetry-tcp-gateway-dr.yaml
@@ -99,6 +99,16 @@ spec:
               value: "crash-traces"
             - name: IDLE_TIMEOUT_SEC
               value: "300"
+            # Rate limiting in-memory per-pod (audit P1-L) — debe espejar el
+            # manifest primary para que el failover a DR mantenga la misma
+            # barrera DoS. Ver telemetry-tcp-gateway.yaml para el detalle del
+            # presupuesto de memoria (1Gi ≈ ~5000 conns) y de la calibración.
+            - name: MAX_CONCURRENT_CONNECTIONS
+              value: "5000"
+            - name: ENROLLMENT_RATE_MAX
+              value: "30"
+            - name: ENROLLMENT_RATE_WINDOW_SEC
+              value: "60"
             - name: LOG_LEVEL
               value: "info"
             - name: NODE_ENV

--- a/infrastructure/k8s/telemetry-tcp-gateway.yaml
+++ b/infrastructure/k8s/telemetry-tcp-gateway.yaml
@@ -101,6 +101,30 @@ spec:
               value: "crash-traces"
             - name: IDLE_TIMEOUT_SEC
               value: "300"
+            # Rate limiting in-memory per-pod (audit P1-L). Declarados aquí
+            # explícitamente (no solo defaults del schema Zod) para que el valor
+            # ACTIVO en prod sea legible/auditable desde el repo y tuneable sin
+            # leer el código.
+            #
+            # MAX_CONCURRENT_CONNECTIONS: cap concurrente por pod → protege FDs/
+            # memoria. Presupuesto: el pod tiene memory limit 1Gi y un socket TCP
+            # (buffers user+kernel) cuesta ~150–200KB → ~5000 conns ≈ ~1GB, en el
+            # borde del OOM. 5000 es holgado para el piloto (10 Teltonika, ~500×)
+            # pero queda cerca del techo de memoria: si se observa presión de
+            # memoria con flota mayor, BAJARLO (el cap debe disparar ANTES del OOM
+            # para cumplir su función). Re-calibrar con datos de carga reales.
+            - name: MAX_CONCURRENT_CONNECTIONS
+              value: "5000"
+            # ENROLLMENT_RATE_MAX/_WINDOW_SEC: techo de IMEIs nuevos por ventana
+            # → acota crecimiento de dispositivos_pendientes ante flood. 30/60s:
+            # un instalador enrola un puñado; 10 devices piloto están muy por
+            # debajo. Un rechazo con flota real = flood o burst de instalación
+            # anómalo → vigilado por la alerta gateway_enrollment_rate_limited
+            # (infrastructure/telemetry-monitoring.tf).
+            - name: ENROLLMENT_RATE_MAX
+              value: "30"
+            - name: ENROLLMENT_RATE_WINDOW_SEC
+              value: "60"
             - name: LOG_LEVEL
               value: "info"
             - name: NODE_ENV

--- a/infrastructure/telemetry-monitoring.tf
+++ b/infrastructure/telemetry-monitoring.tf
@@ -696,3 +696,149 @@ resource "google_monitoring_alert_policy" "wave2_consumer_stalled" {
     mime_type = "text/markdown"
   }
 }
+
+# ──────────────────────────────────────────────────────────────────────────
+# P1-L (audit 2026-06-14) — Observabilidad de la barrera DoS del gateway.
+#
+# El rate limiting del open enrollment (PR #489) rechaza conexiones/enrollments
+# en memoria. Sin observabilidad, un rechazo es INVISIBLE: o un atacante floodea
+# sin que nadie se entere, o el limiter está mal calibrado y descarta devices
+# legítimos en silencio (no aparecen en el panel) → el primer síntoma sería una
+# llamada del instalador, no una alerta. Review SRE pre-merge de #489 (P1-A).
+#
+# El gateway no tiene MeterProvider OTel (otel-bootstrap solo cablea tracing →
+# un counter OTel iría al no-op provider y nunca llegaría a Cloud Monitoring).
+# Se usa el patrón log-from-metric del resto de este archivo: los logs WARN ya
+# llevan los campos (imei/sourceIp). Literales de `message` = CONTRATO con
+# apps/telemetry-tcp-gateway/src/{imei-auth,main}.ts. ⚠️ messageKey='message'.
+# =============================================================================
+
+# Enrollments rechazados por rate limit — el IMEI desconocido se descartó SIN
+# escribir en dispositivos_pendientes. Con flota real (10 Teltonika << 30/60s),
+# un rechazo sostenido = flood de IMEIs falsos O un burst de instalación anómalo
+# que está tirando devices legítimos. En ambos casos el operador debe mirar.
+resource "google_logging_metric" "gateway_enrollment_rate_limited" {
+  name    = "telemetry/gateway_enrollment_rate_limited"
+  project = google_project.booster_ai.project_id
+
+  description = "Enrollments de IMEI desconocido descartados por rate limit (P1-L). >0 sostenido → flood o limiter mal calibrado tirando devices legítimos."
+
+  filter = <<-EOT
+    resource.type="k8s_container"
+    resource.labels.container_name="gateway"
+    severity>=WARNING
+    jsonPayload.message=~"enrollment rate limit excedido"
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    unit         = "1"
+    display_name = "Gateway enrollment rate-limited"
+    labels {
+      key         = "source_ip"
+      value_type  = "STRING"
+      description = "IP origen del enrollment rechazado (externalTrafficPolicy: Local preserva la IP cliente)"
+    }
+  }
+
+  label_extractors = {
+    "source_ip" = "EXTRACT(jsonPayload.sourceIp)"
+  }
+}
+
+# Conexiones TCP rechazadas por el cap concurrente — el pod alcanzó
+# MAX_CONCURRENT_CONNECTIONS y destruyó la conexión sin tocar DB/buffers. En
+# pre-comercial (10 devices, cap 5000) esto es altamente anómalo: señala un
+# flood de conexiones o un cap mal calibrado (demasiado bajo).
+resource "google_logging_metric" "gateway_connection_cap_reached" {
+  name    = "telemetry/gateway_connection_cap_reached"
+  project = google_project.booster_ai.project_id
+
+  description = "Conexiones TCP rechazadas por el cap concurrente del pod (P1-L). >0 → flood de conexiones o cap mal calibrado."
+
+  filter = <<-EOT
+    resource.type="k8s_container"
+    resource.labels.container_name="gateway"
+    severity>=WARNING
+    jsonPayload.message=~"cap de conexiones concurrentes alcanzado"
+  EOT
+
+  metric_descriptor {
+    metric_kind  = "DELTA"
+    value_type   = "INT64"
+    unit         = "1"
+    display_name = "Gateway connection cap reached"
+    labels {
+      key         = "source_ip"
+      value_type  = "STRING"
+      description = "IP origen de la conexión rechazada"
+    }
+  }
+
+  label_extractors = {
+    "source_ip" = "EXTRACT(jsonPayload.sourceIp)"
+  }
+}
+
+# P1 — Enrollment rate limit activo sostenido. threshold 0 + duration 300s con
+# ALIGN_DELTA: dispara solo si hay rechazos sostenidos por 5min (filtra un
+# rechazo aislado). Severidad ERROR: puede estar tirando devices legítimos.
+resource "google_monitoring_alert_policy" "gateway_enrollment_rate_limited_p1" {
+  display_name = "Gateway enrollment rate-limited sostenido (P1)"
+  project      = google_project.booster_ai.project_id
+  combiner     = "OR"
+  severity     = "ERROR"
+
+  conditions {
+    display_name = "enrollment rejections sustained > 5 min"
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.gateway_enrollment_rate_limited.name}\" AND resource.type=\"k8s_container\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_DELTA"
+      }
+    }
+  }
+
+  notification_channels = local.alert_channel_ids
+
+  documentation {
+    content   = "El gateway está rechazando enrollments de IMEI nuevos (rate limit P1-L). Con la flota piloto (<<30/60s) esto NO debería pasar: o es un flood de IMEIs falsos, o el limiter está descartando devices legítimos en una instalación (no aparecen en panel). Revisar source_ip de la métrica: una sola IP → flood; muchas → revisar si hay una instalación masiva legítima y subir ENROLLMENT_RATE_MAX. Runbook: docs/runbooks/oncall-telemetry-incidents.md"
+    mime_type = "text/markdown"
+  }
+}
+
+# P2 — Cap de conexiones concurrentes alcanzado. Anómalo en pre-comercial.
+resource "google_monitoring_alert_policy" "gateway_connection_cap_reached_p2" {
+  display_name = "Gateway connection cap alcanzado (P2)"
+  project      = google_project.booster_ai.project_id
+  combiner     = "OR"
+  severity     = "WARNING"
+
+  conditions {
+    display_name = "connection cap rejections sustained > 5 min"
+    condition_threshold {
+      filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.gateway_connection_cap_reached.name}\" AND resource.type=\"k8s_container\""
+      duration        = "300s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 0
+
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_DELTA"
+      }
+    }
+  }
+
+  notification_channels = local.alert_channel_ids
+
+  documentation {
+    content   = "El pod del gateway está rechazando conexiones TCP por alcanzar MAX_CONCURRENT_CONNECTIONS (cap 5000). Con 10 devices piloto esto es altamente anómalo: flood de conexiones (revisar source_ip) o cap mal calibrado. Si es flota real creciendo, evaluar subir el cap (ojo presupuesto memoria 1Gi ≈ ~5000 conns) o escalar pods (HPA max 20). Runbook: docs/runbooks/oncall-telemetry-incidents.md"
+    mime_type = "text/markdown"
+  }
+}


### PR DESCRIPTION
## Qué

Resuelve **P1-L** de la auditoría 2026-06-14. El `telemetry-tcp-gateway` expone puertos TCP a la red (devices Teltonika) y hace **open enrollment** de IMEIs desconocidos (`imei-auth.ts`) **sin rate limiting**. Un atacante en la red podía:
- abrir muchas conexiones → agotar **FDs/memoria** (las conexiones con IMEI desconocido quedan abiertas);
- ciclar IMEIs falsos → inflar `dispositivos_pendientes` (1 `INSERT` por conexión).

## Fix — dos primitivas in-memory per-pod

Sin Redis (el gateway no lo tiene) y **sin depender de la IP cliente** (el LB TCP la enmascara → un rate-limit per-IP sería inútil o rompería todo):

| Primitiva | Qué acota | Config (default) |
|---|---|---|
| **ConnectionGuard** (cap concurrente) | FDs/memoria | `MAX_CONCURRENT_CONNECTIONS` (5000) |
| **SlidingWindowLimiter** (enrollment) | crecimiento de `dispositivos_pendientes` | `ENROLLMENT_RATE_MAX`/`ENROLLMENT_RATE_WINDOW_SEC` (30 / 60s) |

- **Cap de conexiones**: aplicado en `main.ts` a los dos servers (plain 5027 + TLS 5061). Conexión sobre el cap → `destroy()` inmediato, sin tocar la DB ni asignar buffers; libera el slot al `close`.
- **Rate limit de enrollment**: en `resolveImei`, **solo** se consulta cuando el IMEI es desconocido (los devices autorizados retornan antes y **nunca** se limitan). Si excede, se descarta sin `upsert`.
- Defaults holgados para flota real (instalador enrola un puñado) pero muy por debajo de un flood de atacante; todo configurable por env.

## TDD

- `rate-limiter.test.ts` (nuevo): ConnectionGuard (acquire/release/cap, doble-release defensivo) + SlidingWindowLimiter con clock inyectable (ventana deslizante).
- `imei-auth.test.ts`: skip del `upsert` cuando el limiter rechaza (solo 1 query, no INSERT); IMEI conocido no consulta el limiter; backwards-compat sin limiter.
- RED→GREEN observado en ambos.

## Evidencia

- **Tests**: `@booster-ai/telemetry-tcp-gateway` → **43 passed (6 files)**.
- **Typecheck**: `tsc --noEmit` → 0 errores.
- **Lint**: `biome check` → limpio.
- **Coverage**: `rate-limiter.ts` 100% stmts, `imei-auth.ts` 100% stmts; gateway sobre threshold (lines/funcs/stmts 93%+, branches 79.68% > gate 75).
- **Pre-commit**: gitleaks (no leaks), spec-drift OK.

### ADR compliance
- Sin nuevas dependencias ni cambio de patrón → no requiere ADR.
- Validación en boundary (3 env vars nuevas con Zod en `config.ts`). Lógica de telemetría sin cambios; solo se añade la barrera DoS.

> Nota: al mergear, el deploy del gateway corre por el nuevo step automático `gke-deploy` (ADR-065 #488) — este release también valida ese camino.

🤖 Generated with [Claude Code](https://claude.com/claude-code)