### PR TITLE
feat(api): repositorio documental por orden de transporte — F4 sub-fase 4a

### DIFF
--- a/apps/api/drizzle/0044_documentos_transporte.sql
+++ b/apps/api/drizzle/0044_documentos_transporte.sql
@@ -1,0 +1,60 @@
+-- Migration 0044 — repositorio documental de transporte (ADR-070, frente F4-4a)
+--
+-- Crea la tabla `documentos_transporte`: Booster RECIBE y ARCHIVA documentos
+-- tributarios de terceros (Guía de Despacho DTE 52, Factura 33, etc.) que
+-- amparan la carga de una orden (`viajes`). NO se emite DTE ni hay integración
+-- SII (ADR-069). El worker (sub-fase 4b) decodifica el TED PDF417 best-effort;
+-- el cierre flexible (4a) exige ≥1 documento subido aunque el TED no decodifique.
+--
+-- Naming bilingüe (CLAUDE.md): tabla y columnas en español snake_case sin
+-- tildes; los valores de `tipo_documento_transporte` son códigos literales del
+-- SII (33/34/52/56/61) más `other` y NO se traducen; los demás enums en español.
+--
+-- Expand-only (audit P1-H / ADR-066): solo CREATE TYPE / CREATE TABLE / CREATE
+-- INDEX. Sin DROP, sin RENAME, sin SET NOT NULL retroactivo sobre tablas
+-- existentes (es tabla nueva, así que NOT NULL interno es seguro). El rollback
+-- de código es seguro — una revisión previa simplemente ignora la tabla nueva.
+--
+-- FK `viaje_id` → `viajes(id)` ON DELETE RESTRICT: la retención legal (6 años)
+-- prohíbe borrar un documento dentro del período; sin cascada al cerrar/borrar
+-- la orden (spec O-3).
+--
+-- Riesgo de despliegue: bajo. No afecta filas ni constraints existentes.
+
+-- 1. Enums.
+CREATE TYPE "tipo_documento_transporte" AS ENUM ('33', '34', '52', '56', '61', 'other');
+--> statement-breakpoint
+CREATE TYPE "estado_extraccion" AS ENUM ('pendiente', 'procesando', 'decodificado', 'ingreso_manual', 'fallido');
+--> statement-breakpoint
+CREATE TYPE "origen_documento" AS ENUM ('pdf_upload', 'photo_upload', 'xml_intercambio');
+--> statement-breakpoint
+
+-- 2. Tabla documentos_transporte.
+CREATE TABLE "documentos_transporte" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "viaje_id" uuid NOT NULL REFERENCES "viajes"("id") ON DELETE RESTRICT,
+  "file_path" text NOT NULL,
+  "file_mime" text NOT NULL,
+  "doc_type" "tipo_documento_transporte" NOT NULL,
+  "folio" text,
+  "rut_emisor" text,
+  "razon_social_emisor" text,
+  "rut_receptor" text,
+  "razon_social_receptor" text,
+  "fecha_emision" date,
+  "monto_total" numeric(14, 2),
+  "ted_raw" text,
+  "ted_signature_valid" boolean,
+  "extraction_status" "estado_extraccion" NOT NULL DEFAULT 'pendiente',
+  "source" "origen_documento" NOT NULL,
+  "retention_until" date,
+  "subido_por" uuid REFERENCES "usuarios"("id"),
+  "creado_en" timestamptz NOT NULL DEFAULT now(),
+  "actualizado_en" timestamptz NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+-- 3. Indexes: por orden (listado del shipper/carrier) y por estado (worker 4b).
+CREATE INDEX "idx_documentos_transporte_viaje" ON "documentos_transporte"("viaje_id");
+--> statement-breakpoint
+CREATE INDEX "idx_documentos_transporte_estado" ON "documentos_transporte"("extraction_status");

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1780876800007,
       "tag": "0043_consent_evidencia_21719",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1780876800008,
+      "tag": "0044_documentos_transporte",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/scripts/check-route-default-deny.ts
+++ b/apps/api/scripts/check-route-default-deny.ts
@@ -89,6 +89,11 @@ export const ROUTE_CLASSIFICATION: Record<string, RouteClassificationEntry> = {
   // Router-vars montados bajo /assignments (userContext en app.use('/assignments/*', …)).
   assignmentsRouter: { category: 'ENFORCED', rationale: '' },
   chatRouter: { category: 'ENFORCED', rationale: '' },
+  // Repositorio documental de transporte (ADR-070, F4-4a): firebaseAuth +
+  // userContext preceden el mount vía app.use('/transport-orders/*', …) y
+  // app.use('/documents/*', …); la autorización por tenant (shipper-owner |
+  // carrier-assigned) la resuelve cada handler.
+  transportDocsRouter: { category: 'ENFORCED', rationale: '' },
 
   // --- GATED-CLOSED (bare firebaseAuth, gate in-handler) ---
   meRouter: {

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -193,6 +193,55 @@ export const apiEnvSchema = commonEnvSchema
     CHAT_PUBSUB_TOPIC: z.string().min(1).optional(),
 
     /**
+     * Repositorio documental de transporte (ADR-070, frente F4-4a).
+     *
+     * TRANSPORT_DOCUMENTS_BUCKET: bucket GCS donde se archivan los documentos
+     *   tributarios de terceros (Guía/Factura) bajo prefijo
+     *   `transport-documents/{viajeId}/{uuid}.{ext}`. Reusa el bucket
+     *   `documents` (storage.tf, retención SII 6a). Optional: si está ausente,
+     *   el endpoint de subida devuelve 503 (sin GCS no se puede archivar).
+     */
+    TRANSPORT_DOCUMENTS_BUCKET: z.string().min(1).optional(),
+
+    /**
+     * Pub/Sub topic name del evento `document.uploaded` (creado en
+     * messaging.tf). El endpoint de subida publica acá tras persistir la fila
+     * `pendiente`; el worker TED (sub-fase 4b) lo consume. Optional: si está
+     * ausente, el endpoint persiste + responde 202 igual (el worker llega en
+     * 4b), solo no publica el evento.
+     */
+    DOCUMENT_UPLOADED_TOPIC: z.string().min(1).optional(),
+
+    /**
+     * Cierre flexible (ADR-070 / spec O-7). Si `true`, una orden requiere ≥1
+     * documento subido para transicionar a `entregado` (independiente del
+     * estado de extracción). Solo aplica a órdenes creadas en/después de
+     * `REQUIRE_DOCUMENT_TO_CLOSE_SINCE`; las legacy/en-curso quedan exentas.
+     * Default `true` (O-7 resuelta 2026-06-18). `booleanFlag` (no
+     * `z.coerce.boolean()` — footgun, memoria Redis TLS 2026-06).
+     */
+    REQUIRE_DOCUMENT_TO_CLOSE: booleanFlag(true),
+
+    /**
+     * Fecha de corte ISO (YYYY-MM-DD) del cierre flexible: el guard de
+     * `REQUIRE_DOCUMENT_TO_CLOSE` solo aplica a órdenes con `creado_en >=`
+     * esta fecha. Sin esta var, el guard NO se aplica (las órdenes quedan
+     * exentas) aunque el flag esté ON — defensa contra bloquear viajes en
+     * ruta antes de definir el corte del rollout.
+     */
+    REQUIRE_DOCUMENT_TO_CLOSE_SINCE: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'REQUIRE_DOCUMENT_TO_CLOSE_SINCE debe ser ISO date YYYY-MM-DD')
+      .optional(),
+
+    /**
+     * Si `true`, el cierre exige al menos un documento `decodificado` (no solo
+     * subido). Default `false` (spec invariante): el TED es enriquecimiento, no
+     * condición de cierre. El worker decodificador llega en 4b.
+     */
+    REQUIRE_TED_DECODE: booleanFlag(false),
+
+    /**
      * VAPID keys para Web Push (P3.c). Generadas con
      * `npx web-push generate-vapid-keys` post-deploy y subidas a Secret
      * Manager. La pública se sirve via GET /webpush/vapid-public-key

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -6,6 +6,7 @@ import {
   char,
   check,
   customType,
+  date,
   index,
   integer,
   jsonb,
@@ -2281,6 +2282,87 @@ export const solicitudesRegistro = pgTable('solicitudes_registro', {
 });
 
 // =============================================================================
+// REPOSITORIO DOCUMENTAL DE TRANSPORTE (ADR-070, frente F4 — migration 0044)
+// =============================================================================
+// Booster RECIBE y ARCHIVA documentos tributarios de terceros (Guía de
+// Despacho DTE 52, Factura 33, etc.) que amparan la carga de una orden. NO
+// emite DTE ni se integra con el SII (ADR-069). El worker (4b) decodifica el
+// TED PDF417 best-effort; el cierre flexible exige ≥1 documento subido.
+//
+// Naming bilingüe: tabla `documentos_transporte`; los valores de `doc_type`
+// son códigos literales del SII (no se traducen); los demás enums en español.
+
+/** Códigos de tipo de documento del SII + `other` para tipos no esperados. */
+export const docTypeEnum = pgEnum('tipo_documento_transporte', [
+  '33',
+  '34',
+  '52',
+  '56',
+  '61',
+  'other',
+]);
+
+/** Estado de extracción del TED (lo mueve el worker 4b / manual-entry). */
+export const extractionStatusEnum = pgEnum('estado_extraccion', [
+  'pendiente',
+  'procesando',
+  'decodificado',
+  'ingreso_manual',
+  'fallido',
+]);
+
+/** Origen del documento. `xml_intercambio` reservado para el stub de 4c. */
+export const documentSourceEnum = pgEnum('origen_documento', [
+  'pdf_upload',
+  'photo_upload',
+  'xml_intercambio',
+]);
+
+export const transportDocuments = pgTable(
+  'documentos_transporte',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    // FK a `viajes`. `restrict`: NO cascada al borrar/cerrar la orden — la
+    // retención legal (6a) prohíbe borrar un documento dentro del período.
+    viajeId: uuid('viaje_id')
+      .notNull()
+      .references(() => trips.id, { onDelete: 'restrict' }),
+    // Objeto GCS (no URI completa; el bucket viene de env). Prefijo
+    // `transport-documents/{viajeId}/{uuid}.{ext}`.
+    filePath: text('file_path').notNull(),
+    fileMime: text('file_mime').notNull(),
+    docType: docTypeEnum('doc_type').notNull(),
+    // Campos del `<DD>` del TED — nullable hasta decodificar / manual-entry.
+    folio: text('folio'),
+    rutEmisor: text('rut_emisor'),
+    razonSocialEmisor: text('razon_social_emisor'),
+    rutReceptor: text('rut_receptor'),
+    razonSocialReceptor: text('razon_social_receptor'),
+    // `<DD><FE>` — insumo del cálculo de `retention_until`.
+    fechaEmision: date('fecha_emision'),
+    // `<DD><MNT>` — CLP entero; scale 2 por defensa.
+    montoTotal: numeric('monto_total', { precision: 14, scale: 2 }),
+    // XML crudo del `<TED>` decodificado (4b). Nullable.
+    tedRaw: text('ted_raw'),
+    // NULL = firma no validada (flag off); true/false = validada (4b).
+    tedSignatureValid: boolean('ted_signature_valid'),
+    extractionStatus: extractionStatusEnum('extraction_status').notNull().default('pendiente'),
+    source: documentSourceEnum('source').notNull(),
+    // Política de custodia del archivador (ADR-070): fecha_emision + 6a
+    // (fallback created_at + 6a). Sin purga automática en F4.
+    retentionUntil: date('retention_until'),
+    uploadedBy: uuid('subido_por').references(() => users.id),
+    createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => ({
+    viajeIdx: index('idx_documentos_transporte_viaje').on(table.viajeId),
+    // Para el worker/listados que filtran por estado de extracción.
+    estadoIdx: index('idx_documentos_transporte_estado').on(table.extractionStatus),
+  }),
+);
+
+// =============================================================================
 // TYPE EXPORTS
 // =============================================================================
 
@@ -2361,3 +2443,7 @@ export type NewCuentaDemoRow = typeof cuentasDemo.$inferInsert;
 // SEC-001 Sprint 2b H1.2 — solicitudes_registro (migration 0039)
 export type SolicitudRegistroRow = typeof solicitudesRegistro.$inferSelect;
 export type NewSolicitudRegistroRow = typeof solicitudesRegistro.$inferInsert;
+
+// Repositorio documental de transporte — documentos_transporte (migration 0044)
+export type TransportDocumentRow = typeof transportDocuments.$inferSelect;
+export type NewTransportDocumentRow = typeof transportDocuments.$inferInsert;

--- a/apps/api/src/middleware/rate-limit-transport-documents.test.ts
+++ b/apps/api/src/middleware/rate-limit-transport-documents.test.ts
@@ -1,0 +1,232 @@
+import type { Logger } from '@booster-ai/logger';
+import { Hono } from 'hono';
+import { describe, expect, it } from 'vitest';
+import {
+  KEY_PREFIX,
+  createRateLimitTransportDocumentsMiddleware,
+} from './rate-limit-transport-documents.js';
+
+// Review F4-4a finding 5 — middleware rate-limit de las ESCRITURAS del
+// repositorio documental de transporte: cap per-user (uid, default 20 / 60s)
+// con fallback a IP. 21º POST → 429. GET no consume cuota. Redis down → 503
+// fail-closed con Retry-After:30 (paridad rate-limit-signup SC-1.2.5).
+
+const noop = (): void => undefined;
+const noopLogger = {
+  trace: noop,
+  debug: noop,
+  info: noop,
+  warn: noop,
+  error: noop,
+  fatal: noop,
+  child: () => noopLogger,
+} as unknown as Logger;
+
+interface MockPipelineCalls {
+  incrCalled: string[];
+  expireCalled: Array<[string, number, string]>;
+}
+
+interface MakeRedisOptions {
+  counters?: number[];
+  throwOnExec?: Error;
+}
+
+function makeRedis(opts: MakeRedisOptions | number[]): {
+  redis: unknown;
+  calls: MockPipelineCalls;
+} {
+  const normalized: MakeRedisOptions = Array.isArray(opts) ? { counters: opts } : opts;
+  const counters = normalized.counters ?? [];
+  const calls: MockPipelineCalls = { incrCalled: [], expireCalled: [] };
+  let i = 0;
+  const pipeline = {
+    incr(key: string) {
+      calls.incrCalled.push(key);
+      return this;
+    },
+    expire(key: string, seconds: number, flag: string) {
+      calls.expireCalled.push([key, seconds, flag]);
+      return this;
+    },
+    async exec(): Promise<unknown[]> {
+      if (normalized.throwOnExec) {
+        throw normalized.throwOnExec;
+      }
+      const c = counters[i] ?? 0;
+      i += 1;
+      return [[null, c]];
+    },
+  };
+  const redis = { multi: () => pipeline };
+  return { redis, calls };
+}
+
+/**
+ * App con un middleware que simula firebaseAuth seteando `firebaseClaims.uid`
+ * (cuando `uid` se pasa), seguido del middleware bajo test y handlers POST/GET.
+ */
+function makeApp(
+  middleware: ReturnType<typeof createRateLimitTransportDocumentsMiddleware>,
+  uid?: string,
+) {
+  const app = new Hono();
+  app.use('/transport-orders/*', async (c, next) => {
+    if (uid) {
+      c.set('firebaseClaims', {
+        uid,
+        email: undefined,
+        emailVerified: false,
+        name: undefined,
+        picture: undefined,
+        custom: {},
+      });
+    }
+    await next();
+  });
+  app.use('/transport-orders/*', middleware);
+  app.post('/transport-orders/:id/documents', (c) => c.json({ ok: true }, 202));
+  app.get('/transport-orders/:id/documents', (c) => c.json({ documents: [] }));
+  return app;
+}
+
+function post(app: Hono, xff?: string) {
+  return app.request('/transport-orders/trip-1/documents', {
+    method: 'POST',
+    headers: xff ? { 'x-forwarded-for': xff } : {},
+  });
+}
+
+function getReq(app: Hono, xff?: string) {
+  return app.request('/transport-orders/trip-1/documents', {
+    method: 'GET',
+    headers: xff ? { 'x-forwarded-for': xff } : {},
+  });
+}
+
+describe('rate-limit-transport-documents middleware (F4-4a finding 5)', () => {
+  it('happy path: 1 POST con uid → 202 + counter scope=user incrementado', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const middleware = createRateLimitTransportDocumentsMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware, 'uid-abc');
+
+    const res = await post(app, '1.2.3.4');
+    expect(res.status).toBe(202);
+    expect(calls.incrCalled).toEqual([`${KEY_PREFIX}uid-abc`]);
+    expect(calls.expireCalled[0]?.[1]).toBe(60);
+    expect(calls.expireCalled[0]?.[2]).toBe('NX');
+  });
+
+  it('GET no consume cuota: passthrough sin tocar Redis', async () => {
+    const { redis, calls } = makeRedis([]);
+    const middleware = createRateLimitTransportDocumentsMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware, 'uid-abc');
+
+    const res = await getReq(app, '1.2.3.4');
+    expect(res.status).toBe(200);
+    expect(calls.incrCalled).toEqual([]);
+  });
+
+  it('20 POSTs passthrough, 21º → 429 con Retry-After:60 + X-RateLimit-Scope:user', async () => {
+    const counters = Array.from({ length: 21 }, (_, i) => i + 1); // 1..21
+    const { redis } = makeRedis(counters);
+    const middleware = createRateLimitTransportDocumentsMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware, 'uid-abc');
+
+    for (let i = 0; i < 20; i++) {
+      expect((await post(app, '9.9.9.9')).status).toBe(202);
+    }
+    const over = await post(app, '9.9.9.9');
+    expect(over.status).toBe(429);
+    expect(over.headers.get('Retry-After')).toBe('60');
+    expect(over.headers.get('X-RateLimit-Scope')).toBe('user');
+    const json = (await over.json()) as { error: string; code: string };
+    expect(json.error).toBe('too_many_attempts');
+    expect(json.code).toBe('too_many_attempts');
+  });
+
+  it('mismo uid desde IPs distintas comparte counter → 429 igual (cap por cuenta)', async () => {
+    const counters = Array.from({ length: 21 }, (_, i) => i + 1);
+    const { redis, calls } = makeRedis(counters);
+    const middleware = createRateLimitTransportDocumentsMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware, 'uid-rotador');
+
+    for (let i = 0; i < 20; i++) {
+      expect((await post(app, `10.0.0.${i}`)).status).toBe(202);
+    }
+    const over = await post(app, '10.0.0.99');
+    expect(over.status).toBe(429);
+    // Todas las keys son del mismo uid sin importar la IP.
+    expect(calls.incrCalled.every((k) => k === `${KEY_PREFIX}uid-rotador`)).toBe(true);
+  });
+
+  it('fallback a IP cuando no hay uid: scope=ip', async () => {
+    const { redis, calls } = makeRedis([1]);
+    const middleware = createRateLimitTransportDocumentsMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware); // sin uid
+
+    const res = await post(app, '5.5.5.5');
+    expect(res.status).toBe(202);
+    expect(calls.incrCalled).toEqual([`${KEY_PREFIX}5.5.5.5`]);
+  });
+
+  it('Redis pipeline throw → 503 fail-closed con Retry-After:30', async () => {
+    const { redis } = makeRedis({ throwOnExec: new Error('ECONNREFUSED') });
+    const middleware = createRateLimitTransportDocumentsMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const app = makeApp(middleware, 'uid-abc');
+
+    const res = await post(app, '1.2.3.4');
+    expect(res.status).toBe(503);
+    expect(res.headers.get('Retry-After')).toBe('30');
+    const json = (await res.json()) as { error: string; code: string };
+    expect(json.error).toBe('service_unavailable');
+    expect(json.code).toBe('service_unavailable');
+  });
+
+  it('uids distintos tienen counters independientes', async () => {
+    const { redis } = makeRedis([1, 1, 2, 2]);
+    const middlewareA = createRateLimitTransportDocumentsMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+    });
+    const appA = makeApp(middlewareA, 'uid-1');
+    const appB = makeApp(middlewareA, 'uid-2');
+
+    for (let i = 0; i < 2; i++) {
+      expect((await post(appA, '1.1.1.1')).status).toBe(202);
+      expect((await post(appB, '1.1.1.1')).status).toBe(202);
+    }
+  });
+
+  it('límite configurable: limit=2 → 3º POST es 429', async () => {
+    const { redis } = makeRedis([1, 2, 3]);
+    const middleware = createRateLimitTransportDocumentsMiddleware({
+      redis: redis as never,
+      logger: noopLogger,
+      limit: 2,
+    });
+    const app = makeApp(middleware, 'uid-abc');
+
+    expect((await post(app, '4.4.4.4')).status).toBe(202);
+    expect((await post(app, '4.4.4.4')).status).toBe(202);
+    expect((await post(app, '4.4.4.4')).status).toBe(429);
+  });
+});

