### PR TITLE
docs(followups): cierra stubs verificados-hechos + deuda aceptada

### DIFF
--- a/.specs/_followups/deploy-telemetry-gateway-repo-root-bug.md
+++ b/.specs/_followups/deploy-telemetry-gateway-repo-root-bug.md
@@ -15,4 +15,12 @@
 
 ## Estado
 
-Pendiente. Sin asignar a ciclo.
+✅ **RESUELTO** (verificado en `main`, 2026-06-22).
+
+1. El bug `REPO_ROOT` está corregido: `scripts/deploy-telemetry-gateway.sh:73` usa
+   `git rev-parse --show-toplevel` directo (sin el `/..` que apuntaba al padre);
+   el branch de primer deploy ya referencia el manifiesto correcto.
+2. El banner de deprecación ya existe (`deploy-telemetry-gateway.sh:3-9`): apunta a
+   los pipelines `cloudbuild-primary-{deploy,check}.yaml` (ADR-059/ADR-065) como vía
+   canónica y deja este script como **break-glass** manual. Consistente con P0-I
+   (deploy GKE automatizado).

--- a/.specs/_followups/redis-tls-cn-pinning.md
+++ b/.specs/_followups/redis-tls-cn-pinning.md
@@ -21,4 +21,18 @@ new Error('CN mismatch')`, con `EXPECTED_INSTANCE_UID` inyectado por env desde T
 cert sea efectivamente el UID estable de la instancia.
 
 ## Estado
-Pendiente de priorizar (hardening, no bloqueante).
+**Deuda conscientemente NO tomada (2026-06-22)** — hardening de valor marginal,
+cerrado como aceptado salvo cambio de topología.
+
+`packages/config/src/redis-tls.ts:30-34,59` ya documenta por qué NO se pinea el CN:
+se conecta por **IP privada** (el CN del leaf cert es el UID de la instancia, no la
+IP) y el control anti-MITM real es la **validación de cadena contra la CA pinneada
+por-instancia** (`REDIS_CA_CERT`). Bajo ese modelo (CA per-instancia + IP fija en
+`PRIVATE_SERVICE_ACCESS` + AUTH habilitado) no hay otro host bajo la misma CA dentro
+del VPC al que redirigir, así que pinear el CN agrega defensa marginal sobre lo que
+la cadena CA ya garantiza. El security-auditor lo evaluó **aceptable** (`spec.md §7b`).
+
+**Re-evaluar SI**: la topología cambia a una CA compartida entre instancias, o
+Memorystore pasa a accederse por hostname en vez de IP — ahí el CN-pinning sí cierra
+un gap. Mientras tanto, implementarlo sería complejidad (inyectar `EXPECTED_INSTANCE_UID`
+desde Terraform + verificar que el CN sea el UID estable) sin beneficio de seguridad real.

--- a/.specs/_followups/shared-schemas-contratos-canonicos.md
+++ b/.specs/_followups/shared-schemas-contratos-canonicos.md
@@ -19,4 +19,19 @@ Dos contratos núcleo tienen doble fuente de verdad:
 
 ## Estado
 
-Pendiente. Sin asignar a ciclo.
+✅ **RESUELTO en los 2 contratos núcleo** (verificado en `main`, 2026-06-22).
+
+- **Wire format telemetry-events**: ya hay fuente única canónica
+  `packages/shared-schemas/src/events/telemetry-record.ts` (`telemetryRecordMessageSchema`);
+  el espejo Zod copiado a mano se eliminó (desde 2026-06-11). Gateway (tipo) y
+  processor (validación) la consumen.
+- **Estados de viaje**: `packages/trip-state-machine/src/estados.ts` (9 estados
+  español) == `tripStatusEnum` (`apps/api/src/db/schema.ts`), garantizado por
+  `trip-state-machine-parity.test.ts`. El vocabulario muerto ADR-004 (17 estados
+  inglés, cero consumidores) se eliminó (ADR-061).
+
+**Residual menor (no bloqueante)**: el sub-ítem "~18 de 38 tablas sin schema
+domain" es una aspiración de cobertura del CLAUDE.md, no un contrato duplicado
+activo. No es un bug; se cierra/ajusta cuando se priorice la cobertura domain (o se
+ajuste la regla del CLAUDE.md a la realidad deliberada). Los dos riesgos ALTOS que
+originaron este follow-up (doble fuente de verdad) están cerrados.


### PR DESCRIPTION
## Qué

Higiene del backlog `.specs/_followups/`: cierra 3 stubs tras verificarlos contra el código vivo de `main`. Solo docs.

| Stub | Veredicto | Evidencia |
|---|---|---|
| `shared-schemas-contratos-canonicos` | ✅ RESUELTO (2 contratos núcleo) | Wire telemetry canónico en `telemetry-record.ts` (espejo eliminado); estados de viaje con `trip-state-machine-parity.test.ts`. Residual menor: cobertura domain de ~18 tablas (aspiración CLAUDE.md, no duplicación). |
| `deploy-telemetry-gateway-repo-root-bug` | ✅ RESUELTO | `REPO_ROOT` sin `/..` (`deploy-telemetry-gateway.sh:73`) + banner deprecación break-glass (líneas 3-9). |
| `redis-tls-cn-pinning` | Deuda aceptada | El código ya documenta por qué no se pinea CN (conexión por IP privada; CA per-instancia = control anti-MITM real). Valor marginal. Re-evaluar si cambia la topología. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)