### PR TITLE
chore(infra): mueve REDIS_PASSWORD a Secret Manager (espejo de DATABASE_URL)

### DIFF
--- a/.specs/_followups/redis-password-to-secret-manager.md
+++ b/.specs/_followups/redis-password-to-secret-manager.md
@@ -22,4 +22,18 @@ Mover `auth_string` a Secret Manager y montarlo vía `common_secrets` (igual que
 en `compute.tf:29`). Aplica a todos los services que usan Redis (api, whatsapp-bot, …).
 
 ## Estado
-Pendiente de priorizar.
+✅ **TF ESCRITO (2026-06-22)** — espejo exacto de `DATABASE_URL`, pendiente `terraform apply` del owner:
+
+- `security.tf`: `redis-auth` agregado a `local.secret_names` (crea el secret).
+- `data.tf`: `google_secret_manager_secret_version "redis_auth"` con
+  `secret_data = google_redis_instance.main.auth_string` (**auto-derivado**, NO
+  placeholder → sin el modo de falla de INC-2026-06-19).
+- `compute.tf`: `REDIS_PASSWORD` movido de `common_env_vars` (plaintext) a
+  `common_secrets` (secret-mount) + agregado a `all_secret_versions_ready`.
+- IAM: el runtime SA ya tiene `secretmanager.secretAccessor` a **nivel proyecto**
+  (`security.tf:312`) → los 7 services lo leen sin binding extra.
+
+`terraform validate` ✔ + `fmt` ✔. **No pude `terraform apply`** (read-only/ADC): el
+owner aplica + verifica que los 7 services arranquen sanos (conectividad Redis) en
+el apply, como con cualquier cambio de infra (patrón #511/#420). Riesgo bajo: replica
+un secret-mount que ya funciona (DATABASE_URL) con valor real.

--- a/infrastructure/compute.tf
+++ b/infrastructure/compute.tf
@@ -14,10 +14,14 @@ locals {
     # Memorystore Redis — compartido entre services para conversation store +
     # caching de OIDC tokens + rate limiting. Privado por VPC con AUTH +
     # transit encryption (SERVER_AUTHENTICATION) requeridos.
-    REDIS_HOST     = google_redis_instance.main.host
-    REDIS_PORT     = tostring(google_redis_instance.main.port)
-    REDIS_PASSWORD = google_redis_instance.main.auth_string
-    REDIS_TLS      = "true"
+    REDIS_HOST = google_redis_instance.main.host
+    REDIS_PORT = tostring(google_redis_instance.main.port)
+    # REDIS_PASSWORD se movió a `common_secrets` (Secret Manager) para no exponer
+    # el auth_string en plaintext en la config de la revisión Cloud Run
+    # (redis-password-to-secret-manager). El valor sigue auto-derivado del recurso
+    # (`google_redis_instance.main.auth_string`), NO es un placeholder → sin riesgo
+    # del patrón INC-2026-06-19.
+    REDIS_TLS = "true"
     # Server CA de Memorystore (SERVER_AUTHENTICATION): cert firmado por CA privada
     # por-instancia que NO está en el bundle público del sistema. Sin pinnearla,
     # ioredis falla con UNABLE_TO_VERIFY_LEAF_SIGNATURE (incidente 2026-06-07 tras
@@ -30,6 +34,9 @@ locals {
 
   common_secrets = {
     DATABASE_URL = google_secret_manager_secret.secrets["database-url"].secret_id
+    # Auth string de Memorystore como secret-mount (antes plaintext env). Valor
+    # auto-derivado vía la version `redis_auth` (secret_data = auth_string).
+    REDIS_PASSWORD = google_secret_manager_secret.secrets["redis-auth"].secret_id
   }
 
   # Lista de IDs de todas las secret versions que deben existir antes de crear
@@ -42,6 +49,7 @@ locals {
   all_secret_versions_ready = concat(
     [for v in values(google_secret_manager_secret_version.placeholder) : v.id],
     [google_secret_manager_secret_version.database_url.id],
+    [google_secret_manager_secret_version.redis_auth.id],
     [for v in values(google_secret_manager_secret_version.hotfix_2026_05_14_placeholder) : v.id],
     [google_secret_manager_secret_version.pin_rate_limit_hmac_pepper.id],
   )

--- a/infrastructure/data.tf
+++ b/infrastructure/data.tf
@@ -303,6 +303,17 @@ resource "google_secret_manager_secret_version" "database_url" {
 # MEMORYSTORE REDIS
 # =============================================================================
 
+# Version del secret `redis-auth`: el auth_string de Memorystore. Auto-derivado
+# del recurso (NO un placeholder) — patrón idéntico a `database_url`, evita el
+# modo de falla de INC-2026-06-19 (placeholder que no matchea formato). Mueve el
+# auth_string de un plaintext env var (visible en la config de la revisión Cloud
+# Run) a un secret-mount. El runtime SA ya tiene secretAccessor a nivel proyecto
+# (security.tf:312), así que los 7 services lo leen sin IAM extra.
+resource "google_secret_manager_secret_version" "redis_auth" {
+  secret      = google_secret_manager_secret.secrets["redis-auth"].id
+  secret_data = google_redis_instance.main.auth_string
+}
+
 resource "google_redis_instance" "main" {
   name           = "booster-ai-redis"
   project        = google_project.booster_ai.project_id

--- a/infrastructure/security.tf
+++ b/infrastructure/security.tf
@@ -174,6 +174,10 @@ locals {
     # Database
     "database-url",
 
+    # Memorystore Redis auth_string — movido de plaintext env a Secret Manager
+    # (redis-password-to-secret-manager). La version se auto-deriva del recurso.
+    "redis-auth",
+
     # AI providers
     # NOTA: gemini-api-key eliminada en ADR-037 — el backend ahora usa
     # Vertex AI Gemini con ADC (workload identity del SA cloud_run_runtime).


### PR DESCRIPTION
## Qué

`REDIS_PASSWORD` (el `auth_string` de Memorystore) vivía en un **plaintext env var** (`compute.tf` `common_env_vars`) → visible en `gcloud run services describe` y para cualquier principal con `run.services.get`. CLAUDE.md §Seguridad exige Secret Manager.

Fix = **espejo exacto del patrón `DATABASE_URL`**:
- `security.tf`: `redis-auth` al set `local.secret_names`.
- `data.tf`: `secret_version.redis_auth` con `secret_data = google_redis_instance.main.auth_string` (**auto-derivado**, NO placeholder → sin el modo de falla de INC-2026-06-19).
- `compute.tf`: `REDIS_PASSWORD` de `common_env_vars` → `common_secrets` + a `all_secret_versions_ready`.
- **IAM**: el runtime SA ya tiene `secretmanager.secretAccessor` a **nivel proyecto** (`security.tf:312`) → los 7 services lo leen sin binding extra.

## Evidencia
- `terraform validate` → **Success! The configuration is valid.**
- `terraform fmt` → OK.

⚠️ **Requiere `terraform apply` del owner** (no pude aplicar — ADC read-only). En el apply, verificar que los 7 services arranquen sanos (conectividad Redis). **Riesgo bajo**: replica un secret-mount que ya funciona (DATABASE_URL) con un valor real auto-derivado. Patrón de los otros PRs de infra (#511/#420).

🤖 Generated with [Claude Code](https://claude.com/claude-code)