### PR TITLE
feat(db): estrategia de rollback de migraciones + guard CI expand/contract (audit P1-H)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,39 @@ jobs:
         run: pnpm --filter @booster-ai/api test:integration
 
   # ---------------------------------------------------------------------------
+  # Migration safety (audit P1-H, ADR-066) — bloquea migraciones Drizzle nuevas
+  # con DDL destructivo (rompe expand/contract → rollback de código deja de ser
+  # seguro) salvo que declaren `-- contract-phase: <ref>`. Solo chequea los .sql
+  # AÑADIDOS en el PR, nunca las migraciones ya aplicadas. No necesita deps.
+  # ---------------------------------------------------------------------------
+  migration-safety:
+    name: Migration safety (expand/contract)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Unit test del guard
+        run: node --test scripts/repo-checks/check-migration-safety.test.mjs
+      - name: Guard sobre migraciones añadidas en el PR
+        if: github.event_name == 'pull_request'
+        run: |
+          BASE='${{ github.event.pull_request.base.sha }}'
+          ADDED=$(git diff --name-only --diff-filter=A "$BASE" HEAD -- apps/api/drizzle \
+            | grep -E '^apps/api/drizzle/[0-9]{4}_.*\.sql$' || true)
+          if [ -z "$ADDED" ]; then
+            echo "Sin migraciones nuevas en este PR — nada que chequear."
+            exit 0
+          fi
+          echo "Migraciones nuevas:"; echo "$ADDED"
+          # shellcheck disable=SC2086
+          node scripts/repo-checks/check-migration-safety.mjs $ADDED
+
+  # ---------------------------------------------------------------------------
   # Build — cada app y package compila a producción
   # ---------------------------------------------------------------------------
   build:
@@ -241,7 +274,7 @@ jobs:
   # ---------------------------------------------------------------------------
   ci-success:
     name: CI Success
-    needs: [lint, terraform-fmt, typecheck, test, integration-tests, build]
+    needs: [lint, terraform-fmt, typecheck, test, integration-tests, migration-safety, build]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -252,6 +285,7 @@ jobs:
              [ "${{ needs.typecheck.result }}" != "success" ] || \
              [ "${{ needs.test.result }}" != "success" ] || \
              [ "${{ needs.integration-tests.result }}" != "success" ] || \
+             [ "${{ needs.migration-safety.result }}" != "success" ] || \
              [ "${{ needs.build.result }}" != "success" ]; then
             echo "::error::One or more CI jobs failed"
             exit 1