--- a/apps/api/src/middleware/rate-limit-transport-documents.ts
+++ b/apps/api/src/middleware/rate-limit-transport-documents.ts
@@ -1,0 +1,94 @@
+import type { Logger } from '@booster-ai/logger';
+import type { MiddlewareHandler } from 'hono';
+import type Redis from 'ioredis';
+import { extractClientIp } from './client-ip.js';
+
+/**
+ * Review F4-4a finding 5 — middleware Hono que rate-limita las ESCRITURAS del
+ * repositorio documental de transporte (`POST /transport-orders/:id/documents`
+ * y `POST /documents/:id/manual-entry`).
+ *
+ * A diferencia de rate-limit-signup/public-tracking (pre-auth, scope solo-IP),
+ * estas rutas SÍ están autenticadas: el chain firebaseAuth corre ANTES de este
+ * middleware, así que tenemos `firebaseClaims.uid` como señal de identidad
+ * estable. Scope primario = uid del usuario; fallback a IP si el uid no está
+ * (no debería pasar tras firebaseAuth, pero fail-safe). Esto acota el abuso por
+ * cuenta (subir cientos de archivos a GCS) que un cap solo-IP no atrapa si el
+ * atacante rota IPs con un mismo token.
+ *
+ * Counter Redis: `rl:transport-docs:<uid|ip-fallback>` — default 20 escrituras
+ * / 60s. El 21º → 429 con `Retry-After: 60` + `X-RateLimit-Scope: user`.
+ *
+ * Solo cuenta métodos de escritura. Los GET (listado / detalle con signed URL)
+ * NO incrementan el counter — son lecturas baratas que no justifican cap aquí
+ * (el chain de auth + autorización por tenant ya los protege de abuso masivo).
+ *
+ * Fail-closed loudly (paridad rate-limit-pin/signup SC-1.2.5): si el pipeline
+ * Redis falla, retorna `503 service_unavailable` + `Retry-After: 30`.
+ * Rate-limit es defensa de seguridad — no degradar a fail-open.
+ *
+ * Trust boundary X-Forwarded-For: misma fuente única (`extractClientIp`) que
+ * pin/signup/public-tracking — solo relevante en el fallback-IP.
+ */
+
+export const KEY_PREFIX = 'rl:transport-docs:';
+const DEFAULT_LIMIT = 20;
+const DEFAULT_WINDOW_SECONDS = 60;
+const FAIL_CLOSED_RETRY_AFTER_SECONDS = 30;
+const WRITE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+
+export interface RateLimitTransportDocumentsOptions {
+  redis: Redis;
+  logger: Logger;
+  limit?: number;
+  windowSeconds?: number;
+}
+
+export function createRateLimitTransportDocumentsMiddleware(
+  opts: RateLimitTransportDocumentsOptions,
+): MiddlewareHandler {
+  const limit = opts.limit ?? DEFAULT_LIMIT;
+  const window = opts.windowSeconds ?? DEFAULT_WINDOW_SECONDS;
+
+  return async function rateLimitTransportDocuments(c, next) {
+    // Solo las escrituras consumen cuota. Las lecturas (GET) pasan directo.
+    if (!WRITE_METHODS.has(c.req.method)) {
+      return next();
+    }
+
+    // Identidad: uid del Firebase ID token (seteado por firebaseAuth, que corre
+    // antes en el chain). Fallback a IP si por algún motivo no está presente.
+    const uid = c.get('firebaseClaims')?.uid;
+    const ip = extractClientIp(c.req.header('x-forwarded-for'));
+    const scope = uid ? 'user' : 'ip';
+    const subject = uid ?? ip;
+    const key = `${KEY_PREFIX}${subject}`;
+
+    let count: number;
+    try {
+      const results = await opts.redis.multi().incr(key).expire(key, window, 'NX').exec();
+      count = Number(results?.[0]?.[1] ?? 0);
+    } catch (err) {
+      // Fail-closed loudly: rate-limit es defensa de seguridad; si Redis cae,
+      // bloqueamos la escritura en lugar de pasar todo.
+      opts.logger.error(
+        { err, scope, ip: scope === 'ip' ? ip : undefined },
+        'rate-limit-transport-documents: Redis pipeline failed; fail-closed con 503',
+      );
+      c.header('Retry-After', String(FAIL_CLOSED_RETRY_AFTER_SECONDS));
+      return c.json({ error: 'service_unavailable', code: 'service_unavailable' }, 503);
+    }
+
+    if (count > limit) {
+      opts.logger.warn(
+        { scope, count, limit, windowSeconds: window },
+        `rate-limit-transport-documents: 429 too_many_attempts scope=${scope}`,
+      );
+      c.header('Retry-After', String(window));
+      c.header('X-RateLimit-Scope', scope);
+      return c.json({ error: 'too_many_attempts', code: 'too_many_attempts' }, 429);
+    }
+
+    return next();
+  };
+}

--- a/apps/api/src/routes/assignments.ts
+++ b/apps/api/src/routes/assignments.ts
@@ -39,7 +39,10 @@ import {
   DriverNotInCarrierError,
   asignarConductorAAssignment,
 } from '../services/asignar-conductor-a-assignment.js';
-import { confirmarEntregaViaje } from '../services/confirmar-entrega-viaje.js';
+import {
+  type DocumentClosePolicy,
+  confirmarEntregaViaje,
+} from '../services/confirmar-entrega-viaje.js';
 import type { EmitirCertificadoConfig } from '../services/emitir-certificado-viaje.js';
 import { getAssignmentEcoRoute } from '../services/get-assignment-eco-route.js';
 import { INCIDENT_TYPES, reportarIncidente } from '../services/reportar-incidente.js';
