### PR TITLE
fix(auth): reset-on-success del counter per-RUT en rate-limit-pin (XFF P2)

### DIFF
--- a/.specs/_followups/xff-trust-boundary-resto-endpoints.md
+++ b/.specs/_followups/xff-trust-boundary-resto-endpoints.md
@@ -15,4 +15,23 @@
 
 ## Estado
 
-Pendiente. Sin asignar a ciclo.
+✅ **RESUELTO (2026-06-22)**.
+
+- **Parte 1 (XFF trust boundary)** — ya estaba hecha en `main`: `extractClientIp`
+  (penúltima entry) vive en `apps/api/src/middleware/client-ip.ts` y es la fuente
+  única en los 3 sitios + 5 más (`rate-limit-signup.ts:50`, `demo-cache-warm.ts:65`,
+  `rate-limit-pin`, `rate-limit-public-tracking`, `rate-limit-transport-documents`,
+  `me-consents`, `me`). Verificado: 0 lecturas de `xff[0]` fuera del util.
+- **Parte 2 (counter per-RUT)** — esta PR: **reset-on-success** en
+  `rate-limit-pin.ts` (DEL del `rutKey` cuando el handler responde 2xx). Un login
+  legítimo ya no cuenta para el lockout; el per-IP NO se resetea; fallo=401 → el
+  counter persiste (mantiene anti-brute-force). TDD: 4 casos nuevos (éxito→DEL,
+  401→no, 429→no, DEL-falla→best-effort).
+
+**Residual aceptado (inherente)**: el DoS dirigido con requests **fallidos**
+(alguien con un RUT conocido manda 5 fallidos y bloquea a la víctima 15min) no se
+elimina con reset-on-success ni con "contar-solo-fallidos" — es inherente a
+cualquier rate-limit per-RUT. Mitigado por el counter per-IP (30/15min) + Cloud
+Armor (1000/min/IP). Eliminarlo del todo exigiría quitar el límite per-RUT, lo que
+debilitaría la protección anti-brute-force del PIN/clave. Se documenta como deuda
+conscientemente no tomada.

--- a/apps/api/src/middleware/rate-limit-pin.test.ts
+++ b/apps/api/src/middleware/rate-limit-pin.test.ts
@@ -339,3 +339,117 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
     expect(calls.incrCalled).toEqual([]);
   });
 });
