### PR TITLE
chore(infra): preflight de placeholder en secrets validados (INC-2026-06-19)

### DIFF
--- a/docs/incidents/INC-2026-06-19-content-sid-placeholder-startup.md
+++ b/docs/incidents/INC-2026-06-19-content-sid-placeholder-startup.md
@@ -1,0 +1,68 @@
+# INC-2026-06-19 — `terraform apply` mountó un content-sid placeholder → `service_api` no arranca
+
+| Campo | Valor |
+|---|---|
+| **Severidad** | SEV-2 (deploys/rollforward bloqueados; **sin impacto a usuarios**) |
+| **Estado** | Mitigado (prod siempre sirvió la revisión sana); resolución en curso (poblar el SID real) |
+| **Detectado por** | Felipe Vicencio (PO) — error de `terraform apply` en su terminal |
+| **Servicio** | `booster-ai-api` (Cloud Run, southamerica-west1) |
+| **Fecha** | 2026-06-18 ~22:10 America/Santiago (2026-06-19 ~02:10 UTC) |
+| **Síntoma** | `Error waiting for Updating Service: ... container failed the configured startup probe checks` (revisión `booster-ai-api-00363/00364`) |
+
+## Resumen
+
+Durante el cierre de infraestructura de F4/F3 (PR #503), un `terraform apply` —que además barría **drift preexistente**— creó el secreto `content-sid-safety-alert` con su valor **placeholder** (`ROTATE_ME_CONTENT_SID_SAFETY_ALERT_PLACEHOLDER`) y lo montó en `service_api` como `CONTENT_SID_SAFETY_ALERT`. El api valida ese env var con `^HX[a-fA-F0-9]+$` (Twilio Content SID) en `apps/api/src/config.ts`. El placeholder no matchea → el api responde **"Invalid environment configuration. Refusing to start." → exit(1)** → la revisión nueva falla el startup probe.
+
+**No hubo impacto a usuarios**: Cloud Run no enruta tráfico a una revisión que falla su probe, así que `booster-ai-api-00407` (revisión sana, que NO montaba el secreto) siguió sirviendo el 100%. El daño real fue **bloquear deploys/rollforward**: toda revisión nueva —incluido el próximo deploy de cloudbuild— montaría el placeholder y fallaría.
+
+## Impacto
+
+- **Usuarios**: ninguno. Prod sirvió ininterrumpidamente en `00407`.
+- **Operacional**: `service_api` quedó sin poder crear revisiones nuevas hasta poblar el valor real. Las release approvals pendientes (#495–#502) no podían desplegarse.
+- **Datos**: ninguno. (Los 2 secretos `dte-provider-*` sí se destruyeron — acción autorizada e intencional, no parte del incidente.)
+
+## Línea de tiempo (referencia)
+
+1. PR #503 (cablear bucket F4 + retirar secretos DTE) aprobado para apply; el plan mostraba `4 add / 10 change / 4 destroy`, incluyendo **drift preexistente** (topic `document.uploaded`, secreto `content-sid-safety-alert`).
+2. `terraform apply`: creó pubsub + `content-sid-safety-alert` (placeholder) + actualizó `service_document` (sano) y **falló** al actualizar `service_api` (revisión `00363` → startup probe).
+3. Diagnóstico: prod sano en `00407`. **Por qué no se cayó**: Cloud Run **no mueve tráfico a una revisión que no llega a READY** — la nueva falló el startup probe y el tráfico quedó en la asignación previa (`00407`, que NO monta el secreto). (Ojo: `service_api` usa `traffic_managed_externally=true` — el split lo maneja Cloud Build canary, **no** un target `LATEST`; igual aplica el invariante de "revisión no-READY no recibe tráfico".) Logs de la revisión fallida: `path: CONTENT_SID_SAFETY_ALERT, "Debe empezar con HX seguido de hex chars"`.
+4. Confirmado: `00364` (gcloud, misma imagen que la sana `00407`) también falla → descarta "imagen vieja"; la causa es el **placeholder del secreto validado**.
+5. Resolución: poblar el SID real (`HX…`) en `content-sid-safety-alert` y crear revisión nueva. (En curso por el PO; el SID es credencial.)
+
+## Causa raíz
+
+Un secreto con **validación de formato** en el env schema (`CONTENT_SID_*` = `^HX…`) fue **creado con su placeholder y montado en un service en el mismo apply**. El service valida el env var al arrancar y rechaza el placeholder. No existía un preflight que detectara "placeholder de secreto validado montado en un service".
+
+## Factores contribuyentes
+
+1. **Drift barrido en un apply ajeno**: `content-sid-safety-alert` era drift preexistente (alguien lo agregó a `security.tf` sin aplicar). Se aplicó junto con cambios no relacionados (F4/F3) en vez de resolverse aparte.
+2. **Revisión de plan incompleta (agente)**: en el review del plan se clasificó el `content-sid-safety-alert` como "benigno" sin cruzar que (a) lo monta `service_api` y (b) `CONTENT_SID_SAFETY_ALERT` tiene validación de formato. Las dos señales estaban en el plan.
+3. **Hipótesis de causa equivocada al inicio**: se atribuyó primero a "imagen stale de terraform" y luego a `TRANSPORT_DOCUMENTS_BUCKET`; recién los **logs** del contenedor dieron la causa real. (Lección: ir a los logs antes de teorizar — systematic-debugging.)
+4. **terraform crea placeholder + monta en el mismo grafo**, sin gate que exija el valor real primero.
+
+## Qué salió bien
+
+- Cloud Run protegió prod (no enrutó a la revisión que falla el probe).
+- Los 4 destroy fueron exactamente los esperados (secretos DTE); el plan se auditó recurso por recurso antes de aplicar.
+- La diagnosis usó evidencia (Cloud Run API + Cloud Logging), no adivinanza, una vez que se fue a los logs.
+
+## Acción correctiva / preventiva
+
+| # | Acción | Estado | Ref |
+|---|---|---|---|
+| A1 | Poblar `content-sid-safety-alert` con el SID real + revisión nueva | En curso (PO) | — |
+| A2 | **Preflight check (script)**: dado el plan JSON, falla si un secreto validado por formato queda placeholder y está montado en un service. Cubre `content-sid-*` (`^HX`) + `twilio-account-sid` (`^AC`), y cruza contra el estado resultante completo (`planned_values`), no solo `resource_changes`. | **Hecho (este PR)** — es un **script manual**, NO previene la recurrencia por sí solo | `scripts/repo-checks/check-validated-secret-placeholders.mjs` |
+| A5 | **Gate pre-apply**: cablear A2 en el flujo de deploy (emitir `plan.json` y correr el check antes de `terraform apply`). **ESTA es la prevención real** — A2 sin A5 sigue dependiendo de que un humano lo corra (y el incidente lo causó un humano que no verificó). | **Pendiente** | — |
+| A3 | Aplicar terraform **scoped** (no barrer drift ajeno); resolver el drift preexistente en su propio change | Pendiente | — |
+| A4 | Revisión de plan: checklist de "secret nuevo → ¿lo monta un service? ¿el env var está validado?" en `booster-stack-conventions` | Pendiente (draft junto al preflight) | — |
+| A6 | **Corregir comentarios engañosos** en `infrastructure/security.tf` (~l.243-245) y `infrastructure/compute.tf` (~l.256-258) que afirman que un secret en placeholder "degrada a solo-push" — es **FALSO**: el placeholder mata el startup. Esos comentarios fueron la fuente documentada del juicio "benigno" en la revisión del plan. | Pendiente | — |
+| A7 | Evaluar que terraform no monte un secreto validado hasta tener valor real (mount condicional / ordering); y derivar el set validado de A2 de los `.regex` de los config.ts (anti-drift) | Pendiente | — |
+
+## Cómo correr el preflight (antes de cualquier `terraform apply`)
+
+```bash
+terraform -chdir=infrastructure show -json tfplan > plan.json
+node scripts/repo-checks/check-validated-secret-placeholders.mjs plan.json
+```
+
+Validado contra el plan real de este incidente: detecta `content-sid-safety-alert → booster-ai-api` y sale con código 1.

--- a/scripts/repo-checks/check-validated-secret-placeholders.mjs
+++ b/scripts/repo-checks/check-validated-secret-placeholders.mjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+/**
+ * @booster-ai/scripts — check-validated-secret-placeholders (INC-2026-06-19)
+ *
+ * Preflight de `terraform apply`: impide que un secreto con valor PLACEHOLDER
+ * (`ROTATE_ME_<NAME>_PLACEHOLDER`, ver infrastructure/security.tf) y FORMATO
+ * VALIDADO en el env schema sea montado en un Cloud Run service — porque el
+ * service rechaza el arranque (`Invalid environment configuration. Refusing to
+ * start.`) y la revisión falla el startup probe, bloqueando deploys.
+ *
+ * Origen (post-mortem INC-2026-06-19): un `terraform apply` creó
+ * `content-sid-safety-alert` con su placeholder `ROTATE_ME_..._PLACEHOLDER` y
+ * lo montó en `service_api` como `CONTENT_SID_SAFETY_ALERT`, que el api valida
+ * con `^HX[a-fA-F0-9]+$` (apps/api/src/config.ts). El placeholder no matchea →
+ * el api "Refusing to start" → toda revisión nueva (incluido el próximo deploy
+ * de cloudbuild) falla. Prod siguió sirviendo la revisión vieja, que NO montaba
+ * el secreto. Este check lo habría atajado ANTES del apply.
+ *
+ * Cobertura de mounts: cruzamos los placeholders contra el ESTADO RESULTANTE
+ * COMPLETO (`planned_values.root_module` + child_modules recursivos), no solo
+ * `resource_changes` — un service que ya monta el secreto puede no aparecer en
+ * resource_changes (image/traffic/scaling están en `ignore_changes`), y aun así
+ * su próxima revisión montaría el placeholder y fallaría (FN hallado en review).
+ *
+ * Secretos "validados por formato": sus env vars tienen un `.regex(/^XX.../)`
+ * anclado en los env schema (apps/api/src/config.ts y apps/whatsapp-bot/src/
+ * config.ts) — el valor DEBE empezar con literales, que el placeholder
+ * `ROTATE_ME_*` nunca cumple. Hoy: `content-sid-*` (`^HX`) y `twilio-account-sid`
+ * (`^AC`). (`twilio-auth-token` usa `.min(16)`: el placeholder de 38 chars pasa
+ * → NO está en alcance.) Mantener en sync; follow-up: derivarlo de los `.regex`.
+ *
+ * El `secret_data` es sensible y el plan JSON lo redacta, así que detectamos el
+ * placeholder por el ADDRESS del recurso
+ * (`google_secret_manager_secret_version.placeholder[...]`) y por el sentinel
+ * cuando viene visible.
+ *
+ * Usage:
+ *   terraform -chdir=infrastructure show -json tfplan > plan.json
+ *   node scripts/repo-checks/check-validated-secret-placeholders.mjs plan.json
+ *
+ * Exit codes:
+ *   0 = sin placeholders validados montados (ok; puede haber warnings no-fatales)
+ *   1 = al menos un secreto validado con placeholder montado en un service
+ *   2 = error de uso (archivo no legible / JSON inválido)
+ */
+import { readFileSync } from 'node:fs';
+import process from 'node:process';
+
+/**
+ * Prefijos de nombres de secretos cuyo env var tiene validación de FORMATO
+ * (`.regex(/^...)` anclado) en los env schema. Un placeholder los rompe.
+ */
+export const VALIDATED_SECRET_PREFIXES = ['content-sid-'];
+
+/** Nombres exactos de secretos validados por formato que no comparten prefijo. */
+export const VALIDATED_SECRET_NAMES = ['twilio-account-sid'];
+
+/** Sentinel de placeholder que setea infrastructure/security.tf. */
+const PLACEHOLDER_RE = /^ROTATE_ME_.*_PLACEHOLDER$/;
+
+const DEFAULT_VALIDATED = { prefixes: VALIDATED_SECRET_PREFIXES, names: VALIDATED_SECRET_NAMES };
+
+/** Última parte de un id de secret (`projects/x/secrets/NAME` → `NAME`). */
+function secretShortName(id) {
+  if (typeof id !== 'string') {
+    return undefined;
+  }
+  const parts = id.split('/secrets/');
+  return (parts[1] ?? id).split('/')[0];
+}
+
+/** Extrae la key entre comillas de un address `...placeholder["<key>"]`. */
+function keyFromAddress(address) {
+  const m = /\["([^"]+)"\]/.exec(address ?? '');
+  return m ? m[1] : undefined;
+}
+
+/** Normaliza un bloque nested de plan JSON (objeto o array-de-uno) a array. */
+function asArray(v) {
+  if (Array.isArray(v)) {
+    return v;
+  }
+  return v == null ? [] : [v];
+}
+
+function isValidated(secretName, validated = DEFAULT_VALIDATED) {
+  if (!secretName) {
+    return false;
+  }
+  const prefixes = validated.prefixes ?? [];
+  const names = validated.names ?? [];
+  return prefixes.some((p) => secretName.startsWith(p)) || names.includes(secretName);
+}
+
+/**
+ * Secretos validados que se CREAN/quedan como placeholder en el plan. Detecta
+ * por recurso `google_secret_manager_secret_version` cuyo nombre de recurso es
+ * `placeholder` (convención de security.tf) o cuyo `secret_data` visible matchea
+ * el sentinel.
+ * @returns {{secret:string, address:string}[]}
+ */
+export function findValidatedPlaceholders(resourceChanges, validated = DEFAULT_VALIDATED) {
+  const out = [];
+  for (const rc of resourceChanges ?? []) {
+    if (rc?.type !== 'google_secret_manager_secret_version') {
+      continue;
+    }
+    const actions = rc.change?.actions ?? [];
+    // Solo nos importan creates/updates que dejan el valor placeholder vigente.
+    if (!actions.includes('create') && !actions.includes('update')) {
+      continue;
+    }
+    const after = rc.change?.after ?? {};
+    const secret = secretShortName(after.secret) ?? keyFromAddress(rc.address);
+    if (!isValidated(secret, validated)) {
+      continue;
+    }
+    const isPlaceholderResource =
+      rc.name === 'placeholder' || /\.placeholder\b/.test(rc.address ?? '');
+    const dataLooksPlaceholder =
+      typeof after.secret_data === 'string' && PLACEHOLDER_RE.test(after.secret_data);
+    if (isPlaceholderResource || dataLooksPlaceholder) {
+      out.push({ secret, address: rc.address });
+    }
+  }
+  return out;
+}
+
+/** Recolecta secretos montados como env (secret_key_ref) de un objeto de service. */
+function collectMounts(serviceObj, serviceName, map) {
+  for (const tmpl of asArray(serviceObj?.template)) {
+    for (const container of asArray(tmpl?.containers)) {
+      for (const env of asArray(container?.env)) {
+        for (const vs of asArray(env?.value_source)) {
+          for (const ref of asArray(vs?.secret_key_ref)) {
+            const secret = secretShortName(ref?.secret);
+            if (!secret) {
+              continue;
+            }
+            if (!map.has(secret)) {
+              map.set(secret, new Set());
+            }
+            map.get(secret).add(serviceName);
+          }
+        }
+      }
+    }
+  }
+}
+
+/** Recorre root_module + child_modules recursivamente aplicando `visit(resource)`. */
+function walkPlannedModules(module, visit) {
+  if (!module) {
+    return;
+  }
+  for (const r of module.resources ?? []) {
+    visit(r);
+  }
+  for (const cm of module.child_modules ?? []) {
+    walkPlannedModules(cm, visit);
+  }
+}
+
+/**
+ * Mapa secret → Set(serviceName) de secretos montados como env. Une dos fuentes:
+ *  - `resource_changes` (services que CAMBIAN en este plan) vía `change.after`.
+ *  - `planned_values.root_module` recursivo (ESTADO resultante completo, incluye
+ *    services que montan el secreto pero NO cambian) vía `resource.values`.
+ * @returns {Map<string, Set<string>>}
+ */
+export function findServiceSecretMounts(plan) {
+  const map = new Map();
+  for (const rc of plan?.resource_changes ?? []) {
+    if (rc?.type !== 'google_cloud_run_v2_service') {
+      continue;
+    }
+    const after = rc.change?.after ?? {};
+    collectMounts(after, after.name ?? rc.address, map);
+  }
+  walkPlannedModules(plan?.planned_values?.root_module, (r) => {
+    if (r?.type !== 'google_cloud_run_v2_service') {
+      return;
+    }
+    const values = r.values ?? {};
+    collectMounts(values, values.name ?? r.address, map);
+  });
+  return map;
+}
+
+/**
+ * @returns {{violations:{secret:string,services:string[]}[], warnings:{secret:string}[]}}
+ */
+export function analyzePlan(plan, validated = DEFAULT_VALIDATED) {
+  const placeholders = findValidatedPlaceholders(plan?.resource_changes ?? [], validated);
+  const mounts = findServiceSecretMounts(plan);
+  const violations = [];
+  const warnings = [];
+  for (const { secret } of placeholders) {
+    const services = mounts.get(secret);
+    if (services && services.size > 0) {
+      violations.push({ secret, services: [...services].sort() });
+    } else {
+      warnings.push({ secret });
+    }
+  }
+  return { violations, warnings };
+}
+
+export function main(argv) {
+  const files = argv.filter((a) => !a.startsWith('-'));
+  const file = files[0];
+  if (!file) {
+    process.stderr.write(
+      '[check-validated-secret-placeholders] uso: <plan.json>\n' +
+        '  terraform -chdir=infrastructure show -json tfplan > plan.json\n',
+    );
+    return 2;
+  }
+  let plan;
+  try {
+    plan = JSON.parse(readFileSync(file, 'utf-8'));
+  } catch (err) {
+    process.stderr.write(
+      `[check-validated-secret-placeholders] no se pudo leer ${file}: ${err.message}\n`,
+    );
+    return 2;
+  }
+
+  const { violations, warnings } = analyzePlan(plan);
+
+  for (const w of warnings) {
+    process.stdout.write(
+      `[check-validated-secret-placeholders] NOTA — '${w.secret}' se crea como placeholder ` +
+        'y no está montado en ningún service en este plan (poblá su valor real antes de montarlo).\n',
+    );
+  }
+
+  if (violations.length === 0) {
+    process.stdout.write(
+      '[check-validated-secret-placeholders] OK — ningún secreto validado con placeholder montado.\n',
+    );
+    return 0;
+  }
+
+  process.stderr.write(
+    `[check-validated-secret-placeholders] FAIL — ${violations.length} secreto(s) validado(s) por formato ` +
+      'con placeholder, montados en un service (romperán el startup probe):\n',
+  );
+  for (const v of violations) {
+    process.stderr.write(`  ${v.secret} → ${v.services.join(', ')}\n`);
+  }
+  process.stderr.write(
+    '\nUn secreto cuyo env var se valida con regex (ej. CONTENT_SID_* = /^HX[a-fA-F0-9]+$/ o\n' +
+      'TWILIO_ACCOUNT_SID = /^AC.../ en los config.ts) NO puede aplicarse con su placeholder\n' +
+      'ROTATE_ME_*: el service rechaza el arranque y toda revisión nueva (incluido el próximo\n' +
+      'deploy) falla. Antes del apply:\n' +
+      '  1. Poblá el valor real:\n' +
+      "       printf %s '<valor real>' | gcloud secrets versions add <secret> --data-file=-\n" +
+      '  2. O excluí el mount/secret de ESTE apply hasta tener el valor real.\n' +
+      'Post-mortem: docs/incidents/INC-2026-06-19-content-sid-placeholder-startup.md\n',
+  );
+  return 1;
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/repo-checks/check-validated-secret-placeholders.test.mjs
+++ b/scripts/repo-checks/check-validated-secret-placeholders.test.mjs
@@ -1,0 +1,248 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  analyzePlan,
+  findServiceSecretMounts,
+  findValidatedPlaceholders,
+  main,
+} from './check-validated-secret-placeholders.mjs';
+
+/** Recurso: placeholder de un secret validado siendo creado (resource_changes). */
+function placeholderChange(secret) {
+  return {
+    address: `google_secret_manager_secret_version.placeholder["${secret}"]`,
+    type: 'google_secret_manager_secret_version',
+    name: 'placeholder',
+    change: { actions: ['create'], after: { secret: `projects/p/secrets/${secret}` } },
+  };
+}
+
+/** Bloque template[containers[env]] que monta `secret` como env `envName`. */
+function templateMounting(envName, secret, { asList = false } = {}) {
+  const keyRef = { secret, version: 'latest' };
+  const env = [
+    {
+      name: envName,
+      value_source: asList ? [{ secret_key_ref: [keyRef] }] : { secret_key_ref: keyRef },
+    },
+  ];
+  const containers = [{ env }];
+  return asList ? [{ containers }] : { containers };
+}
+
+/** Recurso service (resource_changes, vía change.after). */
+function serviceChange(serviceName, envName, secret, opts = {}) {
+  return {
+    address: `module.${serviceName}.google_cloud_run_v2_service.service`,
+    type: 'google_cloud_run_v2_service',
+    name: 'service',
+    change: {
+      actions: ['update'],
+      after: { name: serviceName, template: templateMounting(envName, secret, opts) },
+    },
+  };
+}
+
+/** Recurso service en planned_values (vía resource.values) dentro de un child_module. */
+function plannedPlanWithService(serviceName, envName, secret) {
+  return {
+    planned_values: {
+      root_module: {
+        resources: [],
+        child_modules: [
+          {
+            address: `module.${serviceName}`,
+            resources: [
+              {
+                type: 'google_cloud_run_v2_service',
+                address: `module.${serviceName}.google_cloud_run_v2_service.service`,
+                values: { name: serviceName, template: templateMounting(envName, secret) },
+              },
+            ],
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe('findValidatedPlaceholders', () => {
+  it('detecta un placeholder de secret validado por prefijo (content-sid-*)', () => {
+    const res = findValidatedPlaceholders([placeholderChange('content-sid-safety-alert')]);
+    expect(res).toEqual([expect.objectContaining({ secret: 'content-sid-safety-alert' })]);
+  });
+
+  it('detecta un placeholder de secret validado por nombre exacto (twilio-account-sid)', () => {
+    expect(findValidatedPlaceholders([placeholderChange('twilio-account-sid')])).toHaveLength(1);
+  });
+
+  it('detecta también por sentinel ROTATE_ME visible en secret_data', () => {
+    const change = {
+      address: 'google_secret_manager_secret_version.otra["content-sid-x"]',
+      type: 'google_secret_manager_secret_version',
+      name: 'otra',
+      change: {
+        actions: ['create'],
+        after: { secret: 'content-sid-x', secret_data: 'ROTATE_ME_CONTENT_SID_X_PLACEHOLDER' },
+      },
+    };
+    expect(findValidatedPlaceholders([change])).toHaveLength(1);
+  });
+
+  it('ignora secretos NO validados (flow-api-key, twilio-auth-token) aunque sean placeholder', () => {
+    expect(findValidatedPlaceholders([placeholderChange('flow-api-key')])).toHaveLength(0);
+    expect(findValidatedPlaceholders([placeholderChange('twilio-auth-token')])).toHaveLength(0);
+  });
+
+  it('ignora destroys (no dejan placeholder vigente)', () => {
+    const c = placeholderChange('content-sid-safety-alert');
+    c.change.actions = ['delete'];
+    expect(findValidatedPlaceholders([c])).toHaveLength(0);
+  });
+});
+
+describe('findServiceSecretMounts', () => {
+  it('extrae el mount desde resource_changes (shape objeto)', () => {
+    const m = findServiceSecretMounts({
+      resource_changes: [
+        serviceChange('service_api', 'CONTENT_SID_SAFETY_ALERT', 'content-sid-safety-alert'),
+      ],
+    });
+    expect([...(m.get('content-sid-safety-alert') ?? [])]).toEqual(['service_api']);
+  });
+
+  it('extrae el mount desde resource_changes (shape lista del provider)', () => {
+    const m = findServiceSecretMounts({
+      resource_changes: [
+        serviceChange('service_api', 'CONTENT_SID_SAFETY_ALERT', 'content-sid-safety-alert', {
+          asList: true,
+        }),
+      ],
+    });
+    expect([...(m.get('content-sid-safety-alert') ?? [])]).toEqual(['service_api']);
+  });
+
+  it('extrae el mount desde planned_values (service que NO cambia, recursivo en child_modules)', () => {
+    const m = findServiceSecretMounts(
+      plannedPlanWithService(
+        'booster-ai-api',
+        'CONTENT_SID_SAFETY_ALERT',
+        'content-sid-safety-alert',
+      ),
+    );
+    expect([...(m.get('content-sid-safety-alert') ?? [])]).toEqual(['booster-ai-api']);
+  });
+});
+
+describe('analyzePlan', () => {
+  it('INCIDENTE INC-2026-06-19: placeholder validado + montado (resource_changes) → violación', () => {
+    const plan = {
+      resource_changes: [
+        placeholderChange('content-sid-safety-alert'),
+        serviceChange('booster-ai-api', 'CONTENT_SID_SAFETY_ALERT', 'content-sid-safety-alert'),
+      ],
+    };
+    const { violations, warnings } = analyzePlan(plan);
+    expect(violations).toEqual([
+      { secret: 'content-sid-safety-alert', services: ['booster-ai-api'] },
+    ]);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('FN#1: placeholder en resource_changes + service SOLO en planned_values → violación (no warning)', () => {
+    const plan = {
+      resource_changes: [placeholderChange('content-sid-safety-alert')],
+      ...plannedPlanWithService(
+        'booster-ai-api',
+        'CONTENT_SID_SAFETY_ALERT',
+        'content-sid-safety-alert',
+      ),
+    };
+    const { violations, warnings } = analyzePlan(plan);
+    expect(violations).toEqual([
+      { secret: 'content-sid-safety-alert', services: ['booster-ai-api'] },
+    ]);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('FN#2: twilio-account-sid placeholder + montado → violación', () => {
+    const plan = {
+      resource_changes: [
+        placeholderChange('twilio-account-sid'),
+        serviceChange('booster-ai-api', 'TWILIO_ACCOUNT_SID', 'twilio-account-sid'),
+      ],
+    };
+    const { violations } = analyzePlan(plan);
+    expect(violations).toEqual([{ secret: 'twilio-account-sid', services: ['booster-ai-api'] }]);
+  });
+
+  it('placeholder validado creado pero NO montado en ningún lado → warning, sin violación', () => {
+    const plan = { resource_changes: [placeholderChange('content-sid-safety-alert')] };
+    const { violations, warnings } = analyzePlan(plan);
+    expect(violations).toHaveLength(0);
+    expect(warnings).toEqual([{ secret: 'content-sid-safety-alert' }]);
+  });
+
+  it('plan limpio (sin placeholders validados) → sin violaciones ni warnings', () => {
+    const plan = {
+      resource_changes: [
+        placeholderChange('flow-api-key'),
+        serviceChange('booster-ai-api', 'FLOW_API_KEY', 'flow-api-key'),
+      ],
+    };
+    expect(analyzePlan(plan)).toEqual({ violations: [], warnings: [] });
+  });
+});
+
+describe('main (exit codes)', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'preflight-'));
+  const writePlan = (name, plan) => {
+    const p = join(dir, name);
+    writeFileSync(p, JSON.stringify(plan));
+    return p;
+  };
+
+  it('exit 1 con la violación del incidente', () => {
+    const p = writePlan('viol.json', {
+      resource_changes: [
+        placeholderChange('content-sid-safety-alert'),
+        serviceChange('booster-ai-api', 'CONTENT_SID_SAFETY_ALERT', 'content-sid-safety-alert'),
+      ],
+    });
+    expect(main([p])).toBe(1);
+  });
+
+  it('exit 1 cuando el mount solo está en planned_values (FN#1)', () => {
+    const p = writePlan('fn1.json', {
+      resource_changes: [placeholderChange('content-sid-safety-alert')],
+      ...plannedPlanWithService(
+        'booster-ai-api',
+        'CONTENT_SID_SAFETY_ALERT',
+        'content-sid-safety-alert',
+      ),
+    });
+    expect(main([p])).toBe(1);
+  });
+
+  it('exit 0 con plan limpio', () => {
+    const p = writePlan('clean.json', { resource_changes: [] });
+    expect(main([p])).toBe(0);
+  });
+
+  it('exit 0 con placeholder no montado (solo warning)', () => {
+    const p = writePlan('warn.json', {
+      resource_changes: [placeholderChange('content-sid-safety-alert')],
+    });
+    expect(main([p])).toBe(0);
+  });
+
+  it('exit 2 sin argumento de archivo', () => {
+    expect(main([])).toBe(2);
+  });
+
+  it('exit 2 con archivo ilegible', () => {
+    expect(main([join(dir, 'no-existe.json')])).toBe(2);
+  });
+});


### PR DESCRIPTION
## Qué hace

Post-mortem + **prevención** del incidente **INC-2026-06-19**: un `terraform apply` (PR #503) creó `content-sid-safety-alert` con su placeholder `ROTATE_ME_*` y lo montó en `service_api` como `CONTENT_SID_SAFETY_ALERT` (validado con `^HX[a-fA-F0-9]+$` en `apps/api/src/config.ts`). El placeholder no matchea → el api **"Refusing to start"** → la revisión nueva falla el startup probe. **Prod no se cayó** (Cloud Run no enruta a una revisión no-READY), pero **los deploys quedaron bloqueados**.

- `docs/incidents/INC-2026-06-19-content-sid-placeholder-startup.md` — post-mortem (causa raíz, SEV-2, factores humanos, action items A1–A7).
- `scripts/repo-checks/check-validated-secret-placeholders.mjs` (+ test) — preflight: dado `terraform show -json`, **falla** si un secreto validado por formato queda placeholder y está montado en un service.

## Diseño del check

- Cubre `content-sid-*` (`^HX`) **+ `twilio-account-sid`** (`^AC`, montado en api y whatsapp-bot). `twilio-auth-token` (`.min(16)`) NO está en alcance (el placeholder de 38 chars pasa).
- Cruza los placeholders contra el **estado resultante completo** (`planned_values.root_module` + child_modules recursivos), no solo `resource_changes` — un service que ya monta el secreto puede no aparecer en `resource_changes`.
- Detecta el placeholder por el **address** del recurso (el `secret_data` es sensible y el plan JSON lo redacta).

## Evidencia

```
repo-checks test:coverage   111 passed (5 files); 19 del check nuevo
pnpm lint (biome+lint:rls)  EXIT 0
check vs plan REAL del incidente:  exit 1  →  content-sid-safety-alert → booster-ai-api
```

**Revisión adversarial (2 lentes)** halló y se corrigieron **2 falsos negativos** (FN#1: mounts solo en `planned_values`; FN#2: `twilio-account-sid` fuera del set) y **2 imprecisiones** del post-mortem (mecánica de tráfico de `service_api` — usa `traffic_managed_externally`, no `LATEST`; A2 script vs A5 gate).

## Uso (preflight, antes de cualquier `terraform apply`)

```bash
terraform -chdir=infrastructure show -json tfplan > plan.json
node scripts/repo-checks/check-validated-secret-placeholders.mjs plan.json
```

## Pendiente explícito (NO incluido)

- **A5 — gate pre-apply**: el check es un **script manual**; NO está cableado en CI/release. La recurrencia solo se previene cableándolo en el flujo de deploy (emitir `plan.json` + correr el check antes del apply). Decisión del PO.
- **A6** — corregir comentarios engañosos en `security.tf`/`compute.tf` ("placeholder degrada a solo-push" — falso). Se deja como follow-up para no chocar con #503 (que edita esos archivos).
- **A4 — draft para `booster-stack-conventions`** (skill, repo `booster-skills`): agregar la regla
  > **Secret validado por formato + placeholder = no se monta.** Un secreto cuyo env var tiene `.regex(/^…)` anclado (p.ej. `CONTENT_SID_*` `^HX`, `TWILIO_ACCOUNT_SID` `^AC`) NO puede aplicarse con su placeholder `ROTATE_ME_*`: el service "Refusing to start". En la revisión de un `terraform plan`: por cada secret nuevo/placeholder, verificar (a) ¿lo monta un service? (b) ¿su env var está validado por formato? Si ambas → poblar el valor real ANTES del apply. Preflight: `scripts/repo-checks/check-validated-secret-placeholders.mjs`.

## Apply de #503

Sigue **pendiente / on hold** hasta que prod esté sano (poblar `content-sid-safety-alert` con el SID real — el PO lo está haciendo). #503 no se mergea hasta entonces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
