### PR TITLE
ci(release): paths-ignore para cambios test-only (no-op deploy)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,14 @@ on:
       - 'references/**'
       - 'playbooks/**'
       - '*.md'
+      # Cambios test-only no van en ningún bundle de runtime → no deben
+      # disparar un deploy no-op que encola la lane de concurrency (#422 lo
+      # hizo, hubo que rechazar el run). Igual que arriba: skipea solo si TODO
+      # el push matchea (código+test mezclado SÍ despliega). No hay .spec.ts
+      # fuera de e2e (verificado). Ver _followups/release-paths-ignore-test-only-changes.
+      - '**/*.test.ts'
+      - '**/*.test.tsx'
+      - 'apps/**/e2e/**'
 
 concurrency:
   group: release-${{ github.workflow }}-main

--- a/.specs/_followups/release-deploy-job-timeout-vs-canary.md
+++ b/.specs/_followups/release-deploy-job-timeout-vs-canary.md
@@ -1,7 +1,7 @@
 # Follow-up — `release.yml` deploy-production: timeout (30m) < canary (30m) → run "cancelled" engañoso
 
 **Origen**: deploy de App Check (PR #401) 2026-06-04 — el GHA run figuró `cancelled` pero el deploy fue exitoso.
-**Tipo**: CI/CD reliability / observabilidad. **Riesgo**: medio (no rompe el deploy, pero el estado MIENTE → riesgo de re-lanzar innecesariamente o creer que falló). **Estado**: pendiente.
+**Tipo**: CI/CD reliability / observabilidad. **Riesgo**: medio (no rompe el deploy, pero el estado MIENTE → riesgo de re-lanzar innecesariamente o creer que falló). **Estado**: ✅ **RESUELTO** — `release.yml:87` ya tiene `timeout-minutes: 75` (fix 2026-06-12, opción #1 con margen: gate ~10 + build ~15 + canary 30 + verify/promoción ~10 + smoke). El run ya refleja el estado real y el smoke final corre.
 
 ## Problema (causa raíz confirmada)
 

--- a/.specs/_followups/release-paths-ignore-test-only-changes.md
+++ b/.specs/_followups/release-paths-ignore-test-only-changes.md
@@ -48,4 +48,9 @@ paths-ignore:
   (push con código → sí dispara).
 
 ## Estado
-Pendiente de priorizar. Relacionado: [[ci-release-paths-ignore-2026-06]].
+✅ **RESUELTO (2026-06-22)**. Agregados `**/*.test.ts`, `**/*.test.tsx`, `apps/**/e2e/**`
+al `paths-ignore` de `release.yml`. Verificado que NO hay `.spec.ts` fuera de `e2e/`
+(grep), así que `apps/**/e2e/**` cubre los Playwright sin tocar productivo; los tests
+no se consumen en ningún bundle de runtime. YAML válido (parse OK, jobs intactos).
+**Validación end-to-end igual que #415 (post-merge)**: SC-1 (push test-only → 0 runs)
++ SC-2 (push con código → dispara). Relacionado: [[ci-release-paths-ignore-2026-06]].


### PR DESCRIPTION
## Qué

Un push **100% test** (e2e Playwright o `*.test.ts/tsx`) disparaba `release.yml` → `deploy-production` no-op que quedaba `waiting` en el gate y, con `cancel-in-progress:false`, **retenía el lock de concurrency** y bloqueaba el próximo deploy real (pasó con #422 en la sesión del incidente Redis).

**Fix**: agrega `**/*.test.ts`, `**/*.test.tsx`, `apps/**/e2e/**` al `paths-ignore`.

## Cuidados (heredados de #415)
- `paths-ignore` skipea **solo si TODOS** los archivos del push matchean → un commit con código+test **igual despliega** (correcto).
- Verificado: **0** `.spec.ts` fuera de `e2e/` → `apps/**/e2e/**` no cruza a productivo.
- Los tests no se consumen en ningún bundle de runtime.
- No se agregó `**/*.md` (rompería Changesets) — sin cambios a esa regla.

## Evidencia
- YAML válido (parse OK; jobs `version-or-publish` + `deploy-production` intactos; paths-ignore = los 5 previos + 3 nuevos).
- **Validación end-to-end post-merge** (igual que #415): SC-1 (push test-only → 0 runs de release), SC-2 (push con código → sí dispara).

Además marca resuelto el stub `release-deploy-job-timeout` (`release.yml:87` ya tiene `timeout-minutes:75`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)