+
+// XFF follow-up parte 2 (.specs/_followups/xff-trust-boundary-resto-endpoints.md):
+// reset-on-success del counter per-RUT. Un auth EXITOSO (2xx) limpia el counter
+// per-RUT para que un login legítimo no cuente para el lockout (y reduce el DoS
+// dirigido: alguien con un RUT conocido ya no acumula intentos contra la víctima
+// en cada login exitoso de esta). El per-IP NUNCA se resetea (un éxito puntual no
+// perdona el abuso cross-RUT desde la misma IP).
+describe('createRateLimitPinMiddleware — reset-on-success per-RUT', () => {
+  function makeRedisWithDel(rutCount: number, ipCount: number) {
+    const delCalled: string[] = [];
+    const pipeline = {
+      incr() {
+        return this;
+      },
+      expire() {
+        return this;
+      },
+      async exec(): Promise<unknown[]> {
+        return [
+          [null, rutCount],
+          [null, 1],
+          [null, ipCount],
+          [null, 1],
+        ];
+      },
+    };
+    const redis = {
+      multi: () => pipeline,
+      del: async (key: string): Promise<number> => {
+        delCalled.push(key);
+        return 1;
+      },
+    };
+    return { redis, delCalled };
+  }
+
+  function makeAppWithStatus(
+    mw: ReturnType<typeof createRateLimitPinMiddleware>,
+    status: 200 | 401,
+  ) {
+    const app = new Hono();
+    app.use('/x', mw);
+    app.post('/x', (c) => c.json({ ok: status < 400 }, status));
+    return app;
+  }
+
+  it('auth exitoso (2xx) → DEL del counter per-RUT, NO del per-IP', async () => {
+    const { redis, delCalled } = makeRedisWithDel(1, 1);
+    const mw = createRateLimitPinMiddleware({ redis: redis as never, logger: noopLogger });
+    const res = await makeAppWithStatus(mw, 200).request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(200);
+    expect(delCalled).toEqual([`${KEY_PREFIX}12345678-5`]);
+  });
+
+  it('auth fallido (401) → NO resetea el counter per-RUT', async () => {
+    const { redis, delCalled } = makeRedisWithDel(1, 1);
+    const mw = createRateLimitPinMiddleware({ redis: redis as never, logger: noopLogger });
+    const res = await makeAppWithStatus(mw, 401).request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(401);
+    expect(delCalled).toEqual([]);
+  });
+
+  it('429 (rate-limited) → NO resetea (el handler no corre)', async () => {
+    const { redis, delCalled } = makeRedisWithDel(6, 1); // rutCount 6 > limit 5
+    const mw = createRateLimitPinMiddleware({ redis: redis as never, logger: noopLogger });
+    const res = await makeAppWithStatus(mw, 200).request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(429);
+    expect(delCalled).toEqual([]);
+  });
+
+  it('DEL falla en éxito → la respuesta exitosa no se rompe (best-effort)', async () => {
+    const pipeline = {
+      incr() {
+        return this;
+      },
+      expire() {
+        return this;
+      },
+      async exec(): Promise<unknown[]> {
+        return [
+          [null, 1],
+          [null, 1],
+          [null, 1],
+          [null, 1],
+        ];
+      },
+    };
+    const redis = {
+      multi: () => pipeline,
+      del: async (): Promise<number> => {
+        throw new Error('redis del boom');
+      },
+    };
+    const mw = createRateLimitPinMiddleware({ redis: redis as never, logger: noopLogger });
+    const res = await makeAppWithStatus(mw, 200).request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/middleware/rate-limit-pin.ts
+++ b/apps/api/src/middleware/rate-limit-pin.ts
@@ -146,7 +146,26 @@ export function createRateLimitPinMiddleware(opts: RateLimitPinOptions): Middlew
       return c.json({ error: 'too_many_attempts', code: 'too_many_attempts' }, 429);
     }
 
-    return next();
+    await next();
+
+    // Reset-on-success per-RUT (XFF follow-up parte 2): un auth EXITOSO (2xx)
+    // limpia el counter per-RUT. Motivo: el counter incrementa pre-handler en
+    // CADA intento, así que sin esto >5 logins legítimos/ventana bloquean al
+    // usuario, y alguien con un RUT conocido acumula intentos contra la víctima.
+    // Solo se resetea en éxito real (fallo=401 → el counter persiste, mantiene la
+    // protección anti-brute-force). El per-IP NO se resetea: un éxito puntual no
+    // debe perdonar el abuso cross-RUT desde la misma IP. Best-effort: si el DEL
+    // falla, el TTL de la ventana limpia igual; no rompemos la respuesta exitosa.
+    if (c.res.status >= 200 && c.res.status < 300) {
+      try {
+        await opts.redis.del(rutKey);
+      } catch (err) {
+        opts.logger.warn(
+          { err, rutNormalizado: normRut, keyPrefix },
+          'rate-limit-pin: reset-on-success DEL falló (no bloqueante; el TTL limpia igual)',
+        );
+      }
+    }
   };
 }
 


### PR DESCRIPTION
## Qué

Cierra la **Parte 2** del follow-up `xff-trust-boundary-resto-endpoints`. El counter per-RUT de `rate-limit-pin` incrementa **pre-handler en cada intento**, así que >5 logins legítimos/ventana bloqueaban al usuario, y alguien con un RUT conocido acumulaba intentos contra la víctima.

**Fix**: tras `next()`, si la respuesta es **2xx**, `DEL` del `rutKey` (reset-on-success).
- Solo en éxito real: un **401** deja el counter intacto → se mantiene la protección anti-brute-force del PIN/clave.
- El **per-IP NO se resetea**: un éxito puntual no perdona el abuso cross-RUT desde la misma IP.
- Best-effort: si el `DEL` falla, el TTL de la ventana limpia igual; no se rompe la respuesta exitosa.

**Parte 1** (XFF penúltima-entry en signup/demo-cache-warm) **ya estaba en `main`** vía el util compartido `extractClientIp` — verificado: 0 lecturas de `xff[0]` fuera del util.

## Residual aceptado (inherente)

El DoS dirigido con requests **fallidos** (alguien con un RUT conocido manda 5 fallidos y bloquea a la víctima 15min) **no** se elimina con reset-on-success ni con "contar-solo-fallidos" — es inherente a cualquier rate-limit per-RUT. Mitigado por el per-IP (30/15min) + Cloud Armor (1000/min/IP). Documentado como deuda conscientemente no tomada.

## Evidencia (node 24)

- **TDD**: 4 casos nuevos (éxito→DEL solo del per-RUT, 401→no resetea, 429→no resetea, DEL-falla→2xx intacto). Rojo→verde verificado.
- `rate-limit-pin.test.ts` → **16/16**.
- Suite api completa → **128 files / 1552 passed** (2 skip) — sin regresiones en auth.
- `typecheck` → 0 errores.

> Nota: este archivo de test tiene 12 supresiones `biome-ignore` muertas pre-existentes en `main` que [#509](https://github.com/boosterchile/booster-ai/pull/509) ya remueve; mis adiciones usan `as never` (limpias). Sin conflicto (cambios append-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)