### PR TITLE
fix(observability): corrige consumer de la alerta safety-p0 (apps/api, no skeleton)

### DIFF
--- a/.specs/_followups/P0-G-skeletons-eventos-safety.md
+++ b/.specs/_followups/P0-G-skeletons-eventos-safety.md
@@ -1,5 +1,33 @@
 # P0-G — Servicios skeleton consumiendo eventos P0 de seguridad física
 
+> ✅ **PREMISA CORREGIDA (2026-06-22)** — el gap P0 que describía este stub **ya
+> está cerrado**. La verificación en vivo contra `main` + infra mostró:
+>
+> - El fan-out de eventos safety-p0 (crash/unplug/jamming) al transportista
+>   **está implementado y aplicado en prod**, pero **NO** por notification-service:
+>   el consumer es `apps/api` vía **PUSH subscription** → `POST /internal/safety-events`
+>   (OIDC). Productor en `telemetry-processor/panic-events.ts` + crash; routing
+>   `route-safety-recipients.ts`; dispatch push+WhatsApp `dispatch-safety-notification.ts`.
+>   Decisión **del PO** en `.specs/safety-event-fanout/spec.md` ("Consumer en apps/api,
+>   no construir notification-service; el skeleton se retira en el cleanup de demo").
+>   `SAFETY_EVENTS_TOPIC` (compute.tf:464) + `SAFETY_PUSH_CALLER_SA` (compute.tf:102)
+>   cableados; `terraform plan` desde main = No changes → **vivo en prod**. Pendiente
+>   solo el leg WhatsApp (template Meta `safety_alert_v2`, ver [[safety-alert-template-2026-06]]);
+>   web push ya opera.
+> - Las subs PULL "huérfanas" (security-p1, eco-score, trip-transitions → skeletons
+>   notification-service/matching-engine/trip-state-machine) **no tienen productor**
+>   (`telemetry-processor/config.ts` solo define `SAFETY_EVENTS_TOPIC`) → backlog
+>   cero → benignas (infra adelantada a la implementación).
+> - **Residual real corregido en esta sesión**: la alerta CRITICAL `safety_p0` en
+>   `telemetry-monitoring.tf` documentaba `consumer = "notification-service"` (servicio
+>   equivocado) → on-call iría al skeleton en un incidente de seguridad física. Fix:
+>   apunta a `apps/api · POST /internal/safety-events`.
+>
+> **Pendiente (decisión PO, baja urgencia)**: retirar los 3 skeletons
+> (notification-service, matching-engine) + cerrar/limpiar las subs huérfanas en el
+> cleanup de demo (ver [[demo-subsystem-debt]]). NO urgente: sin productores no hay
+> backlog ni costo de mensajes.
+
 **Dimensión**: sre / tech-debt · **Esfuerzo**: M · **Requiere decisión PO**
 **Fuente**: audit 2026-06-14
 

--- a/infrastructure/telemetry-monitoring.tf
+++ b/infrastructure/telemetry-monitoring.tf
@@ -635,8 +635,12 @@ locals {
       subscription_id = "telemetry-events-safety-p0-notification-sub"
       threshold_s     = 600 # 10 min — fan-out de eventos panic, debe ackear en <30s
       severity        = "CRITICAL"
-      consumer        = "notification-service"
-      detail          = "El fan-out de eventos panic (crash/unplug/jamming) al transportista (SMS/push/WhatsApp) está detenido. La detección del evento en sí ya la cubre crash_event_p0/unplug_event_p0/gnss_jamming_p0; esta alerta es que la NOTIFICACIÓN no se entrega."
+      # El consumer del safety fan-out es el endpoint OIDC en apps/api (PUSH
+      # subscription), NO notification-service (skeleton). Ver messaging.tf
+      # `telemetry_events_safety_p0_notification` + spec safety-event-fanout.
+      # On-call debe mirar apps/api / la PUSH subscription, no el skeleton.
+      consumer = "apps/api · POST /internal/safety-events (PUSH)"
+      detail   = "El fan-out de eventos panic (crash/unplug/jamming) al transportista (SMS/push/WhatsApp) está detenido. La detección del evento en sí ya la cubre crash_event_p0/unplug_event_p0/gnss_jamming_p0; esta alerta es que la NOTIFICACIÓN no se entrega."
     }
     security_p1 = {
       subscription_id = "telemetry-events-security-p1-notification-sub"


### PR DESCRIPTION
## Qué

La alerta **CRITICAL** `wave2 safety_p0 consumer stalled` (en `infrastructure/telemetry-monitoring.tf`) documentaba `consumer = "notification-service"`. Ese servicio es un **skeleton** — el consumer real del fan-out de eventos panic (crash/unplug/jamming) es el endpoint OIDC **`POST /internal/safety-events` en apps/api** (PUSH subscription, ver `messaging.tf` `telemetry_events_safety_p0_notification` + `.specs/safety-event-fanout/`).

**Por qué importa**: cuando dispare esta alerta (la notificación de seguridad física no se entrega al transportista), on-call leería la documentación y se iría a investigar `notification-service` (un skeleton que no consume nada) en vez de apps/api → tiempo perdido en un incidente de seguridad física.

## Contexto — verificación de P0-G (audit 2026-06-14)

Verifiqué en vivo el hallazgo P0-G ("eventos safety encolados sin consumer"). **La premisa del stub está desactualizada**:

- ✅ El fan-out safety-p0 **está implementado y vivo en prod** vía apps/api (decisión del PO en `safety-event-fanout`: consumer en apps/api, NO notification-service). `SAFETY_EVENTS_TOPIC` (compute.tf:464) + `SAFETY_PUSH_CALLER_SA` (compute.tf:102) cableados; `terraform plan` desde main = No changes. Pendiente solo el leg WhatsApp (template Meta `safety_alert_v2`); web push opera.
- Las subs PULL huérfanas (security-p1 / eco-score / trip-transitions → skeletons) **no tienen productor** → backlog cero → benignas.

Este PR corrige el único residual real (el label) + marca el stub P0-G con la premisa corregida.

## Evidencia

- `terraform validate` → **Success! The configuration is valid.**
- `terraform fmt -check -recursive` → exit 0.
- Cambio acotado a `documentation.content` de la alerta (vía `local.wave2_stall_alerts.safety_p0.consumer`) — **sin** cambios de umbral, filtro, severidad ni canal.
- Pre-commit: gitleaks sin leaks, `check-adr-numbering` OK, `spec-canonical-drift` OK.

⚠️ **Requiere `terraform apply` (owner)** para reflejarse en prod. Hasta el apply, `terraform-drift.yml` mostrará este único diff esperado (texto de la doc de la alerta). No toca runtime de producto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)