@@ -48,6 +51,12 @@ export function createAssignmentsRoutes(opts: {
   db: Db;
   logger: Logger;
   certConfig?: Partial<EmitirCertificadoConfig>;
+  /**
+   * Política de cierre flexible documental (ADR-070, F4-4a). Si se provee y el
+   * flag está ON, el cierre POD del carrier exige ≥1 documento subido (según
+   * fecha de corte). Ausente → sin precondición documental.
+   */
+  documentClosePolicy?: DocumentClosePolicy | undefined;
   /**
    * GCP project ID — usado como X-Goog-User-Project en Routes API (ADR-038).
    * Si está presente, el endpoint /assignments/:id/eco-route fetches polyline
@@ -330,6 +339,7 @@ export function createAssignmentsRoutes(opts: {
         userId: auth.userContext.user.id,
       },
       config: opts.certConfig ?? {},
+      ...(opts.documentClosePolicy ? { documentClosePolicy: opts.documentClosePolicy } : {}),
     });
 
     if (!result.ok) {

--- a/apps/api/src/routes/transport-documents.ts
+++ b/apps/api/src/routes/transport-documents.ts
@@ -1,0 +1,555 @@
+import { randomUUID } from 'node:crypto';
+import type { Logger } from '@booster-ai/logger';
+import { transportDocumentManualEntryInputSchema } from '@booster-ai/shared-schemas';
+import { PubSub } from '@google-cloud/pubsub';
+import { Storage } from '@google-cloud/storage';
+import { zValidator } from '@hono/zod-validator';
+import { and, desc, eq, inArray } from 'drizzle-orm';
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import type { Db } from '../db/client.js';
+import { assignments, transportDocuments, trips } from '../db/schema.js';
+import { calcularRetentionUntil } from '../services/calcular-retention-until.js';
+
+/**
+ * Repositorio documental de transporte (ADR-070, frente F4-4a).
+ *
+ * 4 endpoints Hono para que el generador de carga (dueño de la orden) o el
+ * transportista asignado suban/listen/corrijan/descarguen documentos
+ * tributarios de terceros (Guía de Despacho 52, Factura 33, etc.) que amparan
+ * la carga de una orden (`viajes`). Booster RECIBE y ARCHIVA — no emite DTE
+ * (ADR-069).
+ *
+ *   - POST /transport-orders/:id/documents  → multipart, sube a GCS, fila
+ *       `pendiente`, publica `document.uploaded`, 202.
+ *   - POST /documents/:id/manual-entry      → corrige campos → `ingreso_manual`.
+ *   - GET  /transport-orders/:id/documents  → lista metadatos de la orden.
+ *   - GET  /documents/:id                   → detalle + signed URL v4 de descarga.
+ *
+ * Autorización multitenant: el actor debe pertenecer a la empresa generadora
+ * de carga dueña de la orden, o a la empresa transportista asignada. IDOR
+ * cross-empresa → 403.
+ *
+ * El worker decodificador del TED es de la sub-fase 4b: en 4a el endpoint solo
+ * persiste + publica + 202. Si `DOCUMENT_UPLOADED_TOPIC` no está seteado, el
+ * publish se omite (el consumer llega en 4b) sin romper el flujo.
+ */
+
+const ALLOWED_MIME_TYPES = ['application/pdf', 'image/jpeg', 'image/png'] as const;
+type AllowedMime = (typeof ALLOWED_MIME_TYPES)[number];
+const MAX_DOCUMENT_BYTES = 15 * 1024 * 1024; // 15 MB
+const SIGNED_URL_TTL_SECONDS = 300; // 5 min
+
+/**
+ * Estados de assignment (`estado_asignacion`) que mantienen vigente el vínculo
+ * transportista↔viaje para autorizar acceso documental. Excluye `cancelado`:
+ * un assignment cancelado NO debe seguir autorizando al transportista a
+ * subir/ver/corregir documentos de la orden (review F4-4a finding 2). Si el
+ * transportista vuelve a quedar asignado, será una fila nueva con estado
+ * vigente (la tabla tiene UNIQUE por viaje_id, así que a lo más una vigente).
+ */
+const ASSIGNMENT_ESTADOS_VIGENTES = ['asignado', 'recogido', 'entregado'] as const;
+
+function extForMime(mime: AllowedMime): string {
+  switch (mime) {
+    case 'application/pdf':
+      return 'pdf';
+    case 'image/jpeg':
+      return 'jpg';
+    case 'image/png':
+      return 'png';
+  }
+}
+
+function sourceForMime(mime: AllowedMime): 'pdf_upload' | 'photo_upload' {
+  return mime === 'application/pdf' ? 'pdf_upload' : 'photo_upload';
+}
+
+/**
+ * Magic bytes (file signatures) de cada MIME permitido. Defensa en profundidad
+ * (review F4-4a finding 3): `file.type` lo controla el cliente y puede mentir
+ * (ej. renombrar un `.exe` a `.pdf` y declarar `application/pdf`). Validamos el
+ * CONTENIDO real del buffer antes de archivarlo en GCS.
+ *
+ *   - PDF  → 25 50 44 46            ("%PDF")
+ *   - JPEG → FF D8 FF
+ *   - PNG  → 89 50 4E 47 0D 0A 1A 0A
+ */
+const MAGIC_BYTES: Record<AllowedMime, readonly number[]> = {
+  'application/pdf': [0x25, 0x50, 0x44, 0x46],
+  'image/jpeg': [0xff, 0xd8, 0xff],
+  'image/png': [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+};
+
+/**
+ * Detecta el MIME real de un buffer por sus magic bytes. Función pura: devuelve
+ * el `AllowedMime` cuyo prefijo de firma coincide con el inicio del buffer, o
+ * `null` si no coincide con ninguno permitido. No depende de la extensión ni
+ * del `file.type` declarado.
+ */
+export function detectMagicByteMime(buffer: Uint8Array): AllowedMime | null {
+  for (const mime of ALLOWED_MIME_TYPES) {
+    const signature = MAGIC_BYTES[mime];
+    if (buffer.length < signature.length) {
+      continue;
+    }
+    let matches = true;
+    for (let i = 0; i < signature.length; i++) {
+      if (buffer[i] !== signature[i]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) {
+      return mime;
+    }
+  }
+  return null;
+}
+
+let cachedStorage: Storage | null = null;
+function getStorage(): Storage {
+  if (!cachedStorage) {
+    cachedStorage = new Storage();
+  }
+  return cachedStorage;
+}
+
+let cachedPubSub: PubSub | null = null;
+function getPubSub(): PubSub {
+  if (!cachedPubSub) {
+    cachedPubSub = new PubSub();
+  }
+  return cachedPubSub;
+}
+
+/**
+ * Publica `document.uploaded` fire-and-forget. Si falla, la fila ya está en
+ * DB; el worker 4b puede reconciliar por estado `pendiente`. No crashea el
+ * endpoint (que ya respondió 202).
+ */
+async function publishDocumentUploaded(opts: {
+  topicName: string;
+  logger: Logger;
+  documentId: string;
+  viajeId: string;
+  filePath: string;
+  fileMime: string;
+}): Promise<void> {
+  const { topicName, logger, documentId, viajeId, filePath, fileMime } = opts;
+  try {
+    const data = JSON.stringify({
+      documentId,
+      viajeId,
+      filePath,
+      fileMime,
+    });
+    await getPubSub()
+      .topic(topicName)
+      .publishMessage({ data: Buffer.from(data) });
+  } catch (err) {
+    logger.error(
+      { err, documentId, viajeId },
+      'publishDocumentUploaded falló (fila ya en DB; worker 4b reconcilia por estado pendiente)',
+    );
+  }
+}
+
+export function createTransportDocumentsRoutes(opts: {
+  db: Db;
+  logger: Logger;
+  /** Bucket GCS para archivar los documentos. Si ausente, POST/GET descarga → 503. */
+  transportDocumentsBucket?: string | undefined;
+  /** Topic `document.uploaded`. Si ausente, el publish se omite (worker llega en 4b). */
+  documentUploadedTopic?: string | undefined;
+}) {
+  const app = new Hono();
+
+  function requireUserContext(c: Context) {
+    const userContext = c.get('userContext');
+    if (!userContext) {
+      opts.logger.error({ path: c.req.path }, '/transport-documents without userContext');
+      return { ok: false as const, response: c.json({ error: 'unauthorized' }, 401) };
+    }
+    const active = userContext.activeMembership;
+    if (!active) {
+      return {
+        ok: false as const,
+        response: c.json({ error: 'no_active_empresa', code: 'no_active_empresa' }, 403),
+      };
+    }
+    return {
+      ok: true as const,
+      userContext,
+      activeMembership: active,
+      empresaId: active.empresa.id,
+    };
+  }
+
+  /**
+   * Gate de rol de ESCRITURA (review F4-4a finding 4). Reusa el mismo conjunto
+   * que `documentos.ts:requireWriteRole`: solo dueño/admin/despachador del
+   * membership activo pueden mutar el repositorio documental (subir, corregir).
+   * Visualizador/conductor/stakeholder → 403 `write_role_required`. Los GET no
+   * pasan por este gate (lectura abierta a cualquier rol del tenant autorizado).
+   */
+  function requireWriteRole(c: Context) {
+    const auth = requireUserContext(c);
+    if (!auth.ok) {
+      return auth;
+    }
+    const role = auth.activeMembership.membership.role;
+    if (role !== 'dueno' && role !== 'admin' && role !== 'despachador') {
+      return {
+        ok: false as const,
+        response: c.json({ error: 'forbidden', code: 'write_role_required' }, 403),
+      };
+    }
+    return auth;
+  }
+
+  /**
+   * Verifica que `empresaId` está autorizada sobre el viaje `tripId`: dueña
+   * generadora de carga del viaje, O transportista del assignment. Devuelve
+   * `{ authorized, exists }`.
+   */
+  async function authorizeOverTrip(tripId: string, empresaId: string) {
+    const tripRows = await opts.db
+      .select({ id: trips.id, generadorCargaEmpresaId: trips.generadorCargaEmpresaId })
+      .from(trips)
+      .where(eq(trips.id, tripId))
+      .limit(1);
+    const trip = tripRows[0];
+    if (!trip) {
+      return { exists: false as const, authorized: false as const };
+    }
+    if (trip.generadorCargaEmpresaId === empresaId) {
+      return { exists: true as const, authorized: true as const };
+    }
+    const asgRows = await opts.db
+      .select({ empresaId: assignments.empresaId })
+      .from(assignments)
+      .where(
+        and(
+          eq(assignments.tripId, tripId),
+          inArray(assignments.status, ASSIGNMENT_ESTADOS_VIGENTES),
+        ),
+      )
+      .limit(1);
+    const asg = asgRows[0];
+    if (asg && asg.empresaId === empresaId) {
+      return { exists: true as const, authorized: true as const };
+    }
+    return { exists: true as const, authorized: false as const };
+  }
+
+  // ---------------------------------------------------------------------
+  // POST /transport-orders/:id/documents — subir PDF/foto a una orden.
+  // ---------------------------------------------------------------------
+  app.post('/transport-orders/:id/documents', async (c) => {
+    const auth = requireWriteRole(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const tripId = c.req.param('id');
+
+    if (!opts.transportDocumentsBucket) {
+      opts.logger.error({ tripId }, 'TRANSPORT_DOCUMENTS_BUCKET ausente — no se puede archivar');
+      return c.json({ error: 'storage_unavailable', code: 'storage_unavailable' }, 503);
+    }
+
+    const authz = await authorizeOverTrip(tripId, auth.empresaId);
+    if (!authz.exists) {
+      return c.json({ error: 'trip_not_found', code: 'trip_not_found' }, 404);
+    }
+    if (!authz.authorized) {
+      return c.json({ error: 'forbidden', code: 'forbidden' }, 403);
+    }
+
+    const formData = await c.req.formData().catch(() => null);
+    if (!formData) {
+      return c.json({ error: 'multipart_required', code: 'multipart_required' }, 400);
+    }
+    const file = formData.get('file');
+    if (!(file instanceof File)) {
+      return c.json({ error: 'file_missing', code: 'file_missing' }, 400);
+    }
+    const mime = file.type;
+    if (!ALLOWED_MIME_TYPES.includes(mime as AllowedMime)) {
+      return c.json(
+        { error: 'mime_not_allowed', code: 'mime_not_allowed', allowed: ALLOWED_MIME_TYPES },
+        400,
+      );
+    }
+    if (file.size > MAX_DOCUMENT_BYTES) {
+      return c.json(
+        { error: 'file_too_large', code: 'file_too_large', max_bytes: MAX_DOCUMENT_BYTES },
+        413,
+      );
+    }
+
+    const allowedMime = mime as AllowedMime;
+    const buffer = Buffer.from(await file.arrayBuffer());
+
+    // Defensa en profundidad (review F4-4a finding 3): validar magic bytes del
+    // contenido, no solo `file.type` (que controla el cliente). Si el contenido
+    // real no coincide con el MIME declarado (o no es ningún tipo permitido),
+    // rechazamos ANTES de archivar en GCS.
+    const detectedMime = detectMagicByteMime(buffer);
+    if (detectedMime !== allowedMime) {
+      opts.logger.warn(
+        { tripId, declaredMime: allowedMime, detectedMime },
+        'transport-document mime_mismatch — magic bytes no coinciden con el tipo declarado',
+      );
+      return c.json(
+        { error: 'mime_mismatch', code: 'mime_mismatch', allowed: ALLOWED_MIME_TYPES },
+        400,
+      );
+    }
+
+    const objectName = `transport-documents/${tripId}/${randomUUID()}.${extForMime(allowedMime)}`;
+
+    try {
+      await getStorage()
+        .bucket(opts.transportDocumentsBucket)
+        .file(objectName)
+        .save(buffer, {
+          contentType: allowedMime,
+          metadata: { cacheControl: 'private, max-age=3600' },
+        });
+    } catch (err) {
+      opts.logger.error({ err, objectName, tripId }, 'transport-document GCS upload failed');
+      return c.json({ error: 'upload_failed', code: 'upload_failed' }, 500);
+    }
+
+    let documentId: string;
+    try {
+      const inserted = await opts.db
+        .insert(transportDocuments)
+        .values({
+          viajeId: tripId,
+          filePath: objectName,
+          fileMime: allowedMime,
+          // doc_type real lo determina el TED (4b) o manual-entry. Defaulteamos
+          // a 'other' hasta entonces (el enum lo exige notNull).
+          docType: 'other',
+          extractionStatus: 'pendiente',
+          source: sourceForMime(allowedMime),
+          uploadedBy: auth.userContext.user.id,
+        })
+        .returning({ id: transportDocuments.id });
+      const row = inserted[0];
+      if (!row) {
+        throw new Error('insert returned no row');
+      }
+      documentId = row.id;
+    } catch (err) {
+      opts.logger.error({ err, objectName, tripId }, 'transport-document INSERT failed');
+      return c.json({ error: 'persist_failed', code: 'persist_failed' }, 500);
+    }
+
+    opts.logger.info(
+      { documentId, tripId, mime: allowedMime, source: sourceForMime(allowedMime) },
+      'transport-document subido (pendiente)',
+    );
+
+    // Publish fire-and-forget. El consumer (worker TED) llega en 4b.
+    if (opts.documentUploadedTopic) {
+      await publishDocumentUploaded({
+        topicName: opts.documentUploadedTopic,
+        logger: opts.logger,
+        documentId,
+        viajeId: tripId,
+        filePath: objectName,
+        fileMime: allowedMime,
+      });
+    }
+
+    return c.json({ document_id: documentId, extraction_status: 'pendiente' }, 202);
+  });
+
+  // ---------------------------------------------------------------------
+  // POST /documents/:id/manual-entry — corregir campos a mano.
+  // ---------------------------------------------------------------------
+  app.post(
+    '/documents/:id/manual-entry',
+    zValidator('json', transportDocumentManualEntryInputSchema),
+    async (c) => {
+      const auth = requireWriteRole(c);
+      if (!auth.ok) {
+        return auth.response;
+      }
+      const documentId = c.req.param('id');
+      const body = c.req.valid('json');
+
+      const docRows = await opts.db
+        .select({
+          id: transportDocuments.id,
+          viajeId: transportDocuments.viajeId,
+          createdAt: transportDocuments.createdAt,
+        })
+        .from(transportDocuments)
+        .where(eq(transportDocuments.id, documentId))
+        .limit(1);
+      const doc = docRows[0];
+      if (!doc) {
+        return c.json({ error: 'document_not_found', code: 'document_not_found' }, 404);
+      }
+
+      const authz = await authorizeOverTrip(doc.viajeId, auth.empresaId);
+      if (!authz.authorized) {
+        return c.json({ error: 'forbidden', code: 'forbidden' }, 403);
+      }
+
+      // Recalcula retention_until: con fecha_emision provista → +6a; si no,
+      // fallback created_at + 6a (marca de revisión).
+      const retention = calcularRetentionUntil({
+        fechaEmision: body.fecha_emision ?? null,
+        createdAt: doc.createdAt,
+      });
+
+      try {
+        await opts.db
+          .update(transportDocuments)
+          .set({
+            ...(body.doc_type !== undefined ? { docType: body.doc_type } : {}),
+            ...(body.folio !== undefined ? { folio: body.folio } : {}),
+            ...(body.rut_emisor !== undefined ? { rutEmisor: body.rut_emisor } : {}),
+            ...(body.razon_social_emisor !== undefined
+              ? { razonSocialEmisor: body.razon_social_emisor }
+              : {}),
+            ...(body.rut_receptor !== undefined ? { rutReceptor: body.rut_receptor } : {}),
+            ...(body.razon_social_receptor !== undefined
+              ? { razonSocialReceptor: body.razon_social_receptor }
+              : {}),
+            ...(body.fecha_emision !== undefined ? { fechaEmision: body.fecha_emision } : {}),
+            ...(body.monto_total !== undefined ? { montoTotal: body.monto_total } : {}),
+            extractionStatus: 'ingreso_manual',
+            retentionUntil: retention.retentionUntil,
+            updatedAt: new Date(),
+          })
+          .where(eq(transportDocuments.id, documentId));
+      } catch (err) {
+        opts.logger.error({ err, documentId }, 'transport-document manual-entry UPDATE failed');
+        return c.json({ error: 'update_failed', code: 'update_failed' }, 500);
+      }
+
+      opts.logger.info(
+        { documentId, needsReview: retention.needsReview },
+        'transport-document manual-entry → ingreso_manual',
+      );
+
+      return c.json({
+        ok: true,
+        document_id: documentId,
+        extraction_status: 'ingreso_manual',
+        retention_until: retention.retentionUntil,
+      });
+    },
+  );
+
+  // ---------------------------------------------------------------------
+  // GET /transport-orders/:id/documents — listar metadatos de la orden.
+  // ---------------------------------------------------------------------
+  app.get('/transport-orders/:id/documents', async (c) => {
+    const auth = requireUserContext(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const tripId = c.req.param('id');
+
+    const authz = await authorizeOverTrip(tripId, auth.empresaId);
+    if (!authz.exists) {
+      return c.json({ error: 'trip_not_found', code: 'trip_not_found' }, 404);
+    }
+    if (!authz.authorized) {
+      return c.json({ error: 'forbidden', code: 'forbidden' }, 403);
+    }
+
+    const rows = await opts.db
+      .select({
+        id: transportDocuments.id,
+        docType: transportDocuments.docType,
+        folio: transportDocuments.folio,
+        fileMime: transportDocuments.fileMime,
+        extractionStatus: transportDocuments.extractionStatus,
+        source: transportDocuments.source,
+        fechaEmision: transportDocuments.fechaEmision,
+        montoTotal: transportDocuments.montoTotal,
+        retentionUntil: transportDocuments.retentionUntil,
+        createdAt: transportDocuments.createdAt,
+      })
+      .from(transportDocuments)
+      .where(eq(transportDocuments.viajeId, tripId))
+      .orderBy(desc(transportDocuments.createdAt));
+
+    return c.json({ documents: rows });
+  });
+
+  // ---------------------------------------------------------------------
+  // GET /documents/:id — detalle + signed URL v4 de descarga.
+  // ---------------------------------------------------------------------
+  app.get('/documents/:id', async (c) => {
+    const auth = requireUserContext(c);
+    if (!auth.ok) {
+      return auth.response;
+    }
+    const documentId = c.req.param('id');
+
+    const docRows = await opts.db
+      .select()
+      .from(transportDocuments)
+      .where(eq(transportDocuments.id, documentId))
+      .limit(1);
+    const doc = docRows[0];
+    if (!doc) {
+      return c.json({ error: 'document_not_found', code: 'document_not_found' }, 404);
+    }
+
+    const authz = await authorizeOverTrip(doc.viajeId, auth.empresaId);
+    if (!authz.authorized) {
+      return c.json({ error: 'forbidden', code: 'forbidden' }, 403);
+    }
+
+    let downloadUrl: string | null = null;
+    if (opts.transportDocumentsBucket) {
+      try {
+        const [url] = await getStorage()
+          .bucket(opts.transportDocumentsBucket)
+          .file(doc.filePath)
+          .getSignedUrl({
+            version: 'v4',
+            action: 'read',
+            expires: Date.now() + SIGNED_URL_TTL_SECONDS * 1000,
+          });
+        downloadUrl = url;
+      } catch (err) {
+        opts.logger.error({ err, documentId }, 'transport-document signed URL failed');
+      }
+    }
+
+    return c.json({
+      document: {
+        id: doc.id,
+        viaje_id: doc.viajeId,
+        doc_type: doc.docType,
+        folio: doc.folio,
+        file_mime: doc.fileMime,
+        rut_emisor: doc.rutEmisor,
+        razon_social_emisor: doc.razonSocialEmisor,
+        rut_receptor: doc.rutReceptor,
+        razon_social_receptor: doc.razonSocialReceptor,
+        fecha_emision: doc.fechaEmision,
+        monto_total: doc.montoTotal,
+        ted_signature_valid: doc.tedSignatureValid,
+        extraction_status: doc.extractionStatus,
+        source: doc.source,
+        retention_until: doc.retentionUntil,
+        creado_en: doc.createdAt,
+      },
+      download_url: downloadUrl,
+    });
+  });
+
+  return app;
+}

--- a/apps/api/src/routes/transport-documents.ts
+++ b/apps/api/src/routes/transport-documents.ts
@@ -144,6 +144,8 @@ async function publishDocumentUploaded(opts: {
       filePath,
       fileMime,
     });
+    // rls-allowlist: publishMessage de Pub/Sub (document.uploaded); no es query Drizzle —
+    // el linter interpreta el `data` de .publishMessage({ data }) como nombre de tabla (falso positivo).
     await getPubSub()
       .topic(topicName)
       .publishMessage({ data: Buffer.from(data) });
@@ -409,6 +411,8 @@ export function createTransportDocumentsRoutes(opts: {
       });
 
       try {
+        // rls-allowlist: autorización por tenant vía authorizeOverTrip (el viaje pertenece al tenant);
+        // documentos_transporte es hija de viajes, sin empresa_id propia para filtrar.
         await opts.db
           .update(transportDocuments)
           .set({

--- a/apps/api/src/routes/trip-requests-v2.ts
+++ b/apps/api/src/routes/trip-requests-v2.ts
@@ -19,7 +19,10 @@ import {
   users as usersTable,
   vehicles,
 } from '../db/schema.js';
-import { confirmarEntregaViaje } from '../services/confirmar-entrega-viaje.js';
+import {
+  type DocumentClosePolicy,
+  confirmarEntregaViaje,
+} from '../services/confirmar-entrega-viaje.js';
 import type { EmitirCertificadoConfig } from '../services/emitir-certificado-viaje.js';
 import { TripRequestNotFoundError, runMatching } from '../services/matching.js';
 import type { NotifyOfferDeps } from '../services/notify-offer.js';
@@ -66,6 +69,12 @@ export function createTripRequestsV2Routes(opts: {
    * warn en el wire fire-and-forget). Útil para dev sin KMS.
    */
   certConfig?: Partial<EmitirCertificadoConfig>;
+  /**
+   * Política de cierre flexible documental (ADR-070, F4-4a). Si se provee y el
+   * flag está ON, confirmar-recepcion exige ≥1 documento subido (según fecha
+   * de corte). Ausente → sin precondición documental.
+   */
+  documentClosePolicy?: DocumentClosePolicy | undefined;
 }) {
   const app = new Hono();
 
@@ -469,6 +478,7 @@ export function createTripRequestsV2Routes(opts: {
         userId: auth.userContext.user.id,
       },
       config: opts.certConfig ?? {},
+      ...(opts.documentClosePolicy ? { documentClosePolicy: opts.documentClosePolicy } : {}),
     });
 
     if (!result.ok) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -16,6 +16,7 @@ import { createIsDemoEnforcementMiddleware } from './middleware/is-demo-enforcem
 import { createRateLimitPinMiddleware } from './middleware/rate-limit-pin.js';
 import { createRateLimitPublicTrackingMiddleware } from './middleware/rate-limit-public-tracking.js';
 import { createRateLimitSignupMiddleware } from './middleware/rate-limit-signup.js';
+import { createRateLimitTransportDocumentsMiddleware } from './middleware/rate-limit-transport-documents.js';
 import { skipPublicVerify } from './middleware/skip-public-verify.js';
 import { createUserContextMiddleware } from './middleware/user-context.js';
 import { createAdminCobraHoyRoutes } from './routes/admin-cobra-hoy.js';
@@ -53,6 +54,7 @@ import {
   createSiteSettingsRoutes,
 } from './routes/site-settings.js';
 import { createSucursalesRoutes } from './routes/sucursales.js';
+import { createTransportDocumentsRoutes } from './routes/transport-documents.js';
 import { createTripRequestsV2Routes } from './routes/trip-requests-v2.js';
 import { createTripRequestsRoutes } from './routes/trip-requests.js';
 import { createVehiculosRoutes } from './routes/vehiculos.js';
@@ -398,6 +400,19 @@ export function createServer(opts: CreateServerOptions): Hono {
       verifyBaseUrl: config.API_AUDIENCE[0] ?? 'https://api.boosterchile.com',
     };
 
+    // Política de cierre flexible documental (ADR-070, F4-4a). Compartida por
+    // los dos endpoints de cierre (shipper confirmar-recepcion + carrier POD).
+    // `requireDocumentSince` parsea la env ISO date a Date UTC; si está ausente
+    // queda null y el guard NO aplica precondición aunque el flag esté ON
+    // (defensa contra bloquear viajes en ruta antes de definir el corte).
+    const documentClosePolicy = {
+      requireDocumentToClose: config.REQUIRE_DOCUMENT_TO_CLOSE,
+      requireTedDecode: config.REQUIRE_TED_DECODE,
+      requireDocumentSince: config.REQUIRE_DOCUMENT_TO_CLOSE_SINCE
+        ? new Date(`${config.REQUIRE_DOCUMENT_TO_CLOSE_SINCE}T00:00:00.000Z`)
+        : null,
+    };
+
     app.use(
       '/trip-requests-v2/*',
       firebaseAuthMiddleware,
@@ -411,6 +426,7 @@ export function createServer(opts: CreateServerOptions): Hono {
         db: opts.db,
         logger,
         certConfig,
+        documentClosePolicy,
         ...(opts.notify ? { notify: opts.notify } : {}),
       }),
     );
@@ -432,6 +448,38 @@ export function createServer(opts: CreateServerOptions): Hono {
         ...(opts.notifyTrackingLink ? { notifyTrackingLink: opts.notifyTrackingLink } : {}),
       }),
     );
+
+    // Repositorio documental de transporte (ADR-070, frente F4-4a). Mismo
+    // chain firebaseAuth + userContext: el generador de carga (dueño) o el
+    // transportista asignado suben/listan/corrigen/descargan documentos
+    // tributarios de terceros que amparan la carga de una orden. La
+    // autorización por tenant (shipper-owner | carrier-assigned) la resuelve
+    // el handler contra `viajes`/`asignaciones`. El worker decodificador del
+    // TED es de la sub-fase 4b.
+    const transportDocsRouter = createTransportDocumentsRoutes({
+      db: opts.db,
+      logger,
+      ...(config.TRANSPORT_DOCUMENTS_BUCKET
+        ? { transportDocumentsBucket: config.TRANSPORT_DOCUMENTS_BUCKET }
+        : {}),
+      ...(config.DOCUMENT_UPLOADED_TOPIC
+        ? { documentUploadedTopic: config.DOCUMENT_UPLOADED_TOPIC }
+        : {}),
+    });
+    // Review F4-4a finding 5 — rate-limit per-user (uid) / fallback-IP de las
+    // ESCRITURAS (POST), fail-closed 503 si Redis down. Se monta DESPUÉS de
+    // firebaseAuth (necesita `firebaseClaims.uid`) y antes del handler. Las
+    // lecturas (GET) lo atraviesan sin consumir cuota. 20 escrituras/60s.
+    const rateLimitTransportDocs = createRateLimitTransportDocumentsMiddleware({
+      redis: redisForRateLimit,
+      logger,
+    });
+    for (const prefix of ['/transport-orders/*', '/documents/*']) {
+      app.use(prefix, firebaseAuthMiddleware, demoExpiresMiddleware, isDemoEnforcementMiddleware);
+      app.use(prefix, rateLimitTransportDocs);
+      app.use(prefix, userContextMiddleware);
+    }
+    app.route('/', transportDocsRouter);
 
     // Admin jobs — endpoints internos disparados por Cloud Scheduler
     // (P3.d chat WhatsApp fallback). Auth: OIDC token con email = SA del
@@ -482,6 +530,8 @@ export function createServer(opts: CreateServerOptions): Hono {
       db: opts.db,
       logger,
       certConfig,
+      // Cierre flexible documental (ADR-070, F4-4a) en el POD del carrier.
+      documentClosePolicy,
       // ADR-038: Routes API via ADC. GOOGLE_CLOUD_PROJECT va como
       // X-Goog-User-Project. Sin él, GET /assignments/:id/eco-route
       // devuelve polyline_encoded=null con status='no_routes_api_key'.

--- a/apps/api/src/services/calcular-retention-until.test.ts
+++ b/apps/api/src/services/calcular-retention-until.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { calcularRetentionUntil } from './calcular-retention-until.js';
+
+describe('calcularRetentionUntil', () => {
+  it('con fecha_emision → fecha_emision + 6 años (ISO date)', () => {
+    const r = calcularRetentionUntil({
+      fechaEmision: '2026-06-15',
+      createdAt: new Date('2026-06-18T10:00:00.000Z'),
+    });
+    expect(r.retentionUntil).toBe('2032-06-15');
+    expect(r.needsReview).toBe(false);
+  });
+
+  it('sin fecha_emision → created_at + 6 años + marca de revisión', () => {
+    const r = calcularRetentionUntil({
+      fechaEmision: null,
+      createdAt: new Date('2026-06-18T10:00:00.000Z'),
+    });
+    expect(r.retentionUntil).toBe('2032-06-18');
+    expect(r.needsReview).toBe(true);
+  });
+
+  it('maneja año bisiesto (29-feb → 28-feb a +6a no bisiesto preserva mes/día válido)', () => {
+    // 2024-02-29 + 6a = 2030-02-28 (2030 no bisiesto). El cálculo debe
+    // producir una fecha válida, no 2030-02-29 (inexistente) ni overflow a marzo.
+    const r = calcularRetentionUntil({
+      fechaEmision: '2024-02-29',
+      createdAt: new Date('2024-03-01T00:00:00.000Z'),
+    });
+    expect(r.retentionUntil).toBe('2030-02-28');
+  });
+
+  it('fecha_emision string vacío se trata como ausente (fallback)', () => {
+    const r = calcularRetentionUntil({
+      fechaEmision: '',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    });
+    expect(r.retentionUntil).toBe('2032-01-01');
+    expect(r.needsReview).toBe(true);
+  });
+});

--- a/apps/api/src/services/calcular-retention-until.ts
+++ b/apps/api/src/services/calcular-retention-until.ts
@@ -1,0 +1,67 @@
+/**
+ * Cálculo de `retention_until` (frente F4, ADR-070, dominio crítico).
+ *
+ * Política de custodia del archivador (spec O-3 / O-8): Booster conserva el
+ * documento tributario 6 años desde la `fecha_emision` (fallback
+ * `created_at + 6a` cuando no hay fecha, marcando el documento para revisión).
+ * Fundamento: Código Tributario DL 830 Art. 17/200. PROHIBIDO borrado
+ * automático dentro del período (no se implementa purga en F4, solo el cálculo).
+ *
+ * Función PURA: sin DB, sin red. Devuelve la fecha como ISO date (YYYY-MM-DD,
+ * tipo `date` en Postgres, sin componente de hora).
+ */
+
+const RETENTION_YEARS = 6;
+
+/** Días del mes (1-12) en el año dado, considerando bisiesto. */
+function lastDayOfMonth(year: number, monthIndex0: number): number {
+  // Date.UTC con día 0 del mes siguiente = último día del mes actual.
+  return new Date(Date.UTC(year, monthIndex0 + 1, 0)).getUTCDate();
+}
+
+/** Suma N años a un ISO date YYYY-MM-DD, clampeando el día al mes destino. */
+function addYearsIsoDate(isoDate: string, years: number): string {
+  const [y, m, d] = isoDate.split('-').map((p) => Number.parseInt(p, 10));
+  const targetYear = (y as number) + years;
+  const monthIndex0 = (m as number) - 1;
+  const maxDay = lastDayOfMonth(targetYear, monthIndex0);
+  const day = Math.min(d as number, maxDay);
+  const mm = String(monthIndex0 + 1).padStart(2, '0');
+  const dd = String(day).padStart(2, '0');
+  return `${targetYear}-${mm}-${dd}`;
+}
+
+/** Extrae el ISO date (YYYY-MM-DD) en UTC de un Date. */
+function toIsoDateUtc(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export interface RetentionResult {
+  /** ISO date YYYY-MM-DD hasta el cual se conserva el documento. */
+  retentionUntil: string;
+  /**
+   * `true` cuando se usó el fallback `created_at + 6a` (no había
+   * `fecha_emision`): el plazo es conservador y debe revisarse al decodificar
+   * o corregir la fecha real.
+   */
+  needsReview: boolean;
+}
+
+export function calcularRetentionUntil(input: {
+  /** `<DD><FE>` decodificado o ingresado manualmente. Null/"" => fallback. */
+  fechaEmision: string | null;
+  /** `creado_en` de la fila del documento. */
+  createdAt: Date;
+}): RetentionResult {
+  const fecha = input.fechaEmision?.trim();
+  if (fecha && /^\d{4}-\d{2}-\d{2}$/.test(fecha)) {
+    return {
+      retentionUntil: addYearsIsoDate(fecha, RETENTION_YEARS),
+      needsReview: false,
+    };
+  }
+  return {
+    retentionUntil: addYearsIsoDate(toIsoDateUtc(input.createdAt), RETENTION_YEARS),
+    needsReview: true,
+  };
+}

--- a/apps/api/src/services/confirmar-entrega-viaje.test.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.test.ts
@@ -1,0 +1,221 @@
+import { getTableName } from 'drizzle-orm';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+});
+
+// Mockeamos los side-effects post-commit (cert, scoring, coaching, liquidación,
+// factor matching) — sus propios tests los cubren. Acá solo validamos la
+// precondición de cierre flexible documental (F4-4a) dentro de la tx.
+vi.mock('../services/emitir-certificado-viaje.js', () => ({
+  emitirCertificadoViaje: vi.fn(async () => ({ skipped: true, reason: 'test' })),
+}));
+vi.mock('./emitir-certificado-viaje.js', () => ({
+  emitirCertificadoViaje: vi.fn(async () => ({ skipped: true, reason: 'test' })),
+}));
+vi.mock('./calcular-metricas-viaje.js', () => ({
+  recalcularNivelPostEntrega: vi.fn(async () => undefined),
+}));
+vi.mock('./actualizar-factor-matching.js', () => ({
+  actualizarFactorMatchingViaje: vi.fn(async () => undefined),
+}));
+vi.mock('./calcular-score-conduccion-viaje.js', () => ({
+  calcularScoreConduccionViaje: vi.fn(async () => undefined),
+}));
+vi.mock('./generar-coaching-viaje.js', () => ({
+  generarCoachingViaje: vi.fn(async () => undefined),
+}));
+vi.mock('./liquidar-trip.js', () => ({ liquidarTrip: vi.fn(async () => ({ status: 'skipped' })) }));
+
+const { confirmarEntregaViaje } = await import('./confirmar-entrega-viaje.js');
+
+const noop = (): void => undefined;
+const logger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: noop,
+  child: () => logger,
+} as never;
+
+const TRIP_ID = 'b3b8c1d2-0000-4000-8000-000000000010';
+const SHIPPER_EMP = 'b3b8c1d2-0000-4000-8000-000000000020';
+const USER_ID = 'b3b8c1d2-0000-4000-8000-000000000030';
+const ASSIGN_ID = 'b3b8c1d2-0000-4000-8000-000000000040';
+
+const corte = new Date('2026-06-18T00:00:00.000Z');
+
+/**
+ * Fake tx que responde a la secuencia de selects del service:
+ *   1. trips (id/status/createdAt/generadorCargaEmpresaId)  [.limit con .for('update')]
+ *   2. assignments (id/empresaId/deliveredAt)               [.limit]
+ *   3. documentos_transporte (extractionStatus)             [sin .limit — devuelve array directo]
+ * y captura los UPDATE/INSERT.
+ */
+function makeDb(opts: {
+  tripStatus: string;
+  tripCreatedAt: Date;
+  documentos: Array<{ extractionStatus: string }>;
+}) {
+  const updates: unknown[] = [];
+
+  const tx = {
+    select: vi.fn((_cols?: unknown) => {
+      const chain: Record<string, unknown> = {};
+      let table: 'trips' | 'assignments' | 'docs' | 'unknown' = 'unknown';
+      chain.from = vi.fn((t: unknown) => {
+        let name: string | undefined;
+        try {
+          // biome-ignore lint/suspicious/noExplicitAny: drizzle table runtime introspection en test.
+          name = getTableName(t as any);
+        } catch {
+          name = undefined;
+        }
+        if (name === 'viajes') {
+          table = 'trips';
+        } else if (name === 'asignaciones') {
+          table = 'assignments';
+        } else if (name === 'documentos_transporte') {
+          table = 'docs';
+        }
+        return chain;
+      });
+      const rowsFor = (): unknown[] => {
+        if (table === 'trips') {
+          return [
+            {
+              id: TRIP_ID,
+              status: opts.tripStatus,
+              createdAt: opts.tripCreatedAt,
+              generadorCargaEmpresaId: SHIPPER_EMP,
+            },
+          ];
+        }
+        if (table === 'assignments') {
+          return [{ id: ASSIGN_ID, empresaId: SHIPPER_EMP, deliveredAt: null }];
+        }
+        if (table === 'docs') {
+          return opts.documentos;
+        }
+        return [];
+      };
+      chain.where = vi.fn(() => chain);
+      // El chain es thenable: `await select().from().where()` (docs query, sin
+      // .limit) resuelve aquí; las demás encadenan .limit()/.for('update').
+      chain.then = (resolve: (rows: unknown[]) => void) => resolve(rowsFor());
+      // .limit() devuelve un sub-chain thenable que además expone .for('update')
+      // (trips usa .where().limit(1).for('update'); assignments usa .where().limit(1)).
+      chain.limit = vi.fn(() => {
+        const limited: Record<string, unknown> = {
+          then: (resolve: (rows: unknown[]) => void) => resolve(rowsFor()),
+          for: vi.fn(() => ({
+            then: (resolve: (rows: unknown[]) => void) => resolve(rowsFor()),
+          })),
+        };
+        return limited;
+      });
+      return chain;
+    }),
+    update: vi.fn(() => {
+      const chain: Record<string, unknown> = {};
+      chain.set = vi.fn((v: unknown) => {
+        updates.push(v);
+        return chain;
+      });
+      chain.where = vi.fn(() => chain);
+      chain.returning = vi.fn(async () => [{ id: TRIP_ID }]);
+      return chain;
+    }),
+    insert: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+  };
+
+  const db = {
+    transaction: vi.fn(async (fn: (t: typeof tx) => unknown) => fn(tx)),
+    // post-commit select de assignment para liquidación
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({ limit: vi.fn(async () => [{ id: ASSIGN_ID }]) })),
+      })),
+    })),
+  };
+
+  return { db: db as never, updates };
+}
+
+const baseArgs = {
+  logger,
+  tripId: TRIP_ID,
+  source: 'shipper' as const,
+  actor: { empresaId: SHIPPER_EMP, userId: USER_ID },
+  config: {},
+};
+
+describe('confirmarEntregaViaje — cierre flexible documental (F4-4a)', () => {
+  it('sin documentClosePolicy: cierra sin precondición (backward-compat)', async () => {
+    const { db } = makeDb({ tripStatus: 'asignado', tripCreatedAt: corte, documentos: [] });
+    const r = await confirmarEntregaViaje({ ...baseArgs, db });
+    expect(r.ok).toBe(true);
+  });
+
+  it('flag ON + orden nueva + 0 docs → rechaza con documento_requerido', async () => {
+    const { db } = makeDb({
+      tripStatus: 'asignado',
+      tripCreatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      documentos: [],
+    });
+    const r = await confirmarEntregaViaje({
+      ...baseArgs,
+      db,
+      documentClosePolicy: {
+        requireDocumentToClose: true,
+        requireTedDecode: false,
+        requireDocumentSince: corte,
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('documento_requerido');
+    }
+  });
+
+  it('flag ON + orden nueva + 1 doc pendiente → cierra (TED no requerido)', async () => {
+    const { db } = makeDb({
+      tripStatus: 'asignado',
+      tripCreatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      documentos: [{ extractionStatus: 'pendiente' }],
+    });
+    const r = await confirmarEntregaViaje({
+      ...baseArgs,
+      db,
+      documentClosePolicy: {
+        requireDocumentToClose: true,
+        requireTedDecode: false,
+        requireDocumentSince: corte,
+      },
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('flag ON + orden legacy (antes del corte) + 0 docs → cierra (exenta)', async () => {
+    const { db } = makeDb({
+      tripStatus: 'asignado',
+      tripCreatedAt: new Date('2026-06-01T00:00:00.000Z'),
+      documentos: [],
+    });
+    const r = await confirmarEntregaViaje({
+      ...baseArgs,
+      db,
+      documentClosePolicy: {
+        requireDocumentToClose: true,
+        requireTedDecode: false,
+        requireDocumentSince: corte,
+      },
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/apps/api/src/services/confirmar-entrega-viaje.test.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.test.ts
@@ -71,8 +71,7 @@ function makeDb(opts: {
       chain.from = vi.fn((t: unknown) => {
         let name: string | undefined;
         try {
-          // biome-ignore lint/suspicious/noExplicitAny: drizzle table runtime introspection en test.
-          name = getTableName(t as any);
+          name = getTableName(t as Parameters<typeof getTableName>[0]);
         } catch {
           name = undefined;
         }

--- a/apps/api/src/services/confirmar-entrega-viaje.ts
+++ b/apps/api/src/services/confirmar-entrega-viaje.ts
@@ -35,7 +35,7 @@ import { and, eq, inArray } from 'drizzle-orm';
 // recibe la función como opt parameter (`opts.config: Partial<EmitirCertificadoConfig>`).
 import { config as appConfig } from '../config.js';
 import type { Db } from '../db/client.js';
-import { assignments, tripEvents, trips } from '../db/schema.js';
+import { assignments, transportDocuments, tripEvents, trips } from '../db/schema.js';
 import { actualizarFactorMatchingViaje } from './actualizar-factor-matching.js';
 import { recalcularNivelPostEntrega } from './calcular-metricas-viaje.js';
 import { calcularScoreConduccionViaje } from './calcular-score-conduccion-viaje.js';
@@ -45,6 +45,11 @@ import {
 } from './emitir-certificado-viaje.js';
 import { generarCoachingViaje } from './generar-coaching-viaje.js';
 import { liquidarTrip } from './liquidar-trip.js';
+import {
+  type DocumentoParaCierre,
+  type FlagsCierreDocumental,
+  puedeCerrarConDocumentos,
+} from './puede-cerrar-con-documentos.js';
 
 // El guard de estados confirmables vive en @booster-ai/trip-state-machine
 // (esConfirmableEntrega: asignado|en_proceso — ADR-061). 'entregado' es
@@ -57,9 +62,22 @@ export type ConfirmarEntregaResult =
   | { ok: true; alreadyDelivered: true; deliveredAt: Date }
   | {
       ok: false;
-      code: 'trip_not_found' | 'no_assignment' | 'forbidden_owner_mismatch' | 'invalid_status';
+      code:
+        | 'trip_not_found'
+        | 'no_assignment'
+        | 'forbidden_owner_mismatch'
+        | 'invalid_status'
+        | 'documento_requerido';
       currentStatus?: string;
     };
+
+/**
+ * Política de cierre flexible documental (ADR-070, frente F4-4a). Inyectada
+ * por el wire desde las env vars (`booleanFlag`) para mantener el guard
+ * testeable. Si no se provee, el cierre NO aplica precondición documental
+ * (backward-compat: equivalente a `requireDocumentToClose=false`).
+ */
+export interface DocumentClosePolicy extends FlagsCierreDocumental {}
 
 export async function confirmarEntregaViaje(opts: {
   db: Db;
@@ -72,8 +90,14 @@ export async function confirmarEntregaViaje(opts: {
     userId: string;
   };
   config: Partial<EmitirCertificadoConfig>;
+  /**
+   * Política de cierre flexible documental (ADR-070, F4-4a). Si se provee y
+   * `requireDocumentToClose=true`, la orden requiere ≥1 documento subido para
+   * cerrar (según fecha de corte). Ausente → sin precondición documental.
+   */
+  documentClosePolicy?: DocumentClosePolicy;
 }): Promise<ConfirmarEntregaResult> {
-  const { db, logger, tripId, source, actor, config } = opts;
+  const { db, logger, tripId, source, actor, config, documentClosePolicy } = opts;
 
   // Tx de escritura — todo o nada para mantener consistencia.
   const txResult = await db.transaction(async (tx) => {
@@ -82,6 +106,7 @@ export async function confirmarEntregaViaje(opts: {
       .select({
         id: trips.id,
         status: trips.status,
+        createdAt: trips.createdAt,
         generadorCargaEmpresaId: trips.generadorCargaEmpresaId,
       })
       .from(trips)
@@ -153,6 +178,33 @@ export async function confirmarEntregaViaje(opts: {
     // assignment row borrado por algún proceso externo.
     if (!assignment) {
       return { ok: false as const, code: 'no_assignment' as const };
+    }
+
+    // (6.5) Cierre flexible documental (ADR-070, F4-4a). Precondición de
+    // negocio (NO toca la tabla de transiciones): si el flag está ON y la
+    // orden fue creada en/después de la fecha de corte, exige ≥1 documento
+    // subido. La semántica vive en la función pura `puedeCerrarConDocumentos`.
+    // Las órdenes legacy (creadas antes del corte) quedan exentas.
+    if (documentClosePolicy?.requireDocumentToClose) {
+      const docRows = await tx
+        .select({ extractionStatus: transportDocuments.extractionStatus })
+        .from(transportDocuments)
+        .where(eq(transportDocuments.viajeId, tripId));
+      const documentos: DocumentoParaCierre[] = docRows.map((r) => ({
+        extractionStatus: r.extractionStatus,
+      }));
+      const decision = puedeCerrarConDocumentos({
+        flags: documentClosePolicy,
+        tripCreatedAt: trip.createdAt,
+        documentos,
+      });
+      if (!decision.puedeCerrar) {
+        logger.info(
+          { tripId, razon: decision.razon, docs: documentos.length },
+          'cierre rechazado por precondición documental (F4)',
+        );
+        return { ok: false as const, code: 'documento_requerido' as const };
+      }
     }
 
     // (7) UPDATEs en el orden esperado por el lifecycle.

--- a/apps/api/src/services/puede-cerrar-con-documentos.test.ts
+++ b/apps/api/src/services/puede-cerrar-con-documentos.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type DocumentoParaCierre,
+  type FlagsCierreDocumental,
+  puedeCerrarConDocumentos,
+} from './puede-cerrar-con-documentos.js';
+
+const corte = new Date('2026-06-18T00:00:00.000Z');
+
+const flagsBase: FlagsCierreDocumental = {
+  requireDocumentToClose: true,
+  requireTedDecode: false,
+  requireDocumentSince: corte,
+};
+
+const docPendiente: DocumentoParaCierre = { extractionStatus: 'pendiente' };
+const docDecodificado: DocumentoParaCierre = { extractionStatus: 'decodificado' };
+const docFallido: DocumentoParaCierre = { extractionStatus: 'fallido' };
+
+describe('puedeCerrarConDocumentos', () => {
+  it('permite cerrar cuando el flag está OFF, sin importar documentos', () => {
+    const r = puedeCerrarConDocumentos({
+      flags: { ...flagsBase, requireDocumentToClose: false },
+      tripCreatedAt: new Date('2026-07-01T00:00:00.000Z'),
+      documentos: [],
+    });
+    expect(r.puedeCerrar).toBe(true);
+  });
+
+  it('EXENTA órdenes legacy creadas antes de la fecha de corte (flag ON, 0 docs)', () => {
+    const r = puedeCerrarConDocumentos({
+      flags: flagsBase,
+      tripCreatedAt: new Date('2026-06-01T00:00:00.000Z'),
+      documentos: [],
+    });
+    expect(r.puedeCerrar).toBe(true);
+    expect(r.razon).toBe('orden_legacy_exenta');
+  });
+
+  it('exige documento a una orden creada en la fecha de corte exacta (>=)', () => {
+    const r = puedeCerrarConDocumentos({
+      flags: flagsBase,
+      tripCreatedAt: corte,
+      documentos: [],
+    });
+    expect(r.puedeCerrar).toBe(false);
+    expect(r.razon).toBe('documento_requerido');
+  });
+
+  it('rechaza el cierre si la orden es nueva y no tiene documentos', () => {
+    const r = puedeCerrarConDocumentos({
+      flags: flagsBase,
+      tripCreatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      documentos: [],
+    });
+    expect(r.puedeCerrar).toBe(false);
+    expect(r.razon).toBe('documento_requerido');
+  });
+
+  it('permite cerrar con >=1 documento subido aunque el TED NO decodifique (pendiente)', () => {
+    const r = puedeCerrarConDocumentos({
+      flags: flagsBase,
+      tripCreatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      documentos: [docPendiente],
+    });
+    expect(r.puedeCerrar).toBe(true);
+  });
+
+  it('permite cerrar con un documento fallido (cierre flexible)', () => {
+    const r = puedeCerrarConDocumentos({
+      flags: flagsBase,
+      tripCreatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      documentos: [docFallido],
+    });
+    expect(r.puedeCerrar).toBe(true);
+  });
+
+  it('con REQUIRE_TED_DECODE=true exige al menos un documento decodificado', () => {
+    const flags = { ...flagsBase, requireTedDecode: true };
+    const sinDecode = puedeCerrarConDocumentos({
+      flags,
+      tripCreatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      documentos: [docPendiente, docFallido],
+    });
+    expect(sinDecode.puedeCerrar).toBe(false);
+    expect(sinDecode.razon).toBe('ted_no_decodificado');
+
+    const conDecode = puedeCerrarConDocumentos({
+      flags,
+      tripCreatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      documentos: [docPendiente, docDecodificado],
+    });
+    expect(conDecode.puedeCerrar).toBe(true);
+  });
+
+  it('un ingreso_manual cuenta como documento subido válido', () => {
+    const r = puedeCerrarConDocumentos({
+      flags: flagsBase,
+      tripCreatedAt: new Date('2026-06-20T00:00:00.000Z'),
+      documentos: [{ extractionStatus: 'ingreso_manual' }],
+    });
+    expect(r.puedeCerrar).toBe(true);
+  });
+
+  it('si requireDocumentSince es null y el flag ON, aplica a todas las órdenes', () => {
+    const r = puedeCerrarConDocumentos({
+      flags: { ...flagsBase, requireDocumentSince: null },
+      tripCreatedAt: new Date('2020-01-01T00:00:00.000Z'),
+      documentos: [],
+    });
+    expect(r.puedeCerrar).toBe(false);
+    expect(r.razon).toBe('documento_requerido');
+  });
+});

--- a/apps/api/src/services/puede-cerrar-con-documentos.ts
+++ b/apps/api/src/services/puede-cerrar-con-documentos.ts
@@ -1,0 +1,88 @@
+import type { ExtractionStatus } from '@booster-ai/shared-schemas';
+
+/**
+ * Regla de cierre flexible (frente F4, ADR-070, dominio crítico).
+ *
+ * Función PURA que decide si una orden de transporte (`viajes`) puede
+ * transicionar a `entregado` según la política documental, aislada de la
+ * orquestación de DB/transacciones para ser testeable sin red.
+ *
+ * Invariantes (spec §7 + §10):
+ *   - `REQUIRE_DOCUMENT_TO_CLOSE=true` (default): la orden requiere ≥1
+ *     documento **subido** (la fila existe), independiente del estado de
+ *     extracción. Solo aplica a órdenes creadas en/después de la fecha de
+ *     corte (`REQUIRE_DOCUMENT_TO_CLOSE_SINCE`). Las órdenes legacy/en-curso
+ *     (creadas antes del corte) quedan EXENTAS — no se bloquea un viaje en
+ *     ruta por falta de documento.
+ *   - `REQUIRE_TED_DECODE=false` (default): el TED decodificado NO es
+ *     condición de cierre. Un documento subido cuyo TED quedó `fallido` o
+ *     `pendiente` igual permite cerrar. Con el override `=true`, se exige al
+ *     menos un documento `decodificado`.
+ *
+ * No toca la tabla de transiciones de `trip-state-machine`: la legalidad
+ * `asignado|en_proceso → entregado` no cambia; esto es una PRECONDICIÓN de
+ * negocio adicional.
+ */
+
+export interface FlagsCierreDocumental {
+  /** REQUIRE_DOCUMENT_TO_CLOSE. */
+  requireDocumentToClose: boolean;
+  /** REQUIRE_TED_DECODE. */
+  requireTedDecode: boolean;
+  /**
+   * Fecha de corte (REQUIRE_DOCUMENT_TO_CLOSE_SINCE). El guard solo aplica a
+   * órdenes con `creado_en >= esta fecha`. `null` => aplica a todas (sin
+   * exención legacy) cuando el flag está ON.
+   */
+  requireDocumentSince: Date | null;
+}
+
+export interface DocumentoParaCierre {
+  extractionStatus: ExtractionStatus;
+}
+
+export type RazonCierre =
+  | 'flag_off'
+  | 'orden_legacy_exenta'
+  | 'documento_requerido'
+  | 'ted_no_decodificado'
+  | 'documento_presente';
+
+export interface ResultadoCierreDocumental {
+  puedeCerrar: boolean;
+  razon: RazonCierre;
+}
+
+export function puedeCerrarConDocumentos(input: {
+  flags: FlagsCierreDocumental;
+  /** `viajes.creado_en` de la orden. */
+  tripCreatedAt: Date;
+  documentos: readonly DocumentoParaCierre[];
+}): ResultadoCierreDocumental {
+  const { flags, tripCreatedAt, documentos } = input;
+
+  // Flag OFF → sin precondición documental.
+  if (!flags.requireDocumentToClose) {
+    return { puedeCerrar: true, razon: 'flag_off' };
+  }
+
+  // Exención legacy: órdenes creadas antes del corte no requieren documento.
+  if (flags.requireDocumentSince !== null && tripCreatedAt < flags.requireDocumentSince) {
+    return { puedeCerrar: true, razon: 'orden_legacy_exenta' };
+  }
+
+  // Requiere ≥1 documento subido (fila existe), cualquier estado de extracción.
+  if (documentos.length === 0) {
+    return { puedeCerrar: false, razon: 'documento_requerido' };
+  }
+
+  // REQUIRE_TED_DECODE=true → exige al menos un documento decodificado.
+  if (flags.requireTedDecode) {
+    const hayDecodificado = documentos.some((d) => d.extractionStatus === 'decodificado');
+    if (!hayDecodificado) {
+      return { puedeCerrar: false, razon: 'ted_no_decodificado' };
+    }
+  }
+
+  return { puedeCerrar: true, razon: 'documento_presente' };
+}

--- a/apps/api/test/unit/transport-document-parity.test.ts
+++ b/apps/api/test/unit/transport-document-parity.test.ts
@@ -1,0 +1,29 @@
+import {
+  docTypeSchema,
+  documentSourceSchema,
+  extractionStatusSchema,
+} from '@booster-ai/shared-schemas';
+import { describe, expect, it } from 'vitest';
+import { docTypeEnum, documentSourceEnum, extractionStatusEnum } from '../../src/db/schema.js';
+
+/**
+ * Paridad DDL Drizzle (`documentos_transporte`) ↔ schema Zod de dominio
+ * (`@booster-ai/shared-schemas` transport-document). Frente F4-4a (ADR-070).
+ *
+ * El enum SQL y el enum Zod son espejos manuales (el package shared-schemas
+ * no importa Drizzle). Este test es la barrera anti-drift: cambiar un lado
+ * sin el otro rompe acá. Mismo patrón que trip-state-machine-parity.
+ */
+describe('paridad documentos_transporte ↔ enums Zod dominio', () => {
+  it('doc_type: DDL ≡ docTypeSchema (códigos SII literales + other)', () => {
+    expect(docTypeEnum.enumValues).toEqual(docTypeSchema.options);
+  });
+
+  it('extraction_status: DDL ≡ extractionStatusSchema (5 estados español)', () => {
+    expect(extractionStatusEnum.enumValues).toEqual(extractionStatusSchema.options);
+  });
+
+  it('source: DDL ≡ documentSourceSchema (3 orígenes)', () => {
+    expect(documentSourceEnum.enumValues).toEqual(documentSourceSchema.options);
+  });
+});

--- a/apps/api/test/unit/transport-documents-route.test.ts
+++ b/apps/api/test/unit/transport-documents-route.test.ts
@@ -1,0 +1,608 @@
+import { getTableName } from 'drizzle-orm';
+import { Hono } from 'hono';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+beforeAll(() => {
+  process.env.NODE_ENV = 'test';
+  process.env.DATABASE_URL = 'postgresql://test:test@localhost:5432/test';
+  process.env.GOOGLE_CLOUD_PROJECT = 'test';
+});
+
+// Mock GCS y Pub/Sub: el route los usa para archivar + publicar. Validamos el
+// wiring HTTP (auth, multipart, status codes), no la nube real.
+const saveMock = vi.fn(async () => undefined);
+const getSignedUrlMock = vi.fn(async () => ['https://signed.example/doc?sig=abc']);
+const fileMock = vi.fn(() => ({ save: saveMock, getSignedUrl: getSignedUrlMock }));
+const bucketMock = vi.fn(() => ({ file: fileMock }));
+vi.mock('@google-cloud/storage', () => ({
+  // `new Storage()` en el route → necesita un constructor real (no arrow).
+  Storage: class {
+    bucket = bucketMock;
+  },
+}));
+
+const publishMessageMock = vi.fn(async () => 'msg-id');
+const topicMock = vi.fn(() => ({ publishMessage: publishMessageMock }));
+vi.mock('@google-cloud/pubsub', () => ({
+  PubSub: class {
+    topic = topicMock;
+  },
+}));
+
+const { createTransportDocumentsRoutes, detectMagicByteMime } = await import(
+  '../../src/routes/transport-documents.js'
+);
+
+const noop = (): void => undefined;
+const logger = {
+  trace: noop,
+  debug: noop,
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  fatal: noop,
+  child: () => logger,
+} as never;
+
+const TRIP_ID = 'b3b8c1d2-0000-4000-8000-000000000100';
+const DOC_ID = 'b3b8c1d2-0000-4000-8000-000000000200';
+const SHIPPER_EMP = 'b3b8c1d2-0000-4000-8000-000000000300';
+const CARRIER_EMP = 'b3b8c1d2-0000-4000-8000-000000000400';
+const OTHER_EMP = 'b3b8c1d2-0000-4000-8000-000000000500';
+const USER_ID = 'b3b8c1d2-0000-4000-8000-000000000600';
+
+const userCtx = (empresaId: string, role = 'dueno') => ({
+  user: { id: USER_ID, email: 'u@e.cl' },
+  memberships: [],
+  activeMembership: { empresa: { id: empresaId }, membership: { role } },
+});
+
+interface DbScenario {
+  /** trip row (o null si no existe). */
+  trip?: { generadorCargaEmpresaId: string } | null;
+  /**
+   * assignment row del trip (o null). `status` opcional (default 'asignado'):
+   * el route filtra por estados vigentes (excluye 'cancelado', finding 2), y el
+   * mock replica ese filtro para que el test valide comportamiento, no solo SQL.
+   */
+  assignment?: { empresaId: string; status?: string } | null;
+  /** doc row para manual-entry / GET detail. */
+  doc?: {
+    id: string;
+    viajeId: string;
+    createdAt: Date;
+    filePath: string;
+    docType: string;
+    fileMime: string;
+    extractionStatus: string;
+    source: string;
+    folio: string | null;
+    rutEmisor: string | null;
+    razonSocialEmisor: string | null;
+    rutReceptor: string | null;
+    razonSocialReceptor: string | null;
+    fechaEmision: string | null;
+    montoTotal: string | null;
+    tedSignatureValid: boolean | null;
+    retentionUntil: string | null;
+  } | null;
+  /** lista de docs para GET listado. */
+  list?: unknown[];
+  insertedId?: string;
+}
+
+const updateSetSpy = vi.fn();
+const insertValuesSpy = vi.fn();
+
+function makeDb(s: DbScenario) {
+  // El route hace varios .select() en orden distinto según endpoint. Usamos
+  // getTableName en runtime para decidir qué devolver, igual que el service test.
+  const select = vi.fn(() => {
+    let table: string | undefined;
+    const chain: Record<string, unknown> = {};
+    chain.from = vi.fn((t: unknown) => {
+      try {
+        table = getTableName(t);
+      } catch {
+        table = undefined;
+      }
+      return chain;
+    });
+    chain.where = vi.fn(() => chain);
+    chain.orderBy = vi.fn(() => chain); // GET listado: await sobre el chain
+    const rows = (): unknown[] => {
+      if (table === 'viajes') {
+        return s.trip ? [{ id: TRIP_ID, ...s.trip }] : [];
+      }
+      if (table === 'asignaciones') {
+        // Replica el filtro `inArray(status, ESTADOS_VIGENTES)` del route: un
+        // assignment 'cancelado' NO se devuelve (como en SQL real). Default
+        // 'asignado' (vigente) para los assignments que no fijan status.
+        if (!s.assignment) {
+          return [];
+        }
+        const status = s.assignment.status ?? 'asignado';
+        const vigentes = ['asignado', 'recogido', 'entregado'];
+        return vigentes.includes(status) ? [s.assignment] : [];
+      }
+      if (table === 'documentos_transporte') {
+        // GET listado no usa .limit; manual-entry/detail sí.
+        return s.doc ? [s.doc] : (s.list ?? []);
+      }
+      return [];
+    };
+    chain.then = (resolve: (r: unknown[]) => void) => resolve(rows());
+    chain.limit = vi.fn(async () => rows());
+    return chain;
+  });
+
+  const insert = vi.fn(() => ({
+    values: vi.fn((v: unknown) => {
+      insertValuesSpy(v);
+      return { returning: vi.fn(async () => [{ id: s.insertedId ?? DOC_ID }]) };
+    }),
+  }));
+
+  const update = vi.fn(() => ({
+    set: vi.fn((v: unknown) => {
+      updateSetSpy(v);
+      return { where: vi.fn(async () => undefined) };
+    }),
+  }));
+
+  return { select, insert, update } as never;
+}
+
+function buildApp(db: unknown, empresaId: string, withBucketTopic = true, role = 'dueno') {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('userContext', userCtx(empresaId, role));
+    await next();
+  });
+  app.route(
+    '/',
+    createTransportDocumentsRoutes({
+      db: db as never,
+      logger,
+      ...(withBucketTopic
+        ? { transportDocumentsBucket: 'documents-test', documentUploadedTopic: 'document.uploaded' }
+        : {}),
+    }),
+  );
+  return app;
+}
+
+// Magic bytes reales (el route valida el CONTENIDO, no solo file.type).
+const PDF_MAGIC = [0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]; // "%PDF-1.7"
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function pdfForm(): FormData {
+  const fd = new FormData();
+  fd.append('file', new File([new Uint8Array(PDF_MAGIC)], 'g.pdf', { type: 'application/pdf' }));
+  return fd;
+}
+
+beforeEach(() => {
+  saveMock.mockClear();
+  publishMessageMock.mockClear();
+  insertValuesSpy.mockClear();
+  updateSetSpy.mockClear();
+  getSignedUrlMock.mockClear();
+});
+
+describe('POST /transport-orders/:id/documents', () => {
+  it('PDF válido del shipper dueño → 202, GCS save, fila pendiente, publish', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(202);
+    const json = (await res.json()) as { document_id: string; extraction_status: string };
+    expect(json.extraction_status).toBe('pendiente');
+    expect(saveMock).toHaveBeenCalledTimes(1);
+    expect(publishMessageMock).toHaveBeenCalledTimes(1);
+    expect(insertValuesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        viajeId: TRIP_ID,
+        extractionStatus: 'pendiente',
+        source: 'pdf_upload',
+        docType: 'other',
+      }),
+    );
+  });
+
+  it('carrier asignado puede subir (autorizado vía assignment)', async () => {
+    const db = makeDb({
+      trip: { generadorCargaEmpresaId: SHIPPER_EMP },
+      assignment: { empresaId: CARRIER_EMP },
+    });
+    const app = buildApp(db, CARRIER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(202);
+  });
+
+  it('IDOR: empresa ajena → 403', async () => {
+    const db = makeDb({
+      trip: { generadorCargaEmpresaId: SHIPPER_EMP },
+      assignment: { empresaId: CARRIER_EMP },
+    });
+    const app = buildApp(db, OTHER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(403);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('trip inexistente → 404', async () => {
+    const db = makeDb({ trip: null });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('MIME no permitido → 400', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP);
+    const fd = new FormData();
+    fd.append('file', new File([new Uint8Array([1])], 'x.txt', { type: 'text/plain' }));
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: fd,
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('sin file → 400', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: new FormData(),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('sin bucket configurado → 503', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP, false);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  // Finding 4 (role gate): solo dueño/admin/despachador pueden escribir.
+  it('rol visualizador → 403 write_role_required (sin tocar GCS)', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP, true, 'visualizador');
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe('write_role_required');
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('rol conductor → 403 write_role_required', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP, true, 'conductor');
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe('write_role_required');
+  });
+
+  it('rol despachador SÍ puede subir → 202', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP, true, 'despachador');
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(202);
+  });
+
+  // Finding 3 (magic bytes): contenido que no coincide con el MIME declarado.
+  it('PDF declarado pero contenido no-PDF → 400 mime_mismatch (sin subir a GCS)', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP);
+    const fd = new FormData();
+    // file.type miente: dice PDF pero el contenido son bytes basura.
+    fd.append(
+      'file',
+      new File([new Uint8Array([0x00, 0x01, 0x02, 0x03])], 'fake.pdf', {
+        type: 'application/pdf',
+      }),
+    );
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: fd,
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe('mime_mismatch');
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('contenido PNG declarado como JPEG → 400 mime_mismatch', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP);
+    const fd = new FormData();
+    fd.append(
+      'file',
+      new File([new Uint8Array(PNG_MAGIC)], 'mislabeled.jpg', { type: 'image/jpeg' }),
+    );
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: fd,
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe('mime_mismatch');
+  });
+
+  it('PNG válido (magic bytes correctos) → 202', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP } });
+    const app = buildApp(db, SHIPPER_EMP);
+    const fd = new FormData();
+    fd.append('file', new File([new Uint8Array(PNG_MAGIC)], 'g.png', { type: 'image/png' }));
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: fd,
+    });
+    expect(res.status).toBe(202);
+    expect(saveMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Finding 2: assignment CANCELADO no autoriza al carrier.
+  it('carrier con assignment cancelado → 403 (assignment cancelado no autoriza)', async () => {
+    const db = makeDb({
+      trip: { generadorCargaEmpresaId: SHIPPER_EMP },
+      assignment: { empresaId: CARRIER_EMP, status: 'cancelado' },
+    });
+    const app = buildApp(db, CARRIER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(403);
+    expect(saveMock).not.toHaveBeenCalled();
+  });
+
+  it('carrier con assignment recogido (vigente) SÍ autoriza → 202', async () => {
+    const db = makeDb({
+      trip: { generadorCargaEmpresaId: SHIPPER_EMP },
+      assignment: { empresaId: CARRIER_EMP, status: 'recogido' },
+    });
+    const app = buildApp(db, CARRIER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`, {
+      method: 'POST',
+      body: pdfForm(),
+    });
+    expect(res.status).toBe(202);
+  });
+});
+
+const docRow = (overrides: Record<string, unknown> = {}) => ({
+  id: DOC_ID,
+  viajeId: TRIP_ID,
+  createdAt: new Date('2026-06-18T10:00:00.000Z'),
+  filePath: `transport-documents/${TRIP_ID}/x.pdf`,
+  docType: 'other',
+  fileMime: 'application/pdf',
+  extractionStatus: 'fallido',
+  source: 'pdf_upload',
+  folio: null,
+  rutEmisor: null,
+  razonSocialEmisor: null,
+  rutReceptor: null,
+  razonSocialReceptor: null,
+  fechaEmision: null,
+  montoTotal: null,
+  tedSignatureValid: null,
+  retentionUntil: null,
+  ...overrides,
+});
+
+describe('POST /documents/:id/manual-entry', () => {
+  it('corrige campos del shipper dueño → 200, ingreso_manual, retention recalculada', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP }, doc: docRow() });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/documents/${DOC_ID}/manual-entry`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ doc_type: '52', folio: '999', fecha_emision: '2026-06-15' }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { extraction_status: string; retention_until: string };
+    expect(json.extraction_status).toBe('ingreso_manual');
+    expect(json.retention_until).toBe('2032-06-15');
+    expect(updateSetSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        docType: '52',
+        folio: '999',
+        fechaEmision: '2026-06-15',
+        extractionStatus: 'ingreso_manual',
+        retentionUntil: '2032-06-15',
+      }),
+    );
+  });
+
+  it('sin fecha_emision → retention fallback created_at + 6a', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP }, doc: docRow() });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/documents/${DOC_ID}/manual-entry`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ folio: '123' }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { retention_until: string };
+    expect(json.retention_until).toBe('2032-06-18');
+  });
+
+  it('body vacío → 400 (Zod refine)', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP }, doc: docRow() });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/documents/${DOC_ID}/manual-entry`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it('IDOR empresa ajena → 403', async () => {
+    const db = makeDb({
+      trip: { generadorCargaEmpresaId: SHIPPER_EMP },
+      assignment: { empresaId: CARRIER_EMP },
+      doc: docRow(),
+    });
+    const app = buildApp(db, OTHER_EMP);
+    const res = await app.request(`/documents/${DOC_ID}/manual-entry`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ folio: '1' }),
+    });
+    expect(res.status).toBe(403);
+    expect(updateSetSpy).not.toHaveBeenCalled();
+  });
+
+  it('documento inexistente → 404', async () => {
+    const db = makeDb({ doc: null });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/documents/${DOC_ID}/manual-entry`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ folio: '1' }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // Finding 4 (role gate) también aplica a manual-entry.
+  it('rol visualizador → 403 write_role_required (sin UPDATE)', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP }, doc: docRow() });
+    const app = buildApp(db, SHIPPER_EMP, true, 'visualizador');
+    const res = await app.request(`/documents/${DOC_ID}/manual-entry`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ folio: '1' }),
+    });
+    expect(res.status).toBe(403);
+    const json = (await res.json()) as { code: string };
+    expect(json.code).toBe('write_role_required');
+    expect(updateSetSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /transport-orders/:id/documents', () => {
+  it('lista los documentos de la orden (shipper dueño)', async () => {
+    const db = makeDb({
+      trip: { generadorCargaEmpresaId: SHIPPER_EMP },
+      list: [{ id: DOC_ID, extractionStatus: 'pendiente' }],
+    });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { documents: unknown[] };
+    expect(json.documents).toHaveLength(1);
+  });
+
+  it('IDOR empresa ajena → 403', async () => {
+    const db = makeDb({
+      trip: { generadorCargaEmpresaId: SHIPPER_EMP },
+      assignment: { empresaId: CARRIER_EMP },
+      list: [],
+    });
+    const app = buildApp(db, OTHER_EMP);
+    const res = await app.request(`/transport-orders/${TRIP_ID}/documents`);
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('GET /documents/:id', () => {
+  it('detalle + signed URL v4 (shipper dueño)', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP }, doc: docRow() });
+    const app = buildApp(db, SHIPPER_EMP);
+    const res = await app.request(`/documents/${DOC_ID}`);
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { document: { id: string }; download_url: string };
+    expect(json.document.id).toBe(DOC_ID);
+    expect(json.download_url).toContain('https://signed.example');
+    expect(getSignedUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({ version: 'v4', action: 'read' }),
+    );
+  });
+
+  it('IDOR empresa ajena → 403', async () => {
+    const db = makeDb({
+      trip: { generadorCargaEmpresaId: SHIPPER_EMP },
+      assignment: { empresaId: CARRIER_EMP },
+      doc: docRow(),
+    });
+    const app = buildApp(db, OTHER_EMP);
+    const res = await app.request(`/documents/${DOC_ID}`);
+    expect(res.status).toBe(403);
+  });
+
+  // Finding 4: los GET NO tienen role gate — visualizador puede leer.
+  it('rol visualizador SÍ puede leer detalle (GET sin role gate) → 200', async () => {
+    const db = makeDb({ trip: { generadorCargaEmpresaId: SHIPPER_EMP }, doc: docRow() });
+    const app = buildApp(db, SHIPPER_EMP, true, 'visualizador');
+    const res = await app.request(`/documents/${DOC_ID}`);
+    expect(res.status).toBe(200);
+  });
+});
+
+// Finding 3: validación de magic bytes (función pura).
+describe('detectMagicByteMime', () => {
+  it('detecta PDF por "%PDF"', () => {
+    expect(detectMagicByteMime(new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d]))).toBe(
+      'application/pdf',
+    );
+  });
+
+  it('detecta JPEG por FF D8 FF', () => {
+    expect(detectMagicByteMime(new Uint8Array([0xff, 0xd8, 0xff, 0xe0]))).toBe('image/jpeg');
+  });
+
+  it('detecta PNG por su firma de 8 bytes', () => {
+    expect(
+      detectMagicByteMime(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])),
+    ).toBe('image/png');
+  });
+
+  it('null para contenido que no coincide con ningún tipo permitido', () => {
+    expect(detectMagicByteMime(new Uint8Array([0x00, 0x01, 0x02, 0x03]))).toBeNull();
+  });
+
+  it('null para buffer más corto que la firma (no out-of-bounds match)', () => {
+    // 0x89 0x50 son el prefijo de PNG pero el buffer es demasiado corto.
+    expect(detectMagicByteMime(new Uint8Array([0x89, 0x50]))).toBeNull();
+  });
+
+  it('null para buffer vacío', () => {
+    expect(detectMagicByteMime(new Uint8Array([]))).toBeNull();
+  });
+
+  it('no confunde JPEG-prefijo con PDF (FF D8 no es %PDF)', () => {
+    // Defensa: un PNG que NO termina su firma completa no debe matchear PNG.
+    expect(detectMagicByteMime(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x00]))).toBeNull();
+  });
+});

--- a/infrastructure/messaging.tf
+++ b/infrastructure/messaging.tf
@@ -14,6 +14,7 @@ locals {
     "telemetry-events-security-p1",      # Wave 2: Tow/Auto Geofence → notification
     "telemetry-events-eco-score",        # Wave 2: Idling/Green/Speed → matching-algorithm
     "telemetry-events-trip-transitions", # Wave 2: Trip start-end/Geofence → trip-state-machine
+    "document.uploaded",                 # F4-4a: api → worker TED (document-service, 4b)
   ]
 }
 
@@ -101,6 +102,23 @@ resource "google_pubsub_topic" "chat_messages" {
     managed_by = "terraform"
   }
   message_retention_duration = "3600s" # 1h
+  depends_on                 = [google_project_service.apis]
+}
+
+# Repositorio documental de transporte (ADR-070, frente F4). El api publica acá
+# tras persistir una fila `pendiente` en `documentos_transporte` (endpoint de
+# subida, 4a). El worker TED (apps/document-service, sub-fase 4b) lo consume,
+# decodifica el TED PDF417 y actualiza la fila. El consumer NO existe aún en 4a.
+resource "google_pubsub_topic" "document_uploaded" {
+  name    = "document.uploaded"
+  project = google_project.booster_ai.project_id
+  labels = {
+    env        = var.environment
+    managed_by = "terraform"
+    consumer   = "document-service"
+  }
+  # 7 días: documentos tributarios no se pueden perder si el worker está caído.
+  message_retention_duration = "604800s"
   depends_on                 = [google_project_service.apis]
 }
 
@@ -225,6 +243,45 @@ resource "google_pubsub_subscription" "telemetry_events_processor" {
     env        = var.environment
     managed_by = "terraform"
     consumer   = "telemetry-processor"
+  }
+}
+
+# F4-4a — Subscription pull dedicada del worker TED (apps/document-service, 4b).
+# Patrón idéntico a telemetry_events_processor: pull, DLQ tras 5 nack/timeout,
+# retry exponencial. El consumer se implementa en 4b; la infra se provisiona
+# acá (4a) para que el endpoint de subida ya pueda publicar al topic.
+resource "google_pubsub_subscription" "document_uploaded_processor" {
+  name    = "document-uploaded-processor-sub"
+  topic   = google_pubsub_topic.document_uploaded.name
+  project = google_project.booster_ai.project_id
+
+  # 120s: rasterizar PDF + decodificar PDF417 + parsear TED puede tardar.
+  ack_deadline_seconds = 120
+
+  # 7 días de retención en el broker para tolerar downtime del worker.
+  message_retention_duration = "604800s"
+
+  # Subscription perpetua — el worker no debería borrarse sin update aquí.
+  expiration_policy {
+    ttl = ""
+  }
+
+  # DLQ: tras 5 nack/timeout, el mensaje va a pubsub-dead-letter.
+  dead_letter_policy {
+    dead_letter_topic     = google_pubsub_topic.dlq.id
+    max_delivery_attempts = 5
+  }
+
+  # Retry exponencial entre 10s y 600s.
+  retry_policy {
+    minimum_backoff = "10s"
+    maximum_backoff = "600s"
+  }
+
+  labels = {
+    env        = var.environment
+    managed_by = "terraform"
+    consumer   = "document-service"
   }
 }
 

--- a/packages/logger/src/redaction.test.ts
+++ b/packages/logger/src/redaction.test.ts
@@ -30,6 +30,13 @@ describe('redactionPaths', () => {
     expect(redactionPaths).toContain('*.credit_card');
   });
 
+  it('incluye RUTs de documentos tributarios de transporte (emisor/receptor, ambas convenciones)', () => {
+    expect(redactionPaths).toContain('*.rutEmisor');
+    expect(redactionPaths).toContain('*.rut_emisor');
+    expect(redactionPaths).toContain('*.rutReceptor');
+    expect(redactionPaths).toContain('*.rut_receptor');
+  });
+
   it('incluye datos de pago (creditCard, cvv, cvc)', () => {
     expect(redactionPaths).toContain('*.creditCard');
     expect(redactionPaths).toContain('*.cvv');

--- a/packages/logger/src/redaction.ts
+++ b/packages/logger/src/redaction.ts
@@ -34,6 +34,14 @@ export const redactionPaths: string[] = [
   '*.phoneNumber',
   '*.phone_number',
   '*.rut',
+  // Variantes de RUT en documentos tributarios de transporte (review F4-4a
+  // finding 6): emisor/receptor en camelCase (manual-entry body) y snake_case
+  // (payloads/rows DB). Defensa en profundidad — la value-based redaction ya
+  // cubre RUTs en strings, esto los redacta también por path.
+  '*.rutEmisor',
+  '*.rut_emisor',
+  '*.rutReceptor',
+  '*.rut_receptor',
   '*.dni',
   '*.passport',
   '*.ssn',

--- a/packages/shared-schemas/src/domain/transport-document.test.ts
+++ b/packages/shared-schemas/src/domain/transport-document.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import {
+  docTypeSchema,
+  documentSourceSchema,
+  extractionStatusSchema,
+  transportDocumentManualEntryInputSchema,
+  transportDocumentSchema,
+} from './transport-document.js';
+
+describe('docTypeSchema', () => {
+  it('acepta los códigos SII y other', () => {
+    for (const v of ['33', '34', '52', '56', '61', 'other']) {
+      expect(docTypeSchema.parse(v)).toBe(v);
+    }
+  });
+
+  it('rechaza un código fuera del enum', () => {
+    expect(() => docTypeSchema.parse('99')).toThrow();
+  });
+});
+
+describe('extractionStatusSchema', () => {
+  it('acepta los 5 estados en español', () => {
+    for (const v of ['pendiente', 'procesando', 'decodificado', 'ingreso_manual', 'fallido']) {
+      expect(extractionStatusSchema.parse(v)).toBe(v);
+    }
+  });
+
+  it('rechaza un estado en inglés (naming bilingüe)', () => {
+    expect(() => extractionStatusSchema.parse('pending')).toThrow();
+  });
+});
+
+describe('documentSourceSchema', () => {
+  it('acepta los 3 orígenes', () => {
+    for (const v of ['pdf_upload', 'photo_upload', 'xml_intercambio']) {
+      expect(documentSourceSchema.parse(v)).toBe(v);
+    }
+  });
+
+  it('rechaza un origen desconocido', () => {
+    expect(() => documentSourceSchema.parse('email_upload')).toThrow();
+  });
+});
+
+describe('transportDocumentSchema', () => {
+  const base = {
+    id: 'b3b8c1d2-0000-4000-8000-000000000001',
+    viaje_id: 'b3b8c1d2-0000-4000-8000-000000000002',
+    file_path: 'transport-documents/abc/doc.pdf',
+    file_mime: 'application/pdf',
+    doc_type: '52' as const,
+    folio: null,
+    rut_emisor: null,
+    razon_social_emisor: null,
+    rut_receptor: null,
+    razon_social_receptor: null,
+    fecha_emision: null,
+    monto_total: null,
+    ted_raw: null,
+    ted_signature_valid: null,
+    extraction_status: 'pendiente' as const,
+    source: 'pdf_upload' as const,
+    retention_until: null,
+    uploaded_by: 'b3b8c1d2-0000-4000-8000-000000000003',
+    creado_en: '2026-06-18T10:00:00.000Z',
+    actualizado_en: '2026-06-18T10:00:00.000Z',
+  };
+
+  it('parsea una fila recién subida (pendiente, campos TED null)', () => {
+    const parsed = transportDocumentSchema.parse(base);
+    expect(parsed.extraction_status).toBe('pendiente');
+    expect(parsed.folio).toBeNull();
+    expect(parsed.ted_signature_valid).toBeNull();
+  });
+
+  it('parsea una fila decodificada con campos del <DD>', () => {
+    const parsed = transportDocumentSchema.parse({
+      ...base,
+      doc_type: '52',
+      folio: '12345',
+      rut_emisor: '76123456-7',
+      rut_receptor: '77000000-0',
+      razon_social_receptor: 'Generador Carga SpA',
+      fecha_emision: '2026-06-15',
+      monto_total: '1500000.00',
+      ted_raw: '<TED>...</TED>',
+      ted_signature_valid: true,
+      extraction_status: 'decodificado',
+      retention_until: '2032-06-15',
+    });
+    expect(parsed.monto_total).toBe('1500000.00');
+    expect(parsed.ted_signature_valid).toBe(true);
+  });
+
+  it('rechaza extraction_status fuera del enum', () => {
+    expect(() => transportDocumentSchema.parse({ ...base, extraction_status: 'done' })).toThrow();
+  });
+
+  it('uploaded_by puede ser null', () => {
+    const parsed = transportDocumentSchema.parse({ ...base, uploaded_by: null });
+    expect(parsed.uploaded_by).toBeNull();
+  });
+});
+
+describe('transportDocumentManualEntryInputSchema', () => {
+  it('acepta una corrección parcial', () => {
+    const parsed = transportDocumentManualEntryInputSchema.parse({
+      doc_type: '52',
+      folio: '999',
+      fecha_emision: '2026-06-15',
+      monto_total: '1000000.00',
+    });
+    expect(parsed.folio).toBe('999');
+  });
+
+  it('rechaza un body vacío (al menos un campo)', () => {
+    expect(() => transportDocumentManualEntryInputSchema.parse({})).toThrow();
+  });
+
+  it('rechaza fecha_emision con formato no ISO', () => {
+    expect(() =>
+      transportDocumentManualEntryInputSchema.parse({ fecha_emision: '15-06-2026' }),
+    ).toThrow();
+  });
+
+  it('rechaza monto_total con más de 2 decimales', () => {
+    expect(() =>
+      transportDocumentManualEntryInputSchema.parse({ monto_total: '1000.999' }),
+    ).toThrow();
+  });
+});

--- a/packages/shared-schemas/src/domain/transport-document.ts
+++ b/packages/shared-schemas/src/domain/transport-document.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import { tripRequestIdSchema, userIdSchema, uuidSchema } from '../primitives/ids.js';
+
+/**
+ * TransportDocument = documento tributario de un tercero (Guía de Despacho
+ * DTE 52, Factura 33, etc.) que ampara la carga de una orden de transporte
+ * (`viajes`). Booster lo **recibe y archiva** — NO emite ni se integra con
+ * el SII (ADR-069 / ADR-070, frente F4).
+ *
+ * Naming bilingüe (ver CLAUDE.md): la tabla SQL es `documentos_transporte`,
+ * el export TS es `transportDocuments` / `TransportDocumentRow`. Los valores
+ * de enum van en español snake_case sin tildes, EXCEPTO `doc_type`, cuyos
+ * valores son los códigos literales del SII (`33`/`34`/`52`/`56`/`61`) más
+ * `other` para tipos no esperados.
+ *
+ * El DDL Drizzle canónico vive en `apps/api/src/db/schema.ts` y debe tener
+ * paridad 1:1 de campos/enums con este schema (test de paridad).
+ */
+
+/**
+ * Tipo de documento tributario. Los códigos numéricos son los del SII
+ * (33=Factura electrónica, 34=Factura exenta, 52=Guía de Despacho,
+ * 56=Nota de Débito, 61=Nota de Crédito). `other` cubre tipos no esperados
+ * sin romper el insert.
+ */
+export const docTypeSchema = z.enum(['33', '34', '52', '56', '61', 'other']);
+export type DocType = z.infer<typeof docTypeSchema>;
+
+/**
+ * Estado de extracción del TED. `pendiente` al subir; el worker (4b) lo
+ * mueve a `procesando` → `decodificado` o `fallido`. `ingreso_manual` lo
+ * setea el endpoint de corrección manual cuando el usuario completa los
+ * campos a mano.
+ */
+export const extractionStatusSchema = z.enum([
+  'pendiente',
+  'procesando',
+  'decodificado',
+  'ingreso_manual',
+  'fallido',
+]);
+export type ExtractionStatus = z.infer<typeof extractionStatusSchema>;
+
+/**
+ * Origen del documento. `pdf_upload`/`photo_upload` desde el endpoint de
+ * subida (4a); `xml_intercambio` reservado para el canal de Intercambio
+ * entre Contribuyentes (stub en 4c).
+ */
+export const documentSourceSchema = z.enum(['pdf_upload', 'photo_upload', 'xml_intercambio']);
+export type DocumentSource = z.infer<typeof documentSourceSchema>;
+
+/**
+ * Schema de dominio canónico de un documento de transporte. Paridad 1:1 con
+ * la tabla `documentos_transporte`. Campos nullable hasta que el worker (4b)
+ * o el manual-entry (4a) los pueblen.
+ */
+export const transportDocumentSchema = z.object({
+  id: uuidSchema,
+  viaje_id: tripRequestIdSchema,
+  file_path: z.string().min(1),
+  file_mime: z.string().min(1),
+  doc_type: docTypeSchema,
+  folio: z.string().nullable(),
+  rut_emisor: z.string().nullable(),
+  razon_social_emisor: z.string().nullable(),
+  rut_receptor: z.string().nullable(),
+  razon_social_receptor: z.string().nullable(),
+  /** ISO date (YYYY-MM-DD) del `<DD><FE>`. Insumo de `retention_until`. */
+  fecha_emision: z.string().nullable(),
+  /** Monto total como string decimal (numeric(14,2) en SQL). */
+  monto_total: z.string().nullable(),
+  ted_raw: z.string().nullable(),
+  /** NULL = firma no validada (flag off); true/false = validada. */
+  ted_signature_valid: z.boolean().nullable(),
+  extraction_status: extractionStatusSchema,
+  source: documentSourceSchema,
+  /** ISO date (YYYY-MM-DD) hasta el cual se conserva el documento. */
+  retention_until: z.string().nullable(),
+  uploaded_by: userIdSchema.nullable(),
+  creado_en: z.string().datetime(),
+  actualizado_en: z.string().datetime(),
+});
+export type TransportDocument = z.infer<typeof transportDocumentSchema>;
+
+/**
+ * Input del endpoint de corrección manual (`POST /documents/:id/manual-entry`).
+ * Todos los campos opcionales: el usuario corrige solo los que conoce. Al
+ * menos uno debe venir (validado en el handler / refine).
+ */
+export const transportDocumentManualEntryInputSchema = z
+  .object({
+    doc_type: docTypeSchema.optional(),
+    folio: z.string().min(1).max(40).optional(),
+    rut_emisor: z.string().min(1).max(20).optional(),
+    razon_social_emisor: z.string().min(1).max(200).optional(),
+    rut_receptor: z.string().min(1).max(20).optional(),
+    razon_social_receptor: z.string().min(1).max(200).optional(),
+    /** ISO date YYYY-MM-DD. */
+    fecha_emision: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, 'fecha_emision debe ser ISO date YYYY-MM-DD')
+      .optional(),
+    /** Monto total como string decimal. */
+    monto_total: z
+      .string()
+      .regex(/^\d{1,12}(\.\d{1,2})?$/, 'monto_total debe ser decimal con hasta 2 decimales')
+      .optional(),
+  })
+  .refine((v) => Object.values(v).some((x) => x !== undefined), {
+    message: 'al menos un campo debe ser provisto',
+  });
+export type TransportDocumentManualEntryInput = z.infer<
+  typeof transportDocumentManualEntryInputSchema
+>;

--- a/packages/shared-schemas/src/index.ts
+++ b/packages/shared-schemas/src/index.ts
@@ -68,3 +68,7 @@ export * from './domain/signup-request.js';
 
 // Safety events — Pub/Sub payload para topic safety-p0 (feat/safety-event-fanout)
 export * from './domain/safety-event.js';
+
+// Repositorio documental de transporte — recepción/archivo de DTE de terceros
+// (ADR-070, frente F4). Booster NO emite DTE (ADR-069), solo recibe/archiva.
+export * from './domain/transport-document.js';


### PR DESCRIPTION
## Resumen

**Sub-fase 4a de F4** (repositorio documental de terceros): datos + API + cierre flexible. **NO incluye** el worker TED (4b) ni el stub XML (4c). La feature queda **"dark" en prod** hasta el cableado de infra — degradación segura a `503` sin el bucket configurado.

## Cambios

- **Datos**: migración `0044` `documentos_transporte` (expand-only, FK `viaje_id` RESTRICT, enums español, `retention_until`) + schema Drizzle + Zod de dominio en `shared-schemas`.
- **API** (4 endpoints Hono): POST upload (multipart→GCS→`202`), POST manual-entry, GET listado, GET detalle+signed URL. **Autorización multitenant** (shipper-owner | carrier con assignment **vigente**).
- **Cierre flexible**: `REQUIRE_DOCUMENT_TO_CLOSE` exige ≥1 documento subido **solo en órdenes nuevas** (`viajes.creado_en ≥ corte`; legacy/en-curso exentas). `REQUIRE_TED_DECODE=false` (el TED no es condición). Guard en `confirmar-entrega-viaje` (no toca `trip-state-machine`).
- **Retención**: `retention_until = fecha_emision + 6a` (fallback `created_at+6a`); sin purga (O-3).
- **Infra**: topic `document.uploaded` + subscription + DLQ en `messaging.tf` (el consumer es 4b).

## Seguridad (6 mustFix de review aplicados + re-review aprobado)
- **Role gate** `dueno/admin/despachador` en escrituras (`visualizador`/`conductor` → `403`).
- `authorizeOverTrip` **excluye assignments cancelados**.
- **Magic bytes** (PDF/JPEG/PNG) — no solo `Content-Type` → `400 mime_mismatch`.
- **Rate limiting** Redis fail-closed (20/60s, solo escrituras, `503` fail-closed).
- RUTs (`rutEmisor`/`rutReceptor`) en `redactionPaths` de Pino.
- **Zero `any`**: Context de Hono tipado correctamente (no silenciado).

## Evidencia
```
api typecheck: 0 ; shared-schemas typecheck: 0
api tests: 1545 passed | 2 skipped ; shared-schemas: 228 ; logger: 56
biome: 0 ; frozen-lockfile: consistente ; migration-safety 0044: OK (expand-only)
```
TDD red→green. Reviews adversariales: spec-compliance ✅, deuda ✅, **seguridad rechazó → 6 mustFix aplicados → re-review ✅** (5 findings P1/P2 cerrados).

## ⚠️ Pendiente antes del go-live (NO bloquea el merge del código — degrada a 503 sin esto)
- **Infra**: cablear env (`TRANSPORT_DOCUMENTS_BUCKET`, `DOCUMENT_UPLOADED_TOPIC`, `REQUIRE_DOCUMENT_TO_CLOSE*`, `REQUIRE_TED_DECODE`) en `compute.tf` (`service_api`) + **IAM `objectCreator`** del SA api sobre el bucket `documents`.
- **4b** (worker TED) + **4c** (stub XML).
- **ADR-070** `Proposed`→`Accepted` (sign-off legal de custodia).
- **O-7 rollout**: confirmar órdenes en curso antes de activar `REQUIRE_DOCUMENT_TO_CLOSE`.
- **Migración `0044`**: colisión con #428 → renumerar a `0045` si #428 entra antes.

## Notas (informacional, del re-review — sin impacto de seguridad)
- N1: manual-entry/GET detalle responden `403` (no `404`) si el viaje no existe — imposible por la FK `RESTRICT`.
- N2: GET detalle hace `SELECT *` antes del authz (PII en memoria, **no** se filtra al cliente); mejora de mínimo-privilegio para una iteración futura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
