### PR TITLE
feat(api): rate limiting per-IP del endpoint público de tracking (audit P1-4)

### DIFF
--- a/apps/api/src/middleware/rate-limit-public-tracking.test.ts
+++ b/apps/api/src/middleware/rate-limit-public-tracking.test.ts
@@ -1,0 +1,213 @@
+import type { Logger } from '@booster-ai/logger';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import {
+  KEY_PREFIX,
+  createRateLimitPublicTrackingMiddleware,
+} from './rate-limit-public-tracking.js';
+
+// P1-4 (audit 2026-06-14) — middleware rate-limit del endpoint público de
+// tracking GET /public/tracking/:token: cap per-IP (default 60 / 60s) contra
+// enumeración de tokens / agotamiento de recursos. 61º → 429. Redis down →
+// 503 fail-closed con Retry-After:30 (paridad rate-limit-signup SC-1.2.5).
+// Sin auth: la 1ª defensa es la opacidad del token (122 bits); este es
+// defense-in-depth por IP, la única señal estable pre-auth.
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as Logger;
+
+interface MockPipelineCalls {
+  incrCalled: string[];
+  expireCalled: Array<[string, number, string]>;
+}
+
+interface MakeRedisOptions {
+  counters?: number[];
+  throwOnExec?: Error;
+}
+
+function makeRedis(opts: MakeRedisOptions | number[]): {
+  redis: unknown;
+  calls: MockPipelineCalls;
+} {
+  const normalized: MakeRedisOptions = Array.isArray(opts) ? { counters: opts } : opts;
+  const counters = normalized.counters ?? [];
+  const calls: MockPipelineCalls = { incrCalled: [], expireCalled: [] };
+  let i = 0;
+  const pipeline = {
+    incr(key: string) {
+      calls.incrCalled.push(key);
+      return this;
+    },
+    expire(key: string, seconds: number, flag: string) {
+      calls.expireCalled.push([key, seconds, flag]);
+      return this;
+    },
+    async exec(): Promise<unknown[]> {
+      if (normalized.throwOnExec) {
+        throw normalized.throwOnExec;
+      }
+      const c = counters[i] ?? 0;
+      i += 1;
+      return [[null, c]];
+    },
+  };
+  const redis = { multi: () => pipeline };
+  return { redis, calls };
+}
+
+function makeApp(middleware: ReturnType<typeof createRateLimitPublicTrackingMiddleware>) {
+  const app = new Hono();
+  app.use('/public/tracking/*', middleware);
+  app.get('/public/tracking/:token', (c) => c.json({ status: 'ok', token: c.req.param('token') }));
+  return app;
+}
+
+function get(app: Hono, token: string, xff?: string) {
+  return app.request(`/public/tracking/${token}`, {
+    method: 'GET',
+    headers: xff ? { 'x-forwarded-for': xff } : {},
+  });
+}
+
+describe('rate-limit-public-tracking middleware (P1-4)', () => {
+  it('happy path: 1 GET → passthrough → 200 + counter ip incrementado a 1', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware);
+
+    const res = await get(app, 'tok-abc', '1.2.3.4');
+    expect(res.status).toBe(200);
+    expect(calls.incrCalled).toEqual([`${KEY_PREFIX}1.2.3.4`]);
+    expect(calls.expireCalled[0]?.[0]).toBe(`${KEY_PREFIX}1.2.3.4`);
+    expect(calls.expireCalled[0]?.[1]).toBe(60);
+    expect(calls.expireCalled[0]?.[2]).toBe('NX');
+  });
+
+  it('60 GETs passthrough, 61º → 429 con Retry-After:60 + X-RateLimit-Scope:ip', async () => {
+    const counters = Array.from({ length: 61 }, (_, i) => i + 1); // 1..61
+    const { redis } = makeRedis(counters);
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware);
+
+    for (let i = 0; i < 60; i++) {
+      const r = await get(app, 'tok-abc', '9.9.9.9');
+      expect(r.status).toBe(200);
+    }
+    const over = await get(app, 'tok-abc', '9.9.9.9');
+    expect(over.status).toBe(429);
+    expect(over.headers.get('Retry-After')).toBe('60');
+    expect(over.headers.get('X-RateLimit-Scope')).toBe('ip');
+    const json = (await over.json()) as { error: string; code: string };
+    expect(json.error).toBe('too_many_attempts');
+    expect(json.code).toBe('too_many_attempts');
+  });
+
+  it('enumeración: tokens distintos desde la MISMA IP comparten counter → 429 igual', async () => {
+    // El ataque que P1-4 cierra: un atacante iterando tokens (mayoría 404)
+    // desde una IP. El cap es per-IP, así que NO se evade variando el token.
+    const counters = Array.from({ length: 61 }, (_, i) => i + 1);
+    const { redis, calls } = makeRedis(counters);
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware);
+
+    for (let i = 0; i < 60; i++) {
+      const r = await get(app, `enum-token-${i}`, '7.7.7.7');
+      expect(r.status).toBe(200);
+    }
+    const over = await get(app, 'enum-token-999', '7.7.7.7');
+    expect(over.status).toBe(429);
+    // Todas las keys son la misma IP, sin importar el token.
+    expect(calls.incrCalled.every((k) => k === `${KEY_PREFIX}7.7.7.7`)).toBe(true);
+  });
+
+  it('Redis pipeline throw → 503 fail-closed con Retry-After:30 (paridad SC-1.2.5)', async () => {
+    const { redis } = makeRedis({ throwOnExec: new Error('ECONNREFUSED') });
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware);
+
+    const res = await get(app, 'tok-abc', '1.2.3.4');
+    expect(res.status).toBe(503);
+    expect(res.headers.get('Retry-After')).toBe('30');
+    const json = (await res.json()) as { error: string; code: string };
+    expect(json.error).toBe('service_unavailable');
+    expect(json.code).toBe('service_unavailable');
+  });
+
+  it('XFF spoofeado (multi-entry) → counter de la IP que vio el LB (penúltima), no la del atacante', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware);
+
+    const res = await get(app, 'tok-abc', '6.6.6.6, 198.51.100.7, 35.1.1.1');
+    expect(res.status).toBe(200);
+    expect(calls.incrCalled).toEqual([`${KEY_PREFIX}198.51.100.7`]);
+    expect(calls.incrCalled.some((k) => k.includes('6.6.6.6'))).toBe(false);
+  });
+
+  it('IPs distintas tienen counters independientes', async () => {
+    const { redis } = makeRedis([1, 1, 2, 2]);
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware);
+
+    for (let i = 0; i < 2; i++) {
+      const a = await get(app, 'tok-a', '1.1.1.1');
+      expect(a.status).toBe(200);
+      const b = await get(app, 'tok-b', '2.2.2.2');
+      expect(b.status).toBe(200);
+    }
+  });
+
+  it('sin X-Forwarded-For → bucket "unknown" (aceptable en dev)', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware);
+
+    const res = await get(app, 'tok-abc');
+    expect(res.status).toBe(200);
+    expect(calls.incrCalled).toEqual([`${KEY_PREFIX}unknown`]);
+  });
+
+  it('límite configurable: limitPerIp=2 → 3º GET es 429', async () => {
+    const { redis } = makeRedis([1, 2, 3]);
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+      limitPerIp: 2,
+    });
+    const app = makeApp(middleware);
+
+    expect((await get(app, 't', '4.4.4.4')).status).toBe(200);
+    expect((await get(app, 't', '4.4.4.4')).status).toBe(200);
+    expect((await get(app, 't', '4.4.4.4')).status).toBe(429);
+  });
+});

