### PR TITLE
chore(lint): elimina 62 warnings de Biome → 0

### DIFF
--- a/apps/api/scripts/smoke-wave1-conductor.mjs
+++ b/apps/api/scripts/smoke-wave1-conductor.mjs
@@ -37,7 +37,6 @@ const PLATFORM_ADMIN_EMAIL = process.env.PLATFORM_ADMIN_EMAIL ?? 'dev@boosterchi
 const FIREBASE_WEB_API_KEY = process.env.FIREBASE_WEB_API_KEY;
 
 if (!FIREBASE_WEB_API_KEY) {
-  // biome-ignore lint/suspicious/noConsole: script CLI, output va a stdout.
   console.error('ERROR: falta FIREBASE_WEB_API_KEY (export desde cloudbuild env vars).');
   process.exit(1);
 }
@@ -61,7 +60,6 @@ function log(level, ...args) {
     fail: `${COLOR_RED}✗${COLOR_RESET}`,
     step: `${COLOR_GRAY}→${COLOR_RESET}`,
   }[level];
-  // biome-ignore lint/suspicious/noConsole: script CLI.
   console.log(prefix, ...args);
 }
 
@@ -154,7 +152,7 @@ async function step2SeedDemo(adminIdToken) {
   const activationPin = seedRes.credentials.conductor.activation_pin;
   log(
     'ok',
-    `Conductor demo creado/reusado: RUT ${conductorRut} | PIN ${activationPin ? activationPin.slice(0, 2) + '••••' : 'NULL (ya activado)'}`,
+    `Conductor demo creado/reusado: RUT ${conductorRut} | PIN ${activationPin ? `${activationPin.slice(0, 2)}••••` : 'NULL (ya activado)'}`,
   );
   return { conductorRut, activationPin, seedCredentials: seedRes.credentials };
 }

--- a/apps/api/src/middleware/demo-expires.test.ts
+++ b/apps/api/src/middleware/demo-expires.test.ts
@@ -68,7 +68,7 @@ function makeAuthStub(
     }
     if (opts.hangForever) {
       // Promise que nunca resuelve — exercise el timeout race.
-      return new Promise<UserRecord>(() => {});
+      return new Promise<UserRecord>(() => undefined);
     }
     return (opts.user ?? {}) as UserRecord;
   });

