### PR TITLE
refactor(web): coloca translate-auth-error login + provider (Opción B)

### DIFF
--- a/.specs/_followups/translate-auth-error-unify.md
+++ b/.specs/_followups/translate-auth-error-unify.md
@@ -1,8 +1,20 @@
 # Followup: translate-auth-error-unify
 
-**Status**: Draft (stub; not urgent)
+**Status**: ✅ **RESUELTO (2026-06-22)** vía **Opción B** (colocación, copy verbatim).
 **Created**: 2026-05-27 by Sprint 2c-B T2 PR (per plan v4 F-B1 acceptance — option (a) login-domain-only extraction; AuthProvidersSection.tsx untouched).
-**Estimated effort**: 60-90 min (reconcile + tests + UX review).
+
+## Resolución (Opción B, sin cambio de UX)
+
+`apps/web/src/lib/translate-auth-error.ts` ahora exporta **dos** funciones en el
+mismo módulo: `translateLoginAuthError` (rename de la de login, `+message`) y
+`translateProviderAuthError` (extraída **verbatim** desde `AuthProvidersSection.tsx`).
+El componente importa la segunda y borró su función inline; `login.tsx` usa la primera.
+**Copy preservado byte a byte** → sin reconciliación UX necesaria (la divergencia por
+dominio es intencional y queda fijada por tests, incl. un invariante explícito de que
+`auth/email-already-in-use` produce copy distinto en cada dominio). Resuelto antes de
+"Post-Sprint-2c-B" porque es un refactor de comportamiento idéntico (riesgo nulo para
+el sprint). Evidencia (node 24): web 110 files/1047 passed (47 del módulo), typecheck 0,
+biome 0. **La sub-decisión fail-closed NO aplica a este finding** (era de booleanFlag).
 
 ---
 

--- a/apps/web/src/components/profile/AuthProvidersSection.tsx
+++ b/apps/web/src/components/profile/AuthProvidersSection.tsx
@@ -15,6 +15,7 @@ import {
   useAuth,
 } from '../../hooks/use-auth.js';
 import { passwordPolicySchema } from '../../lib/password.js';
