### PR TITLE
docs(followups): cierra segundo-canal (código hecho) + cloudbuild-sub (moot)

### DIFF
--- a/.specs/_followups/cloudbuild-substitution-canonicalization.md
+++ b/.specs/_followups/cloudbuild-substitution-canonicalization.md
@@ -4,6 +4,17 @@
 **Owner**: PO (Felipe Vicencio)
 **Priority**: **P1** (escalated 2026-05-28 by Sprint 2b T13-fix DA v1 P1 finding — second plan amendment in 48h triggered the escalation clause below)
 
+> ✅ **CERRADO (2026-06-22)**:
+> - **Item 1 (`_AUTH_BLOCKING_DEPLOY` strict-match) → MOOT**: la lane auth-blocking
+>   completa **se removió** del pipeline con el decomiso de la blocking function
+>   (`cloudbuild.production.yaml:551-552` lo documenta; ADR-057 cerró el leg Google por
+>   boundary+reaper en vez de re-desplegar la blocking function). No queda substitution
+>   ni steps gateados por `_AUTH_BLOCKING_DEPLOY` que canonicalizar.
+> - **Item 2 (plan-amendment exception note) → DOCUMENTADO**: es una decisión de
+>   governance ya registrada (excepción puntual de T3-fix + regla "≤10 LOC/≤1 archivo o
+>   sub-spec"). No es una acción de código; su cláusula de escalación queda como trigger
+>   futuro (3ª enmienda → ADR de proceso). Sin pendiente accionable.
+
 ## Escalation log
 
 - 2026-05-28 — Sprint 2c-B T3-fix DA v5: original creation as P2 residual.

--- a/.specs/_followups/segundo-canal-alertas-sre.md
+++ b/.specs/_followups/segundo-canal-alertas-sre.md
@@ -17,4 +17,17 @@ TODAS las alertas de Cloud Monitoring — incluidas las P0 de crash forensics y 
 
 ## Estado
 
-Pendiente, bloqueado por insumo PO.
+✅ **CÓDIGO RESUELTO** (verificado en `main`, 2026-06-22) — el wiring del 2º canal
+**ya existe** (el stub es de la auditoría 06-09, anterior al "sed global 2026-06-11"):
+
+- `infrastructure/monitoring.tf:10-21` define `google_monitoring_notification_channel.sre_webhook`
+  (`webhook_tokenauth`), **count-gated** a `var.sre_webhook_url != ""` → sin URL no se
+  crea nada (email-only, consistente con la decisión #470).
+- `monitoring.tf:25-30` lo concatena en `local.alert_channel_ids`, el local **único** que
+  referencian **todas** las alert policies (P0 crash, telemetry-stall, cost-guardrails, etc.).
+  Agregar el canal = ya está; activarlo propaga a todas.
+
+**Único pendiente (no es código)**: el PO setea `var.sre_webhook_url = "<Slack/Telegram webhook>"`
+en el tfvars + `terraform apply` (count pasa a 1 → el canal se crea inactivo→activo en todas
+las policies) + dispara una alerta de prueba (paso 3). El secret shell `sre-notification-webhook`
+quedó vestigial (la implementación usa la var directamente en `labels.url`).


### PR DESCRIPTION
## Qué

Higiene del backlog: 2 stubs verificados contra `main`. Solo docs.

- **`segundo-canal-alertas-sre`** → ✅ **código ya resuelto**: el 2º canal de alertas existe (`monitoring.tf:10` `sre_webhook`, count-gated a `var.sre_webhook_url`) y ya está en `local.alert_channel_ids` — el local **único** que referencian **todas** las alert policies. El stub es de la auditoría 06-09, anterior al wiring del 06-11. **Único pendiente** = el PO setea `var.sre_webhook_url` en tfvars + `apply` (un valor, no código).
- **`cloudbuild-substitution-canonicalization`** → ✅ **cerrado**: Item-1 (`_AUTH_BLOCKING_DEPLOY`) es **MOOT** — la lane auth-blocking se removió del pipeline con el decomiso de la blocking function (ADR-057; `cloudbuild.production.yaml:551` lo documenta). Item-2 es una decisión de governance ya documentada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)