--- a/apps/api/src/middleware/rate-limit-public-tracking.test.ts
+++ b/apps/api/src/middleware/rate-limit-public-tracking.test.ts
@@ -210,4 +210,24 @@ describe('rate-limit-public-tracking middleware (P1-4)', () => {
     expect((await get(app, 't', '4.4.4.4')).status).toBe(200);
     expect((await get(app, 't', '4.4.4.4')).status).toBe(429);
   });
+
+  it('bucket "unknown" al límite → 429 (fail-safe: bloquea, NO bypass)', async () => {
+    // Review seguridad #490 P1-A: las requests sin XFF comparten el bucket
+    // `rl:public-tracking:unknown`. Si se supera el límite, se bloquea (no se
+    // hace skip): un control de seguridad debe fallar cerrando. En prod el
+    // tráfico legítimo nunca cae acá (Cloud Run appendea XFF tras el GCLB).
+    const { redis } = makeRedis([1, 2, 3]);
+    const middleware = createRateLimitPublicTrackingMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+      limitPerIp: 2,
+    });
+    const app = makeApp(middleware);
+
+    expect((await get(app, 't')).status).toBe(200);
+    expect((await get(app, 't')).status).toBe(200);
+    const over = await get(app, 't');
+    expect(over.status).toBe(429);
+    expect(over.headers.get('X-RateLimit-Scope')).toBe('ip');
+  });
 });