+import { translateProviderAuthError } from '../../lib/translate-auth-error.js';
 import { FormField, inputClass } from '../FormField.js';
 
 /**
@@ -142,7 +143,7 @@ function ProviderRow({
       if (code === 'auth/popup-closed-by-user' || code === 'auth/cancelled-popup-request') {
         setError(null);
       } else {
-        setError(translateAuthError(code) ?? `No pudimos ${label}.`);
+        setError(translateProviderAuthError(code) ?? `No pudimos ${label}.`);
       }
     } finally {
       setBusy(false);
@@ -265,7 +266,7 @@ function PasswordLinkForm({
         });
       } else {
         setError('root', {
-          message: translateAuthError(code) ?? 'No pudimos vincular email + contraseña.',
+          message: translateProviderAuthError(code) ?? 'No pudimos vincular email + contraseña.',
         });
       }
     }
@@ -283,7 +284,9 @@ function PasswordLinkForm({
       closeAndReset();
     } catch (err) {
       const code = (err as FirebaseError).code;
-      setError('root', { message: translateAuthError(code) ?? 'No pudimos re-autenticar.' });
+      setError('root', {
+        message: translateProviderAuthError(code) ?? 'No pudimos re-autenticar.',
+      });
     }
   }
 
@@ -463,7 +466,7 @@ function ChangePasswordForm({ user }: { user: User }) {
         setError('newPassword', { message: 'Contraseña muy débil para Firebase.' });
       } else {
         setError('root', {
-          message: translateAuthError(code) ?? 'No pudimos cambiar la contraseña.',
+          message: translateProviderAuthError(code) ?? 'No pudimos cambiar la contraseña.',
         });
       }
     }
@@ -591,31 +594,6 @@ function ChangePasswordForm({ user }: { user: User }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Errors
-// ---------------------------------------------------------------------------
-
-function translateAuthError(code: string | undefined): string | null {
-  switch (code) {
-    case 'auth/credential-already-in-use':
-    case 'auth/email-already-in-use':
-      return 'Esa cuenta ya pertenece a otro usuario de Booster. Cerrá sesión y entrá con esa cuenta directamente.';
-    case 'auth/provider-already-linked':
-      return 'Este proveedor ya está vinculado a tu cuenta.';
-    case 'auth/weak-password':
-      return 'La contraseña es muy débil. Usá al menos 6 caracteres.';
-    case 'auth/invalid-email':
-      return 'El email no es válido.';
-    case 'auth/wrong-password':
-    case 'auth/invalid-credential':
-      return 'Email o contraseña incorrectos.';
-    case 'auth/popup-blocked':
-      return 'El navegador bloqueó el popup. Permite popups para app.boosterchile.com.';
-    case 'auth/no-such-provider':
-      return 'No puedes quitar este proveedor porque es el único que tienes.';
-    case 'auth/network-request-failed':
-      return 'Sin conexión a internet. Inténtalo de nuevo.';
-    default:
-      return null;
-  }
-}
+// El mapeo de errores de provider-linking vive ahora en
+// `../../lib/translate-auth-error.ts` (translateProviderAuthError) — colocado
+// junto al de login pero como función separada (copy diferenciado por dominio).

--- a/apps/web/src/lib/translate-auth-error.test.ts
+++ b/apps/web/src/lib/translate-auth-error.test.ts
@@ -1,74 +1,75 @@
 import { describe, expect, it } from 'vitest';
-import { translateAuthError } from './translate-auth-error';
+import { translateLoginAuthError, translateProviderAuthError } from './translate-auth-error';
 
 /**
- * Sprint 2c-B T2 tests — `translateAuthError` extraction + extension.
- *
- * Preserves all 10 existing cases from the inline function previously
- * in `apps/web/src/routes/login.tsx:382-406`. Adds new
- * `auth/internal-error` branch with `BLOCKED_SIGNUP_PENDING_APPROVAL`
- * substring detection (Sprint 2c-A T7 handler returns this code; Firebase
- * web SDK wraps as `auth/internal-error` with custom message per ADR-054).
+ * Tests de `translateLoginAuthError` (dominio login/signup) y
+ * `translateProviderAuthError` (dominio provider-linking), colocados en el
+ * mismo módulo (translate-auth-error-unify, Opción B). Copy diferenciado por
+ * dominio para los códigos que se solapan — los tests lo fijan.
  */
 
