### PR TITLE
docs(followups): marca P0-B/P0-C resueltos en código (#495/#496)

### DIFF
--- a/.specs/_followups/P0-B-idor-consent-portafolio.md
+++ b/.specs/_followups/P0-B-idor-consent-portafolio.md
@@ -1,5 +1,13 @@
 # P0-B 🔒 — IDOR en consent ESG `portafolio_viajes`
 
+> ✅ **RESUELTO en [#495](https://github.com/boosterchile/booster-ai/pull/495)** (`dad32ae`, merged). `userCanGrantOnScope` en
+> `apps/api/src/routes/me-consents.ts:91-128` exige `empresaId === scopeId` +
+> rol `dueno`/`admin` **activo** sobre la empresa específica del scope; el scope
+> `portafolio_viajes` se **deniega siempre** (decisión PO O-1b 2026-06-17: el
+> modelo de portafolio no existe — sin tabla, FK ni call sites). Cubre también
+> **P1-B**. Spec: `.specs/consent-idor-y-modelo-19628-21719/`. Verificado en vivo
+> contra el código de `main` (2026-06-22).
+
 **Dimensión**: security · **Estado**: requiere revisión legal (consentimiento sobre datos de terceros).
 **Fuente**: audit 2026-06-14
 

--- a/.specs/_followups/P0-C-pii-firebase-uids-git.md
+++ b/.specs/_followups/P0-C-pii-firebase-uids-git.md
@@ -1,5 +1,14 @@
 # P0-C 🔒 — Firebase UIDs reales (PII) hardcoded y versionados
 
+> ✅ **CÓDIGO RESUELTO en [#496](https://github.com/boosterchile/booster-ai/pull/496)** (`796c0c3`, merged). Los UIDs salen del código
+> vivo: `apps/api/src/services/harden-demo-accounts.ts:59-73` los lee de
+> `DEMO_OLD_UIDS` (env var validada por Zod, CSV), con inyección por `opts.oldUids`
+> en tests. Spec: `.specs/p0c-uids-demo-secret-manager/`. Verificado en vivo
+> contra `main` (2026-06-22).
+> ⚠️ **Pendiente (legal, NO-código)**: la decisión sobre `git filter-repo` del
+> historial sigue abierta (los UIDs persisten en commits previos) — ver §Plan de
+> pago paso 2.
+
 **Dimensión**: security · **Estado**: requiere revisión legal (PII en historial git).
 **Fuente**: audit 2026-06-14
 


### PR DESCRIPTION
## Qué

Corrige dos stubs de `.specs/_followups/` que seguían marcados como **🔒 P0 abiertos** cuando el código ya está resuelto en `main`. Dejarlos así hace leer un IDOR / leak de PII como vulnerabilidad **abierta** cuando está **cerrada**.

| Stub | Estado real | Resuelto en |
|---|---|---|
| **P0-B** IDOR consent ESG `portafolio_viajes` | ✅ código | [#495](https://github.com/boosterchile/booster-ai/pull/495) (`dad32ae`) — `userCanGrantOnScope` exige `empresaId===scopeId` + rol `dueno`/`admin` activo; `portafolio_viajes` deny total (PO O-1b). Cubre P1-B. |
| **P0-C** Firebase UIDs (PII) en código vivo | ✅ código (legal pendiente) | [#496](https://github.com/boosterchile/booster-ai/pull/496) (`796c0c3`) — UIDs leídos de `DEMO_OLD_UIDS` (env Zod). Queda abierta **solo** la decisión legal de `git filter-repo` del historial. |

## Evidencia

Verificado en vivo contra el código de `main` (2026-06-22):
- `apps/api/src/routes/me-consents.ts:91-128` — `userCanGrantOnScope` implementado.
- `apps/api/src/services/harden-demo-accounts.ts:59-73` — `getDemoOldUids` desde env.
- Specs presentes: `.specs/consent-idor-y-modelo-19628-21719/`, `.specs/p0c-uids-demo-secret-manager/`.

Solo docs (`.specs/**`, cubierto por `paths-ignore` de `release.yml` → no dispara deploy). Pre-commit: gitleaks sin leaks, `check-adr-numbering` OK, `spec-canonical-drift` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)