--- a/apps/api/src/middleware/rate-limit-public-tracking.ts
+++ b/apps/api/src/middleware/rate-limit-public-tracking.ts
@@ -57,6 +57,15 @@ export function createRateLimitPublicTrackingMiddleware(
 
   return async function rateLimitPublicTracking(c, next) {
     const ip = extractClientIp(c.req.header('x-forwarded-for'));
+    // Bucket "unknown" (XFF ausente): en prod detrás del GCLB Cloud Run SIEMPRE
+    // appendea el client IP al XFF, así que el tráfico legítimo nunca cae acá —
+    // solo requests anómalas sin XFF (acceso directo a *.run.app). Que ese
+    // bucket compartido se bloquee es fail-SAFE deliberado (un control de
+    // seguridad debe fallar cerrando, no abriendo: NO se hace skip-en-unknown
+    // porque sería un bypass para quien pueda strippear el XFF). El cierre
+    // sistémico es restringir el ingress a internal-and-cloud-load-balancing:
+    // .specs/_followups/cloud-run-ingress-internal-lb.md (ALTO, compartido con
+    // rate-limit-pin/signup).
     const ipKey = `${KEY_PREFIX}${ip}`;
 
     let ipCount: number;

--- a/apps/api/src/middleware/rate-limit-public-tracking.ts
+++ b/apps/api/src/middleware/rate-limit-public-tracking.ts
@@ -1,0 +1,89 @@
+import type { Logger } from '@booster-ai/logger';
+import type { MiddlewareHandler } from 'hono';
+import type Redis from 'ioredis';
+import { extractClientIp } from './client-ip.js';
+
+/**
+ * P1-4 (audit 2026-06-14) — middleware Hono que rate-limita el endpoint
+ * público de tracking `GET /public/tracking/:token` per-IP.
+ *
+ * El endpoint NO requiere auth: la 1ª defensa es la opacidad del token (UUID,
+ * 122 bits) + redacción del payload (sin plate completa / driver / precio /
+ * telemetría >30min). Sin un cap, un atacante puede:
+ *   - enumerar tokens (mayoría 404) buscando links válidos;
+ *   - martillar un link conocido para agotar recursos (cada hit hace lookup
+ *     DB + posible call a Routes API).
+ *
+ * Counter Redis: `rl:public-tracking:<ip>` — default 60 req / 60s por IP.
+ * 61º → 429 con `Retry-After: 60` + `X-RateLimit-Scope: ip`.
+ *
+ * **Scope solo-IP** (paridad con rate-limit-signup): la IP es la única señal
+ * estable pre-auth. El cap per-IP cubre la amenaza declarada (enumeración /
+ * agotamiento desde un origen) sin crear una key Redis por token probado
+ * (un counter per-token incrementaría una key distinta por cada token
+ * inexistente → amplificación de memoria bajo enumeración). La protección
+ * contra un flood DISTRIBUIDO de un mismo token (muchas IPs) es trabajo de la
+ * cascada Cloud Armor (1000/min/IP global, docs/qa/rate-limit-cascade.md),
+ * no de este middleware.
+ *
+ * **Fail-closed loudly** (paridad rate-limit-pin/signup SC-1.2.5): si el
+ * pipeline Redis falla, retorna `503 service_unavailable` + `Retry-After: 30`.
+ * Rate-limit es defensa de seguridad — no degradar a fail-open. Durante una
+ * caída de Redis el resto de la app (login/signup/SSE) ya está degradado, así
+ * que el tracking público fallando-cerrado es consistente con ese estado.
+ *
+ * Trust boundary X-Forwarded-For: misma fuente única (`extractClientIp`) que
+ * pin/signup — bajo GCLB la IP confiable es la penúltima entry (la primera la
+ * controla el cliente). Header ausente (dev sin LB) → bucket `unknown`.
+ */
+
+export const KEY_PREFIX = 'rl:public-tracking:';
+const DEFAULT_LIMIT_PER_IP = 60;
+const DEFAULT_WINDOW_SECONDS = 60;
+const FAIL_CLOSED_RETRY_AFTER_SECONDS = 30;
+
+export interface RateLimitPublicTrackingOptions {
+  redis: Redis;
+  logger: Logger;
+  limitPerIp?: number;
+  windowSeconds?: number;
+}
+
+export function createRateLimitPublicTrackingMiddleware(
+  opts: RateLimitPublicTrackingOptions,
+): MiddlewareHandler {
+  const ipLimit = opts.limitPerIp ?? DEFAULT_LIMIT_PER_IP;
+  const window = opts.windowSeconds ?? DEFAULT_WINDOW_SECONDS;
+
+  return async function rateLimitPublicTracking(c, next) {
+    const ip = extractClientIp(c.req.header('x-forwarded-for'));
+    const ipKey = `${KEY_PREFIX}${ip}`;
+
+    let ipCount: number;
+    try {
+      const results = await opts.redis.multi().incr(ipKey).expire(ipKey, window, 'NX').exec();
+      ipCount = Number(results?.[0]?.[1] ?? 0);
+    } catch (err) {
+      // Fail-closed loudly: rate-limit es defensa de seguridad; si Redis cae,
+      // bloqueamos el endpoint en lugar de pasar todo.
+      opts.logger.error(
+        { err, ip },
+        'rate-limit-public-tracking: Redis pipeline failed; fail-closed con 503',
+      );
+      c.header('Retry-After', String(FAIL_CLOSED_RETRY_AFTER_SECONDS));
+      return c.json({ error: 'service_unavailable', code: 'service_unavailable' }, 503);
+    }
+
+    if (ipCount > ipLimit) {
+      opts.logger.warn(
+        { ip, ipCount, ipLimit, windowSeconds: window },
+        'rate-limit-public-tracking: 429 too_many_attempts scope=ip',
+      );
+      c.header('Retry-After', String(window));
+      c.header('X-RateLimit-Scope', 'ip');
+      return c.json({ error: 'too_many_attempts', code: 'too_many_attempts' }, 429);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/public-tracking.ts
+++ b/apps/api/src/routes/public-tracking.ts
@@ -10,10 +10,12 @@
  *   - Precio
  *   - Telemetría histórica más vieja que 30 min
  *
- * **Rate limiting**: TODO post-deploy con Cloud Armor o middleware
- * propio. Por ahora confiamos en la opacidad UUID + el threshold de
- * tokens enumerables (122 bits). Pre-MVP es aceptable; antes de
- * publicarlo masivamente metemos cap (ej. 60 req/min por IP por token).
+ * **Rate limiting** (P1-4, audit 2026-06-14): cap per-IP de 60 req/60s
+ * aplicado por el middleware `rate-limit-public-tracking` en server.ts
+ * (montado en `/public/tracking/*` antes de estas rutas). Defense-in-depth
+ * sobre la opacidad del token (122 bits): acota enumeración / agotamiento
+ * desde un origen. El flood distribuido de un mismo token queda para Cloud
+ * Armor (cascade, docs/qa/rate-limit-cascade.md).
  */
 
 import type { Logger } from '@booster-ai/logger';

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -14,6 +14,7 @@ import { createFirebaseAuthMiddleware } from './middleware/firebase-auth.js';
 import { ALLOWLISTED_PATHS } from './middleware/is-demo-allowlist.js';
 import { createIsDemoEnforcementMiddleware } from './middleware/is-demo-enforcement.js';
 import { createRateLimitPinMiddleware } from './middleware/rate-limit-pin.js';
+import { createRateLimitPublicTrackingMiddleware } from './middleware/rate-limit-public-tracking.js';
 import { createRateLimitSignupMiddleware } from './middleware/rate-limit-signup.js';
 import { skipPublicVerify } from './middleware/skip-public-verify.js';
 import { createUserContextMiddleware } from './middleware/user-context.js';
@@ -243,6 +244,17 @@ export function createServer(opts: CreateServerOptions): Hono {
   // de API key — el SA del runtime se autentica via workload identity, y
   // el projectId va en X-Goog-User-Project. Si la env var está ausente,
   // fallback transparente al ETA al centroide regional (PR-L2b).
+  //
+  // P1-4 (audit 2026-06-14): rate-limit per-IP (60/60s, fail-closed 503 si
+  // Redis down) ANTES del handler — el endpoint es público sin auth y sin cap
+  // un atacante podía enumerar tokens o agotar recursos (lookup DB + Routes
+  // API por hit). Mismo patrón que signup-request. Cloud Armor cascade actúa
+  // como pre-filtro upstream — docs/qa/rate-limit-cascade.md.
+  const rateLimitPublicTracking = createRateLimitPublicTrackingMiddleware({
+    redis: redisForRateLimit,
+    logger,
+  });
+  app.use('/public/tracking/*', rateLimitPublicTracking);
   app.route(
     '/public/tracking',
     createPublicTrackingRoutes({


### PR DESCRIPTION
## Qué

Resuelve **P1-4** de la auditoría 2026-06-14. `GET /public/tracking/:token` es un endpoint **público sin auth** (la 1ª defensa es la opacidad del token UUID, 122 bits) que servía estado del trip + posición **sin rate limiting** — el propio código lo marcaba como `TODO`. Un atacante en la red podía:
- **enumerar** tokens (mayoría 404) buscando links válidos;
- **martillar** un link conocido agotando recursos (lookup DB + call a Routes API por hit).

## Fix

Middleware `rate-limit-public-tracking` (nuevo), montado en `/public/tracking/*` antes del handler:

| Aspecto | Valor |
|---|---|
| Cap | **60 req / 60s por IP** (configurable; lo que sugería el TODO) |
| Sobre el límite | `429 too_many_attempts` + `Retry-After: 60` + `X-RateLimit-Scope: ip` |
| Redis caído | **fail-closed** `503 service_unavailable` + `Retry-After: 30` |
| IP | `extractClientIp` (trust boundary XFF compartido: penúltima entry bajo GCLB) |
| Redis | misma instancia `redisForRateLimit` que pin/signup |

**Scope solo-IP** (paridad con `rate-limit-signup`, el precedente directo de rate-limit a un endpoint público): la IP es la única señal estable pre-auth y cubre la amenaza declarada (enumeración / agotamiento desde un origen). Un counter per-token incrementaría una key Redis distinta **por cada token inexistente** → amplificación de memoria bajo enumeración. El flood **distribuido** de un mismo token (muchas IPs) queda para la cascada **Cloud Armor** (`docs/qa/rate-limit-cascade.md`), no para este middleware.

**fail-closed** coherente con pin/signup ("rate-limit es defensa de seguridad, no degradable"): durante una caída de Redis el resto de la app (login/signup/SSE) ya está degradado.

## TDD

`rate-limit-public-tracking.test.ts` (8 casos, RED→GREEN observado):
- happy path GET → 200 + counter IP a 1 (`expire NX`, ttl 60);
- 60 passthrough, 61º → 429 con headers correctos;
- **enumeración**: tokens distintos misma IP comparten counter → 429 igual (no se evade variando el token);
- Redis throw → 503 fail-closed;
- XFF spoofeado multi-entry → usa la penúltima (la que vio el LB), no la del atacante;
- IPs distintas independientes; sin XFF → `unknown`; límite configurable.

## Evidencia

- **Tests**: `vitest run src/middleware/` → **69 passed (7 files)**, incluidos los 8 nuevos.
- **Coverage** (`rate-limit-public-tracking.ts`): **100%** stmts/lines/funcs, **87.5%** branches (> gate 80; la rama no cubierta es el `?? 0` defensivo del parse del counter).
- **Typecheck**: `tsc --noEmit` → 0 errores.
- **Lint**: `biome check` → limpio.
- **Pre-commit**: check-adr-numbering OK.

### ADR compliance
- Sin nuevas dependencias ni cambio de patrón → no requiere ADR.
- Validación/seguridad en boundary: el cap se aplica antes del handler; reusa el middleware Redis fail-closed existente. Observabilidad: `logger.warn` (429) / `logger.error` (503 fail-closed) estructurados.
- Sin cambios de infra ni de deploy: el fix es app-only (apps/api), se despliega por `release.yml` como cualquier cambio de la API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)