--- a/.specs/db-migration-rollback-strategy/spec.md
+++ b/.specs/db-migration-rollback-strategy/spec.md
@@ -1,0 +1,57 @@
+# Spec — Estrategia de rollback de migraciones de BD (audit P1-H)
+
+**Estado**: Approved (diseño aprobado por el PO 2026-06-17)
+**Origen**: auditoría 2026-06-14, hallazgo **P1-H** (`apps/api/drizzle/`, 41 migraciones forward-only sin down-migrations → recovery DDL manual en prod).
+**ADR**: [ADR-066](../../docs/adr/066-db-migration-rollback-strategy.md)
+
+## Problema
+
+Las migraciones se aplican **al startup del servicio** (`apps/api/src/db/migrator.ts` vía `runMigrationsGated` en `main.ts`), son **forward-only** (Drizzle no genera down-migrations) y no hay procedimiento ni convención de rollback. Consecuencia: un deploy que aplica un DDL malo deja el esquema migrado **aunque se revierta la revisión Cloud Run** — el código viejo queda corriendo contra un esquema nuevo, sin red de seguridad documentada.
+
+Drizzle es forward-only por diseño. Los "down migrations" literales (reverse SQL aplicado automáticamente) son **parcialmente un anti-patrón** en este setup (startup-migrate + canary): un down ejecutado durante un rollback puede **perder datos** (p.ej. revertir un `ADD COLUMN` dropea la columna con sus datos). La causa raíz no es "faltan 41 reverse files" sino la **ausencia de procedimiento y de disciplina preventiva**.
+
+## Decisión (Opción A, aprobada)
+
+Tres capas, de preventiva a correctiva:
+
+1. **Convención expand/contract (preventiva, primaria)**: toda migración debe ser **backward-compatible** dentro del mismo deploy que el código que la usa — solo cambios aditivos (ADD COLUMN nullable / con default, CREATE TABLE/INDEX). Los cambios destructivos (DROP/RENAME columna o tabla, SET NOT NULL sin default, narrowing de tipo, DROP CONSTRAINT, TRUNCATE) se parten en **≥2 deploys**: expand → backfill → **contract** (recién cuando el código viejo ya no corre). Con esto, **el rollback de código siempre es seguro**.
+
+2. **PITR / clone (correctiva, emergencia)**: el undo real de un DDL catastrófico es restaurar/clonar Cloud SQL a un punto previo (`point_in_time_recovery_enabled = true`, ya activo, 7 días de logs) — **no** down-migrations.
+
+3. **Reverse-SQL manual (último recurso)**: para reversiones limpias y data-safe se permite un archivo `NNNN_name.down.sql`, aplicado por **procedimiento psql documentado** (vía bastion), NUNCA por el auto-migrator.
+
+## Entregables
+
+1. **ADR-066** `docs/adr/066-db-migration-rollback-strategy.md` — contexto (4 puntos: startup-migrate, forward-only, PITR ya activo, por qué down-auto es anti-patrón), decisión (las 3 capas), consecuencias, criterios de validación. Status Accepted.
+
+2. **Runbook** `docs/runbooks/db-migration-rollback.md` — árbol de decisión + procedimientos paso a paso:
+   - Gotcha: revertir la revisión Cloud Run NO revierte el esquema.
+   - Árbol: (a) ¿cambio backward-compatible? → rollback de código, listo. (b) ¿DDL/data malos con datos a preservar? → **forward-fix** (migración correctiva, preferido). (c) ¿catastrófico/corrupción? → **PITR clone** a timestamp pre-deploy + promover.
+   - Procedimiento `gcloud sql instances clone --point-in-time` concreto (instancia, región southamerica-west1).
+   - Procedimiento reverse-SQL manual vía bastion (`scripts/db` / bastion existente).
+
+3. **`apps/api/drizzle/README.md`** — convención para autores de migraciones: checklist expand/contract, cómo hacer un cambio destructivo en fases, ubicación del template, punteros a ADR-066 + runbook + el guard de CI.
+
+4. **Template** `apps/api/drizzle/down/_TEMPLATE.down.sql` — convención de nombres + header "manual-apply-only, no lo trackea el migrator".
+
+5. **Guard de CI bloqueante** `scripts/repo-checks/check-migration-safety.mjs` (+ `.test.mjs` con `node:test`):
+   - Funciones puras `findDestructiveStatements(sql)` y `hasContractMarker(sql)`.
+   - Detecta en migraciones **nuevas** (no las 41 existentes): DROP TABLE, DROP COLUMN, RENAME (TO/COLUMN), ALTER COLUMN ... (SET NOT NULL | TYPE | SET DATA TYPE), DROP CONSTRAINT, TRUNCATE. Ignora `--` comentarios (evita FP por la palabra "drop" en prosa).
+   - **Override**: un archivo con una línea `-- contract-phase: <ref no vacía>` queda exento (es la fase contract planificada de un expand/contract).
+   - Exit codes: 0 OK, 1 destructivo sin marcador, 2 error de uso.
+   - Nuevo job en `.github/workflows/ci.yml` (`migration-safety`): corre el test del guard (`node --test`) + el guard contra los `.sql` **añadidos** en el diff vs la base (`git diff --diff-filter=A`). En push a main sin base, no-op.
+
+## Fuera de scope
+
+- No se escriben reverse-SQL para las 41 migraciones existentes (ya aplicadas; inmutables).
+- No se cambia el runtime del migrator (`migrator.ts`) — su lógica de advisory lock + recovery out-of-order se conserva intacta.
+- No se cambia `STRICT_MIGRATION_ORDERING`.
+
+## Criterios de aceptación
+
+- SC-1: ADR-066 Accepted, número validado por `check-adr-numbering`.
+- SC-2: runbook con los 3 caminos + comandos concretos de PITR clone y reverse-SQL manual.
+- SC-3: README de drizzle con el checklist expand/contract y punteros.
+- SC-4: guard falla (exit 1) ante una migración nueva con `DROP COLUMN` sin marcador; pasa (exit 0) si lleva `-- contract-phase: ADR-XXX`; NO marca las 41 existentes (solo opera sobre archivos pasados como argumento = los añadidos en el diff).
+- SC-5: test del guard (`node --test`) verde, cubriendo cada patrón destructivo + el override + el comment-stripping.
+- SC-6: job `migration-safety` en ci.yml; `pnpm ci` (lint/typecheck/test/build) verde.

--- a/apps/api/drizzle/README.md
+++ b/apps/api/drizzle/README.md
@@ -1,0 +1,57 @@
+# Migraciones de la API (Drizzle)
+
+Migraciones SQL generadas desde `apps/api/src/db/schema.ts` con `drizzle-kit`.
+
+```
+pnpm --filter @booster-ai/api exec drizzle-kit generate
+```
+
+Se aplican **automáticamente al startup del servicio** (`src/db/migrator.ts` vía
+`runMigrationsGated` en `src/main.ts`), bajo advisory lock, forward-only. **No**
+correr `drizzle-kit migrate` a mano en prod.
+
+## Regla de oro: backward-compatible (expand/contract)
+
+Cada migración debe ser **backward-compatible** con la revisión de código anterior,
+porque migra el esquema **antes** de servir tráfico y el rollback de una revisión
+Cloud Run **no revierte el esquema**. Ver [ADR-066](../../../docs/adr/066-db-migration-rollback-strategy.md).
+
+En un solo deploy → **solo cambios aditivos**:
+
+- ✅ `ADD COLUMN` nullable o con `DEFAULT`.
+- ✅ `CREATE TABLE`, `CREATE INDEX` (preferí `CONCURRENTLY` en tablas grandes).
+- ✅ `ADD CONSTRAINT ... NOT VALID` y un `VALIDATE CONSTRAINT` posterior.
+
+Los cambios **destructivos** se parten en **≥2 deploys** (expand → backfill → contract):
+
+| En vez de… (1 deploy) | Hacé… (en fases) |
+|---|---|
+| `DROP COLUMN vieja` | Deploy 1: dejá de usarla en código. Deploy posterior: el `DROP` como fase **contract**. |
+| `RENAME COLUMN a → b` | Expand: `ADD COLUMN b` + escribir en ambas. Backfill. Contract: `DROP COLUMN a`. |
+| `SET NOT NULL` | Expand: agregá con default / backfilleá. Contract: `SET NOT NULL` cuando no haya NULLs ni código viejo. |
+| `ALTER COLUMN TYPE` (narrowing) | Columna nueva del tipo correcto + backfill + contract. |
+
+Así **el rollback de código siempre es seguro**.
+
+## Guard de CI
+
+`scripts/repo-checks/check-migration-safety.mjs` (job `migration-safety` en
+`.github/workflows/ci.yml`) **bloquea** una migración nueva con DDL destructivo
+(`DROP TABLE/COLUMN/CONSTRAINT`, `RENAME`, `SET NOT NULL`, `ALTER COLUMN TYPE`,
+`TRUNCATE`).
+
+Si **esta** migración es la fase **contract** planificada de un expand/contract
+(el expand ya se desplegó antes), declaralo con una línea en el `.sql`:
+
+```sql
+-- contract-phase: ADR-066   (o el issue/PR del expand previo)
+```
+
+Eso es un override **explícito y auditable**, no desactiva el guard.
+
+## Rollback
+
+No hay down-migrations auto-aplicadas (anti-patrón con startup-migrate; ver ADR-066).
+Para revertir: **docs/runbooks/db-migration-rollback.md** (rollback de código si fue
+aditiva → forward-fix → PITR clone para lo catastrófico). El reverse-SQL manual de
+último recurso vive en `down/` (no lo trackea el migrator).

