### PR TITLE
fix(web): corta reconnect del chat SSE en errores permanentes + cierra cluster SSE

### DIFF
--- a/.specs/_followups/sse-auth-token-en-url.md
+++ b/.specs/_followups/sse-auth-token-en-url.md
@@ -30,4 +30,12 @@ Tocaría: `apps/api` (mint + validate ticket, middleware del SSE), `apps/web` (`
 Ninguna a nivel app. Las palancas de infra (bajar sampling de Cloud Trace, desactivar request logging del path) son toscas y con pérdida — no se recomiendan; ir directo al fix real.
 
 ## Estado
-Pendiente — decisión del PO sobre si se encara el ciclo del ticket SSE.
+✅ **RESUELTO** (verificado en `main`, 2026-06-22). El ciclo del ticket SSE está
+implementado: `apps/api/src/routes/chat.ts:411` expone `POST /:id/messages/stream-ticket`
+(autenticado por Bearer + userContext + `resolveChatAccess`) que mintea un ticket
+efímero single-use vía `mintStreamTicket` (`services/sse-ticket.ts`, Redis, TTL ~60s,
+scoped al assignment+uid). `apps/web/src/hooks/use-chat-stream.ts:88-138` ya pide el
+ticket con el Bearer header y abre el `EventSource` con `?ticket=` — el Firebase ID
+token **ya no viaja en la URL** → su filtrado a Cloud Trace/Logging quedó cerrado. El
+`RedactingSpanExporter` (#451) se mantiene como defensa en profundidad. (commit
+"fix-sse-ticket-auth").

--- a/.specs/_followups/sse-realtime-multi-empresa.md
+++ b/.specs/_followups/sse-realtime-multi-empresa.md
@@ -11,4 +11,10 @@ El POST `/stream-ticket` (y antes el SSE con `?auth=`) usa raw fetch/EventSource
 - (EventSource del stream no puede mandar header, pero ya no lo necesita: la identidad+empresa se fijan en el mint.)
 
 ## Estado
-Pendiente (BAJA). Afecta solo a users multi-empresa con chat en empresa no-default.
+✅ **RESUELTO** (verificado en `main`, 2026-06-22). `apps/web/src/hooks/use-chat-stream.ts:102-105`
+ya manda `X-Empresa-Id` (la empresa activa de la PWA vía `getActiveEmpresaId()`) en el
+POST `/stream-ticket`, igualando lo que el api-client hace para el resto de requests.
+`resolveChatAccess` resuelve la empresa correcta para users multi-empresa con chat en
+empresa no-default → el ticket se emite y el realtime conecta. (commit
+"fix-sse-ticket-x-empresa".) El re-mint al CAMBIAR de empresa con un stream vivo es un
+residual menor distinto, trackeado en [[use-chat-stream-hardening]] #2.

--- a/.specs/_followups/use-chat-stream-hardening.md
+++ b/.specs/_followups/use-chat-stream-hardening.md
@@ -21,4 +21,23 @@ El `useEffect` depende de `[enabled, opts.assignmentId]`, no de la empresa activ
 El fetch del mint duplica lo que `api-client.ts` ya hace (Bearer + X-Empresa-Id). Migrar a `api.post(...)` unificaría la inyección de headers (incluida cualquier futura: trace headers, etc.). Cuidar: el api-client arma su propio Content-Type/AbortController; el hook tiene un timeout de 10s y manejo de error específico que no debe perderse.
 
 ## Estado
-Pendiente (BAJA). Los tres se pueden abordar en un solo ciclo corto (todo en `use-chat-stream.ts` + su test).
+
+**Parcial (2026-06-22)** — #1 resuelto; #2/#3 deuda conscientemente no tomada.
+
+- **#1 (reconnect en error permanente)** — ✅ RESUELTO. `use-chat-stream.ts`: un
+  mint con **401/403** ya NO reagenda reconnect (log + `onDisconnect` + return); el
+  realtime queda off y el polling/useQuery cubre la lectura. Los transitorios
+  (5xx/network/abort/timeout) siguen con backoff. TDD: 3 casos (403→sin reconnect,
+  401→sin reconnect, 503→reconnect), fake timers.
+- **#2 (re-mint al cambiar empresa activa)** — NO tomado. `getActiveEmpresaId()` es
+  estado de módulo (api-client), no reactivo; no hay subscripción a `setActiveEmpresaId`.
+  Re-mintear al cambiar empresa exige plumbing reactivo (event emitter o pasar la
+  empresa como prop reactiva del caller). **Seguridad intacta** (empresa fija en el
+  mint + re-autz server-side); el costo afecta solo a users multi-empresa que cambian
+  de empresa con un stream vivo (caso raro, degrada a polling hasta el próximo
+  reconnect). No justifica el riesgo del plumbing por ahora.
+- **#3 (consolidar el fetch con api-client)** — NO tomado. `api-client.ts` **no tiene
+  timeout propio** (verificado: sin AbortController/setTimeout); migrar el mint a
+  `api.post` perdería el **timeout duro de 10s** del hook = net-negativo. La
+  duplicación (Bearer + X-Empresa-Id) es mínima. Re-evaluar si el api-client gana un
+  timeout configurable.

--- a/.specs/_followups/xff-trust-boundary-resto-endpoints.md
+++ b/.specs/_followups/xff-trust-boundary-resto-endpoints.md
@@ -15,4 +15,23 @@
 
 ## Estado
 
-Pendiente. Sin asignar a ciclo.
+✅ **RESUELTO (2026-06-22)**.
+
+- **Parte 1 (XFF trust boundary)** — ya estaba hecha en `main`: `extractClientIp`
+  (penúltima entry) vive en `apps/api/src/middleware/client-ip.ts` y es la fuente
+  única en los 3 sitios + 5 más (`rate-limit-signup.ts:50`, `demo-cache-warm.ts:65`,
+  `rate-limit-pin`, `rate-limit-public-tracking`, `rate-limit-transport-documents`,
+  `me-consents`, `me`). Verificado: 0 lecturas de `xff[0]` fuera del util.
+- **Parte 2 (counter per-RUT)** — esta PR: **reset-on-success** en
+  `rate-limit-pin.ts` (DEL del `rutKey` cuando el handler responde 2xx). Un login
+  legítimo ya no cuenta para el lockout; el per-IP NO se resetea; fallo=401 → el
+  counter persiste (mantiene anti-brute-force). TDD: 4 casos nuevos (éxito→DEL,
+  401→no, 429→no, DEL-falla→best-effort).
+
+**Residual aceptado (inherente)**: el DoS dirigido con requests **fallidos**
+(alguien con un RUT conocido manda 5 fallidos y bloquea a la víctima 15min) no se
+elimina con reset-on-success ni con "contar-solo-fallidos" — es inherente a
+cualquier rate-limit per-RUT. Mitigado por el counter per-IP (30/15min) + Cloud
+Armor (1000/min/IP). Eliminarlo del todo exigiría quitar el límite per-RUT, lo que
+debilitaría la protección anti-brute-force del PIN/clave. Se documenta como deuda
+conscientemente no tomada.

--- a/apps/api/src/middleware/rate-limit-pin.test.ts
+++ b/apps/api/src/middleware/rate-limit-pin.test.ts
@@ -339,3 +339,117 @@ describe('createRateLimitPinMiddleware (T9 SEC-001)', () => {
     expect(calls.incrCalled).toEqual([]);
   });
 });
+
+// XFF follow-up parte 2 (.specs/_followups/xff-trust-boundary-resto-endpoints.md):
+// reset-on-success del counter per-RUT. Un auth EXITOSO (2xx) limpia el counter
+// per-RUT para que un login legítimo no cuente para el lockout (y reduce el DoS
+// dirigido: alguien con un RUT conocido ya no acumula intentos contra la víctima
+// en cada login exitoso de esta). El per-IP NUNCA se resetea (un éxito puntual no
+// perdona el abuso cross-RUT desde la misma IP).
+describe('createRateLimitPinMiddleware — reset-on-success per-RUT', () => {
+  function makeRedisWithDel(rutCount: number, ipCount: number) {
+    const delCalled: string[] = [];
+    const pipeline = {
+      incr() {
+        return this;
+      },
+      expire() {
+        return this;
+      },
+      async exec(): Promise<unknown[]> {
+        return [
+          [null, rutCount],
+          [null, 1],
+          [null, ipCount],
+          [null, 1],
+        ];
+      },
+    };
+    const redis = {
+      multi: () => pipeline,
+      del: async (key: string): Promise<number> => {
+        delCalled.push(key);
+        return 1;
+      },
+    };
+    return { redis, delCalled };
+  }
+
+  function makeAppWithStatus(
+    mw: ReturnType<typeof createRateLimitPinMiddleware>,
+    status: 200 | 401,
+  ) {
+    const app = new Hono();
+    app.use('/x', mw);
+    app.post('/x', (c) => c.json({ ok: status < 400 }, status));
+    return app;
+  }
+
+  it('auth exitoso (2xx) → DEL del counter per-RUT, NO del per-IP', async () => {
+    const { redis, delCalled } = makeRedisWithDel(1, 1);
+    const mw = createRateLimitPinMiddleware({ redis: redis as never, logger: noopLogger });
+    const res = await makeAppWithStatus(mw, 200).request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(200);
+    expect(delCalled).toEqual([`${KEY_PREFIX}12345678-5`]);
+  });
+
+  it('auth fallido (401) → NO resetea el counter per-RUT', async () => {
+    const { redis, delCalled } = makeRedisWithDel(1, 1);
+    const mw = createRateLimitPinMiddleware({ redis: redis as never, logger: noopLogger });
+    const res = await makeAppWithStatus(mw, 401).request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(401);
+    expect(delCalled).toEqual([]);
+  });
+
+  it('429 (rate-limited) → NO resetea (el handler no corre)', async () => {
+    const { redis, delCalled } = makeRedisWithDel(6, 1); // rutCount 6 > limit 5
+    const mw = createRateLimitPinMiddleware({ redis: redis as never, logger: noopLogger });
+    const res = await makeAppWithStatus(mw, 200).request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(429);
+    expect(delCalled).toEqual([]);
+  });
+
+  it('DEL falla en éxito → la respuesta exitosa no se rompe (best-effort)', async () => {
+    const pipeline = {
+      incr() {
+        return this;
+      },
+      expire() {
+        return this;
+      },
+      async exec(): Promise<unknown[]> {
+        return [
+          [null, 1],
+          [null, 1],
+          [null, 1],
+          [null, 1],
+        ];
+      },
+    };
+    const redis = {
+      multi: () => pipeline,
+      del: async (): Promise<number> => {
+        throw new Error('redis del boom');
+      },
+    };
+    const mw = createRateLimitPinMiddleware({ redis: redis as never, logger: noopLogger });
+    const res = await makeAppWithStatus(mw, 200).request('/x', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ rut: '12345678-5' }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/src/middleware/rate-limit-pin.ts
+++ b/apps/api/src/middleware/rate-limit-pin.ts
@@ -146,7 +146,26 @@ export function createRateLimitPinMiddleware(opts: RateLimitPinOptions): Middlew
       return c.json({ error: 'too_many_attempts', code: 'too_many_attempts' }, 429);
     }
 
-    return next();
+    await next();
+
+    // Reset-on-success per-RUT (XFF follow-up parte 2): un auth EXITOSO (2xx)
+    // limpia el counter per-RUT. Motivo: el counter incrementa pre-handler en
+    // CADA intento, así que sin esto >5 logins legítimos/ventana bloquean al
+    // usuario, y alguien con un RUT conocido acumula intentos contra la víctima.
+    // Solo se resetea en éxito real (fallo=401 → el counter persiste, mantiene la
+    // protección anti-brute-force). El per-IP NO se resetea: un éxito puntual no
+    // debe perdonar el abuso cross-RUT desde la misma IP. Best-effort: si el DEL
+    // falla, el TTL de la ventana limpia igual; no rompemos la respuesta exitosa.
+    if (c.res.status >= 200 && c.res.status < 300) {
+      try {
+        await opts.redis.del(rutKey);
+      } catch (err) {
+        opts.logger.warn(
+          { err, rutNormalizado: normRut, keyPrefix },
+          'rate-limit-pin: reset-on-success DEL falló (no bloqueante; el TTL limpia igual)',
+        );
+      }
+    }
   };
 }
 

--- a/apps/web/src/hooks/use-chat-stream.test.tsx
+++ b/apps/web/src/hooks/use-chat-stream.test.tsx
@@ -239,4 +239,53 @@ describe('useChatStream', () => {
     await waitFor(() => expect(lastEventSource?.url).toContain('/assignments/a2/'));
     expect(first?.closed).toBe(true);
   });
+
+  // use-chat-stream-hardening #1: cortar reconnect en errores PERMANENTES.
+  // Fake timers: el reconnect se reagenda con backoff (≥2000ms tras el 1er
+  // error). Avanzamos timers para probar de forma determinística que un 403/401
+  // NO reintenta y un 503 SÍ.
+  it('mint 403 (permanente) → onDisconnect SIN reconnect', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 403,
+      json: async () => ({ error: 'forbidden' }),
+    });
+    const onDisconnect = vi.fn();
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn(), onDisconnect }));
+    await vi.advanceTimersByTimeAsync(50); // corre el connect inicial (getIdToken + fetch)
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onDisconnect).toHaveBeenCalled();
+    expect(lastEventSource).toBeNull();
+    await vi.advanceTimersByTimeAsync(10_000); // muy pasado cualquier backoff
+    expect(fetchMock).toHaveBeenCalledTimes(1); // sin reconnect
+  });
+
+  it('mint 401 (permanente) → SIN reconnect', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'unauthorized' }),
+    });
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn() }));
+    await vi.advanceTimersByTimeAsync(50);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('mint 503 (transitorio) → reconnect (segundo mint)', async () => {
+    vi.useFakeTimers();
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: 'realtime_disabled' }),
+    });
+    renderHook(() => useChatStream({ assignmentId: 'a1', onMessage: vi.fn() }));
+    await vi.advanceTimersByTimeAsync(50);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(2100); // pasa el backoff (2000ms) → reconnect
+    expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/apps/web/src/hooks/use-chat-stream.ts
+++ b/apps/web/src/hooks/use-chat-stream.ts
@@ -114,6 +114,23 @@ export function useChatStream(opts: UseChatStreamOptions): void {
           clearTimeout(timeout);
         }
         if (!res.ok) {
+          // Error PERMANENTE (401/403): reintentar el mismo mint no puede tener
+          // éxito — token inválido, sin acceso, o empresa stale/revocada. NO
+          // reagendamos reconnect (evita el loop indefinido con backoff ≤30s);
+          // el realtime queda off y el polling/useQuery cubre la lectura. Solo
+          // los transitorios (5xx/network/abort/timeout) caen al catch y
+          // reintentan. (use-chat-stream-hardening #1)
+          if (res.status === 401 || res.status === 403) {
+            if (cancelled) {
+              return;
+            }
+            logger.warn(
+              { status: res.status },
+              'useChatStream: stream-ticket rechazado (permanente) — sin reconnect',
+            );
+            onDisconnectRef.current?.();
+            return;
+          }
           throw new Error(`stream-ticket ${res.status}`);
         }
         ticket = ((await res.json()) as { ticket: string }).ticket;


### PR DESCRIPTION
## Qué

**`use-chat-stream-hardening` #1** (el FUERTE del review): el hook trataba todo `!res.ok` del mint igual, así que un **403** (empresa stale/revocada o sin acceso) entraba en **reconnect loop indefinido** (backoff ≤30s), reintentando un request que jamás puede tener éxito.

**Fix**: distinguir permanente (401/403) de transitorio. En permanente → `log + onDisconnect + NO reconnect` (realtime off; polling/useQuery cubre la lectura). En transitorio (5xx/network/abort/timeout) → backoff intacto.

## Cierra el cluster SSE (3 stubs)

Verificación contra `main` mostró que 2 ya estaban resueltos (no requerían código):
- **`sse-auth-token-en-url`** ✅ — el ticket single-use está implementado (`chat.ts` `POST /stream-ticket` + `use-chat-stream` `?ticket=`); el Firebase ID token **ya no viaja en la URL** (cerró la fuga a Cloud Trace/Logging).
- **`sse-realtime-multi-empresa`** ✅ — el hook ya manda `X-Empresa-Id` en el mint.
- **`use-chat-stream-hardening` #2/#3** — documentados como deuda no tomada: #2 (re-mint al cambiar empresa) exige plumbing reactivo y la seguridad está intacta; #3 (consolidar fetch) perdería el timeout de 10s del hook (api-client no tiene timeout propio).

## Evidencia (node 24)

- **TDD**: 3 casos nuevos (403→sin reconnect, 401→sin reconnect, 503→reconnect), fake timers. Rojo→verde verificado (el rojo mostraba `Error: stream-ticket 401` repetido = el loop).
- `use-chat-stream.test.tsx` → **16/16**.
- `typecheck` web → 0; `biome check` de los 2 archivos → 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)