-describe('translateAuthError — existing codes preserved verbatim', () => {
+describe('translateLoginAuthError — existing codes preserved verbatim', () => {
   it('auth/invalid-credential → password incorrect message', () => {
-    expect(translateAuthError('auth/invalid-credential')).toBe('Email o contraseña incorrectos.');
+    expect(translateLoginAuthError('auth/invalid-credential')).toBe(
+      'Email o contraseña incorrectos.',
+    );
   });
 
   it('auth/invalid-login-credentials → same fallthrough message', () => {
-    expect(translateAuthError('auth/invalid-login-credentials')).toBe(
+    expect(translateLoginAuthError('auth/invalid-login-credentials')).toBe(
       'Email o contraseña incorrectos.',
     );
   });
 
   it('auth/user-not-found', () => {
-    expect(translateAuthError('auth/user-not-found')).toBe('No existe una cuenta con ese email.');
+    expect(translateLoginAuthError('auth/user-not-found')).toBe(
+      'No existe una cuenta con ese email.',
+    );
   });
 
   it('auth/wrong-password', () => {
-    expect(translateAuthError('auth/wrong-password')).toBe('Contraseña incorrecta.');
+    expect(translateLoginAuthError('auth/wrong-password')).toBe('Contraseña incorrecta.');
   });
 
   it('auth/user-disabled — references support email', () => {
-    expect(translateAuthError('auth/user-disabled')).toBe(
+    expect(translateLoginAuthError('auth/user-disabled')).toBe(
       'Esta cuenta está deshabilitada. Contacta a soporte@boosterchile.com.',
     );
   });
 
   it('auth/email-already-in-use → signup-existing-account copy (login domain)', () => {
-    expect(translateAuthError('auth/email-already-in-use')).toBe(
+    expect(translateLoginAuthError('auth/email-already-in-use')).toBe(
       'Ya existe una cuenta con ese email. Inicia sesión.',
     );
   });
 
   it('auth/weak-password', () => {
-    expect(translateAuthError('auth/weak-password')).toBe(
+    expect(translateLoginAuthError('auth/weak-password')).toBe(
       'La contraseña es muy débil. Usa al menos 6 caracteres.',
     );
   });
 
   it('auth/invalid-email', () => {
-    expect(translateAuthError('auth/invalid-email')).toBe('El email no es válido.');
+    expect(translateLoginAuthError('auth/invalid-email')).toBe('El email no es válido.');
   });
 
   it('auth/too-many-requests', () => {
-    expect(translateAuthError('auth/too-many-requests')).toBe(
+    expect(translateLoginAuthError('auth/too-many-requests')).toBe(
       'Demasiados intentos fallidos. Espera unos minutos e intenta de nuevo.',
     );
   });
 
   it('auth/network-request-failed', () => {
-    expect(translateAuthError('auth/network-request-failed')).toBe(
+    expect(translateLoginAuthError('auth/network-request-failed')).toBe(
       'Sin conexión a internet. Intenta de nuevo.',
     );
   });
 });
 
-describe('translateAuthError — auth/internal-error new branch (Sprint 2c-B)', () => {
+describe('translateLoginAuthError — auth/internal-error new branch (Sprint 2c-B)', () => {
   it('auth/internal-error with BLOCKED_SIGNUP_PENDING_APPROVAL substring → blocked-signup message', () => {
     expect(
-      translateAuthError(
+      translateLoginAuthError(
         'auth/internal-error',
         'Cloud Function returned an error: BLOCKED_SIGNUP_PENDING_APPROVAL',
       ),
@@ -79,7 +80,7 @@ describe('translateAuthError — auth/internal-error new branch (Sprint 2c-B)', 
 
   it('auth/internal-error with BLOCKED literal embedded in JSON-ish wrap → still matches', () => {
     expect(
-      translateAuthError(
+      translateLoginAuthError(
         'auth/internal-error',
         '{"error":{"message":"HTTP Cloud Function returned a custom error... BLOCKED_SIGNUP_PENDING_APPROVAL"}}',
       ),
@@ -88,25 +89,73 @@ describe('translateAuthError — auth/internal-error new branch (Sprint 2c-B)', 
 
   it('auth/internal-error WITHOUT BLOCKED literal → fallback null', () => {
     expect(
-      translateAuthError('auth/internal-error', 'Some other generic internal error'),
+      translateLoginAuthError('auth/internal-error', 'Some other generic internal error'),
     ).toBeNull();
   });
 
   it('auth/internal-error with no message argument → fallback null', () => {
-    expect(translateAuthError('auth/internal-error')).toBeNull();
+    expect(translateLoginAuthError('auth/internal-error')).toBeNull();
   });
 });
 
-describe('translateAuthError — fallback null for unmapped codes', () => {
+describe('translateLoginAuthError — fallback null for unmapped codes', () => {
   it('unknown code → null', () => {
-    expect(translateAuthError('auth/something-unmapped')).toBeNull();
+    expect(translateLoginAuthError('auth/something-unmapped')).toBeNull();
   });
 
   it('undefined code → null', () => {
-    expect(translateAuthError(undefined)).toBeNull();
+    expect(translateLoginAuthError(undefined)).toBeNull();
   });
 
   it('empty string → null', () => {
-    expect(translateAuthError('')).toBeNull();
+    expect(translateLoginAuthError('')).toBeNull();
+  });
+});
+
+describe('translateProviderAuthError — dominio provider-linking', () => {
+  it('auth/credential-already-in-use → copy de linking', () => {
+    expect(translateProviderAuthError('auth/credential-already-in-use')).toBe(
+      'Esa cuenta ya pertenece a otro usuario de Booster. Cerrá sesión y entrá con esa cuenta directamente.',
+    );
+  });
+
+  it('auth/provider-already-linked', () => {
+    expect(translateProviderAuthError('auth/provider-already-linked')).toBe(
+      'Este proveedor ya está vinculado a tu cuenta.',
+    );
+  });
+
+  it('auth/popup-blocked', () => {
+    expect(translateProviderAuthError('auth/popup-blocked')).toBe(
+      'El navegador bloqueó el popup. Permite popups para app.boosterchile.com.',
+    );
+  });
+
+  it('auth/no-such-provider', () => {
+    expect(translateProviderAuthError('auth/no-such-provider')).toBe(
+      'No puedes quitar este proveedor porque es el único que tienes.',
+    );
+  });
+
+  it('código no mapeado → null', () => {
+    expect(translateProviderAuthError('auth/something-unmapped')).toBeNull();
+  });
+});
+
+describe('copy DIVERGE por dominio en códigos solapados (invariante de unify)', () => {
+  // El mismo código produce copy distinto por dominio — es intencional (UX).
+  it('auth/email-already-in-use: login dice "Inicia sesión", linking dice "Cerrá sesión"', () => {
+    const login = translateLoginAuthError('auth/email-already-in-use');
+    const provider = translateProviderAuthError('auth/email-already-in-use');
+    expect(login).toBe('Ya existe una cuenta con ese email. Inicia sesión.');
+    expect(provider).toBe(
+      'Esa cuenta ya pertenece a otro usuario de Booster. Cerrá sesión y entrá con esa cuenta directamente.',
+    );
+    expect(login).not.toBe(provider);
+  });
+
+  it('auth/weak-password: login "Usa", linking "Usá" (voseo)', () => {
+    expect(translateLoginAuthError('auth/weak-password')).toContain('Usa al menos');
+    expect(translateProviderAuthError('auth/weak-password')).toContain('Usá al menos');
   });
 });

--- a/apps/web/src/lib/translate-auth-error.ts
+++ b/apps/web/src/lib/translate-auth-error.ts
@@ -13,13 +13,16 @@
  * `apps/auth-blocking-functions/test/integration/cross-source-literals.test.ts`.
  *
  * Scope: signup/login domain (provider sign-in + email/pw form errors).
- * Provider-linking errors are translated separately in
- * `apps/web/src/components/profile/AuthProvidersSection.tsx` because the
- * Spanish copy differs (e.g., `auth/email-already-in-use` for linking
- * vs signup-existing-account). Unification tracked in
- * `.specs/_followups/translate-auth-error-unify.md`.
+ *
+ * **Colocación (translate-auth-error-unify, Opción B)**: el dominio de
+ * provider-linking (`translateProviderAuthError`, abajo) vive en ESTE mismo
+ * módulo pero como función separada — el copy en español DIFIERE
+ * deliberadamente por dominio (ej. `auth/email-already-in-use`: login dice
+ * "Inicia sesión", linking dice "Cerrá sesión y entrá con esa cuenta"). Dos
+ * tablas, un archivo: la divergencia es visible y se evita el drift de tener
+ * la función inline en el componente.
  */
-export function translateAuthError(code: string | undefined, message?: string): string | null {
+export function translateLoginAuthError(code: string | undefined, message?: string): string | null {
   switch (code) {
     case 'auth/invalid-credential':
     case 'auth/invalid-login-credentials':
@@ -45,6 +48,41 @@ export function translateAuthError(code: string | undefined, message?: string): 
         return 'Tu solicitud de registro debe ser aprobada por un administrador antes de poder iniciar sesión. Si ya solicitaste registro, espera la confirmación por email.';
       }
       return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Mensajes en español para el dominio de **provider-linking** (vincular/
+ * desvincular/re-link de providers OAuth en el perfil). Copy diferenciado del
+ * dominio de login: aquí los errores apuntan a la cuenta del usuario (ej.
+ * "Cerrá sesión y entrá con esa cuenta directamente"), no al flujo de signup.
+ *
+ * Extraído verbatim desde `AuthProvidersSection.tsx` (translate-auth-error-unify
+ * Opción B). Si un código gana copy en ambos dominios, mantenerlos separados es
+ * intencional — la divergencia es de UX, no un bug.
+ */
+export function translateProviderAuthError(code: string | undefined): string | null {
+  switch (code) {
+    case 'auth/credential-already-in-use':
+    case 'auth/email-already-in-use':
+      return 'Esa cuenta ya pertenece a otro usuario de Booster. Cerrá sesión y entrá con esa cuenta directamente.';
+    case 'auth/provider-already-linked':
+      return 'Este proveedor ya está vinculado a tu cuenta.';
+    case 'auth/weak-password':
+      return 'La contraseña es muy débil. Usá al menos 6 caracteres.';
+    case 'auth/invalid-email':
+      return 'El email no es válido.';
+    case 'auth/wrong-password':
+    case 'auth/invalid-credential':
+      return 'Email o contraseña incorrectos.';
+    case 'auth/popup-blocked':
+      return 'El navegador bloqueó el popup. Permite popups para app.boosterchile.com.';
+    case 'auth/no-such-provider':
+      return 'No puedes quitar este proveedor porque es el único que tienes.';
+    case 'auth/network-request-failed':
+      return 'Sin conexión a internet. Inténtalo de nuevo.';
     default:
       return null;
   }

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -13,7 +13,7 @@ import {
   useAuth,
 } from '../hooks/use-auth.js';
 import { useFeatureFlags } from '../hooks/use-feature-flags.js';
-import { translateAuthError } from '../lib/translate-auth-error.js';
+import { translateLoginAuthError } from '../lib/translate-auth-error.js';
 
 type Mode = 'sign-in' | 'sign-up' | 'reset';
 
@@ -104,7 +104,7 @@ export function LoginRoute() {
         return;
       }
       setError('root', {
-        message: translateAuthError(code, message) ?? 'No pudimos iniciar sesión con Google.',
+        message: translateLoginAuthError(code, message) ?? 'No pudimos iniciar sesión con Google.',
       });
     }
   }
@@ -153,7 +153,7 @@ export function LoginRoute() {
       const code = (err as FirebaseError).code;
       const message = (err as FirebaseError).message;
       setError('root', {
-        message: translateAuthError(code, message) ?? 'No pudimos completar la operación.',
+        message: translateLoginAuthError(code, message) ?? 'No pudimos completar la operación.',
       });
     }
   }


### PR DESCRIPTION
## Qué

Cierra `translate-auth-error-unify` vía **Opción B** (colocación, copy verbatim). Había **dos** `translateAuthError`: una en `lib/translate-auth-error.ts` (login) y otra **inline** en `AuthProvidersSection.tsx` (provider-linking), con copy divergente por dominio.

Ahora ambas viven en `lib/translate-auth-error.ts` como funciones separadas:
- `translateLoginAuthError(code, message?)` — rename de la de login.
- `translateProviderAuthError(code)` — extraída **verbatim** desde el componente (que borró su inline e importa esta).

**Copy preservado byte a byte** → la divergencia por dominio (intencional, UX) se mantiene; sin reconciliación UX necesaria. Resuelto sin esperar "Post-Sprint-2c-B" porque es un refactor de **comportamiento idéntico** (riesgo nulo para el sprint).

## Evidencia (node 24)
- Suite web → **110 files / 1047 passed** (+7 tests nuevos del módulo, incl. un invariante explícito de que `auth/email-already-in-use` produce copy distinto por dominio).
- `typecheck` web → 0; `biome check` de los archivos tocados → 0.

> El warning pre-existente `login.tsx:47 suppressions/unused` lo remueve [#509](https://github.com/boosterchile/booster-ai/pull/509) (líneas distintas → sin conflicto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)