--- a/apps/api/drizzle/down/_TEMPLATE.down.sql
+++ b/apps/api/drizzle/down/_TEMPLATE.down.sql
@@ -1,0 +1,24 @@
+-- =============================================================================
+-- REVERSE-SQL MANUAL — último recurso (ADR-066)
+-- =============================================================================
+-- ⚠️ MANUAL-APPLY-ONLY. El auto-migrator (src/db/migrator.ts) es forward-only y
+--    NO lee este directorio. Esto NO es un down-migration auto-aplicado.
+--
+-- Antes de escribir un reverse, leé docs/runbooks/db-migration-rollback.md:
+-- casi siempre el camino correcto es rollback de código (si la migración era
+-- aditiva), un forward-fix, o PITR clone — NO este archivo.
+--
+-- Usar SOLO para reversiones limpias y data-safe (p.ej. sacar un CREATE INDEX).
+--
+-- Convención de nombre: NNNN_name.down.sql  (mismo NNNN que la migración forward).
+--
+-- Aplicar a mano vía bastion en modo password (DDL):
+--   AUTH_MODE=password bash scripts/db/connect.sh -f apps/api/drizzle/down/NNNN_name.down.sql
+--
+-- ⚠️ Esto NO actualiza drizzle.__drizzle_migrations: si la migración forward sigue
+--    en el repo, el próximo startup la re-aplica. Es un parche puente, no un undo
+--    permanente — coordiná con un forward-fix o PITR.
+-- =============================================================================
+
+-- Reverse statements acá. Ejemplo (sacar un índice agregado por la forward):
+-- DROP INDEX IF EXISTS "idx_ejemplo";

