### PR TITLE
feat(auth): cerrar IDOR en otorgamiento de consent ESG + evidencia 21.719 (P0-B/P1-B)

### DIFF
--- a/.specs/consent-idor-y-modelo-19628-21719/spec.md
+++ b/.specs/consent-idor-y-modelo-19628-21719/spec.md
@@ -1,0 +1,285 @@
+# consent-idor-y-modelo-19628-21719 — Spec (Frente F1)
+
+**Frente del programa**: F1 de `.specs/pivote-documental-y-cierre-legal-2026-06/spec.md`
+**Fecha**: 2026-06-17
+**Status**: **Draft — pendiente aprobación PO** (no ejecutar Fase Act sin firma en §Approval)
+**PO**: Felipe Vicencio — dev@boosterchile.com
+**Cierra**: P0-B (IDOR en `portafolio_viajes`) + P1-B (IDOR cross-empresa en scopes de empresa) de la auditoría 2026-06-14.
+**Relacionado**: ADR-028 (RBAC + consent grants), ADR-034 (organizaciones stakeholder). ADR-068 (nuevo) vincula el modelo legal al schema `consents`.
+
+> Este es el spec de un frente, TDD-ready. La matriz de tests (§Test list) es lo primero a escribir; el código va red→green→refactor. Es dominio crítico (auth/consent) → TDD obligatorio (`booster-skills:tdd-dominio-critico`).
+
+> **O-1b RESUELTA (decisión PO 2026-06-17)**: `portafolio_viajes` se **deniega siempre** (deny real). No hay tabla de portafolio, ni FK, ni call sites — no se infiere autoridad sobre una feature inexistente. `userCanGrantOnScope` devuelve `false` para todo grant `portafolio_viajes`, con `TODO`/backlink a la futura decisión de Producto (probablemente lista explícita de viajes, cuando exista la tabla). Esta decisión **reemplaza** el default "scope_id = empresa" que aparece en versiones previas de §7.1/§10/§11: donde el texto asuma ese default, prevalece el deny-always. No se toca ADR-053.
+
+---
+
+## 1. Objective
+
+Cerrar la vulnerabilidad IDOR en el otorgamiento de consentimientos ESG y versionar en el repo el modelo legal de consentimiento conforme Ley 19.628 + Ley 21.719.
+
+Hoy, en `apps/api/src/routes/me-consents.ts`, la función `userCanGrantOnScope` (líneas 80-107) **no valida** que el otorgante tenga autoridad sobre la empresa/portafolio concretos del `scope_id`:
+
+- **P1-B (líneas 98-106)**: para scopes `organizacion` / `generador_carga` / `transportista`, la query carga las memberships del user **sin filtrar por `empresaId === scopeId`** y devuelve `true` si el user es `dueno`/`admin` de *cualquier* empresa. → un dueño de empresa A otorga grants ESG sobre la empresa B.
+- **P0-B (líneas 85-95)**: para `portafolio_viajes`, basta tener *una* membership cualquiera (ni siquiera `dueno`/`admin`, ni siquiera `activa`) para que devuelva `true`. → cualquier miembro de cualquier empresa otorga acceso a un portafolio arbitrario.
+
+El fix endurece `userCanGrantOnScope` para que valide ownership real contra la empresa específica del scope, y para `portafolio_viajes` contra las empresas dueñas de los trips. Adicionalmente versiona el modelo de consentimiento en `docs/legal/` y añade columnas de evidencia 21.719 al schema `consents` (O-1, default del PO: añadir columnas).
+
+## 2. Why now
+
+- La 21.719 entra en vigencia el **01-dic-2026** (~5.5 meses). El flujo de consentimiento debe ser conforme antes.
+- El modelo legal conforme (`Modelo_Consentimiento_ESG_Booster.docx`, `Aviso_Privacidad_Corto_Booster.md`) ya existe — era el único bloqueo declarado de P0-B/P1-B.
+- IDOR es severidad **High** en ADR-028 §"Riesgos conocidos" (acción derivada §1/§2, pendiente P0). Es un hallazgo de acceso real, no teórico: el endpoint `POST /me/consents` está vivo y montado.
+
+## 3. Success criteria (measurable)
+
+- [ ] `pnpm --filter @booster-ai/api test` verde con la nueva matriz IDOR (§Test list) cubriendo P0-B y P1-B.
+- [ ] `pnpm --filter @booster-ai/api lint` 0 errores, `typecheck` 0 errores.
+- [ ] Coverage ≥80% en `me-consents.ts` (líneas/branches/funciones) sobre código nuevo.
+- [ ] `userCanGrantOnScope` para scopes de empresa filtra por `eq(memberships.empresaId, scopeId)` **AND** `eq(memberships.userId, userId)` **AND** `eq(memberships.status, 'activa')` **AND** `inArray(memberships.role, ['dueno','admin'])`.
+- [ ] `userCanGrantOnScope` para `portafolio_viajes` **deniega siempre** (deny real, O-1b): cualquier grant de ese scope → `403`, independiente de la membership del otorgante.
+- [ ] El error en denegación sigue siendo `403 { error: 'forbidden_scope_authority', code: 'forbidden_scope_authority' }` (string verificado en `me-consents.ts:138`).
+- [ ] Modelo de consentimiento versionado en `docs/legal/modelo-consentimiento-esg-v1.md` + `docs/legal/aviso-privacidad-corto-v1.md`, ambos con marca de borrador (campos `[ ]` + sign-off de abogado pendientes — O-6, dependencia externa).
+- [ ] Migración Drizzle nueva (siguiente número libre) añade a `consentimientos` las columnas de evidencia 21.719: `version_aviso`, `ip_otorgamiento`, `user_agent_otorgamiento` (todas nullable, sin default), y `grantConsent` las persiste.
+- [ ] ADR-068 mergeado vinculando modelo legal ↔ schema `consents` (lo escribe F1; este spec no lo redacta, solo lo referencia).
+
+## 4. User-visible behaviour
+
+| Actor | Antes | Después |
+|---|---|---|
+| Otorgante de consent ESG (dueño/admin de empresa A) | Puede crear grants sobre **cualquier** empresa si es dueño/admin de *alguna* | Solo sobre la empresa A (scope que matchea su membership); empresa B → `403 forbidden_scope_authority` |
+| Otorgante sobre `portafolio_viajes` | Basta *cualquier* membership (incluso `conductor`, incluso no-activa) | **Siempre `403`** — scope deshabilitado hasta que Producto defina el modelo (O-1b) |
+| Otorgante legítimo (dueño de la empresa correcta) | `201` | `201` (sin regresión) |
+| Revocador de consent ajeno | `403 forbidden_not_grantor` (ya correcto, no cambia) | `403 forbidden_not_grantor` (no regresión) |
+| Otorgante (evidencia) | Solo se guarda `consentDocumentUrl` | Se guarda además versión del aviso, IP confiable y user-agent del otorgamiento |
+
+No cambia el contrato HTTP público (mismos códigos, mismos `code` strings, mismo body de request). El único endurecimiento es de autorización: requests que **antes pasaban indebidamente** ahora devuelven `403`. Esto es deliberado y es el fix.
+
+## 5. Out of scope
+
+- **F1b — flujo de captura de consentimiento en signup** (`apps/web` casillas sin premarcar + backend de evidencia del flujo de registro): se dimensiona en §"Sub-fase F1b" y se decide **PR separado**. No entra en este PR.
+- **Completar los campos `[ ]` del modelo/aviso y el sign-off de abogado**: responsabilidad PO/legal (O-6, dependencia externa). El versionado se hace con marca de borrador.
+- **Consumidores de `checkStakeholderConsent`**: hoy no existe ningún handler que sirva data ESG a stakeholders (grep confirma: solo el servicio, la ruta y el schema referencian el consent). El fix es del **otorgamiento** (`POST /me/consents`), no del consumo. La superficie de lectura ESG es F2 del roadmap de stakeholder, fuera de este frente.
+- **Refactor del modelo de `portafolio_viajes`** (crear una tabla de portafolio real): ver O-1b. Este spec valida sobre el modelo existente sin introducir tabla nueva, salvo que el PO resuelva O-1b en sentido contrario.
+- **DROP de columnas**: la migración solo añade columnas nullable (expand-only, compatible con el guard CI expand/contract de P1-H).
+
+## 6. Constraints
+
+- **Stack Booster no-negociable** (CLAUDE.md): zero `any`, Zod en boundaries, `@booster-ai/logger`, OTel + `trace_id`, coverage ≥80%, Conventional Commits con scope, sección `## Evidencia` en el PR.
+- **Naming bilingüe**: columnas SQL en español snake_case sin tildes (`version_aviso`, `ip_otorgamiento`, `user_agent_otorgamiento`); identifiers TS en inglés camelCase (`noticeVersion`, `grantIp`, `grantUserAgent`). La tabla canónica de orden de transporte es `viajes`.
+- **Domain canónico** en `packages/shared-schemas/src/domain/`; DDL Drizzle canónico en `apps/api/src/db/schema.ts`. La tabla `consents` ya existe; el cambio es aditivo.
+- **TDD obligatorio** (`tdd-dominio-critico`): auth/consent es dominio crítico → red-green-refactor. La matriz de tests va antes del fix.
+- **Migración expand-only**: solo `ADD COLUMN ... NULL` (sin default, sin NOT NULL, sin DROP). Compatible con el guard CI expand/contract (P1-H, #491) y con la estrategia de rollback de migraciones.
+- **Numeración de migración**: el plan maestro reserva 0043 a PR #428 abierto. **Tomar el siguiente número libre al ejecutar** (verificar `apps/api/drizzle/meta/_journal.json`; el último aplicado es 0042). No fijar el número en este spec.
+- **No tocar** `firebase-auth.ts` ni la cadena de middlewares: el fix es local a `userCanGrantOnScope`.
+- **ADRs antes de implementar**: ADR-068 se redacta en F1; no se edita ADR-028/034, se complementan.
+
+## 7. Approach
+
+### 7.1 Fix IDOR (TDD-first) — `apps/api/src/routes/me-consents.ts`
+
+La función `userCanGrantOnScope` (líneas 80-107) se reescribe. Imports a añadir desde `drizzle-orm`: `and`, `inArray` (hoy solo importa `eq` — `me-consents.ts:3`). **No** se importa `trips`: P0-B (`portafolio_viajes`) deniega sin consultar la BD (O-1b); P1-B solo usa `memberships` (ya importado vía `../db/schema.js`).
+
+#### P1-B — scopes de empresa (`organizacion` / `generador_carga` / `transportista`)
+
+El `scope_id` apunta a `empresas.id`. La validación correcta filtra la membership por la empresa específica del scope:
+
+```ts
+// reemplaza me-consents.ts:98-106
+const rows = await opts.db
+  .select({ id: memberships.id })
+  .from(memberships)
+  .where(
+    and(
+      eq(memberships.userId, opts2.userId),
+      eq(memberships.empresaId, opts2.scopeId),
+      eq(memberships.status, 'activa'),
+      inArray(memberships.role, ['dueno', 'admin']),
+    ),
+  )
+  .limit(1);
+
+return rows.length > 0;
+```
+
+Nombres de columna verificados contra el schema:
+- `memberships.userId` → `usuario_id` (schema.ts:708).
+- `memberships.empresaId` → `empresa_id` (schema.ts:716, nullable por XOR con `organizacion_stakeholder_id`).
+- `memberships.status` → `estado`, enum `estado_membresia` con valor `'activa'` (schema.ts:80-85, 727).
+- `memberships.role` → `rol`, enum `rol_membresia` con valores `'dueno'`/`'admin'` entre 6 (schema.ts:71-78, 726).
+
+Nota: como `empresaId` es nullable (memberships de stakeholder tienen `empresaId = NULL`, `organizacion_stakeholder_id` set), `eq(memberships.empresaId, scopeId)` excluye correctamente las memberships de organización stakeholder (NULL nunca matchea un UUID). Eso es lo deseado: un stakeholder no otorga grants sobre empresas.
+
+#### P0-B — `portafolio_viajes` (deny real — decisión PO O-1b, 2026-06-17)
+
+El `scope_id` para `portafolio_viajes` es un UUID **sin FK** (`consents.scopeId` → `alcance_id uuid NOT NULL`, schema.ts:1439; sin `references()`). **No existe tabla de portafolio** en el código (grep de `portafolio` solo encuentra el enum, los comentarios, el schema Zod del body y la lógica laxa), ni call sites reales que creen grants de este tipo.
+
+**Decisión del PO (O-1b, 2026-06-17): denegar siempre.** No se infiere semántica de autorización sobre una feature que no está construida. `userCanGrantOnScope` devuelve `false` para todo grant `portafolio_viajes` (deny real, no default de config), hasta que Producto defina el modelo — probablemente lista explícita de viajes (Opción 2 de O-1b) cuando exista la tabla. Es la forma más segura de cerrar el IDOR P0-B: superficie cero.
+
+```ts
+// reemplaza me-consents.ts:85-95
+if (opts2.scopeType === 'portafolio_viajes') {
+  // O-1b (decisión PO 2026-06-17): el modelo de portafolio NO está construido
+  // (sin tabla, sin FK, sin call sites). No se infiere autoridad sobre una
+  // feature inexistente → se deniega TODO grant de este scope hasta que
+  // Producto defina el modelo.
+  // TODO(O-1b): al crear la tabla de portafolio (lista explícita de viajes),
+  // validar que TODAS las empresas dueñas de los viajes estén entre las
+  // memberships dueno/admin activas del otorgante (join viajes→memberships).
+  // Ref: .specs/consent-idor-y-modelo-19628-21719/spec.md §7.1 P0-B.
+  return false;
+}
+```
+
+Bajo esta decisión, el fix de P0-B **no** consulta `viajes` ni `empresas`, por lo que **se elimina** el cambio "añadir `trips` al import de schema" de la lista de cambios clave. Solo `and` e `inArray` (para P1-B) se añaden al import de `drizzle-orm`. La matriz de tests verifica que **cualquier** grant `portafolio_viajes` → `403 forbidden_scope_authority`, independiente de la membership del otorgante.
+
+### 7.2 Gap modelo↔schema (O-1) — columnas de evidencia 21.719
+
+La 21.719 exige **evidencia verificable** de cada aceptación: identidad del titular, finalidades marcadas, fecha/hora, **versión del aviso**, e **IP/dispositivo** (`Aviso_Privacidad_Corto_Booster.md:39`). Estado actual de `consentimientos` (schema.ts:1428-1454):
+
+| Requisito 21.719 | Cubierto hoy | Cómo |
+|---|---|---|
+| Identidad del titular | Sí | `grantedByUserId` → `otorgado_por_id` (FK usuarios) + `stakeholderId` |
+| Finalidades marcadas (granular) | Sí | `dataCategories` array (enum `categoria_dato_consentimiento`, ≥1 por CHECK) |
+| Fecha/hora | Sí | `grantedAt` → `otorgado_en` (default now) |
+| **Versión del aviso** | **No** | — |
+| **IP / dispositivo** | **No** | — |
+| Documento firmado | Sí | `consentDocumentUrl` → `documento_consentimiento_url` |
+| Revocación | Sí | `revokedAt` → `revocado_en` |
+
+**Decisión (default del PO en O-1): añadir columnas.** Hay precedente exacto en el repo: `carrier_memberships` ya guarda evidencia de consentimiento Ley 19.628 con `consent_terms_v2_ip` (text), `consent_terms_v2_user_agent` (text), capturados con `extractClientIp(c.req.header('x-forwarded-for'))` + `c.req.header('user-agent')` (me.ts:567-583, schema.ts:1896-1898). Se replica el patrón en `consentimientos`.
+
+Migración Drizzle (siguiente número libre, expand-only):
+
+```sql
+-- ADD COLUMNs de evidencia 21.719 a consentimientos. Nullable, sin default:
+-- los consents existentes (si los hubiera) no tienen esta evidencia y no se
+-- backfillean (no se puede inventar evidencia retroactiva). Expand-only,
+-- compatible con guard expand/contract (P1-H).
+ALTER TABLE "consentimientos" ADD COLUMN "version_aviso" varchar(20);
+ALTER TABLE "consentimientos" ADD COLUMN "ip_otorgamiento" text;
+ALTER TABLE "consentimientos" ADD COLUMN "user_agent_otorgamiento" text;
+```
+
+Cambio en `schema.ts` (tabla `consents`, tras `consentDocumentUrl` línea 1444):
+
+```ts
+noticeVersion: varchar('version_aviso', { length: 20 }),
+grantIp: text('ip_otorgamiento'),
+grantUserAgent: text('user_agent_otorgamiento'),
+```
+
+Cableado:
+- `grantBodySchema` (me-consents.ts:31) añade `notice_version: z.string().min(1).max(20).optional()` (la versión del aviso que el cliente vio; opcional mientras el flujo F1b no esté vivo).
+- El handler `POST /me/consents` captura `grantIp = extractClientIp(c.req.header('x-forwarded-for'))` (null si `'unknown'`) y `grantUserAgent = c.req.header('user-agent') ?? null`, replicando me.ts:571-573.
+- `GrantOpts` (consent.ts:139) y `grantConsent` (consent.ts:162) reciben y persisten `noticeVersion`, `grantIp`, `grantUserAgent` en el INSERT (consent.ts:170-181).
+
+Las 6 finalidades granulares (una casilla por finalidad) ya están modeladas como `dataCategories` (array de `categoria_dato_consentimiento`: `emisiones_carbono`, `rutas`, `distancias`, `combustibles`, `certificados`, `perfiles_vehiculos` — schema.ts:382-389). **No se requiere columna nueva para finalidades**; el CHECK `array_length >= 1` ya impide grant sin finalidad. El versionado del documento legal (cada cambio de finalidades reinforma) se ata vía `noticeVersion` + el doc versionado en `docs/legal/`.
+
+### 7.3 Versionado del modelo legal en `docs/legal/`
+
+Copiar (convirtiendo el `.docx` a Markdown con `textutil -convert txt` o `anthropic-skills:docx`) los dos documentos a `docs/legal/`, siguiendo la convención de versionado del directorio (`*-v1.md`, `*-v2.md` ya presentes: `terminos-de-servicio-v2.md`, `adendum-cobra-hoy-v1.md`):
+
+- `docs/legal/modelo-consentimiento-esg-v1.md` (de `Modelo_Consentimiento_ESG_Booster.docx`).
+- `docs/legal/aviso-privacidad-corto-v1.md` (de `Aviso_Privacidad_Corto_Booster.md`).
+
+Ambos llevan al inicio una marca de estado (el aviso ya la trae en su línea 3):
+
+```markdown
+> **BORRADOR LEGAL** — los campos entre corchetes `[ ]` y el sign-off de
+> abogado habilitado están **pendientes** (O-6, dependencia externa PO/legal).
+> No publicar ni invocar como texto final hasta completar. La `version_aviso`
+> registrada en `consentimientos` debe coincidir con la versión vigente de
+> este archivo.
+```
+
+El campo `noticeVersion`/`version_aviso` se setea con el slug de versión del archivo vigente (ej. `"esg-v1"`).
+
+### 7.4 ADR-068 (lo redacta F1, fuera del detalle de este spec)
+
+ADR-068: "Modelo de consentimiento ESG conforme Ley 19.628 + Ley 21.719". Vincula el texto legal versionado (`docs/legal/`) al schema `consents`: finalidades = `dataCategories`; evidencia = `grantedByUserId`/`grantedAt`/`noticeVersion`/`grantIp`/`grantUserAgent`/`consentDocumentUrl`; revocación = `revokedAt`. Complementa ADR-028 §4 y ADR-034; no los edita.
+
+## 8. Sub-fase F1b — flujo de captura en signup (dimensionamiento + decisión)
+
+**Qué es**: el flujo de registro (`apps/web`) que presenta las casillas de consentimiento sin premarcar (acción afirmativa, finalidades granulares, prohibición de tácito) y el backend que persiste la evidencia de esa aceptación de registro.
+
+**Alcance estimado**:
+- `apps/web`: componente de registro con 1 casilla obligatoria + ≥2 opcionales separadas (`Aviso_Privacidad_Corto_Booster.md:23-31`), todas `defaultChecked={false}`, validación que bloquea submit si la obligatoria no está marcada, enlace a la Política completa.
+- Backend: endpoint/columnas para registrar la evidencia de la aceptación de registro (distinta del grant ESG a stakeholder — es el consentimiento del titular sobre el tratamiento de sus propios datos). Probablemente una tabla/columnas nuevas (no `consentimientos`, que es para grants a terceros), reusando el patrón de `carrier_memberships` (ip/user-agent/version/timestamp). Requiere su propio modelo de datos y ADR.
+
+**Decisión: PR separado, NO en este PR.** Justificación:
+1. **Superficie distinta**: F1b toca `apps/web` (UI) + un modelo de datos nuevo (consentimiento del titular en registro), ortogonal al fix IDOR (autorización de grants a terceros en `consentimientos`). Mezclarlos infla el diff y el riesgo de regresión auth (R-1).
+2. **El fix IDOR no depende de F1b**: P0-B/P1-B se cierran solo con el endurecimiento de `userCanGrantOnScope` + las columnas de evidencia en `consentimientos`. F1b es el flujo *de registro*, no el de *otorgamiento de grants*.
+3. **Dependencia legal externa (O-6)**: el copy exacto de las casillas y la Política completa dependen del sign-off de abogado, aún pendiente. Versionar el borrador (este PR) desbloquea, pero cablear la UI con texto no-final sería trabajo a rehacer.
+4. **El PO puede aprobar frentes selectivamente** (plan maestro §12). F1b se levanta como `.specs/<slug>/` propio cuando O-6 esté resuelto.
+
+Este PR deja **preparado** el lado de evidencia en `consentimientos` (columnas + captura ip/ua/version en `grantConsent`) para que F1b no tenga que migrar de nuevo esa tabla; F1b agrega su propio modelo para el consentimiento de registro.
+
+## 9. Risks
+
+| ID | Riesgo | L | I | Mitigación |
+|---|---|---|---|---|
+| R-1 | El fix rompe otorgamientos legítimos (regresión auth) | M | H | Matriz IDOR TDD-first con happy path explícito (dueño de la empresa correcta → 201); el test `happy path` existente (me-consents.test.ts:175-189) debe seguir verde tras adaptar su stub al nuevo shape de query |
+| R-2 | El stub de DB de los tests (`makeDbStub`, me-consents.test.ts:36-75) no refleja el nuevo `where(and(...))` y da falsos verdes | M | M | Los tests consumen las queues `selects` por orden de llamada, no inspeccionan el `where`; reescribir los casos para alinear el número/orden de SELECTs del nuevo flujo (P1-B = 2 selects: resolveUser + membership; portafolio = 2-3) |
+| R-3 | Modelo de `portafolio_viajes` ambiguo → fix valida sobre interpretación equivocada | — | — | **Eliminado por O-1b**: deny-always no infiere modelo; cuando Producto lo defina, el `TODO`/backlink guía la implementación segura |
+| R-4 | Modelo legal es borrador (campos `[ ]`, sin sign-off) → versionar algo no-final | M | M | Marca de borrador explícita en ambos docs; el fix de código es independiente del texto (O-6) |
+| R-5 | Columnas nuevas sin backfill dejan consents existentes sin evidencia | L | L | Nullable sin default por diseño (no se inventa evidencia retroactiva); no hay consents en prod hoy (endpoint recién montado) — verificar antes de migrar |
+| R-6 | Migración no expand-safe rompe guard CI (P1-H) | L | M | Solo `ADD COLUMN ... NULL`; sin DROP/NOT NULL/default; verificar contra el guard expand/contract |
+
+## 10. Alternatives considered (rejected)
+
+- **Validar autoridad en el service `grantConsent` en vez del handler**: rechazado. El patrón del repo (consent.ts:155-161, me-consents.ts:124-139) pone la validación de autoridad en el handler para mejor error messaging; el service confía en el caller. Mantener la convención.
+- **No añadir columnas, usar solo `consentDocumentUrl`**: rechazado por el PO (O-1 default = añadir columnas). La 21.719 exige IP/dispositivo + versión como evidencia verificable; un PDF externo no es consultable/auditable en BD ni garantiza esos campos.
+- **Modelar `portafolio_viajes` con tabla explícita ahora**: rechazado para este PR (alcance). Se deja como O-1b; el default `scope_id=empresa` cierra el IDOR sin tabla nueva.
+- **Backfill de evidencia en consents existentes**: rechazado. No se puede inventar IP/versión retroactiva; nullable es lo correcto.
+- **Meter F1b (UI signup) en este PR**: rechazado (§8): infla diff, depende de O-6, mezcla dos modelos de consentimiento distintos.
+
+## 11. Test list (TDD — escribir PRIMERO)
+
+Archivo: `apps/api/test/unit/me-consents.test.ts` (extender la suite existente; reusar `makeDbStub` y `buildApp`). Casos rojo→verde. Códigos de error verificados contra `me-consents.ts`.
+
+**P1-B — IDOR cross-empresa (scopes de empresa):**
+
+1. **dueño de empresa A otorga sobre empresa B → 403 `forbidden_scope_authority`**. Stub: `resolveUserId`→`[{id: USER_ID}]`; query de membership filtrada por `empresaId=scopeId` (empresa B) devuelve `[]` (el user no tiene membership en B). Espera `403`, `code === 'forbidden_scope_authority'`.
+2. **admin de la empresa del scope → 201**. Stub: membership query devuelve `[{id: 'm1'}]`; insert devuelve `[{id: 'new-consent-uuid'}]`. Espera `201`, `consent_id` presente.
+3. **dueño pero membership `suspendida`/`removida` (no `activa`) sobre la empresa correcta → 403**. Bajo el nuevo `where`, la query filtra `status='activa'` → devuelve `[]`. Espera `403 forbidden_scope_authority`. (Caso nuevo: el código viejo no filtraba status correctamente en el branch de empresa.)
+4. **conductor / visualizador de la empresa del scope → 403**. La query filtra `role IN ('dueno','admin')` → `[]`. Espera `403`. (Refina el test existente me-consents.test.ts:144-160 que solo cubría "ninguna empresa".)
+
+**P0-B — IDOR `portafolio_viajes`:**
+
+5. **portafolio_viajes con otorgante dueño/admin de la empresa `scope_id` → 403** (deny real). Aunque el user sea `dueno`/`admin` activo de `scope_id`, el branch deniega siempre (O-1b). Espera `403 forbidden_scope_authority`. (Caso clave: prueba que el deny es real, no condicional a la membership.)
+6. **portafolio_viajes con `scope_id` arbitrario / sin membership → 403**. Espera `403 forbidden_scope_authority`.
+7. **portafolio_viajes deniega ANTES de tocar la BD**. Verificar (vía el stub `makeDbStub`) que el branch portafolio **no consume** ningún SELECT extra (no consulta `viajes` ni `memberships`). Regresión de la decisión O-1b: deny temprano, superficie cero.
+8. _(reservado para O-1b futura)_ — cuando Producto adopte "lista explícita de viajes" y exista la tabla `portafolios_viajes`, reactivar: portafolio con un viaje de empresa ajena → `403`; portafolio con todos los viajes de empresas propias → `201`.
+
+**No-regresión (ya cubiertos, deben seguir verdes tras adaptar stubs):**
+
+9. request sin claims → 500 (me-consents.test.ts:120-129).
+10. user no registrado → 404 `user_not_registered` (me-consents.test.ts:131-142).
+11. `expires_at` en el pasado → 400 `expires_at_must_be_future` (me-consents.test.ts:162-173). Adaptar el stub de membership al nuevo shape.
+12. `data_categories` vacío → 400 (zod) (me-consents.test.ts:191-200).
+13. `consent_document_url` no-HTTPS → 400 (zod refine) (me-consents.test.ts:202-211).
+14. **revoke de consent ajeno → 403 `forbidden_not_grantor`** (me-consents.test.ts:242-254). No cambia, pero se mantiene como guardia de no-regresión (P0-B/P1-B son de otorgamiento, no de revocación).
+15. revoke happy path → 200 `{revoked:true}` (me-consents.test.ts:256-269); idempotente → 200 `{already_revoked:true}` (me-consents.test.ts:271-288).
+
+**Evidencia 21.719 (columnas nuevas):**
+
+16. **grant exitoso persiste `noticeVersion`/`grantIp`/`grantUserAgent`**. Request con header `x-forwarded-for: '1.1.1.1, 2.2.2.2'` y `user-agent`, body con `notice_version: 'esg-v1'`. Verificar (vía spy en el stub de `insert().values()`) que se pasan `grantIp='1.1.1.1'` (penúltima entry, `extractClientIp`), `grantUserAgent`, `noticeVersion='esg-v1'`. (Nuevo.)
+17. **grant sin XFF / sin user-agent persiste nulls** (no rompe). `grantIp=null`, `grantUserAgent=null`, `noticeVersion` ausente → null. Espera `201`. (Nuevo.)
+
+Tests de `consent.ts` (service): si no existe `apps/api/test/unit/consent.test.ts`, añadir cobertura de `grantConsent` persistiendo los 3 campos nuevos; si existe, extender.
+
+## 12. Open questions
+
+- **O-1 (resuelta por default PO)**: ¿añadir columnas de evidencia a `consents`? → **Sí**, `version_aviso` / `ip_otorgamiento` / `user_agent_otorgamiento` nullable (este spec las especifica).
+- **O-1b (RESUELTA — PO 2026-06-17)**: `portafolio_viajes` se **deniega siempre** (deny real). No hay tabla de portafolio ni call sites; no se infiere autoridad sobre una feature inexistente. `TODO`/backlink dejado en el código para la futura decisión de Producto (probablemente lista explícita de viajes cuando exista la tabla `portafolios_viajes`). No se toca ADR-053.
+- **O-6 (legal, dependencia externa)**: ¿quién completa los campos `[ ]` del modelo/aviso y da el sign-off de abogado, y cuándo? Bloquea el "final" del texto en `docs/legal/`, no el fix de código. F1b (UI signup) espera esta resolución.
+- **¿`noticeVersion` debe ser obligatorio en el body una vez F1b esté vivo?** Hoy opcional (el flujo de otorgamiento de grant a stakeholder no necesariamente expone una versión de aviso al otorgante). Revisar al cablear F1b.
+
+## 13. Approval
+
+- [ ] **PO aprueba el spec F1** (chat o comentario sobre este archivo).
+- [x] PO resolvió **O-1b** (2026-06-17): denegar siempre `portafolio_viajes` hasta que Producto defina el modelo.
+- [ ] PO confirma que **no hay consents en producción** que requieran backfill (verificación previa a migrar).
+- [ ] PO confirma que **F1b va en PR separado** (recomendado en §8).
+
+**Pendiente de firma — fecha:** ____________

--- a/.specs/pivote-documental-y-cierre-legal-2026-06/spec.md
+++ b/.specs/pivote-documental-y-cierre-legal-2026-06/spec.md
@@ -1,0 +1,219 @@
+# pivote-documental-y-cierre-legal-2026-06 — Execution Plan
+
+**Generado por**: skill `arquitecto-maestro` v1.1.0
+**Fecha**: 2026-06-17
+**Status**: **Draft — pendiente aprobación PO** (no ejecutar Fase Act sin firma en §13)
+**PO**: Felipe Vicencio — dev@boosterchile.com
+
+> Este documento es el **plan**, no el código. Diseña la descomposición, secuencia y ADRs de un programa de 4 frentes. Cada frente se ejecuta en su propio `.specs/<sub-slug>/` con TDD y PR independiente, **después** de aprobado este plan.
+
+---
+
+## 1. Objective
+
+Cerrar el frente legal pendiente de la auditoría 2026-06-14 y ejecutar el **pivote del modelo documental** de Booster: dejar de **emitir** DTE (remover Sovos) y pasar a **recibir y archivar** los documentos tributarios de terceros (Guía de Despacho DTE 52 / Factura 33) que amparan cada orden de transporte, con extracción "best-effort" del TED.
+
+Comportamiento observable al cierre del programa completo:
+
+- **F1 (consent)**: un usuario solo puede otorgar grants ESG sobre empresas/portafolios donde es `dueno`/`admin`; cualquier intento cross-empresa devuelve `403`. El modelo de consentimiento (19.628 + 21.719) está versionado en el repo y referenciado por el flujo de otorgamiento.
+- **F2 (PII)**: `OLD_DEMO_UIDS` ya no está en el código vivo; queda en Secret Manager/env, con decisión de historial documentada.
+- **F3 (remover Sovos)**: `DTE_PROVIDER`, `SOVOS_*`, el adapter Sovos, el cron de reconciliación y el endpoint de emisión ya no existen ni se ejecutan; ADR-024 superseded; ADR-007 modificado.
+- **F4 (repositorio documental)**: el generador o el transportista sube el PDF/foto de la guía/factura a una orden, un worker la decodifica (TED/PDF417) best-effort, y la orden se puede **cerrar con al menos un documento subido**, decodificado o no.
+
+## 2. Why now
+
+- **Legal desbloqueado**: el modelo de consentimiento conforme Ley 19.628 + Ley 21.719 (vigente 01-dic-2026) ya existe (`Modelo_Consentimiento_ESG_Booster.docx`, `Aviso_Privacidad_Corto_Booster.md`). Era el único bloqueo de P0-B/P1-B. La 21.719 entra en vigencia en ~5.5 meses; el flujo de consentimiento debe ser conforme antes de esa fecha.
+- **Pivote de negocio**: Booster NO será emisor de DTE en esta fase. Mantener la integración Sovos (ADR-024) es deuda activa (código, cron horario, secretos, columnas) que ya no sirve al producto y arrastra el bloqueante legal P0-A (retention lock).
+- **P0-A se resuelve solo**: el gate del retention-lock era "(a) emisión real de DTE en prod". Sin emisión, el gate nunca se cumple → P0-A pasa a **"no aplica"**. El spec `sec-h3-dte-retention-lock` queda obsoleto.
+- **Cierre de la auditoría**: estos frentes agotan los 🔒 legales (P0-A/B/C) + P1-B, que eran el grueso de lo que quedaba bloqueado.
+
+## 3. Success criteria (measurable)
+
+**Programa:**
+- [ ] Los 4 frentes mergeados a `main` vía PR + squash, cada uno con su sección `## Evidencia`.
+- [ ] `pnpm ci` verde (lint 0, typecheck 0, coverage ≥80% en código nuevo, build OK) en cada PR.
+- [ ] 3 ADRs nuevos (068, 069, 070) mergeados; ADR-024 marcado superseded; ADR-007 modificado vía el ADR nuevo.
+
+**F1 — consent:**
+- [ ] Test de integración IDOR: `dueno` de empresa A recibe `403 forbidden_scope_authority` al otorgar sobre empresa B (scopes `organizacion`/`generador_carga`/`transportista`) y sobre `portafolio_viajes` con trips ajenos.
+- [ ] `me-consents.ts` valida `memberships.empresaId === scopeId` (P1-B) y, para `portafolio_viajes`, que todos los trips pertenezcan a empresas del otorgante (P0-B).
+- [ ] Modelo de consentimiento versionado en `docs/legal/` + ADR-068 que lo vincula al schema `consents`.
+
+**F2 — PII:**
+- [ ] `grep -n OLD_DEMO_UIDS apps/api/src` no devuelve literales de UID (vienen de env/Secret Manager).
+- [ ] `harden-demo-accounts.ts` lee los UIDs de configuración validada (Zod) en vez de constante hardcoded.
+- [ ] Documento de decisión (no reescribir historial) + confirmación equipo de que son demo + rotación/invalidación registrada.
+
+**F3 — remover Sovos:**
+- [ ] Reporte de remoción (`report.md`) lista los 32 puntos con ruta:línea y clasificación activo/scaffolding.
+- [ ] `grep -riE 'sovos|DTE_PROVIDER' apps packages infrastructure` solo devuelve historia (ADR), no código vivo.
+- [ ] Cron `reconciliar-dtes` eliminado de `scheduling.tf`; endpoint `/admin/liquidaciones/:id/emitir-dte` eliminado; columnas `dte_*` **deprecadas** (dejan de escribirse), no DROP, salvo confirmación explícita.
+
+**F4 — repositorio documental:**
+- [ ] Tabla `documentos_transporte` (FK a `viajes`) migrada; schema Zod de dominio en `shared-schemas`.
+- [ ] 4 endpoints Hono operativos con Zod en boundaries; upload persiste fila `pending` y publica `document.uploaded`.
+- [ ] Worker Cloud Run decodifica un PDF de guía de ejemplo → `decoded` con campos del `<DD>`; una foto mala → `failed` → habilita manual; DLQ tras N intentos.
+- [ ] Orden cerrable con ≥1 documento subido aunque el TED no decodifique (`REQUIRE_TED_DECODE=false`).
+- [ ] Tags del TED validados contra `formato_dte_202602.pdf` del SII antes de fijar el parser.
+
+## 4. User-visible behaviour
+
+| Actor | Antes | Después |
+|---|---|---|
+| Otorgante de consent ESG | Puede crear grants sobre cualquier empresa si es dueño/admin de *alguna* | Solo sobre empresas/portafolios propios; resto `403` |
+| Admin plataforma | Endpoint para re-emitir DTE Tipo 33 | Endpoint eliminado (Booster ya no emite) |
+| Generador / Transportista | No hay forma de adjuntar la guía/factura que ampara la carga | Sube PDF/foto a la orden; ve estado de extracción (pending→decoded/failed) vía `GET /documents/:id` + canal SSE |
+| Cierre de orden | (definido por estado de viaje actual) | Requiere ≥1 documento subido; el TED es enriquecimiento, no bloqueo |
+| Operador GCP | Cron horario `reconciliar-dtes` corriendo | Cron eliminado |
+
+## 5. Out of scope
+
+- **Espejo Firestore** (decisión PO 2026-06-17): Postgres es la única fuente; estado realtime vía polling `GET /documents/:id` + canal SSE existente. Firestore queda como mejora futura opcional, no dependencia.
+- **Reescritura del historial git** (decisión PO 2026-06-17): no se hace `filter-repo` en este programa. Si los UIDs resultaran ser secretos reales, se trata como incidente separado con ventana planificada.
+- **Conexión real al canal XML de Intercambio SII** (Tarea 6): solo interfaz + stub `XmlIntercambioIngestor`, sin conexión.
+- **Emisión de DTE de cualquier tipo**: Booster no emite. No se integra con facturación electrónica SII en esta fase.
+- **DROP de tablas/columnas con datos** (`facturas_booster_clp`, columnas `dte_*`, BigQuery): deprecación (marcar y dejar de escribir), nunca DROP sin confirmación explícita del PO.
+- **Completar los campos `[ ]` del modelo legal y el sign-off de abogado habilitado**: es responsabilidad del PO/legal; el plan lo trata como dependencia externa, no como tarea de código.
+
+## 6. Constraints
+
+- **Stack Booster no-negociable** (CLAUDE.md): zero `any`, Zod en boundaries, `@booster-ai/logger` (no `console.*`), OTel + `trace_id` por endpoint, coverage ≥80%, Conventional Commits con scope, sección `## Evidencia` en cada PR.
+- **Naming bilingüe**: SQL español snake_case sin tildes → tabla **`documentos_transporte`** (no `transport_documents`); FK a **`viajes`** (no `transport_orders`). Export TS `transportDocuments` / `TransportDocumentRow`.
+- **Domain canónico** en `packages/shared-schemas/src/domain/`; toda tabla Drizzle debe coincidir con un schema del domain. DDL Drizzle canónico en `apps/api/src/db/schema.ts`.
+- **Algoritmos en packages**: la lógica de decodificación TED (rasterizar, PDF417, parseo `<DD>`) vive en `packages/transport-documents`, no inline en services.
+- **TDD obligatorio** (`tdd-dominio-critico`): F1 (auth/consent), F3 (toca facturación/migraciones), F4 (migraciones + parseo de documentos tributarios) son dominio crítico → red-green-refactor.
+- **ADRs antes de implementar**, no en retrospectiva. ADR no se edita: se supersede.
+- **Secretos**: Secret Manager vía Terraform, nunca en código.
+- **Worker WASM-only**: Dockerfile sin binarios de sistema (apt-get). Ver Riesgo R-4 (tensión con `sharp`).
+- **Numeración**: ADR 067 reservado por PR #426 abierto → usar **068/069/070**. Migración 0043 reservada por PR #428 abierto → tomar el siguiente libre al ejecutar.
+
+## 7. Approach
+
+Programa de **4 frentes**, ejecutables en buena medida en paralelo salvo la dependencia F3→F4. Cada frente = su propio `.specs/<sub-slug>/{spec,plan,verify}.md` + PR.
+
+### Secuencia recomendada
+
+```
+Fase A (paralelo, bajo riesgo, cierra P0 legales):
+  F1  consent IDOR + modelo legal       → .specs/consent-idor-y-modelo-19628-21719/
+  F2  PII UIDs demo                      → .specs/p0c-uids-demo-secret-manager/
+
+Fase B (pivote, F3 antes que F4):
+  F3  remover Sovos/DTE (reporte→ADR→remoción)  → .specs/remover-emision-dte-sovos/
+       └─ ADR-069 supersede ADR-024, modifica ADR-007
+  F4  repositorio documental (sub-fases 4a→4b→4c) → .specs/repositorio-documental-transporte/
+       └─ ADR-070 (modelo recepción/archivo de DTE de terceros)
+```
+
+### F1 — Consent IDOR + modelo legal (cierra P0-B + P1-B)
+
+1. **Documentar el modelo legal**: copiar `Modelo_Consentimiento_ESG_Booster` + `Aviso_Privacidad_Corto` a `docs/legal/` (versionados, con marca de "campos `[ ]` y sign-off abogado pendientes — dependencia externa").
+2. **ADR-068**: modelo de consentimiento ESG conforme 19.628 + 21.719; cómo se mapea al schema `consents` (versión del documento, finalidades como `dataCategories`, evidencia: identidad/fecha/versión/IP). Complementa ADR-028/ADR-034.
+3. **Fix IDOR (TDD-first)** en `apps/api/src/routes/me-consents.ts`:
+   - **P1-B (líneas 98-106)**: `WHERE userId = ? AND empresaId = scopeId AND status='activa' AND role IN ('dueno','admin')`.
+   - **P0-B (líneas 85-95)**: `portafolio_viajes` valida que todos los trips del `scope_id` pertenezcan a empresas donde el user es dueño/admin (join `viajes`→`empresas`→`memberships`).
+   - Índice compuesto si la auditoría de scope lo requiere.
+4. **Gap modelo↔schema** (a evaluar en el spec de F1): el modelo legal exige registrar versión del aviso + IP/dispositivo + finalidades-como-casillas; `consents` hoy guarda `consentDocumentUrl` pero no versión/IP. Posible columna nueva → migración menor. **Open question O-1.**
+5. **Flujo de captura en signup** (casillas sin premarcar, granular, evidencia) — la 21.719 prohíbe premarcadas/tácito. **Puede ser sub-fase F1b** (frontend `apps/web` + backend evidencia). Dimensionar en el spec.
+6. Subagents de revisión: `booster-skills:security-scanner` (módulo compliance: Ley 19.628, consent ESG, RBAC) sobre el diff.
+
+### F2 — PII UIDs demo (cierra P0-C)
+
+1. **Confirmar con el equipo** (instrucción PO) si los 4 UIDs (`harden-demo-accounts.ts:34-37`) son de cuentas demo o reales.
+2. Mover `OLD_DEMO_UIDS` a env var validada por Zod en `config.ts` (o Secret Manager si se considera sensible) → fuera del código vivo y de futuros commits.
+3. Si son demo: **rotar/invalidar** esos identificadores en el sistema (Firebase) y documentar el hallazgo; **no** reescribir historial.
+4. Si fueran reales: escalar como incidente separado + ventana planificada (fuera de este programa).
+5. Documento de decisión en `.specs/p0c-uids-demo-secret-manager/` + nota en/junto a ADR-053.
+
+### F3 — Remover Sovos/DTE (cierra P0-A, supersede ADR-024)
+
+Branch propio. **Reporte primero** (lo pide el brief y arquitecto-maestro).
+
+1. **`report.md`**: formalizar el inventario de 32 puntos ya mapeados (packages/SDK, clientes, env/secretos, endpoints, Pub/Sub, tablas/migraciones, jobs, buckets) con ruta:línea y clasificación activo/scaffolding.
+2. **ADR-069**: "Booster deja de emitir DTE; remoción Sovos". Supersede ADR-024; modifica ADR-007 §emisión (Booster pasa de **emisor** a **receptor/archivador** de DTE de terceros). Declara P0-A como "no aplica" y obsoleto `sec-h3-dte-retention-lock`.
+3. **Remoción reversible** (branch aislado; flag si conviene): borrar/archivar `packages/dte-provider`, adapter Sovos, factory, services `emitir-dte-liquidacion`/`reconciliar-dtes`, endpoint admin, env `DTE_PROVIDER`/`SOVOS_*`, cron `scheduling.tf:154-188`, tests asociados.
+4. **Datos**: columnas `dte_*` en `facturas_booster_clp` y la tabla → **deprecar** (dejar de escribir, comentar como legacy), no DROP. **Open question O-2**: ¿`facturas_booster_clp` (facturación de comisiones de Booster) sobrevive como registro interno sin emisión? El reporte lo clarifica.
+5. **Bucket `documents`** (retention 6a, `is_locked=false`): decidir si se reutiliza para los documentos de terceros del F4 o se separa. Ligado a O-3 (retención legal de docs de terceros).
+6. Subagent `booster-skills:sre-oncall` pre-merge (toca infra: cron, posiblemente bucket).
+
+### F4 — Repositorio documental por orden (Tareas 2-6)
+
+Hosting (decisión PO): lógica de dominio en **`packages/transport-documents`**, endpoints montados en **`apps/api`**, worker de extracción TED como **servicio Cloud Run separado** suscrito a `document.uploaded`. Propuesta: construir el worker sobre **`apps/document-service`** (skeleton existente que ADR-007 designó documental; elimina esa deuda) en vez de una app nueva — **Open question O-4**.
+
+Sub-fases:
+
+- **4a — Datos + API (apps/api, TDD)**:
+  - Migración `documentos_transporte` (FK `viajes.id`): `id uuid`, `viaje_id`, `file_path`, `file_mime`, `doc_type` enum(`33,34,52,56,61,other`), `folio` (nullable), `rut_emisor`, `razon_social_emisor`, `rut_receptor`, `razon_social_receptor`, `fecha_emision date`, `monto_total numeric`, `ted_raw text`, `ted_signature_valid bool nullable`, `extraction_status` enum(`pending,processing,decoded,manual_entry,failed`), `source` enum(`pdf_upload,photo_upload,xml_intercambio`), `uploaded_by`, `creado_en`, `actualizado_en`.
+  - Schema Zod de dominio en `shared-schemas/src/domain/`.
+  - Endpoints (Zod en boundaries, auth existente, multipart vía `c.req.formData()` patrón `site-settings.ts`, GCS signed URL patrón `certificate-generator/storage.ts`):
+    - `POST /transport-orders/:id/documents` → persiste `pending`, publica `document.uploaded`, `202`.
+    - `POST /documents/:id/manual-entry` → corrige campos, `extraction_status=manual_entry`.
+    - `GET /transport-orders/:id/documents` → lista.
+    - `GET /documents/:id` → detalle + signed URL.
+- **4b — Worker TED (Cloud Run, `apps/document-service`)**:
+  - Consumer Pub/Sub patrón `telemetry-processor` (Zod + ack/nack + DLQ tras N intentos).
+  - PDF → rasterizar con `@hyzyla/pdfium` (WASM); imagen → preprocesar (ver R-4 sobre `sharp`); decodificar PDF417 con `zxing-wasm`; parsear XML del TED con `fast-xml-parser` mapeando `<DD>`: RE→rut_emisor, TD→doc_type, F→folio, FE→fecha_emision, RR→rut_receptor, RSR→razon_social_receptor, MNT→monto_total.
+  - **Validar tags contra `formato_dte_202602.pdf` del SII** (https://www.sii.cl/factura_electronica/factura_mercado/formato_dte_202602.pdf) **antes** de fijar el parser.
+  - Flag `VALIDATE_TED_SIGNATURE`: firma `<FRMT>` (SHA1withRSA) con pública del `<CAF>` (node:crypto).
+  - Persistir `decoded`/`failed`; lógica en `packages/transport-documents` (interface `DocumentIngestor` + `PdfTedIngestor`).
+  - Dockerfile WASM-only.
+- **4c — Cierre flexible + stub XML**:
+  - Regla (TDD, toca `trip-state-machine`): orden cerrable con ≥1 documento subido; `REQUIRE_TED_DECODE=false` por defecto.
+  - `XmlIntercambioIngestor` stub (interface + no-op), sin conexión SII.
+- Infra: topic `document.uploaded` + subscription + DLQ (`messaging.tf`), bucket de subida, SA del worker, `adding-cloud-run-service` si el worker es app nueva.
+- Subagents: `dependency-auditor` (deps WASM nuevas), `security-scanner` (upload, signed URLs, PII en docs de terceros), `sre-oncall` (worker + DLQ + Cloud Run).
+
+## 8. Risks
+
+| ID | Riesgo | L | I | Mitigación |
+|---|---|---|---|---|
+| R-1 | Fix IDOR rompe otorgamientos legítimos (regresión auth) | M | H | TDD-first con matriz quién-puede-otorgar-sobre-qué; security-scanner; tests de integración antes del merge |
+| R-2 | Remoción Sovos deja referencias colgantes (imports rotos, cron al vacío) | M | M | Reporte exhaustivo previo; `grep` de verificación en success criteria; branch aislado + `pnpm ci` |
+| R-3 | DROP accidental de datos en deprecación de tablas DTE | L | H | Política explícita: deprecar (no escribir), nunca DROP sin confirmación; guard CI de migration-safety ya existe |
+| R-4 | `sharp` no es WASM (usa libvips nativo) — choca con "Dockerfile sin binarios" | H | M | **O-5**: aceptar binarios prebuilt npm de sharp, o reemplazar por preprocesamiento WASM (photon/jsquash), o omitir preprocesamiento (zxing tolera imágenes) |
+| R-5 | Tags TED mal mapeados → metadatos incorrectos en documentos legales | M | H | Validar contra PDF oficial SII antes de fijar parser; test con guía real decodificable |
+| R-6 | El modelo legal es plantilla (campos `[ ]`, sin sign-off abogado) → documentar algo no-final | M | M | Versionar con marca "borrador legal, pendiente completar + sign-off"; el fix de código es independiente del texto |
+| R-7 | Worker como app nueva dispara proceso de 11 pasos (adding-cloud-run-service) | M | M | Reutilizar `apps/document-service` (skeleton) en vez de app nueva (O-4) |
+| R-8 | Retención de docs de terceros mal definida (¿6 años? ¿ninguna?) | M | M | O-3: decisión legal; default propuesto = conservar mientras dure relación, sin lock (Booster no es contribuyente emisor) |
+
+## 9. Alternatives considered (rejected)
+
+- **Espejo Firestore ahora**: rechazado por PO — primer uso de Firestore en backend, superficie de riesgo dentro de feature crítica. Polling + SSE existentes bastan.
+- **Reescribir historial git para P0-C**: rechazado por PO — rompe todos los PRs abiertos e invalida clones; costo desproporcionado para UIDs demo ya deshabilitados.
+- **Worker TED en apps/api**: rechazado — el procesamiento pesado (rasterizar PDF + PDF417) en el request path del API agota slots de concurrencia Cloud Run; va a servicio separado.
+- **DROP de columnas/tablas DTE**: rechazado — pérdida irreversible; se deprecan.
+- **Mantener Sovos "por si acaso"**: rechazado — deuda activa (cron, secretos, código) sin uso de producto; YAGNI.
+
+## 10. Test list
+
+- **F1**: IDOR cross-empresa (`organizacion`/`generador_carga`/`transportista`) → 403; `portafolio_viajes` con trips ajenos → 403; happy path dueño de la empresa correcta → 201; revoke ajeno → 403 (no regresión).
+- **F2**: `harden-demo-accounts` lee UIDs de config (Zod) y aplica el hardening igual que antes; `config.ts` rechaza arranque si la env es inválida.
+- **F3**: tras remoción, `pnpm typecheck` 0 errores (sin imports colgantes); suite API verde sin tests DTE; `grep` de verificación vacío en código vivo.
+- **F4**: PDF de guía de ejemplo → `decoded` con campos `<DD>` correctos; foto ilegible → `failed` → manual-entry corrige → `manual_entry`; orden cierra con doc subido y TED no decodificado; payload Pub/Sub malformado → ack-descarta; N fallos → DLQ; firma TED válida/ inválida con flag on.
+
+## 11. Open questions (para el PO / legal)
+
+- **O-1**: ¿Añadimos columnas a `consents` (versión del aviso, IP/dispositivo, finalidades-como-casillas) para cumplir la evidencia que exige el modelo, o basta `consentDocumentUrl`? (afecta migración en F1)
+- **O-2**: ¿`facturas_booster_clp` (facturación de comisiones de Booster) sobrevive como registro interno sin emisión DTE, o también se deprecia? (F3)
+- **O-3**: Retención legal de los documentos de **terceros** archivados (guías/facturas que amparan carga): ¿aplica plazo SII de 6 años aunque Booster no sea el emisor/contribuyente? Default propuesto: conservar mientras dure la relación, sin retention lock. (F3/F4 + infra)
+- **O-4**: Worker TED, ¿sobre `apps/document-service` (reutiliza skeleton, recomendado) o app Cloud Run nueva? (F4)
+- **O-5**: Preprocesamiento de imagen: ¿aceptamos `sharp` (binarios prebuilt npm, no WASM puro) o exigimos WASM estricto (photon/jsquash) o lo omitimos? (F4, choca con "Dockerfile sin binarios")
+- **O-6 (legal)**: ¿Quién completa los campos `[ ]` del modelo/aviso y da el sign-off de abogado habilitado, y en qué fecha? Es dependencia externa del F1.
+
+## 12. Devils-advocate pass
+
+> Nota: agent-rigor (y su sub-agent `devils-advocate`) fue retirado por ADR-060. Pasada crítica hecha inline por el arquitecto.
+
+- **"¿El fix IDOR necesita el modelo legal para mergearse?"** No técnicamente — el código valida autoridad, no texto. **Pero** el PO condicionó P0-B/P1-B a "revisión legal del modelo de consentimiento". El modelo ya existe (aunque sea borrador). Riesgo: mergear el fix con un modelo aún no firmado por abogado. Mitigación: el fix de control de acceso se mergea (cierra el IDOR real); el versionado del texto se marca "borrador, sign-off pendiente" (O-6). No se bloquean entre sí.
+- **"Remover Sovos, ¿no destruye trabajo válido?"** ADR-024 fue una decisión cara (multi-vendor LATAM). Removerla es un pivote real de negocio, declarado por el PO. El adapter pattern se archiva (git history + ADR), no se pierde conocimiento; si Booster vuelve a emitir, se re-evalúa. Reversible vía branch + ADR.
+- **"P0-A: ¿de verdad se 'resuelve' o se barre bajo la alfombra?"** Se resuelve por eliminación de la causa: sin emisión de DTE no hay obligación de retention lock del emisor. Pero **O-3** abre un riesgo nuevo: los docs de terceros archivados podrían tener su propia obligación de retención. No es el mismo P0-A, pero el ADR-069 debe declararlo explícitamente para no dejar un hueco de compliance.
+- **"4 frentes en un plan, ¿no es demasiado para una sola aprobación?"** Por eso cada frente es PR + spec independiente y la sesión solo entrega el plan. El PO puede aprobar frentes selectivamente (ej. F1+F2 ya, F3+F4 después).
+- **"¿El brief usa nombres en inglés; cambiarlos a español no contradice al PO?"** Es contrato no-negociable del repo (CLAUDE.md naming bilingüe). Se documenta el mapeo (`documentos_transporte`/`transportDocuments`) para que no sorprenda. Gana la regla Booster por precedencia.
+
+## 13. Approval
+
+- [ ] **PO aprueba el plan** (chat o comentario sobre este archivo).
+- [ ] PO resuelve O-1..O-6 (o delega defaults propuestos).
+- [ ] PO indica qué frentes arrancar primero (recomendado: F1 + F2 en paralelo).
+
+**Pendiente de firma — fecha:** ____________

--- a/apps/api/drizzle/0043_consent_evidencia_21719.sql
+++ b/apps/api/drizzle/0043_consent_evidencia_21719.sql
@@ -1,0 +1,26 @@
+-- Migration 0043 — Evidencia verificable de consentimiento (Ley 21.719)
+--
+-- Frente F1 de .specs/consent-idor-y-modelo-19628-21719/ (ADR-068). La Ley
+-- N° 21.719 (vigente 01-dic-2026) exige evidencia verificable de cada
+-- aceptación: identidad, finalidades marcadas, fecha/hora, VERSIÓN DEL AVISO
+-- e IP/DISPOSITIVO. La tabla `consentimientos` ya cubre identidad
+-- (otorgado_por_id), finalidades (categorias_datos), fecha (otorgado_en) y
+-- documento (documento_consentimiento_url); faltaban versión del aviso e
+-- IP/UA del otorgamiento.
+--
+-- Réplica del patrón ya usado en carrier_memberships (consent_terms_v2_ip /
+-- consent_terms_v2_user_agent). Captura en el handler POST /me/consents vía
+-- extractClientIp(x-forwarded-for) + user-agent.
+--
+-- Expand-only (audit P1-H / ADR-066): solo ADD COLUMN nullable, sin default,
+-- sin NOT NULL, sin DROP. Los consents existentes quedan con estas columnas
+-- en NULL: no se inventa evidencia retroactiva (no backfill). El rollback de
+-- código es seguro — cualquier revisión previa encuentra un esquema que aún
+-- soporta lo que esperaba.
+--
+-- Riesgo de despliegue: bajo. No afecta filas existentes ni constraints.
+ALTER TABLE "consentimientos" ADD COLUMN "version_aviso" varchar(20);
+--> statement-breakpoint
+ALTER TABLE "consentimientos" ADD COLUMN "ip_otorgamiento" text;
+--> statement-breakpoint
+ALTER TABLE "consentimientos" ADD COLUMN "user_agent_otorgamiento" text;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1780876800006,
       "tag": "0042_matching_asignaciones_index",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1780876800007,
+      "tag": "0043_consent_evidencia_21719",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1442,6 +1442,12 @@ export const consents = pgTable(
     expiresAt: timestamp('expira_en', { withTimezone: true }),
     revokedAt: timestamp('revocado_en', { withTimezone: true }),
     consentDocumentUrl: text('documento_consentimiento_url').notNull(),
+    // Evidencia verificable Ley 21.719 (versión del aviso vigente + IP/UA del
+    // otorgamiento). Nullable sin default: los consents existentes no tienen
+    // evidencia retroactiva y no se backfillean. Ver ADR-068 + migración 0043.
+    noticeVersion: varchar('version_aviso', { length: 20 }),
+    grantIp: text('ip_otorgamiento'),
+    grantUserAgent: text('user_agent_otorgamiento'),
   },
   (table) => ({
     stakeholderIdx: index('idx_consentimientos_stakeholder').on(table.stakeholderId),

--- a/apps/api/src/routes/me-consents.ts
+++ b/apps/api/src/routes/me-consents.ts
@@ -1,10 +1,11 @@
 import type { Logger } from '@booster-ai/logger';
 import { zValidator } from '@hono/zod-validator';
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { Db } from '../db/client.js';
 import { consents, memberships, users } from '../db/schema.js';
+import { extractClientIp } from '../middleware/client-ip.js';
 import type { FirebaseClaims } from '../middleware/firebase-auth.js';
 import {
   type DataCategory,
@@ -51,6 +52,11 @@ const grantBodySchema = z.object({
     .refine((u) => u.startsWith('https://'), {
       message: 'URL debe ser HTTPS',
     }),
+  // Versión del aviso de privacidad que el otorgante vio al consentir
+  // (evidencia Ley 21.719). Opcional mientras el flujo de captura F1b no
+  // exponga una versión al otorgante; se ata al doc versionado en
+  // docs/legal/ (slug, ej. 'esg-v1').
+  notice_version: z.string().min(1).max(20).optional(),
 });
 
 export function createMeConsentsRoutes(opts: { db: Db; logger: Logger }) {
@@ -70,12 +76,17 @@ export function createMeConsentsRoutes(opts: { db: Db; logger: Logger }) {
   }
 
   /**
-   * Validar que el otorgante tiene autoridad sobre el scope. Para scope
-   * `organizacion` o `generador_carga`/`transportista`, el otorgante debe
-   * ser dueño/admin de la empresa que coincide con `scope_id`. Para
-   * `portafolio_viajes` se valida que la lista de trips pertenezca a una
-   * empresa donde el otorgante es dueño/admin (validación más laxa por
-   * ahora — bookmark P1).
+   * Validar que el otorgante tiene autoridad sobre el scope concreto del
+   * grant (cierra IDOR P0-B/P1-B, auditoría 2026-06-14; ADR-028 §"Riesgos").
+   *
+   * - Scopes de empresa (`organizacion` / `generador_carga` / `transportista`):
+   *   el `scope_id` apunta a `empresas.id`. El otorgante debe tener una
+   *   membership `dueno`/`admin` ACTIVA en ESA empresa específica
+   *   (`empresaId === scopeId`). No basta ser dueño/admin de *otra* empresa
+   *   (P1-B).
+   * - `portafolio_viajes`: deny real SIEMPRE (decisión PO O-1b, 2026-06-17).
+   *   No existe tabla de portafolio, ni FK, ni call sites; no se infiere
+   *   autoridad sobre una feature inexistente (P0-B).
    */
   async function userCanGrantOnScope(opts2: {
     userId: string;
@@ -83,27 +94,37 @@ export function createMeConsentsRoutes(opts: { db: Db; logger: Logger }) {
     scopeId: string;
   }): Promise<boolean> {
     if (opts2.scopeType === 'portafolio_viajes') {
-      // P1: validar que TODOS los trips del portafolio sean de empresas
-      // donde el user es dueño/admin. Por ahora aceptamos si el user tiene
-      // alguna membership dueño/admin (el handler debe complementar con
-      // validación específica del portafolio antes de servir data).
-      const adminMembership = await opts.db
-        .select({ id: memberships.id })
-        .from(memberships)
-        .where(eq(memberships.userId, opts2.userId))
-        .limit(1);
-      return adminMembership.length > 0;
+      // O-1b (decisión PO 2026-06-17): el modelo de portafolio NO está
+      // construido (sin tabla, sin FK, sin call sites). No se infiere
+      // autoridad sobre una feature inexistente → se deniega TODO grant de
+      // este scope hasta que Producto defina el modelo.
+      // TODO(O-1b): al crear la tabla de portafolio (lista explícita de
+      // viajes), validar que TODAS las empresas dueñas de los viajes estén
+      // entre las memberships dueno/admin activas del otorgante
+      // (join viajes→memberships).
+      // Ref: .specs/consent-idor-y-modelo-19628-21719/spec.md §7.1 P0-B.
+      return false;
     }
 
-    // Para scopes que apuntan a una empresa (organizacion / generador_carga / transportista),
-    // validar que el user es dueño/admin de esa empresa específica.
+    // Scopes que apuntan a una empresa (organizacion / generador_carga /
+    // transportista): el user debe ser dueño/admin ACTIVO de la empresa
+    // específica del scope. `empresaId` es nullable (memberships de
+    // stakeholder tienen empresaId=NULL); NULL nunca matchea un UUID, lo que
+    // excluye correctamente las memberships de organización stakeholder.
     const rows = await opts.db
-      .select({ role: memberships.role, status: memberships.status })
+      .select({ id: memberships.id })
       .from(memberships)
-      .where(eq(memberships.userId, opts2.userId))
-      .limit(50);
+      .where(
+        and(
+          eq(memberships.userId, opts2.userId),
+          eq(memberships.empresaId, opts2.scopeId),
+          eq(memberships.status, 'activa'),
+          inArray(memberships.role, ['dueno', 'admin']),
+        ),
+      )
+      .limit(1);
 
-    return rows.some((m) => m.status === 'activa' && (m.role === 'dueno' || m.role === 'admin'));
+    return rows.length > 0;
   }
 
   // POST /me/consents
@@ -143,6 +164,16 @@ export function createMeConsentsRoutes(opts: { db: Db; logger: Logger }) {
       return c.json({ error: 'expires_at_must_be_future', code: 'expires_at_must_be_future' }, 400);
     }
 
+    // Evidencia Ley 21.719 (réplica del patrón de carrier_memberships,
+    // me.ts:571-573). IP confiable = penúltima entry del XFF bajo GCLB
+    // (extractClientIp); 'unknown' (sin XFF) se persiste como null.
+    const trustedIp = extractClientIp(c.req.header('x-forwarded-for'));
+    const grantIp = trustedIp === 'unknown' ? null : trustedIp;
+    // Cap defensivo de longitud del UA (la columna es `text` sin límite): un
+    // User-Agent arbitrariamente largo no debe inflar el audit log de evidencia.
+    const rawUserAgent = c.req.header('user-agent');
+    const grantUserAgent = rawUserAgent ? rawUserAgent.slice(0, 512) : null;
+
     const result = await grantConsent({
       db: opts.db,
       logger: opts.logger,
@@ -153,6 +184,9 @@ export function createMeConsentsRoutes(opts: { db: Db; logger: Logger }) {
       dataCategories: body.data_categories as DataCategory[],
       expiresAt,
       consentDocumentUrl: body.consent_document_url,
+      noticeVersion: body.notice_version ?? null,
+      grantIp,
+      grantUserAgent,
     });
 
     return c.json({ consent_id: result.consentId }, 201);
@@ -171,6 +205,12 @@ export function createMeConsentsRoutes(opts: { db: Db; logger: Logger }) {
     }
 
     const consentId = c.req.param('id');
+    // Zod en boundary (regla Booster): un :id no-UUID llegaría a Postgres y
+    // produciría un 500 observable (oráculo malformado vs 404 vs 403). Validar
+    // acá lo convierte en 400 limpio antes de tocar la BD.
+    if (!z.string().uuid().safeParse(consentId).success) {
+      return c.json({ error: 'invalid_consent_id', code: 'invalid_consent_id' }, 400);
+    }
 
     // Pre-check: el consent debe existir y ser del actor (defense-in-depth
     // con la validación dentro de revokeConsent service). Sin esto, el

--- a/apps/api/src/services/consent.ts
+++ b/apps/api/src/services/consent.ts
@@ -146,6 +146,13 @@ export interface GrantOpts {
   dataCategories: DataCategory[];
   expiresAt?: Date | null;
   consentDocumentUrl: string;
+  /**
+   * Evidencia verificable Ley 21.719 (todas nullable mientras el flujo de
+   * captura F1b no esté vivo). Las persiste `grantConsent` en el INSERT.
+   */
+  noticeVersion?: string | null;
+  grantIp?: string | null;
+  grantUserAgent?: string | null;
 }
 
 export interface GrantResult {
@@ -177,6 +184,9 @@ export async function grantConsent(opts: GrantOpts): Promise<GrantResult> {
       dataCategories: opts.dataCategories,
       expiresAt: opts.expiresAt ?? null,
       consentDocumentUrl: opts.consentDocumentUrl,
+      noticeVersion: opts.noticeVersion ?? null,
+      grantIp: opts.grantIp ?? null,
+      grantUserAgent: opts.grantUserAgent ?? null,
     })
     .returning({ id: consents.id });
 

--- a/apps/api/test/unit/consent.test.ts
+++ b/apps/api/test/unit/consent.test.ts
@@ -22,6 +22,8 @@ interface DbStub {
   select: ReturnType<typeof vi.fn>;
   insert: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
+  /** Captura del primer arg pasado a `.values(...)` en cada INSERT. */
+  __insertValues: unknown[];
 }
 
 /**
@@ -38,6 +40,7 @@ function makeDb(opts: {
   const selectQueue = [...(opts.selectResults ?? [])];
   const insertQueue = [...(opts.insertResults ?? [])];
   const updateQueue = [...(opts.updateResults ?? [])];
+  const insertValues: unknown[] = [];
 
   const buildSelectChain = () => {
     const chain: Record<string, unknown> = {
@@ -58,7 +61,10 @@ function makeDb(opts: {
 
   const buildInsertChain = () => {
     const chain: Record<string, unknown> = {
-      values: vi.fn(() => chain),
+      values: vi.fn((v: unknown) => {
+        insertValues.push(v);
+        return chain;
+      }),
       returning: vi.fn(async () => insertQueue.shift() ?? []),
     };
     return chain;
@@ -77,6 +83,7 @@ function makeDb(opts: {
     select: vi.fn(() => buildSelectChain()),
     insert: vi.fn(() => buildInsertChain()),
     update: vi.fn(() => buildUpdateChain()),
+    __insertValues: insertValues,
   };
 }
 
@@ -269,6 +276,45 @@ describe('grantConsent', () => {
       logger: noopLogger,
     });
     expect(db.insert).toHaveBeenCalledTimes(1);
+  });
+
+  it('persiste evidencia 21.719: noticeVersion/grantIp/grantUserAgent en el INSERT', async () => {
+    const db = makeDb({ insertResults: [[{ id: 'c1' }]] });
+    await grantConsent({
+      ...baseOpts,
+      dataCategories: [...baseOpts.dataCategories],
+      noticeVersion: 'esg-v1',
+      grantIp: '1.1.1.1',
+      grantUserAgent: 'BoosterTest/1.0',
+      db: db as never,
+      logger: noopLogger,
+    });
+    const inserted = db.__insertValues[0] as {
+      noticeVersion?: string | null;
+      grantIp?: string | null;
+      grantUserAgent?: string | null;
+    };
+    expect(inserted.noticeVersion).toBe('esg-v1');
+    expect(inserted.grantIp).toBe('1.1.1.1');
+    expect(inserted.grantUserAgent).toBe('BoosterTest/1.0');
+  });
+
+  it('evidencia 21.719 ausente → INSERT con nulls (sin romper)', async () => {
+    const db = makeDb({ insertResults: [[{ id: 'c1' }]] });
+    await grantConsent({
+      ...baseOpts,
+      dataCategories: [...baseOpts.dataCategories],
+      db: db as never,
+      logger: noopLogger,
+    });
+    const inserted = db.__insertValues[0] as {
+      noticeVersion?: string | null;
+      grantIp?: string | null;
+      grantUserAgent?: string | null;
+    };
+    expect(inserted.noticeVersion).toBeNull();
+    expect(inserted.grantIp).toBeNull();
+    expect(inserted.grantUserAgent).toBeNull();
   });
 });
 

--- a/apps/api/test/unit/me-consents.test.ts
+++ b/apps/api/test/unit/me-consents.test.ts
@@ -26,6 +26,11 @@ const noopLogger = {
 /**
  * DB stub que matchea el patrón fluent de Drizzle. Soporta select/insert/update.
  * Cada chain consume un resultado de las queues correspondientes.
+ *
+ * `insertSpy` captura el primer argumento pasado a `.values(...)` para poder
+ * verificar qué columnas persiste `grantConsent` (evidencia 21.719).
+ * `selectCount` lleva la cuenta de SELECTs ejecutados (para verificar que el
+ * branch portafolio_viajes deniega ANTES de tocar la BD — O-1b, §11 caso 7).
  */
 interface DbQueues {
   selects?: unknown[][];
@@ -38,7 +43,11 @@ function makeDbStub(initial: DbQueues = {}) {
   const inserts = [...(initial.inserts ?? [])];
   const updates = [...(initial.updates ?? [])];
 
+  const insertValues: unknown[] = [];
+  let selectCount = 0;
+
   const buildSelectChain = () => {
+    selectCount += 1;
     const chain: Record<string, unknown> = {
       from: vi.fn(() => chain),
       innerJoin: vi.fn(() => chain),
@@ -54,9 +63,12 @@ function makeDbStub(initial: DbQueues = {}) {
   };
 
   const buildInsertChain = () => ({
-    values: vi.fn(() => ({
-      returning: vi.fn(async () => inserts.shift() ?? []),
-    })),
+    values: vi.fn((v: unknown) => {
+      insertValues.push(v);
+      return {
+        returning: vi.fn(async () => inserts.shift() ?? []),
+      };
+    }),
   });
 
   const buildUpdateChain = () => ({
@@ -71,11 +83,16 @@ function makeDbStub(initial: DbQueues = {}) {
     select: vi.fn(() => buildSelectChain()),
     insert: vi.fn(() => buildInsertChain()),
     update: vi.fn(() => buildUpdateChain()),
+    // Helpers de test (no parte del contrato Drizzle):
+    __insertValues: insertValues,
+    __selectCount: () => selectCount,
   };
 }
 
 const FB_UID = 'fb-uid-grantor';
 const USER_ID = 'user-uuid-grantor';
+// UUID válido para los tests de revoke (el handler valida que :id sea UUID).
+const VALID_CONSENT_ID = '99999999-9999-9999-9999-999999999999';
 
 const validClaimsHeader = JSON.stringify({ uid: FB_UID, email: 'a@b.c' });
 
@@ -141,11 +158,53 @@ describe('POST /me/consents', () => {
     expect(body.code).toBe('user_not_registered');
   });
 
-  it('user sin role dueño/admin en ninguna empresa → 403 forbidden_scope_authority', async () => {
+  // ── P1-B — IDOR cross-empresa (scopes de empresa) ───────────────────────
+
+  it('P1-B caso 1: dueño de empresa A otorga sobre empresa B → 403 forbidden_scope_authority', async () => {
     const db = makeDbStub({
       selects: [
         [{ id: USER_ID }], // resolveUserId
-        [{ role: 'conductor', status: 'activa' }], // memberships (no dueño/admin)
+        [], // membership filtrada por empresaId=scopeId(B) → ninguna (el user no es de B)
+      ],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
+      // scope_id apunta a empresa B (ajena al user)
+      body: JSON.stringify({ ...validBody, scope_id: '33333333-3333-3333-3333-333333333333' }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('forbidden_scope_authority');
+  });
+
+  it('P1-B caso 2: admin de la empresa del scope → 201', async () => {
+    const db = makeDbStub({
+      selects: [
+        [{ id: USER_ID }], // resolveUserId
+        [{ id: 'm1' }], // membership filtrada matchea (dueno/admin activa en la empresa scope)
+      ],
+      inserts: [[{ id: 'new-consent-uuid' }]],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { consent_id: string };
+    expect(body.consent_id).toBe('new-consent-uuid');
+  });
+
+  it('P1-B caso 3: membership suspendida sobre la empresa correcta → 403 (filtra status=activa)', async () => {
+    // El nuevo where filtra status='activa' → una membership suspendida no
+    // matchea, la query devuelve []. El stub refleja ese resultado de la BD.
+    const db = makeDbStub({
+      selects: [
+        [{ id: USER_ID }],
+        [], // membership suspendida no pasa el filtro status='activa'
       ],
     });
     const app = await buildApp(db);
@@ -159,9 +218,111 @@ describe('POST /me/consents', () => {
     expect(body.code).toBe('forbidden_scope_authority');
   });
 
+  it('P1-B caso 4: conductor/visualizador de la empresa del scope → 403 (filtra role)', async () => {
+    // El nuevo where filtra role IN ('dueno','admin') → conductor/visualizador
+    // no matchea, la query devuelve [].
+    const db = makeDbStub({
+      selects: [
+        [{ id: USER_ID }],
+        [], // role no es dueno/admin → no pasa el filtro
+      ],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('forbidden_scope_authority');
+  });
+
+  it('P1-B caso 4b: cross-empresa también deniega en generador_carga y transportista → 403', async () => {
+    // organizacion/generador_carga/transportista comparten el mismo camino de
+    // autorización (misma query). Cubrir los 3 evita que una regresión que
+    // ramifique por scopeType pase desapercibida (GAP-3 review seguridad).
+    for (const scopeType of ['generador_carga', 'transportista'] as const) {
+      const db = makeDbStub({
+        selects: [[{ id: USER_ID }], []], // membership filtrada por empresa ajena → []
+      });
+      const app = await buildApp(db);
+      const res = await app.request('/me/consents', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
+        body: JSON.stringify({
+          ...validBody,
+          scope_type: scopeType,
+          scope_id: '33333333-3333-3333-3333-333333333333',
+        }),
+      });
+      expect(res.status, `scope_type=${scopeType}`).toBe(403);
+      const body = (await res.json()) as { code: string };
+      expect(body.code).toBe('forbidden_scope_authority');
+    }
+  });
+
+  // ── P0-B — IDOR portafolio_viajes (deny real, O-1b) ─────────────────────
+
+  it('P0-B caso 5: portafolio_viajes con otorgante dueño/admin del scope_id → 403 (deny real)', async () => {
+    // Aunque el user fuera dueño/admin activo del scope_id, el branch
+    // portafolio deniega SIEMPRE (O-1b). Solo se consume el SELECT de
+    // resolveUserId; no debe haber un SELECT de membership.
+    const db = makeDbStub({
+      selects: [
+        [{ id: USER_ID }], // resolveUserId
+        // Si el código (incorrectamente) consultara membership, encontraría
+        // un dueño activo. El test prueba que NO se llega a consumirlo.
+        [{ id: 'm1' }],
+      ],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
+      body: JSON.stringify({ ...validBody, scope_type: 'portafolio_viajes' }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('forbidden_scope_authority');
+  });
+
+  it('P0-B caso 6: portafolio_viajes con scope_id arbitrario / sin membership → 403', async () => {
+    const db = makeDbStub({
+      selects: [[{ id: USER_ID }]],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
+      body: JSON.stringify({ ...validBody, scope_type: 'portafolio_viajes' }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('forbidden_scope_authority');
+  });
+
+  it('P0-B caso 7: portafolio_viajes deniega ANTES de tocar la BD (solo resolveUserId)', async () => {
+    const db = makeDbStub({
+      selects: [[{ id: USER_ID }]],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
+      body: JSON.stringify({ ...validBody, scope_type: 'portafolio_viajes' }),
+    });
+    expect(res.status).toBe(403);
+    // Exactamente 1 SELECT: resolveUserId. El branch portafolio NO consulta
+    // memberships ni viajes (superficie cero — O-1b).
+    expect(db.__selectCount()).toBe(1);
+  });
+
+  // ── No-regresión (deben seguir verdes tras adaptar stubs) ───────────────
+
   it('expires_at en el pasado → 400 expires_at_must_be_future', async () => {
     const db = makeDbStub({
-      selects: [[{ id: USER_ID }], [{ role: 'admin', status: 'activa' }]],
+      selects: [[{ id: USER_ID }], [{ id: 'm1' }]],
     });
     const app = await buildApp(db);
     const res = await app.request('/me/consents', {
@@ -170,22 +331,6 @@ describe('POST /me/consents', () => {
       body: JSON.stringify({ ...validBody, expires_at: '2020-01-01T00:00:00Z' }),
     });
     expect(res.status).toBe(400);
-  });
-
-  it('happy path: user dueño + body válido → 201 con consent_id', async () => {
-    const db = makeDbStub({
-      selects: [[{ id: USER_ID }], [{ role: 'dueno', status: 'activa' }]],
-      inserts: [[{ id: 'new-consent-uuid' }]],
-    });
-    const app = await buildApp(db);
-    const res = await app.request('/me/consents', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
-      body: JSON.stringify(validBody),
-    });
-    expect(res.status).toBe(201);
-    const body = (await res.json()) as { consent_id: string };
-    expect(body.consent_id).toBe('new-consent-uuid');
   });
 
   it('rechaza data_categories vacío con 400 (zod validator)', async () => {
@@ -209,13 +354,80 @@ describe('POST /me/consents', () => {
     });
     expect(res.status).toBe(400);
   });
+
+  // ── Evidencia 21.719 (columnas nuevas) ──────────────────────────────────
+
+  it('caso 16: grant exitoso persiste noticeVersion/grantIp/grantUserAgent', async () => {
+    const db = makeDbStub({
+      selects: [[{ id: USER_ID }], [{ id: 'm1' }]],
+      inserts: [[{ id: 'new-consent-uuid' }]],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-test-claims': validClaimsHeader,
+        'x-forwarded-for': '1.1.1.1, 2.2.2.2',
+        'user-agent': 'BoosterTest/1.0',
+      },
+      body: JSON.stringify({ ...validBody, notice_version: 'esg-v1' }),
+    });
+    expect(res.status).toBe(201);
+    const inserted = db.__insertValues[0] as {
+      noticeVersion?: string | null;
+      grantIp?: string | null;
+      grantUserAgent?: string | null;
+    };
+    // extractClientIp con 2 entries devuelve la penúltima.
+    expect(inserted.grantIp).toBe('1.1.1.1');
+    expect(inserted.grantUserAgent).toBe('BoosterTest/1.0');
+    expect(inserted.noticeVersion).toBe('esg-v1');
+  });
+
+  it('caso 17: grant sin XFF / sin user-agent persiste nulls (no rompe)', async () => {
+    const db = makeDbStub({
+      selects: [[{ id: USER_ID }], [{ id: 'm1' }]],
+      inserts: [[{ id: 'new-consent-uuid' }]],
+    });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-test-claims': validClaimsHeader },
+      body: JSON.stringify(validBody),
+    });
+    expect(res.status).toBe(201);
+    const inserted = db.__insertValues[0] as {
+      noticeVersion?: string | null;
+      grantIp?: string | null;
+      grantUserAgent?: string | null;
+    };
+    expect(inserted.grantIp).toBeNull();
+    // hono/undici puede setear un user-agent por defecto en el request de test;
+    // lo importante es que noticeVersion ausente → null.
+    expect(inserted.noticeVersion).toBeNull();
+  });
 });
 
 describe('PATCH /me/consents/:id/revoke', () => {
+  it('GAP-1: :id no-UUID → 400 invalid_consent_id (Zod en boundary, antes de la BD)', async () => {
+    const db = makeDbStub({ selects: [[{ id: USER_ID }]] });
+    const app = await buildApp(db);
+    const res = await app.request('/me/consents/not-a-uuid/revoke', {
+      method: 'PATCH',
+      headers: { 'x-test-claims': validClaimsHeader },
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code: string };
+    expect(body.code).toBe('invalid_consent_id');
+    // Solo resolveUserId tocó la BD; el :id inválido cortó antes del pre-check.
+    expect(db.__selectCount()).toBe(1);
+  });
+
   it('user no registrado → 404 user_not_registered', async () => {
     const db = makeDbStub({ selects: [[]] });
     const app = await buildApp(db);
-    const res = await app.request('/me/consents/c1/revoke', {
+    const res = await app.request(`/me/consents/${VALID_CONSENT_ID}/revoke`, {
       method: 'PATCH',
       headers: { 'x-test-claims': validClaimsHeader },
     });
@@ -230,7 +442,7 @@ describe('PATCH /me/consents/:id/revoke', () => {
       ],
     });
     const app = await buildApp(db);
-    const res = await app.request('/me/consents/c1/revoke', {
+    const res = await app.request(`/me/consents/${VALID_CONSENT_ID}/revoke`, {
       method: 'PATCH',
       headers: { 'x-test-claims': validClaimsHeader },
     });
@@ -244,7 +456,7 @@ describe('PATCH /me/consents/:id/revoke', () => {
       selects: [[{ id: USER_ID }], [{ grantedByUserId: 'OTRO-USER' }]],
     });
     const app = await buildApp(db);
-    const res = await app.request('/me/consents/c1/revoke', {
+    const res = await app.request(`/me/consents/${VALID_CONSENT_ID}/revoke`, {
       method: 'PATCH',
       headers: { 'x-test-claims': validClaimsHeader },
     });
@@ -259,7 +471,7 @@ describe('PATCH /me/consents/:id/revoke', () => {
       updates: [[{ id: 'c1' }]],
     });
     const app = await buildApp(db);
-    const res = await app.request('/me/consents/c1/revoke', {
+    const res = await app.request(`/me/consents/${VALID_CONSENT_ID}/revoke`, {
       method: 'PATCH',
       headers: { 'x-test-claims': validClaimsHeader },
     });
@@ -278,7 +490,7 @@ describe('PATCH /me/consents/:id/revoke', () => {
       updates: [[]], // UPDATE no afecta filas (ya revocado)
     });
     const app = await buildApp(db);
-    const res = await app.request('/me/consents/c1/revoke', {
+    const res = await app.request(`/me/consents/${VALID_CONSENT_ID}/revoke`, {
       method: 'PATCH',
       headers: { 'x-test-claims': validClaimsHeader },
     });

--- a/docs/adr/068-modelo-consentimiento-esg-19628-21719.md
+++ b/docs/adr/068-modelo-consentimiento-esg-19628-21719.md
@@ -1,0 +1,84 @@
+# ADR-068 — Modelo de consentimiento ESG conforme Ley 19.628 + Ley 21.719
+
+**Estado**: Accepted
+**Fecha**: 2026-06-17
+**Decider**: Felipe Vicencio (Product Owner)
+**Related**: [ADR-028](./028-rbac-auth-firebase-multi-tenant-with-consent-grants.md) (RBAC + consent grants), [ADR-034](./034-stakeholder-organizations.md) (organizaciones stakeholder), `docs/legal/modelo-consentimiento-esg-v1.md`, `docs/legal/aviso-privacidad-corto-v1.md`, `apps/api/src/db/schema.ts` (tabla `consents`), `apps/api/drizzle/0043_consent_evidencia_21719.sql`, `.specs/consent-idor-y-modelo-19628-21719/spec.md` (Frente F1)
+
+---
+
+## Contexto
+
+La Ley N° 21.719 entra en vigencia el **1 de diciembre de 2026** y refunde/reemplaza el régimen de la Ley N° 19.628. Exige **evidencia verificable** de cada aceptación de consentimiento: identidad del titular, finalidades marcadas de forma granular, fecha/hora, **versión del aviso** mostrado e **IP/dispositivo** del otorgamiento; prohíbe casillas premarcadas y el consentimiento tácito; y obliga a versionar el documento (cada cambio relevante de finalidades reinforma).
+
+Hasta este frente, el modelo de consentimiento ESG de Booster existía solo como artefactos legales externos (`Modelo_Consentimiento_ESG_Booster.docx`, `Aviso_Privacidad_Corto_Booster.md`), **no versionados en el repo** y **no vinculados al schema** que materializa el consentimiento. La tabla `consents` (`consentimientos`, ADR-028 §4) modelaba identidad, finalidades, fecha y documento, pero **no la versión del aviso ni la IP/UA** — dos campos que la 21.719 exige como evidencia.
+
+Además, la auditoría 2026-06-14 marcó dos IDOR de severidad alta en el **otorgamiento** de grants (`POST /me/consents`): P1-B (un dueño de empresa A podía otorgar sobre empresa B) y P0-B (`portafolio_viajes` aceptaba cualquier membership). El cierre de esos IDOR (Frente F1) y el cierre del gap modelo↔schema son la misma pieza de compliance y se documentan juntos.
+
+ADR-028 y ADR-034 siguen vigentes: este ADR **los complementa**, no los reemplaza ni los edita.
+
+## Decisión
+
+Se adopta un **modelo de consentimiento ESG conforme dual (19.628 + 21.719)** con tres componentes vinculados entre sí:
+
+### 1. Texto legal versionado en `docs/legal/`
+
+El modelo de consentimiento y el aviso de privacidad corto se versionan en el repo con la convención `*-vN.md` del directorio:
+
+- `docs/legal/modelo-consentimiento-esg-v1.md`
+- `docs/legal/aviso-privacidad-corto-v1.md`
+
+Ambos llevan una marca de **BORRADOR LEGAL**: los campos entre corchetes `[ ]` (razón social, RUT, plazos, responsable de datos, canal de derechos) y el sign-off de un abogado habilitado quedan **pendientes** (O-6, dependencia externa PO/legal). El versionado desbloquea el resto del frente sin esperar el texto final.
+
+El slug de versión del archivo vigente (ej. `esg-v1`) es el valor canónico que se registra en `consents.noticeVersion`.
+
+### 2. Evidencia 21.719 en el schema `consents`
+
+Se añaden a `consentimientos` tres columnas de evidencia, **nullable, sin default** (migración 0043, expand-only):
+
+| Columna SQL | Identifier TS | Tipo |
+|---|---|---|
+| `version_aviso` | `noticeVersion` | `varchar(20)` |
+| `ip_otorgamiento` | `grantIp` | `text` |
+| `user_agent_otorgamiento` | `grantUserAgent` | `text` |
+
+Se captura la IP confiable vía `extractClientIp(x-forwarded-for)` (penúltima entry bajo GCLB; `'unknown'` → `null`) y el `user-agent`, replicando el patrón ya usado en `carrier_memberships` para evidencia de consentimiento Ley 19.628. Son nullable porque no se inventa evidencia retroactiva para consents previos y porque el flujo de captura (F1b) que expone la `version_aviso` al otorgante aún no está vivo.
+
+### 3. Mapeo modelo legal ↔ schema
+
+El consentimiento legal y la fila en `consents` quedan vinculados así:
+
+| Requisito legal (19.628 / 21.719) | Campo en `consents` |
+|---|---|
+| Identidad del titular / otorgante | `grantedByUserId` (`otorgado_por_id`) + `stakeholderId` |
+| Finalidades marcadas (granular, una casilla por finalidad) | `dataCategories` (`categorias_datos`, enum, CHECK `array_length >= 1`) |
+| Fecha y hora | `grantedAt` (`otorgado_en`) |
+| Versión del aviso | `noticeVersion` (`version_aviso`) → slug del doc en `docs/legal/` |
+| IP / dispositivo | `grantIp` (`ip_otorgamiento`) + `grantUserAgent` (`user_agent_otorgamiento`) |
+| Documento firmado | `consentDocumentUrl` (`documento_consentimiento_url`) |
+| Revocación (hacia el futuro, sin afectar lo previo) | `revokedAt` (`revocado_en`) |
+
+Las 6 finalidades granulares del modelo (§14) se materializan como los valores del enum `categoria_dato_consentimiento` (`emisiones_carbono`, `rutas`, `distancias`, `combustibles`, `certificados`, `perfiles_vehiculos`): una casilla por finalidad, sin agrupar. **No se requiere columna nueva para finalidades.**
+
+## Consecuencias
+
+**Positivas**:
+- El consentimiento ESG es ahora **auditable desde la BD** (no solo desde un PDF externo): identidad, finalidades, fecha, versión del aviso e IP/UA quedan consultables, como exige la 21.719.
+- El texto legal queda **versionado y vinculado al código** (`noticeVersion`); cada cambio de finalidades obliga a una nueva versión del doc y un nuevo slug.
+- El cierre conjunto con el fix IDOR (Frente F1) deja el **otorgamiento** de grants tanto autorizado correctamente (sin IDOR) como evidenciado conforme.
+
+**Negativas / trade-offs aceptados**:
+- El texto legal queda en **borrador** hasta el sign-off de abogado (O-6); la marca de borrador lo hace explícito. El fix de código es independiente del texto final.
+- `noticeVersion` es **opcional en el body** mientras F1b (flujo de captura en signup) no esté vivo; se revisará al cablear F1b si pasa a obligatorio.
+
+## Alternativas descartadas
+
+- **No añadir columnas, evidenciar solo con `consentDocumentUrl`**: descartada (default PO O-1). Un PDF externo no es consultable/auditable en BD ni garantiza versión + IP/dispositivo como evidencia verificable.
+- **Editar ADR-028 para incorporar la evidencia**: descartada. Los ADRs son decisiones cerradas; se complementa con un ADR nuevo (ADR-068), no se edita el viejo.
+- **Backfill de evidencia en consents existentes**: descartada. No se puede inventar IP/versión retroactiva; nullable sin default es lo correcto.
+
+## Criterios de validación
+
+1. `pnpm --filter @booster-ai/api test` verde con la matriz IDOR + evidencia 21.719 (`test/unit/me-consents.test.ts`, `test/unit/consent.test.ts`).
+2. La migración 0043 pasa el guard expand/contract (`scripts/repo-checks/check-migration-safety.mjs`, exit 0): solo `ADD COLUMN ... NULL`.
+3. `consents.noticeVersion` se persiste con el slug del doc vigente en `docs/legal/`; `grantIp`/`grantUserAgent` con la IP confiable y el user-agent del otorgamiento.

--- a/docs/legal/aviso-privacidad-corto-v1.md
+++ b/docs/legal/aviso-privacidad-corto-v1.md
@@ -1,0 +1,47 @@
+> **BORRADOR LEGAL** — los campos entre corchetes `[ ]` y el sign-off de
+> abogado habilitado están **pendientes** (O-6, dependencia externa PO/legal).
+> No publicar ni invocar como texto final hasta completar. La `version_aviso`
+> registrada en `consentimientos` debe coincidir con la versión vigente de
+> este archivo.
+
+# Aviso de Privacidad — Booster AI
+
+_Versión corta para el flujo de registro. Conforme a la Ley N° 19.628 y a la Ley N° 21.719 (vigente desde el 1 de diciembre de 2026). Los textos entre corchetes `[ ]` deben completarse antes de publicar._
+
+---
+
+## Texto a mostrar en el registro
+
+**Tu privacidad en Booster**
+
+Booster AI ([RAZÓN SOCIAL], RUT [RUT]) es responsable del tratamiento de tus datos personales.
+
+Tratamos los datos que nos entregas y los que se generan al usar la plataforma (incluida tu **geolocalización** cuando el servicio lo requiere) para: prestarte el servicio de logística sostenible, **medir huella de carbono e indicadores ESG**, evaluar criterios de sostenibilidad y cumplir obligaciones legales. Usamos modelos de **inteligencia artificial** para optimizar rutas y estimar emisiones.
+
+No vendemos tus datos. Podemos compartirlos con proveedores tecnológicos que actúan por cuenta de Booster y, cuando lo autorizas, con terceros destinatarios de reportes ESG. Algunos proveedores pueden estar **fuera de Chile**, con las garantías que exige la ley.
+
+Puedes ejercer en cualquier momento tus derechos de **acceso, rectificación, supresión, oposición, portabilidad y bloqueo**, y **revocar tu consentimiento**, escribiendo a **[CORREO / FORMULARIO]**.
+
+Consulta los detalles en nuestra [Política de Privacidad completa]([URL]).
+
+---
+
+## Casilla de aceptación (acción afirmativa — sin premarcar)
+
+> ☐ He leído el Aviso de Privacidad y **autorizo** el tratamiento de mis datos personales para prestar el servicio y para las finalidades ESG descritas.
+
+**Casillas opcionales (separadas, no condicionan el registro):**
+
+> ☐ Autorizo el uso de mis datos para reportes ESG compartidos con terceros (clientes, inversionistas o certificadores).
+>
+> ☐ Autorizo la transferencia de mis datos a proveedores fuera de Chile.
+
+---
+
+## Notas de implementación
+
+- La casilla de aceptación debe ir **sin marcar por defecto**; el usuario la marca activamente (la 21.719 prohíbe casillas premarcadas y consentimiento tácito).
+- Mantén las finalidades opcionales en casillas **separadas**: no condiciones el registro a aceptarlas.
+- Registra evidencia de cada aceptación: identidad, finalidades marcadas, fecha/hora, versión del aviso e IP/dispositivo.
+- Si recoges **datos sensibles**, requieres una casilla de **consentimiento expreso** adicional y específica.
+- Este aviso resume; debe enlazar a la Política de Privacidad completa, que contiene todo el detalle del modelo de consentimiento.

--- a/docs/legal/modelo-consentimiento-esg-v1.md
+++ b/docs/legal/modelo-consentimiento-esg-v1.md
@@ -1,0 +1,195 @@
+> **BORRADOR LEGAL** — los campos entre corchetes `[ ]` y el sign-off de
+> abogado habilitado están **pendientes** (O-6, dependencia externa PO/legal).
+> No publicar ni invocar como texto final hasta completar. La `version_aviso`
+> registrada en `consentimientos` debe coincidir con la versión vigente de
+> este archivo.
+
+# Modelo de Consentimiento para el Tratamiento de Datos Personales en el contexto ESG
+
+_Conforme a la Ley N° 19.628 y a la Ley N° 21.719 (vigente desde el 1 de diciembre de 2026)._
+
+## Nota de uso de este modelo
+
+Este es un documento plantilla. Los textos entre corchetes `[ ]` deben ser completados por Booster antes de su uso (datos de la empresa, plazos, responsable de datos, etc.). Es un instrumento de apoyo y no sustituye la revisión por un abogado habilitado antes de su implementación.
+
+---
+
+## 1. Identificación del Responsable del Tratamiento
+
+Para los efectos de la legislación de protección de datos personales, actúa como Responsable del Tratamiento:
+
+| Campo | Información |
+|---|---|
+| Razón social | [RAZÓN SOCIAL DE BOOSTER] |
+| RUT | [RUT] |
+| Domicilio | [DIRECCIÓN, COMUNA, CIUDAD] |
+| Nombre comercial / plataforma | Booster AI (app.boosterchile.com) |
+| Encargado de Protección de Datos / contacto | [NOMBRE / CORREO, p. ej. privacidad@boosterchile.com] |
+| Canal para ejercer derechos | [CORREO Y/O FORMULARIO WEB] |
+
+## 2. Marco Legal Aplicable
+
+El tratamiento de datos personales descrito en este documento se rige por:
+
+- Ley N° 19.628, sobre Protección de la Vida Privada (régimen vigente).
+- Ley N° 21.719, que regula la protección y el tratamiento de los datos personales y crea la Agencia de Protección de Datos Personales, publicada el 13 de diciembre de 2024 y con entrada en vigencia el 1 de diciembre de 2026. A partir de esa fecha, refunde y reemplaza el régimen de la Ley N° 19.628.
+
+Este modelo se diseña de forma dual: cumple el estándar de consentimiento informado de la Ley N° 19.628 y, simultáneamente, incorpora los requisitos reforzados de la Ley N° 21.719, de modo que conserve validez tras su entrada en vigencia sin necesidad de rehacerse.
+
+## 3. Objeto y Contexto del Tratamiento ESG
+
+Booster opera una plataforma de logística sostenible que, para entregar sus servicios y medir su desempeño ambiental, social y de gobernanza (ESG), trata datos asociados a operaciones de transporte y a las personas que participan en ellas. El presente consentimiento se refiere al tratamiento de datos personales con finalidades vinculadas a la sostenibilidad, tales como:
+
+- Medición y reporte de huella de carbono y emisiones asociadas al transporte y la cadena logística.
+- Evaluación de criterios sociales y de gobernanza de contrapartes (clientes, empresas evaluadas y proveedores).
+- Generación de indicadores y reportes ESG, incluidos los que se entreguen a terceros, inversionistas o entidades de certificación con autorización del titular o por una base de licitud aplicable.
+
+Cuando el titular sea una persona jurídica, este consentimiento aplica respecto de los datos personales de sus representantes, contactos o trabajadores que se traten en el marco de la relación con Booster.
+
+## 4. Categorías de Datos Personales Tratados
+
+Según el tipo de titular, Booster podrá tratar las siguientes categorías de datos. El detalle aplicable a cada caso se especifica al momento de la recolección:
+
+| Tipo de titular | Datos personales que pueden tratarse |
+|---|---|
+| Clientes / empresas evaluadas | Identificación de representantes y contactos (nombre, cargo, correo, teléfono); datos de la relación contractual y de facturación; información operacional y ESG aportada para la evaluación. |
+| Proveedores (incl. transportistas) | Identificación y contacto; datos de habilitación y documentación; datos de vehículos y rutas; datos de geolocalización asociados a operaciones de transporte; antecedentes para diligencia de sostenibilidad de la cadena. |
+| Usuarios de plataforma | Datos de cuenta y autenticación; datos de uso y navegación; datos técnicos del dispositivo; datos de geolocalización cuando el servicio lo requiera; comunicaciones con soporte. |
+| Trabajadores | Datos de identificación y contacto; datos laborales y funcionales necesarios para los indicadores sociales y de gobernanza internos. El tratamiento laboral se rige además por la normativa laboral aplicable. |
+
+Booster aplica los principios de finalidad, proporcionalidad y minimización: solo trata los datos necesarios para las finalidades declaradas.
+
+## 5. Finalidades del Tratamiento
+
+Los datos personales se tratan para las siguientes finalidades específicas, explícitas y legítimas:
+
+- Prestar y administrar los servicios de la plataforma de logística sostenible.
+- Medir, calcular y reportar la huella de carbono y demás indicadores ambientales de las operaciones.
+- Evaluar criterios ESG de clientes, empresas evaluadas y proveedores, y realizar diligencia de sostenibilidad.
+- Elaborar reportes e indicadores ESG y, cuando corresponda, comunicarlos a terceros conforme a la Sección 9.
+- Cumplir obligaciones legales, contractuales y regulatorias.
+- Mejorar la plataforma y los modelos analíticos, incluidos los basados en inteligencia artificial (ver Sección 8).
+
+Los datos no se tratarán para finalidades incompatibles con las anteriores. Cualquier nueva finalidad requerirá información previa al titular y, cuando proceda, un nuevo consentimiento.
+
+## 6. Base de Licitud del Tratamiento
+
+El tratamiento se sustenta en una o más de las siguientes bases de licitud, según el caso:
+
+- Consentimiento del titular: para las finalidades que lo requieran y, en especial, para datos sensibles y para finalidades de reporte a terceros no obligatorias.
+- Ejecución de un contrato o medidas precontractuales solicitadas por el titular.
+- Cumplimiento de una obligación legal del Responsable.
+- Interés legítimo del Responsable o de un tercero, ponderado de modo que no prevalezca sobre los derechos y libertades del titular.
+
+La revocación del consentimiento (Sección 13) no afecta la licitud del tratamiento realizado con anterioridad ni el tratamiento que se ampare en otra base de licitud.
+
+## 7. Tratamiento de Datos Sensibles y de Geolocalización
+
+Cuando el tratamiento involucre datos sensibles, Booster recabará el consentimiento expreso del titular, manifestado de forma específica y separada para esa categoría, salvo que aplique una base de licitud especial prevista por la ley. No se utilizan casillas premarcadas ni consentimientos tácitos.
+
+Los datos de geolocalización asociados a operaciones de transporte se tratan únicamente con la finalidad de prestar el servicio y calcular indicadores de sostenibilidad, por el tiempo necesario para dichos fines, y con medidas de seguridad reforzadas.
+
+## 8. Decisiones Automatizadas e Inteligencia Artificial
+
+La plataforma utiliza modelos analíticos e inteligencia artificial para optimizar rutas, estimar emisiones y generar indicadores ESG. Respecto de ello, el titular tiene derecho a:
+
+- Ser informado de la existencia de tratamientos basados en decisiones automatizadas que le afecten significativamente.
+- Solicitar información significativa sobre la lógica involucrada y las consecuencias previstas de dicho tratamiento.
+- Solicitar la intervención humana, expresar su punto de vista y oponerse, en los términos que franquee la ley.
+
+Booster no adopta decisiones que produzcan efectos jurídicos en el titular, o lo afecten significativamente, basadas únicamente en tratamiento automatizado, salvo que exista una base de licitud y se ofrezcan las garantías correspondientes.
+
+## 9. Comunicación a Terceros y Transferencias Internacionales
+
+Booster podrá comunicar datos personales a: proveedores de servicios tecnológicos (encargados de tratamiento que actúan por cuenta de Booster y bajo contrato), entidades del grupo, clientes o terceros destinatarios de reportes ESG cuando exista consentimiento o base de licitud, y autoridades en cumplimiento de obligaciones legales.
+
+Si los datos se transfieren fuera de Chile (por ejemplo, servicios en la nube), Booster adoptará las garantías que exija la normativa aplicable para asegurar un nivel adecuado de protección. Destinatarios o categorías de destinatarios: [INDICAR PROVEEDORES / PAÍSES, p. ej. servicios cloud].
+
+## 10. Plazo de Conservación
+
+Los datos se conservarán mientras se mantenga la relación con el titular y, posteriormente, durante los plazos exigidos por la ley o necesarios para atender responsabilidades derivadas del tratamiento. Plazo de referencia: [INDICAR PLAZO, p. ej. duración de la relación + N años]. Cumplidos los plazos, los datos serán suprimidos o anonimizados.
+
+## 11. Medidas de Seguridad
+
+Booster aplica medidas técnicas y organizativas apropiadas para proteger los datos contra pérdida, acceso no autorizado, alteración o divulgación, considerando el estado de la técnica y la naturaleza de los datos. En caso de vulneración de seguridad que afecte datos personales, Booster actuará conforme a los deberes de notificación que establezca la normativa vigente.
+
+## 12. Derechos del Titular
+
+El titular puede ejercer en cualquier momento los siguientes derechos:
+
+- **Acceso**: conocer qué datos suyos se tratan y obtener una copia.
+- **Rectificación**: corregir datos inexactos, desactualizados o incompletos.
+- **Cancelación / Supresión**: solicitar la eliminación cuando proceda.
+- **Oposición**: oponerse a tratamientos determinados en los casos que la ley permite.
+- **Portabilidad**: recibir sus datos en un formato estructurado y de uso común, y/o solicitar su traspaso.
+- **Bloqueo**: suspender temporalmente el tratamiento en los supuestos legales.
+
+Los derechos se ejercen gratuitamente a través de [CANAL: correo / formulario]. Booster responderá en los plazos legales. Si el titular estima vulnerados sus derechos, podrá reclamar ante la Agencia de Protección de Datos Personales una vez que esta se encuentre en funciones conforme a la Ley N° 21.719.
+
+## 13. Revocación del Consentimiento
+
+El titular puede revocar su consentimiento en cualquier momento, por el mismo canal en que lo otorgó o el indicado en la Sección 1, sin expresión de causa. La revocación es tan sencilla como el otorgamiento y opera hacia el futuro, sin afectar la licitud del tratamiento previo.
+
+## 14. Declaración y Manifestación del Consentimiento
+
+Declaro que he sido informado/a de forma previa, clara y suficiente sobre el tratamiento de mis datos personales descrito en este documento, y manifiesto mi consentimiento libre, específico, informado e inequívoco respecto de las finalidades que marco a continuación. (Marque cada casilla que autoriza; las casillas no marcadas se entienden no autorizadas.)
+
+**Finalidades necesarias para la prestación del servicio**
+
+> ☐ Autorizo el tratamiento de mis datos para prestar y administrar los servicios de la plataforma (Secciones 5.1 y 5.5).
+>
+> ☐ Autorizo el tratamiento de datos de geolocalización para la prestación del servicio y el cálculo de indicadores de sostenibilidad (Sección 7).
+
+**Finalidades ESG y de reporte**
+
+> ☐ Autorizo el uso de mis datos para medir y reportar huella de carbono e indicadores ambientales (Sección 5.2).
+>
+> ☐ Autorizo la evaluación de criterios ESG y la diligencia de sostenibilidad (Sección 5.3).
+>
+> ☐ Autorizo la comunicación de indicadores ESG a terceros (clientes, inversionistas o entidades de certificación) conforme a la Sección 9.
+
+**Datos sensibles (consentimiento expreso y separado)**
+
+> ☐ Autorizo expresamente el tratamiento de datos sensibles indicados al momento de la recolección: [ESPECIFICAR SI APLICA] (Sección 7). Si no aplica, dejar en blanco.
+
+**Transferencias internacionales**
+
+> ☐ Autorizo la transferencia de mis datos a destinatarios fuera de Chile, con las garantías indicadas en la Sección 9.
+
+## 15. Aceptación y Firma
+
+### a) Otorgamiento presencial / en papel
+
+| Titular de los datos | Detalle |
+|---|---|
+| Nombre completo | [NOMBRE] |
+| RUT / documento | [RUT] |
+| En representación de (si aplica) | [PERSONA JURÍDICA / RUT] |
+| Calidad del titular | Cliente ☐   Proveedor ☐   Usuario ☐   Trabajador ☐ |
+| Fecha y lugar | [FECHA / LUGAR] |
+
+```
+_______________________________________________
+Firma del titular (o representante con poder suficiente)
+```
+
+### b) Otorgamiento digital (en plataforma)
+
+Cuando el consentimiento se otorgue a través de la plataforma, se registrará de forma que permita acreditar su existencia: identificación del titular, finalidades aceptadas, fecha y hora, versión del presente documento y registro técnico de la aceptación (por ejemplo, marca temporal y acción afirmativa explícita, sin casillas premarcadas). El titular podrá descargar una copia de su declaración.
+
+---
+
+## Anexo. Notas de implementación para Booster
+
+Recomendaciones para que el modelo sea efectivamente conforme y no solo en el papel:
+
+- Completar todos los campos resaltados antes de publicar o entregar el documento.
+- Mantener consentimientos granulares: una casilla por finalidad; no agrupar finalidades distintas en una sola aceptación.
+- Conservar evidencia verificable del consentimiento (logs, versión, fecha/hora) por todo el periodo de tratamiento más el de prescripción.
+- Versionar el documento: cada cambio relevante de finalidades exige reinformar y, según el caso, recabar nuevo consentimiento.
+- Llevar un registro de actividades de tratamiento y de los encargados (proveedores) con contrato de tratamiento de datos.
+- Preparar un procedimiento de atención de derechos (acceso, rectificación, supresión, oposición, portabilidad, bloqueo) con plazos.
+- Designar formalmente al responsable/contacto de protección de datos y publicar el canal de ejercicio de derechos.
+- Revisar el modelo con un abogado habilitado en Chile antes de su uso y nuevamente antes del 1 de diciembre de 2026.
+
+_Aviso: Este documento es un modelo de apoyo elaborado con base en la Ley N° 19.628 y la Ley N° 21.719. No constituye asesoría legal formal ni reemplaza la revisión por un profesional habilitado._


### PR DESCRIPTION
## Resumen

Cierra **P0-B** y **P1-B** de la auditoría 2026-06-14: IDOR en el otorgamiento de consentimientos ESG (`POST /me/consents`). Frente **F1** del plan `.specs/pivote-documental-y-cierre-legal-2026-06/`.

Desbloqueado por el modelo de consentimiento conforme **Ley 19.628 + Ley 21.719** (vigente 01-dic-2026) provisto por el PO.

## Cambios

**Fix IDOR** (`apps/api/src/routes/me-consents.ts`, `userCanGrantOnScope`):
- **P1-B**: scopes `organizacion`/`generador_carga`/`transportista` validan `memberships.empresaId === scopeId AND status='activa' AND role IN ('dueno','admin')`. Un dueño/admin de empresa A ya no otorga grants sobre empresa B.
- **P0-B**: `portafolio_viajes` se **deniega siempre** (deny real). No hay tabla de portafolio ni call sites — decisión PO **O-1b** (2026-06-17). `TODO`/backlink para la futura definición de Producto (lista explícita de viajes).

**Evidencia Ley 21.719** (migración `0043` expand-only):
- Columnas `version_aviso` / `ip_otorgamiento` / `user_agent_otorgamiento` en `consentimientos` (nullable, sin backfill), capturadas en el handler (réplica del patrón `carrier_memberships`).

**Hardening adicional** (review de seguridad):
- GAP-1: `PATCH /:id/revoke` valida que `:id` sea UUID → `400 invalid_consent_id` antes de tocar la BD (Zod en boundary).
- GAP-3: cobertura de tests para los 3 scopes de empresa (no solo `organizacion`).
- GAP-4: cap de longitud del user-agent persistido.

**Legal + ADR**:
- `docs/legal/modelo-consentimiento-esg-v1.md` + `docs/legal/aviso-privacidad-corto-v1.md` (⚠️ **BORRADOR**: campos `[ ]` y sign-off de abogado pendientes — O-6).
- `docs/adr/068-modelo-consentimiento-esg-19628-21719.md` vincula el texto legal ↔ schema `consents`.

## Evidencia

```
Tests (pnpm --filter @booster-ai/api test):  1520 passed | 2 skipped (127 files)
Typecheck (tsc --noEmit):                    0 errores
Biome check (archivos F1):                   0 errores
Guard migración (check-migration-safety):    OK — 0 DDL destructivo
Build (pnpm --filter @booster-ai/api build): success
Coverage código nuevo:  me-consents.ts 96.6% · consent.ts 97.5% (>>80%)
```

TDD: la matriz de tests se escribió primero (6 casos en rojo) → fix → verde. Reviews adversariales: spec-compliance ✅, convenciones/deuda ✅, seguridad ✅ (GAP-1/3/4 ya aplicados).

## ADR compliance
- Zero `any`, Zod en boundaries, `@booster-ai/logger`, naming bilingüe (SQL `version_aviso`…), migración **expand-only** (P1-H / ADR-066).
- ADR-068 nuevo; complementa ADR-028/034 sin editarlos.

## Notas para el revisor
- ⚠️ **Migración 0043**: el PR #428 (abierto) también reserva `0043`. Si #428 mergea primero, renumerar a `0044` en el rebase.
- ⚠️ **Texto legal en BORRADOR** (O-6): completar campos `[ ]` + sign-off de abogado habilitado antes de publicar. El fix de código es independiente del texto.
- **F1b** (casillas de consentimiento sin premarcar en signup) va en PR separado: depende de O-6 y es otro modelo de datos (consentimiento del titular vs grant a terceros).
- Verificación PO (no bloqueante): confirmar que no hay `consentimientos` en prod que requieran backfill (columnas nullable, seguro igual).
- Incluye el **plan maestro** del programa (`.specs/pivote-documental-y-cierre-legal-2026-06/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