--- a/apps/api/src/middleware/rate-limit-pin.test.ts
+++ b/apps/api/src/middleware/rate-limit-pin.test.ts
@@ -92,7 +92,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('1er intento → next() (counter=1)', async () => {
     const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -111,7 +110,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('keyPrefix/ipKeyPrefix custom → counters propios sin tocar los de pin-activate', async () => {
     const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
       keyPrefix: 'rl:login-rut:',
@@ -132,7 +130,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('XFF spoofeado (múltiples entries) → usa la PENÚLTIMA (la IP que vio el LB)', async () => {
     const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -157,7 +154,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('5º intento OK (counter=5 ≤ limit)', async () => {
     const { redis } = makeRedis([5, 1]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -173,7 +169,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('6º intento → 429 + Retry-After:900 + X-RateLimit-Scope:rut (SC-H2.1)', async () => {
     const { redis } = makeRedis([6, 1]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -195,7 +190,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
     // hasta 31. La response del 31º request debe ser 429 scope=ip.
     const { redis } = makeRedis([1, 31]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -216,7 +210,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('SC-H2.1b — Redis unreachable → 503 + Retry-After:30 (fail-closed loudly)', async () => {
     const { redis } = makeRedis({ throwOnExec: new Error('ECONNREFUSED') });
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -239,7 +232,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
     // ronda tropieza ambos.
     const { redis } = makeRedis([6, 31]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -265,7 +257,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
     // canónico via la transform del schema.
     const { redis, calls } = makeRedis([1, 1, 2, 2]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -289,7 +280,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('body sin campo rut → skip (no incrementa counter)', async () => {
     const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -306,7 +296,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('body no-JSON → skip (handler downstream maneja el error)', async () => {
     const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });
@@ -325,7 +314,6 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
   it('RUT con formato inválido → skip (no oracle de RUTs válidos)', async () => {
     const { redis, calls } = makeRedis([1, 1]);
     const mw = createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis
       redis: redis as any,
       logger: noopLogger,
     });

--- a/apps/api/test/unit/actualizar-factor-matching.test.ts
+++ b/apps/api/test/unit/actualizar-factor-matching.test.ts
@@ -325,8 +325,8 @@ describe('calcularFactorMatchingGeo (heurística v2 puro)', () => {
       origenNextRegionCode: 'V',
     });
     expect(factor).not.toBeNull();
-    expect(factor!).toBeGreaterThan(0);
-    expect(factor!).toBeLessThan(1);
+    expect(factor).toBeGreaterThan(0);
+    expect(factor).toBeLessThan(1);
   });
 
   it('factor retornado tiene como máximo 2 decimales (encaja BD precision 3,2)', () => {
@@ -446,6 +446,6 @@ describe('actualizarFactorMatchingViaje — wire v2 con region codes', () => {
     });
     expect(result.recomputed).toBe(true);
     expect(result.factorMatching).toBeGreaterThan(0);
-    expect(result.factorMatching!).toBeLessThan(1);
+    expect(result.factorMatching).toBeLessThan(1);
   });
 });

--- a/apps/api/test/unit/admin-observability-route.test.ts
+++ b/apps/api/test/unit/admin-observability-route.test.ts
@@ -363,7 +363,6 @@ describe('admin/observability — error paths', () => {
         getSnapshot: vi.fn(async () => {
           throw new Error('health-fail');
         }),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -382,7 +381,6 @@ describe('admin/observability — error paths', () => {
         getTrend: vi.fn(),
         getTopSkus: vi.fn(),
         getMonthlyHistory: vi.fn(),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -401,7 +399,6 @@ describe('admin/observability — error paths', () => {
         }),
         getTopSkus: vi.fn(),
         getMonthlyHistory: vi.fn(),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -420,7 +417,6 @@ describe('admin/observability — error paths', () => {
           throw new Error('BQ unavailable');
         }),
         getMonthlyHistory: vi.fn(),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -439,7 +435,6 @@ describe('admin/observability — error paths', () => {
         getMonthlyHistory: vi.fn(async () => {
           throw new Error('BQ unavailable');
         }),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -455,7 +450,6 @@ describe('admin/observability — error paths', () => {
         }),
         getCloudSqlMetrics: vi.fn(),
         getUptimeSnapshot: vi.fn(),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -471,7 +465,6 @@ describe('admin/observability — error paths', () => {
           throw new Error('monitoring-fail');
         }),
         getUptimeSnapshot: vi.fn(),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -486,7 +479,6 @@ describe('admin/observability — error paths', () => {
           throw new Error('twilio-fail');
         }),
         getMonthToDateUsage: vi.fn(),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -500,7 +492,6 @@ describe('admin/observability — error paths', () => {
         getUsageSnapshot: vi.fn(async () => {
           throw new Error('workspace-fail');
         }),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });
@@ -521,7 +512,6 @@ describe('admin/observability — error paths', () => {
         getTrend: vi.fn(),
         getTopSkus: vi.fn(),
         getMonthlyHistory: vi.fn(),
-        // biome-ignore lint/suspicious/noExplicitAny: minimal stub
       } as any,
     });
     const app = makeApp(opts, { withContext: true });

--- a/apps/api/test/unit/is-demo-rate-limit-interaction.test.ts
+++ b/apps/api/test/unit/is-demo-rate-limit-interaction.test.ts
@@ -131,7 +131,6 @@ function makeAppWithCanonicalChain(claims: FirebaseClaims | null) {
   app.use(
     '*',
     createRateLimitPinMiddleware({
-      // biome-ignore lint/suspicious/noExplicitAny: mock Redis pattern existente
       redis: redis as any,
       logger: noopLogger,
     }),

--- a/apps/api/test/unit/site-settings.test.ts
+++ b/apps/api/test/unit/site-settings.test.ts
@@ -109,7 +109,6 @@ function makeAdminStub(opts: {
  * el array con un objeto cuando llamamos .from() directo (sin where ni limit).
  */
 function makeDraftStub(maxVersion: number, insertResult: FakeRow) {
-  // biome-ignore lint/suspicious/noExplicitAny: stub flexible — usado solo en tests.
   const fromObj: any = [{ maxVersion }];
   // Make .from() return [maxRow] when awaited (drizzle's pattern: await db.select(...).from(...))
   return {
@@ -163,11 +162,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-async function buildAdminApp(
-  // biome-ignore lint/suspicious/noExplicitAny: db stub flexible.
-  db: any,
-  ctx: typeof adminCtx | typeof notAdminCtx | null,
-) {
+async function buildAdminApp(db: any, ctx: typeof adminCtx | typeof notAdminCtx | null) {
   const { createSiteSettingsRoutes } = await import('../../src/routes/site-settings.js');
   const app = new Hono();
   if (ctx) {

--- a/apps/web/src/components/cobra-hoy/CobraHoyButton.tsx
+++ b/apps/web/src/components/cobra-hoy/CobraHoyButton.tsx
@@ -125,7 +125,7 @@ function CobraHoyModal({
         )}
 
         {solicitarM.isSuccess && solicitarM.data && (
-          <output className="mt-4 flex items-center gap-2 rounded-md border border-success-500/30 bg-success-50 p-3 text-success-700 text-sm">
+          <output className="mt-4 flex items-center gap-2 rounded-md border border-success-500/30 bg-success-50 p-3 text-sm text-success-700">
             <CheckCircle2 className="h-4 w-4" aria-hidden />
             {solicitarM.data.already_requested
               ? 'Ya tenías una solicitud en curso para este viaje.'

--- a/apps/web/src/components/profile/AuthProvidersSection.test.tsx
+++ b/apps/web/src/components/profile/AuthProvidersSection.test.tsx
@@ -30,6 +30,15 @@ function makeUser(over: Partial<User> = {}): User {
   } as unknown as User;
 }
 
+/** Primer botón que matchea `name`. getAllByRole ya lanza si no hay ninguno. */
+function firstButton(name: string | RegExp): HTMLElement {
+  const [button] = screen.getAllByRole('button', { name });
+  if (!button) {
+    throw new Error(`no se encontró botón: ${name}`);
+  }
+  return button;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -79,7 +88,7 @@ describe('AuthProvidersSection — link Google', () => {
       .mockReturnValue(['google.com', 'password']);
     linkGoogleProviderMock.mockResolvedValueOnce(undefined);
     render(<AuthProvidersSection />);
-    fireEvent.click(screen.getAllByRole('button', { name: /Vincular/ })[0]!);
+    fireEvent.click(firstButton(/Vincular/));
     await waitFor(() => expect(linkGoogleProviderMock).toHaveBeenCalledWith(user));
     await waitFor(() => expect(user.reload).toHaveBeenCalled());
   });
@@ -91,7 +100,7 @@ describe('AuthProvidersSection — link Google', () => {
       Object.assign(new Error('popup'), { code: 'auth/popup-closed-by-user' }),
     );
     render(<AuthProvidersSection />);
-    fireEvent.click(screen.getAllByRole('button', { name: /Vincular/ })[0]!);
+    fireEvent.click(firstButton(/Vincular/));
     await waitFor(() => expect(linkGoogleProviderMock).toHaveBeenCalled());
     expect(screen.queryByText(/No pudimos vincular/)).not.toBeInTheDocument();
   });
@@ -103,7 +112,7 @@ describe('AuthProvidersSection — link Google', () => {
       Object.assign(new Error('blocked'), { code: 'auth/popup-blocked' }),
     );
     render(<AuthProvidersSection />);
-    fireEvent.click(screen.getAllByRole('button', { name: /Vincular/ })[0]!);
+    fireEvent.click(firstButton(/Vincular/));
     expect(await screen.findByText(/El navegador bloqueó/)).toBeInTheDocument();
   });
 
@@ -114,7 +123,7 @@ describe('AuthProvidersSection — link Google', () => {
       Object.assign(new Error('boom'), { code: 'auth/something-else' }),
     );
     render(<AuthProvidersSection />);
-    fireEvent.click(screen.getAllByRole('button', { name: /Vincular/ })[0]!);
+    fireEvent.click(firstButton(/Vincular/));
     expect(await screen.findByText(/No pudimos vincular/)).toBeInTheDocument();
   });
 });
@@ -126,7 +135,7 @@ describe('AuthProvidersSection — unlink', () => {
     getLinkedProvidersMock.mockReturnValue(['google.com', 'password']);
     unlinkProviderMock.mockResolvedValueOnce(undefined);
     render(<AuthProvidersSection />);
-    fireEvent.click(screen.getAllByRole('button', { name: 'Quitar' })[0]!);
+    fireEvent.click(firstButton('Quitar'));
     await waitFor(() => expect(unlinkProviderMock).toHaveBeenCalledWith(user, expect.any(String)));
   });
 });

--- a/apps/web/src/components/scoring/AssignmentEcoRouteCard.tsx
+++ b/apps/web/src/components/scoring/AssignmentEcoRouteCard.tsx
@@ -47,7 +47,7 @@ export function AssignmentEcoRouteCard({ assignmentId }: AssignmentEcoRouteCardP
         aria-expanded={expanded}
         data-testid="assignment-eco-route-toggle"
       >
-        <span className="flex items-center gap-2 text-success-800 text-sm">
+        <span className="flex items-center gap-2 text-sm text-success-800">
           <Leaf className="h-4 w-4" aria-hidden />
           <span className="font-semibold">Ruta eco-eficiente sugerida</span>
         </span>

--- a/apps/web/src/components/scoring/DriverAssignmentCard.tsx
+++ b/apps/web/src/components/scoring/DriverAssignmentCard.tsx
@@ -187,7 +187,7 @@ export function DriverAssignmentCard({
           )}
 
           {submitState.kind === 'success' && (
-            <div className="mt-3 inline-flex items-center gap-2 rounded-md border border-success-200 bg-success-50 px-3 py-2 text-success-700 text-sm">
+            <div className="mt-3 inline-flex items-center gap-2 rounded-md border border-success-200 bg-success-50 px-3 py-2 text-sm text-success-700">
               <CheckCircle2 className="h-4 w-4" aria-hidden />
               Conductor asignado: <strong>{submitState.driverName ?? '(sin nombre)'}</strong>
             </div>

--- a/apps/web/src/routes/conductor.tsx
+++ b/apps/web/src/routes/conductor.tsx
@@ -376,7 +376,7 @@ function AssignmentCard({
         )}
         {reporter.isWatching ? (
           <div className="mt-3 space-y-2">
-            <div className="rounded-md bg-success-50 px-3 py-2 text-success-700 text-sm">
+            <div className="rounded-md bg-success-50 px-3 py-2 text-sm text-success-700">
               Reportando posición en vivo · {reporter.pointsSent} puntos enviados
             </div>
             <button

--- a/apps/web/src/routes/legal-cobra-hoy.tsx
+++ b/apps/web/src/routes/legal-cobra-hoy.tsx
@@ -23,7 +23,7 @@ export function LegalCobraHoyRoute() {
             <ArrowLeft className="h-5 w-5" aria-hidden />
           </Link>
           <div>
-            <h1 className="font-semibold text-neutral-900 text-lg">Adendum — Booster Cobra Hoy</h1>
+            <h1 className="font-semibold text-lg text-neutral-900">Adendum — Booster Cobra Hoy</h1>
             <p className="text-neutral-500 text-xs">
               Versión 1 · Vigente desde 2026-05-10 · Marco:{' '}
               <Link to="/legal/terminos" className="underline">

--- a/apps/web/src/routes/legal-terminos.tsx
+++ b/apps/web/src/routes/legal-terminos.tsx
@@ -28,7 +28,7 @@ export function LegalTerminosRoute() {
             <ArrowLeft className="h-5 w-5" aria-hidden />
           </Link>
           <div>
-            <h1 className="font-semibold text-neutral-900 text-lg">Términos de Servicio</h1>
+            <h1 className="font-semibold text-lg text-neutral-900">Términos de Servicio</h1>
             <p className="text-neutral-500 text-xs">Versión 2 · Vigente desde 2026-05-10</p>
           </div>
         </div>

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -44,7 +44,6 @@ const EMPTY_VALUES: LoginFormValues = { name: '', email: '', password: '' };
 export function LoginRoute() {
   const { user, loading } = useAuth();
   const { flags } = useFeatureFlags();
-  // biome-ignore lint/suspicious/noExplicitAny: search params del legacy escape hatch sin type strict.
   const search = (useSearch({ strict: false }) ?? {}) as { legacy?: string };
   const navigate = useNavigate();
   const [mode, setMode] = useState<Mode>('sign-in');

--- a/apps/web/src/routes/platform-admin-matching.tsx
+++ b/apps/web/src/routes/platform-admin-matching.tsx
@@ -167,10 +167,10 @@ function PlatformAdminMatchingPage() {
     }
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: carga única al montar; refreshList se redefine en cada render y listarlo dispararía un refetch en loop.
   useEffect(() => {
     void refreshList();
-    // refreshList se re-define en cada render; queremos cargar la lista
-    // una sola vez al montar — el setter funcional + closures basta.
+    // El setter funcional + closures basta para la carga inicial.
   }, []);
 
   async function handleSignOut() {
@@ -520,7 +520,7 @@ function PesoInput({
     <label className="flex items-start gap-2 text-xs">
       <div className="w-36 shrink-0 pt-1">
         <div className="text-neutral-700">{label}</div>
-        {hint && <div className="text-neutral-500 text-[10px] leading-tight">{hint}</div>}
+        {hint && <div className="text-[10px] text-neutral-500 leading-tight">{hint}</div>}
       </div>
       <input
         type="number"
@@ -764,7 +764,7 @@ function PesoChip({ label, value }: { label: string; value: number }) {
   const pct = Math.round(value * 100);
   return (
     <div className="rounded-md bg-neutral-100 px-2 py-1.5">
-      <div className="text-neutral-500 text-[10px] leading-tight">{label}</div>
+      <div className="text-[10px] text-neutral-500 leading-tight">{label}</div>
       <div className="font-semibold text-neutral-900 text-sm">{pct}%</div>
     </div>
   );

--- a/apps/web/src/routes/platform-admin.tsx
+++ b/apps/web/src/routes/platform-admin.tsx
@@ -613,6 +613,7 @@ function StakeholderOrgsSection() {
   const [showCreate, setShowCreate] = useState(false);
   const [refreshTick, setRefreshTick] = useState(0);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshTick es un trigger de refresh intencional (handleCreated lo incrementa); el efecto no lo lee, pero debe re-ejecutarse cuando cambia.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
@@ -772,6 +773,7 @@ function StakeholderOrgMembersPanel({ orgId }: { orgId: string }) {
   const [showInvite, setShowInvite] = useState(false);
   const [refreshTick, setRefreshTick] = useState(0);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshTick es un trigger de refresh intencional (handleInvited lo incrementa); el efecto no lo lee, pero debe re-ejecutarse cuando cambia.
   useEffect(() => {
     let cancelled = false;
     setLoading(true);

--- a/apps/web/src/routes/stakeholder-zonas.tsx
+++ b/apps/web/src/routes/stakeholder-zonas.tsx
@@ -309,7 +309,7 @@ function StakeholderZonasPage({ me }: { me: MeOnboarded }) {
       </section>
 
       <section className="mt-10 rounded-lg border border-neutral-200 bg-white p-5">
-        <h2 className="font-semibold text-neutral-900 text-lg">Metodología</h2>
+        <h2 className="font-semibold text-lg text-neutral-900">Metodología</h2>
         <ul className="mt-3 space-y-2 text-neutral-700 text-sm">
           <li className="flex items-start gap-2">
             <Shield className="mt-0.5 h-4 w-4 shrink-0 text-emerald-700" aria-hidden />

--- a/apps/web/src/services/wake-word.test.ts
+++ b/apps/web/src/services/wake-word.test.ts
@@ -26,7 +26,7 @@ describe('WakeWordController (stub Wave 5 PR 1)', () => {
     c.on('state', (s) => states.push(s));
     const errors: string[] = [];
     c.on('error', (e) => errors.push(e.message));
-    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    await c.init({ accessKey: '', modelPath: '', onWake: () => undefined });
     expect(c.state).toBe('unavailable');
     expect(states).toContain('unavailable');
     expect(errors.length).toBe(1);
@@ -38,7 +38,7 @@ describe('WakeWordController (stub Wave 5 PR 1)', () => {
     await c.init({
       accessKey: 'pico-key-123',
       modelPath: '/wake-word/oye-booster-cl.ppn',
-      onWake: () => {},
+      onWake: () => undefined,
     });
     // Stub no implementa Porcupine wire todavía — resolve unavailable
     // hasta Wave 5 PR 2. El test futuro a invertir: esperar 'listening'.
@@ -47,7 +47,7 @@ describe('WakeWordController (stub Wave 5 PR 1)', () => {
 
   it('enable() es no-op cuando state=unavailable', async () => {
     const c = createWakeWordController();
-    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    await c.init({ accessKey: '', modelPath: '', onWake: () => undefined });
     c.enable();
     expect(c.state).toBe('unavailable');
   });
@@ -58,7 +58,7 @@ describe('WakeWordController (stub Wave 5 PR 1)', () => {
     const b: WakeWordState[] = [];
     const unsubA = c.on('state', (s) => a.push(s));
     c.on('state', (s) => b.push(s));
-    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    await c.init({ accessKey: '', modelPath: '', onWake: () => undefined });
     expect(a).toEqual(['unavailable']);
     expect(b).toEqual(['unavailable']);
     unsubA();
@@ -72,7 +72,7 @@ describe('WakeWordController (stub Wave 5 PR 1)', () => {
     const c = createWakeWordController();
     const states: WakeWordState[] = [];
     c.on('state', (s) => states.push(s));
-    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    await c.init({ accessKey: '', modelPath: '', onWake: () => undefined });
     await c.destroy();
     expect(c.state).toBe('idle');
   });
@@ -84,7 +84,7 @@ describe('WakeWordController (stub Wave 5 PR 1)', () => {
       throw new Error('boom');
     });
     c.on('state', (s) => ok.push(s));
-    await c.init({ accessKey: '', modelPath: '', onWake: () => {} });
+    await c.init({ accessKey: '', modelPath: '', onWake: () => undefined });
     // El segundo listener debe haber recibido el estado.
     expect(ok).toContain('unavailable');
   });

--- a/packages/pricing-engine/test/liquidacion.test.ts
+++ b/packages/pricing-engine/test/liquidacion.test.ts
@@ -54,9 +54,14 @@ describe('calcularLiquidacion — montos por tier (ADR-026 §2)', () => {
           .montoNetoCarrierClp,
     );
     // Debe ser estrictamente creciente: tiers superiores → mayor neto.
-    expect(netos[0]).toBeLessThan(netos[1]!);
-    expect(netos[1]).toBeLessThan(netos[2]!);
-    expect(netos[2]).toBeLessThan(netos[3]!);
+    for (let i = 1; i < netos.length; i++) {
+      const prev = netos[i - 1];
+      const curr = netos[i];
+      if (prev === undefined || curr === undefined) {
+        throw new Error('neto indefinido en la secuencia de tiers');
+      }
+      expect(prev).toBeLessThan(curr);
+    }
   });
 });
 

--- a/scripts/repo-checks/check-adr-numbering.mjs
+++ b/scripts/repo-checks/check-adr-numbering.mjs
@@ -87,10 +87,11 @@ export function main(argv) {
   }
   if (collisions.length === 0) {
     process.stdout.write(
-      `[check-adr-numbering] OK — no collisions in ${args.dir}` +
-        (args.allowLegacy.size > 0
+      `[check-adr-numbering] OK — no collisions in ${args.dir}${
+        args.allowLegacy.size > 0
           ? ` (legacy allowed: ${[...args.allowLegacy].sort().join(',')})\n`
-          : '\n'),
+          : '\n'
+      }`,
     );
     return 0;
   }

--- a/scripts/repo-checks/check-validated-secret-placeholders.mjs
+++ b/scripts/repo-checks/check-validated-secret-placeholders.mjs
@@ -230,8 +230,7 @@ export function main(argv) {
 
   for (const w of warnings) {
     process.stdout.write(
-      `[check-validated-secret-placeholders] NOTA — '${w.secret}' se crea como placeholder ` +
-        'y no está montado en ningún service en este plan (poblá su valor real antes de montarlo).\n',
+      `[check-validated-secret-placeholders] NOTA — '${w.secret}' se crea como placeholder y no está montado en ningún service en este plan (poblá su valor real antes de montarlo).\n`,
     );
   }
 
@@ -243,8 +242,7 @@ export function main(argv) {
   }
 
   process.stderr.write(
-    `[check-validated-secret-placeholders] FAIL — ${violations.length} secreto(s) validado(s) por formato ` +
-      'con placeholder, montados en un service (romperán el startup probe):\n',
+    `[check-validated-secret-placeholders] FAIL — ${violations.length} secreto(s) validado(s) por formato con placeholder, montados en un service (romperán el startup probe):\n`,
   );
   for (const v of violations) {
     process.stderr.write(`  ${v.secret} → ${v.services.join(', ')}\n`);


### PR DESCRIPTION
## Qué

Lleva \`pnpm lint\` de **62 warnings → 0** (el estándar Booster es 0-warnings). Cambios mecánicos de higiene, **sin alterar comportamiento ni contratos**.

### Desglose de los 62

| Regla | N | Resolución |
|---|---|---|
| `suppressions/unused` | 28 | Borrar `// biome-ignore` muertas: `noExplicitAny`/`noConsole` en tests/scripts donde la regla ya está `off` (biome.json overrides) → la supresión no tenía efecto. |
| `nursery/useSortedClasses` | 9 | Reorden de clases Tailwind (fixer de Biome). |
| `noNonNullAssertion` | 11 | `!` dentro de `expect(...)` eran redundantes; los de acceso a array → narrowing explícito + helper `firstButton` (`noUncheckedIndexedAccess` activo). |
| `noEmptyBlockStatements` | 7 | `() => {}` → `() => undefined` (mismo retorno, ya no es bloque vacío). |
| `useTemplate` | 4 | Concatenación → template literal (output **idéntico**, incl. repo-checks). |
| `useExhaustiveDependencies` | 3 | Patrones intencionales (`refreshTick` trigger de refresh; efecto mount-only) → supresión **documentada** con razón, no el fix de Biome (rompería comportamiento). |

## Evidencia

Verificado bajo **node 24** (`.nvmrc` / CI `NODE_VERSION=24`):

```
$ pnpm lint
  biome check .  → Checked 949 files. (0 errores, 0 warnings)
  lint:rls       → ✅ 0 queries sin filtro empresaId
$ pnpm typecheck → 0 errores (32 packages)
$ pnpm test      → api 1548 passed (2 skip) · web 110 files/1040 passed ·
                   pricing 45 · resto verde
$ pnpm build     → Tasks: 9 successful, 9 total
  cadena (typecheck && test && build) EXIT 0
```

- **Tests**: sin fallos reales (las líneas `FAIL — migración` son fixtures de `check-migration-safety`; los `Failed to persist debug token` son logs benignos de App Check sin `indexedDB`).
- **ADR compliance**: cambio de higiene de lint, no toca stack/contratos/ADRs. `check-adr-numbering` OK, `spec-canonical-drift` OK, gitleaks sin leaks (pre-commit).

> ⚠️ Nota de entorno: bajo **node 25/26** los tests de `apps/web` fallan (jsdom no inicializa `localStorage`/`indexedDB`) — es incompatibilidad del runtime local con el node fijado (24), no del repo. CI corre node 24 y queda verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)