--- a/docs/adr/066-db-migration-rollback-strategy.md
+++ b/docs/adr/066-db-migration-rollback-strategy.md
@@ -1,0 +1,81 @@
+# ADR-066 — Estrategia de rollback de migraciones de base de datos (expand/contract + PITR)
+
+**Estado**: Accepted
+**Fecha**: 2026-06-17
+**Decider**: Felipe Vicencio (Product Owner)
+**Related**: `apps/api/src/db/migrator.ts`, `apps/api/drizzle/`, [ADR-058](./058-cost-optimization-precomercial.md) (Cloud SQL ZONAL + PITR), `docs/runbooks/db-migration-rollback.md`, auditoría 2026-06-14 (P1-H)
+
+---
+
+## Contexto
+
+La auditoría 2026-06-14 marcó **P1-H**: `apps/api/drizzle/` tiene 41 migraciones **forward-only**, sin down-migrations, y no hay procedimiento de rollback documentado → ante una migración errónea el recovery es manual e improvisado en prod.
+
+Cuatro hechos del setup actual condicionan la decisión:
+
+1. **Las migraciones se aplican al STARTUP del servicio** (`runMigrationsGated` en `apps/api/src/main.ts` → `apps/api/src/db/migrator.ts`), bajo advisory lock, con un path de recuperación de pendientes out-of-order. Es decir: cuando una nueva revisión de Cloud Run arranca, **migra la BD antes de servir tráfico**.
+2. **Drizzle es forward-only por diseño**: `drizzle-kit generate` no produce down-migrations. Implementarlas sería tooling propio.
+3. **PITR ya está habilitado** en Cloud SQL (`infrastructure/data.tf`: `point_in_time_recovery_enabled = true`, `transaction_log_retention_days = 7`) + backups retenidos. El undo de un DDL a nivel infra **ya existe**.
+4. **Consecuencia del punto 1**: revertir la revisión de Cloud Run (rollback de código) **NO revierte el esquema**. El código viejo queda corriendo contra un esquema nuevo.
+
+Por el punto 1, los **down-migrations literales aplicados automáticamente son un anti-patrón** en este setup: un down ejecutado durante un rollback puede **perder datos** (revertir un `ADD COLUMN` dropea la columna con su contenido) y, con canary, dejar el esquema en un estado intermedio inconsistente. La causa raíz de P1-H no es "faltan 41 reverse files" — es la **ausencia de procedimiento y de disciplina preventiva**.
+
+## Decisión
+
+Se adopta una estrategia de **tres capas**, de preventiva a correctiva, en vez de down-migrations auto-aplicadas:
+
+### 1. Convención expand/contract (preventiva, primaria)
+
+Toda migración debe ser **backward-compatible** dentro del mismo deploy que el código que la consume. En un solo deploy solo se permiten cambios **aditivos**:
+
+- `ADD COLUMN` nullable o con `DEFAULT`.
+- `CREATE TABLE`, `CREATE INDEX` (preferir `CONCURRENTLY` para tablas grandes), `ADD CONSTRAINT ... NOT VALID` + `VALIDATE` posterior.
+
+Los cambios **destructivos** (DROP/RENAME de columna o tabla, `SET NOT NULL` sin default backfilled, narrowing de tipo, `DROP CONSTRAINT`, `TRUNCATE`) se parten en **≥2 deploys**:
+
+1. **Expand**: agregar lo nuevo (columna nueva, tabla nueva) sin tocar lo viejo. El código pasa a escribir en ambos / leer del nuevo.
+2. **Backfill**: migrar datos del viejo al nuevo.
+3. **Contract**: eliminar lo viejo **recién cuando ninguna revisión que lo usa sigue viva**.
+
+Con esto, **el rollback de código siempre es seguro**: cualquier revisión anterior encuentra un esquema que aún soporta lo que esperaba.
+
+### 2. PITR / clone (correctiva, emergencia)
+
+El undo real de un DDL catastrófico (corrupción, drop accidental con datos) es **restaurar o clonar Cloud SQL a un punto previo** vía PITR — no un down-migration. Procedimiento en el runbook.
+
+### 3. Reverse-SQL manual (último recurso)
+
+Para reversiones limpias y data-safe se permite escribir un archivo `apps/api/drizzle/down/NNNN_name.down.sql`, aplicado por **procedimiento psql manual documentado** (vía bastion), **NUNCA** por el auto-migrator. El migrator (`migrator.ts`) sigue siendo forward-only y no lee `down/`.
+
+### Enforcement
+
+Un guard de CI bloqueante (`scripts/repo-checks/check-migration-safety.mjs`, job `migration-safety` en `ci.yml`) falla si una migración **nueva** trae DDL destructivo, salvo que el archivo declare que es la fase contract planificada con el marcador:
+
+```sql
+-- contract-phase: ADR-066   (o issue#/ref que documente el expand previo)
+```
+
+El guard opera solo sobre los `.sql` **añadidos** en el diff vs la base — nunca sobre las 41 migraciones ya aplicadas (inmutables).
+
+## Consecuencias
+
+**Positivas**:
+- El rollback de código vuelve a ser una operación segura y trivial (revertir la revisión), que es el caso de rollback más común.
+- Se aprovecha PITR (ya pagado) como red real para lo catastrófico, sin construir ni mantener un motor de down-migrations frágil.
+- El guard convierte la disciplina en contrato verificable (coherente con "cero deuda day 0").
+
+**Negativas / trade-offs aceptados**:
+- Los cambios destructivos cuestan ≥2 PRs/deploys (expand/contract). Es intencional: es el costo de poder hacer rollback sin perder datos.
+- El reverse-SQL manual no está automatizado; requiere un humano + bastion. Aceptable porque es último recurso y las primeras dos capas cubren el caso común.
+- El guard puede tener falsos positivos (un `DROP` legítimo de fase contract); se resuelven con el marcador `-- contract-phase:` (override explícito y auditable), no desactivando el guard.
+
+## Criterios de validación
+
+1. `check-adr-numbering` valida que 066 no colisiona.
+2. El guard falla (exit 1) ante una migración nueva con `DROP COLUMN` sin marcador y pasa (exit 0) con `-- contract-phase: …`; no marca las migraciones existentes.
+3. El runbook (`docs/runbooks/db-migration-rollback.md`) cubre los tres caminos con comandos concretos.
+
+## Alternativas descartadas
+
+- **Down-migrations auto-aplicadas (tipo Rails/Knex)**: anti-patrón con startup-migrate + canary (pérdida de datos en rollback, estado intermedio). Descartada.
+- **Solo runbook de PITR, sin convención ni guard**: deja la disciplina preventiva sin codificar; el problema reaparece. Descartada (el PO eligió la opción con ADR + guard).

