### PR TITLE
chore(infra): elimina el topic huérfano document-events (audit P1-F)

### DIFF
--- a/infrastructure/messaging.tf
+++ b/infrastructure/messaging.tf
@@ -10,7 +10,6 @@ locals {
     "notification-events",               # fan-out notificaciones
     "vehicle-availability-events",       # vehículos disponibles para matching
     "traffic-condition-events",          # congestión detectada → eco-routing
-    "document-events",                   # emisiones DTE, OCR requests
     "telemetry-events-safety-p0",        # Wave 2: Crash/Unplug/GNSS Jamming → notification
     "telemetry-events-security-p1",      # Wave 2: Tow/Auto Geofence → notification
     "telemetry-events-eco-score",        # Wave 2: Idling/Green/Speed → matching-algorithm
@@ -72,16 +71,6 @@ resource "google_pubsub_topic" "vehicle_availability" {
 
 resource "google_pubsub_topic" "traffic_condition" {
   name    = "traffic-condition-events"
-  project = google_project.booster_ai.project_id
-  labels = {
-    env        = var.environment
-    managed_by = "terraform"
-  }
-  depends_on = [google_project_service.apis]
-}
-
-resource "google_pubsub_topic" "document_events" {
-  name    = "document-events"
   project = google_project.booster_ai.project_id
   labels = {
     env        = var.environment


### PR DESCRIPTION
## Qué

Elimina el topic Pub/Sub `document-events` de `infrastructure/messaging.tf` (recurso + su línea en la lista-manifiesto `local.pubsub_topics`).

## Por qué (audit P1-F)

El audit 2026-06-14 marcó `document-events` como P1-F: *"topic sin subscription/DLQ → DTE/OCR publicados se pierden silenciosamente"*. Investigación de esta sesión:

- **Sin publisher**: ningún código publica al topic. La emisión DTE (`emitirDteLiquidacion`, `dte-emitter-factory`, `reconciliar-dtes`) es **síncrona al provider**, no por Pub/Sub.
- **Sin consumer**: `apps/document-service` es un **skeleton** (`logger.info('… starting (skeleton)')`).
- **Sin subscription ni DLQ**: el topic está huérfano.

O sea no es un bug activo (nadie publica hoy), sino infra aspiracional que arma una trampa futura: un topic sin subscription **descarta** los mensajes al publicarse.

## Decisión (PO, 2026-06-17)

**Remover el topic prematuro** (YAGNI / cero-deuda day 0) en vez de agregar una subscription de red-de-seguridad hacia un consumer inexistente. Sin el topic, un publish futuro **falla ruidoso** (mejor que el descarte silencioso). Cuando se construya document-service se agregan topic + subscription juntos y bien cableados.

## Alcance / aislamiento

- `local.pubsub_topics` es lista-manifiesto: **ningún `for_each` la consume** → quitar la línea es solo higiene de doc.
- El output `pubsub_topics` **no** incluía `document_events` → sin cambio.
- Sin IAM bindings / subscription / publisher que referencien el topic → remoción aislada.

## Evidencia

- `terraform fmt -check messaging.tf` → OK
- `terraform validate` → Success
- `terraform plan -target=google_pubsub_topic.document_events`:
  ```
  # google_pubsub_topic.document_events will be destroyed
  # (because google_pubsub_topic.document_events is not in configuration)
  Plan: 0 to add, 0 to change, 1 to destroy.
  ```

## Post-merge

⚠️ Requiere **`terraform apply` manual** (no va por `release.yml`). Destruye un topic vacío sin subscription/consumer → seguro.

## Deuda relacionada (fuera de scope, no en esta PR)

`apps/document-service` sigue como **skeleton desplegado** en Cloud Run (`compute.tf:640`) — mismo patrón que el skeleton de notification-service (P0-G). Candidato a follow-up: retirar el skeleton o construir el bounded context.