--- a/docs/runbooks/db-migration-rollback.md
+++ b/docs/runbooks/db-migration-rollback.md
@@ -1,0 +1,128 @@
+# Runbook — Rollback de migraciones de base de datos
+
+Qué hacer cuando un deploy aplicó una migración Drizzle que hay que revertir o
+contener. Decisión + procedimientos. Base conceptual: [ADR-066](../adr/066-db-migration-rollback-strategy.md).
+
+## ⚠️ Lo primero que tenés que entender
+
+Las migraciones se aplican **al startup del servicio** (`apps/api/src/db/migrator.ts`,
+forward-only). Por lo tanto:
+
+> **Revertir la revisión de Cloud Run NO revierte el esquema.**
+
+Si hacés rollback del código a la revisión anterior, esa revisión vieja arranca
+contra el esquema **ya migrado**. Si la migración fue backward-compatible
+(convención expand/contract, ADR-066), eso es seguro. Si no lo fue, el código
+viejo puede romper. Por eso el árbol de decisión de abajo empieza por esa pregunta.
+
+---
+
+## Árbol de decisión
+
+```
+¿Qué pasó?
+│
+├─ El deploy nuevo falla / hay que volver atrás, pero la migración era ADITIVA
+│  (ADD COLUMN nullable, CREATE TABLE/INDEX) → backward-compatible
+│     → CAMINO A: rollback de código. Listo. El esquema nuevo soporta al código viejo.
+│
+├─ La migración metió datos/estado malos pero la BD está sana y querés
+│  preservar los datos
+│     → CAMINO B: forward-fix (migración correctiva nueva). PREFERIDO.
+│
+└─ DDL destructivo/corrupción/drop accidental con pérdida de datos
+      → CAMINO C: PITR clone a un punto previo al deploy. Último recurso.
+```
+
+---
+
+## CAMINO A — Rollback de código (migración backward-compatible)
+
+El caso común y seguro. La migración era aditiva, así que el esquema nuevo sigue
+soportando la revisión anterior.
+
+1. Identificá la revisión sana anterior:
+   ```
+   gcloud run revisions list --service=booster-ai-api --region=southamerica-west1
+   ```
+2. Mové el 100% del tráfico a esa revisión:
+   ```
+   gcloud run services update-traffic booster-ai-api \
+     --region=southamerica-west1 --to-revisions=<REVISION_SANA>=100
+   ```
+3. Verificá `/health` + un flujo real. No hace falta tocar la BD.
+
+> Si la migración NO era backward-compatible, **no uses el Camino A** — saltá a B o C.
+> (El guard `migration-safety` en CI existe justamente para que esto casi nunca pase.)
+
+---
+
+## CAMINO B — Forward-fix (preferido cuando hay que arreglar datos/esquema)
+
+En vez de "deshacer", se avanza con una migración correctiva. Preserva datos y
+mantiene el historial lineal que Drizzle espera.
+
+1. Escribí una migración nueva que corrige el problema (otra columna, un backfill,
+   un `ADD CONSTRAINT ... NOT VALID` + `VALIDATE`, etc.), respetando expand/contract.
+2. Si el problema es una columna recién agregada que está mal: **no la dropees en
+   el mismo deploy** (rompería el Camino A futuro). Dejala sin uso o corregila aditivamente;
+   el drop va como fase contract en un deploy posterior (`-- contract-phase: <ref>`).
+3. Deploy normal vía `release.yml` (gate de prod + canary).
+
+---
+
+## CAMINO C — PITR clone (emergencia: corrupción / pérdida de datos)
+
+El undo real de un DDL catastrófico. Cloud SQL tiene PITR habilitado
+(`point_in_time_recovery_enabled = true`, 7 días de transaction logs —
+`infrastructure/data.tf`). **No se restaura sobre la instancia viva**: se **clona**
+a un instante previo al deploy para inspeccionar/promover sin destruir evidencia.
+
+1. Identificá el timestamp **justo antes** del deploy malo (de los logs del release
+   o de `gcloud sql operations list`). Usá RFC3339 UTC.
+2. Obtené el nombre de la instancia (tiene sufijo aleatorio):
+   ```
+   gcloud sql instances list --project=booster-ai-494222
+   # → booster-ai-pg-<suffix>
+   ```
+3. Cloná a ese punto en el tiempo (instancia nueva, no toca la productiva):
+   ```
+   gcloud sql instances clone booster-ai-pg-<suffix> booster-ai-pg-restore-<fecha> \
+     --point-in-time='2026-06-17T16:55:00Z' --project=booster-ai-494222
+   ```
+4. Verificá en el clon que el esquema/datos están sanos (conectá el bastion al clon).
+5. **Decisión de promoción** (humana, con el PO): apuntar la app al clon implica un
+   cambio de `DATABASE_URL` (Secret Manager) + redeploy, o un swap de IP privada.
+   Coordinar ventana — es disruptivo. Documentar en `docs/handoff/CURRENT.md`.
+6. Hasta promover, podés operar en modo lectura/degradado según el incidente
+   (ver `incident-response`).
+
+> PITR clona a la última operación si no pasás `--point-in-time`. Siempre pasá el
+> timestamp explícito previo al deploy.
+
+---
+
+## Reverse-SQL manual (último recurso, reversión limpia y data-safe)
+
+Solo para casos donde un DDL es reversible **sin pérdida de datos** y B/C no aplican
+(p.ej. un `CREATE INDEX` que hay que sacar). **El auto-migrator NO aplica esto** —
+es manual, vía bastion.
+
+1. Escribí el reverse en `apps/api/drizzle/down/NNNN_name.down.sql` (mismo número que
+   la migración a revertir; ver `apps/api/drizzle/down/_TEMPLATE.down.sql`).
+2. Aplicalo a mano vía bastion en modo password (DDL):
+   ```
+   AUTH_MODE=password bash scripts/db/connect.sh -f apps/api/drizzle/down/NNNN_name.down.sql
+   ```
+3. ⚠️ Esto **no** actualiza `drizzle.__drizzle_migrations`. Si dejás la migración
+   forward en el repo, el próximo startup la re-aplicará. Solo usar como parche puente
+   mientras se prepara el forward-fix (Camino B) o se decide PITR (Camino C).
+
+---
+
+## Después de cualquier rollback
+
+- Anotá el incidente y la decisión en `docs/handoff/CURRENT.md`.
+- Si la causa fue una migración destructiva que pasó el guard: revisá por qué
+  (¿llevaba un `-- contract-phase:` que no correspondía?) y ajustá ADR-066 / el guard.
+- Si fue PITR: no borres el clon hasta confirmar que la app productiva está sana.

--- a/scripts/repo-checks/check-migration-safety.mjs
+++ b/scripts/repo-checks/check-migration-safety.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * @booster-ai/scripts — check-migration-safety (audit P1-H, ADR-066)
+ *
+ * Enforcea la convención expand/contract: una migración Drizzle NUEVA no puede
+ * traer DDL destructivo (que rompe backward-compat → el rollback de código deja
+ * de ser seguro) sin declararlo explícitamente como la fase `contract`
+ * planificada de un expand/contract con el marcador:
+ *
+ *   -- contract-phase: <ADR/issue/ref>
+ *
+ * Las migraciones se aplican al STARTUP del servicio (apps/api/src/db/migrator.ts)
+ * y Drizzle es forward-only; el undo real de un DDL es PITR/clone, no un down
+ * auto-aplicado (ver ADR-066 + docs/runbooks/db-migration-rollback.md).
+ *
+ * Opera SOLO sobre los archivos pasados como argumento (en CI = los .sql
+ * AÑADIDOS en el diff vs la base), nunca sobre las migraciones ya aplicadas.
+ *
+ * Usage:
+ *   node scripts/repo-checks/check-migration-safety.mjs <file.sql> [<file.sql> ...]
+ *
+ * Exit codes:
+ *   0 = sin DDL destructivo, o todos con marcador contract-phase
+ *   1 = al menos un archivo con DDL destructivo sin marcador
+ *   2 = error de uso (archivo no legible)
+ */
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+/**
+ * Patrones de DDL destructivo (rompen backward-compat dentro de un deploy).
+ * Se evalúan sobre el SQL con los comentarios `--` ya removidos.
+ */
+const DESTRUCTIVE_PATTERNS = [
+  { name: 'DROP TABLE', re: /\bdrop\s+table\b/i },
+  { name: 'DROP COLUMN', re: /\bdrop\s+column\b/i },
+  { name: 'DROP CONSTRAINT', re: /\bdrop\s+constraint\b/i },
+  { name: 'RENAME', re: /\brename\s+(to|column)\b/i },
+  { name: 'SET NOT NULL', re: /\bset\s+not\s+null\b/i },
+  { name: 'ALTER COLUMN TYPE', re: /\balter\s+column\b[^;]*\b(set\s+data\s+type|type)\b/i },
+  { name: 'TRUNCATE', re: /\btruncate\b/i },
+];
+
+const CONTRACT_MARKER = /^[ \t]*--[ \t]*contract-phase:[ \t]*\S+/im;
+
+/** Quita los comentarios de línea `-- ...` para no matchear DDL en prosa. */
+function stripLineComments(sql) {
+  return sql
+    .split('\n')
+    .map((line) => {
+      const idx = line.indexOf('--');
+      return idx === -1 ? line : line.slice(0, idx);
+    })
+    .join('\n');
+}
+
+/** Devuelve los nombres de patrones destructivos presentes en el SQL. */
+export function findDestructiveStatements(sql) {
+  const code = stripLineComments(sql);
+  const found = [];
+  for (const { name, re } of DESTRUCTIVE_PATTERNS) {
+    if (re.test(code)) {
+      found.push(name);
+    }
+  }
+  return found;
+}
+
+/** True si el archivo declara explícitamente que es una fase contract. */
+export function hasContractMarker(sql) {
+  return CONTRACT_MARKER.test(sql);
+}
+
+export function main(argv) {
+  const files = argv.filter((a) => !a.startsWith('-'));
+  const violations = [];
+  for (const file of files) {
+    let content;
+    try {
+      content = readFileSync(file, 'utf-8');
+    } catch (err) {
+      process.stderr.write(`[check-migration-safety] no se pudo leer ${file}: ${err.message}\n`);
+      return 2;
+    }
+    const destructive = findDestructiveStatements(content);
+    if (destructive.length > 0 && !hasContractMarker(content)) {
+      violations.push({ file, destructive });
+    }
+  }
+
+  if (violations.length === 0) {
+    process.stdout.write(
+      `[check-migration-safety] OK — ${files.length} migración(es) nueva(s) sin DDL destructivo no declarado\n`,
+    );
+    return 0;
+  }
+
+  process.stderr.write(
+    `[check-migration-safety] FAIL — ${violations.length} migración(es) con DDL destructivo sin marcador:\n`,
+  );
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}: ${v.destructive.join(', ')}\n`);
+  }
+  process.stderr.write(
+    '\nLas migraciones deben ser backward-compatible (expand/contract, ADR-066): el rollback\n' +
+      'de la revisión Cloud Run NO revierte el esquema. Opciones:\n' +
+      '  1. Reescribir como cambio aditivo (ADD COLUMN nullable, CREATE TABLE/INDEX).\n' +
+      '  2. Partir en fases: expand → backfill → contract (deploy aparte, cuando el código\n' +
+      '     viejo ya no corre).\n' +
+      '  3. Si ESTA es la fase contract planificada, declararla con una línea:\n' +
+      '       -- contract-phase: <ADR-XXX | issue#>\n' +
+      'Runbook: docs/runbooks/db-migration-rollback.md\n',
+  );
+  return 1;
+}
+
+// CLI entrypoint — solo corre cuando se ejecuta directo, no al importar.
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/repo-checks/check-migration-safety.test.mjs
+++ b/scripts/repo-checks/check-migration-safety.test.mjs
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import { findDestructiveStatements, hasContractMarker, main } from './check-migration-safety.mjs';
+
+// P1-H (audit 2026-06-14) — guard bloqueante: una migración Drizzle NUEVA con
+// DDL destructivo (DROP/RENAME/SET NOT NULL/TYPE/DROP CONSTRAINT/TRUNCATE) sin
+// el marcador `-- contract-phase: <ref>` rompe el contrato expand/contract
+// (ADR-066) → exit 1. Con marcador, o solo aditiva, pasa. Usa node:test porque
+// los scripts/ no están en el vitest workspace (apps/*, packages/*).
+
+describe('findDestructiveStatements', () => {
+  it('detecta DROP TABLE', () => {
+    assert.ok(findDestructiveStatements('DROP TABLE usuarios;').includes('DROP TABLE'));
+  });
+
+  it('detecta DROP COLUMN (ALTER TABLE)', () => {
+    const sql = 'ALTER TABLE "viajes" DROP COLUMN "precio";';
+    assert.ok(findDestructiveStatements(sql).includes('DROP COLUMN'));
+  });
+
+  it('detecta RENAME TO y RENAME COLUMN', () => {
+    assert.ok(findDestructiveStatements('ALTER TABLE a RENAME TO b;').includes('RENAME'));
+    assert.ok(findDestructiveStatements('ALTER TABLE a RENAME COLUMN x TO y;').includes('RENAME'));
+  });
+
+  it('detecta SET NOT NULL', () => {
+    const sql = 'ALTER TABLE "u" ALTER COLUMN "rut" SET NOT NULL;';
+    assert.ok(findDestructiveStatements(sql).includes('SET NOT NULL'));
+  });
+
+  it('detecta cambio de tipo (TYPE / SET DATA TYPE)', () => {
+    assert.ok(
+      findDestructiveStatements('ALTER TABLE u ALTER COLUMN x TYPE integer;').includes(
+        'ALTER COLUMN TYPE',
+      ),
+    );
+    assert.ok(
+      findDestructiveStatements('ALTER TABLE u ALTER COLUMN x SET DATA TYPE text;').includes(
+        'ALTER COLUMN TYPE',
+      ),
+    );
+  });
+
+  it('detecta DROP CONSTRAINT y TRUNCATE', () => {
+    assert.ok(
+      findDestructiveStatements('ALTER TABLE u DROP CONSTRAINT fk;').includes('DROP CONSTRAINT'),
+    );
+    assert.ok(findDestructiveStatements('TRUNCATE TABLE logs;').includes('TRUNCATE'));
+  });
+
+  it('es case-insensitive', () => {
+    assert.ok(findDestructiveStatements('drop table x;').includes('DROP TABLE'));
+  });
+
+  it('NO marca migración puramente aditiva', () => {
+    const sql = `CREATE TABLE "nueva" ("id" uuid PRIMARY KEY);
+      ALTER TABLE "viajes" ADD COLUMN "nota" text;
+      CREATE INDEX "idx_x" ON "viajes" ("empresa_id");`;
+    assert.deepEqual(findDestructiveStatements(sql), []);
+  });
+
+  it('ignora la palabra "drop" dentro de comentarios (no FP)', () => {
+    const sql = `-- esta migración NO hace DROP TABLE, solo agrega
+      ALTER TABLE "v" ADD COLUMN "x" text;`;
+    assert.deepEqual(findDestructiveStatements(sql), []);
+  });
+
+  it('detecta el statement real aunque haya un comentario en la misma línea', () => {
+    const sql = 'ALTER TABLE v DROP COLUMN y; -- limpieza';
+    assert.ok(findDestructiveStatements(sql).includes('DROP COLUMN'));
+  });
+});
+
+describe('hasContractMarker', () => {
+  it('reconoce el marcador con una ref', () => {
+    assert.equal(hasContractMarker('-- contract-phase: ADR-066\nDROP TABLE x;'), true);
+  });
+
+  it('tolera espacios y mayúsculas variables', () => {
+    assert.equal(hasContractMarker('--   Contract-Phase:   ISSUE-123\n'), true);
+  });
+
+  it('NO acepta el marcador sin ref', () => {
+    assert.equal(hasContractMarker('-- contract-phase:\nDROP TABLE x;'), false);
+  });
+
+  it('NO confunde una mención cualquiera', () => {
+    assert.equal(hasContractMarker('-- esto es una contract-phase futura quizá\n'), false);
+  });
+});
+
+describe('main (CLI)', () => {
+  let dir;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'migsafe-'));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function write(name, content) {
+    const p = join(dir, name);
+    writeFileSync(p, content);
+    return p;
+  }
+
+  it('exit 0 sin archivos', () => {
+    assert.equal(main([]), 0);
+  });
+
+  it('exit 0 para migración aditiva', () => {
+    const f = write('0100_add.sql', 'ALTER TABLE v ADD COLUMN x text;');
+    assert.equal(main([f]), 0);
+  });
+
+  it('exit 1 para DROP COLUMN sin marcador', () => {
+    const f = write('0101_drop.sql', 'ALTER TABLE v DROP COLUMN x;');
+    assert.equal(main([f]), 1);
+  });
+
+  it('exit 0 para DROP COLUMN CON marcador contract-phase', () => {
+    const f = write(
+      '0102_contract.sql',
+      '-- contract-phase: ADR-066\nALTER TABLE v DROP COLUMN x;',
+    );
+    assert.equal(main([f]), 0);
+  });
+
+  it('exit 2 si un archivo no existe', () => {
+    assert.equal(main([join(dir, 'no-existe.sql')]), 2);
+  });
+
+  it('evalúa múltiples archivos y falla si UNO es destructivo', () => {
+    const ok = write('0103_ok.sql', 'ALTER TABLE v ADD COLUMN x text;');
+    const bad = write('0104_bad.sql', 'DROP TABLE v;');
+    assert.equal(main([ok, bad]), 1);
+  });
+});


### PR DESCRIPTION
## Qué

Resuelve **P1-H** de la auditoría 2026-06-14: 41 migraciones Drizzle **forward-only**, sin down-migrations ni procedimiento de rollback → recovery DDL manual e improvisado en prod.

**Reencuadre clave**: las migraciones se aplican **al startup del servicio** (`apps/api/src/db/migrator.ts`) y revertir la revisión Cloud Run **NO revierte el esquema**. Con Drizzle forward-only + canary, los down-migrations auto-aplicados son **anti-patrón** (un down durante el rollback pierde datos). La causa raíz no es "faltan 41 reverse files" — es la ausencia de **procedimiento** y **disciplina preventiva**. PITR ya está habilitado en Cloud SQL.

## Decisión ([ADR-066](docs/adr/066-db-migration-rollback-strategy.md), aprobada por el PO)

Tres capas en vez de down-migrations:

1. **Expand/contract (preventiva)** — migraciones backward-compatible: aditivo en un deploy; destructivo (DROP/RENAME/SET NOT NULL/narrowing/DROP CONSTRAINT) en ≥2 deploys (expand → backfill → contract). Así **el rollback de código siempre es seguro**.
2. **PITR/clone (emergencia)** — undo real de un DDL catastrófico (ya habilitado, 7d de logs).
3. **Reverse-SQL manual (último recurso)** — `apps/api/drizzle/down/`, aplicado a mano vía bastion, NUNCA por el auto-migrator.

## Entregables

| Archivo | Qué |
|---|---|
| `docs/adr/066-db-migration-rollback-strategy.md` | ADR Accepted (contexto, decisión, consecuencias, alternativas descartadas) |
| `docs/runbooks/db-migration-rollback.md` | Árbol de decisión + comandos concretos (`gcloud sql instances clone --point-in-time`, reverse-SQL vía bastion) |
| `apps/api/drizzle/README.md` | Convención para autores (checklist expand/contract, tabla destructivo→fases) |
| `apps/api/drizzle/down/_TEMPLATE.down.sql` | Template reverse-SQL manual-apply-only |
| `scripts/repo-checks/check-migration-safety.mjs` (+ `.test.mjs`) | **Guard CI bloqueante** + 20 tests `node:test` |
| `.github/workflows/ci.yml` | Job `migration-safety` (sumado al agregador `CI Success`) |
| `.specs/db-migration-rollback-strategy/spec.md` | Spec |

## Guard de CI

Bloquea una migración **nueva** con DDL destructivo salvo que declare la fase contract con `-- contract-phase: <ref>` (override explícito y auditable). Opera **solo sobre los `.sql` añadidos** en el diff del PR — nunca sobre las 41 existentes (de las cuales solo 1 tendría DDL destructivo: la convención ya es norma de facto). Ignora comentarios `--` (sin FP por la palabra "drop" en prosa).

## Evidencia

- **Guard tests**: `node --test check-migration-safety.test.mjs` → **20 passed, 0 fail** (cada patrón destructivo + override + comment-stripping + CLI exit codes).
- **Smoke CLI**: `DROP COLUMN` sin marcador → exit 1; con `-- contract-phase: ADR-066` → exit 0. ✓
- **Biome**: limpio sobre ambos `.mjs`.
- **ci.yml**: YAML válido, `migration-safety` en jobs y en `ci-success.needs`.
- **check-adr-numbering**: OK (066 libre).
- Sin cambios de runtime (`migrator.ts` intacto) ni de TypeScript de apps/packages → typecheck/test/build no afectados.

### ADR compliance
- ADR-066 documenta el patrón (aplica a todas las migraciones futuras → ADR obligatorio por CLAUDE.md).
- Guard de CI = nuevo quality gate, justificado por decisión explícita del PO (CLAUDE.md exige justificación para tocar gates de CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)