### PR TITLE
ci(deploy): limpia tags canary-signup-* viejos en deploy-api (fail-safe)

### DIFF
--- a/.specs/_followups/cloud-run-canary-tag-cleanup.md
+++ b/.specs/_followups/cloud-run-canary-tag-cleanup.md
@@ -4,6 +4,14 @@
 **Owner**: PO (Felipe Vicencio)
 **Priority**: P1
 
+> ✅ **RESUELTO (2026-06-22)** vía **Opción A** — el step `deploy-api` de
+> `cloudbuild.production.yaml` ahora, tras `update-traffic --to-latest`, remueve los
+> tags `canary-signup-*` viejos (preserva el de ESTE deploy). **FAIL-SAFE**: corre
+> POST-promoción (ningún canary tag sirve tráfico ya) y si el parseo falla solo loguea
+> `WARN` — NUNCA rompe el deploy (peor caso: los tags siguen acumulando como hoy). YAML
+> validado (`deploy-api` id/waitFor preservados). El owner lo valida en el 1er canary
+> real. Cierra el footgun de quota a ~50 tags.
+
 ## Problem
 
 Sprint 2b T13 canary lane creates a per-deploy traffic tag `canary-signup-<sha12>` via `gcloud run services update --tag=...` on `booster-ai-api`. Cloud Run retains the tag on the revision until explicitly removed. With daily deploys, tags accumulate.

--- a/cloudbuild.production.yaml
+++ b/cloudbuild.production.yaml
@@ -378,15 +378,34 @@ steps:
   # resolver. Cambiar el id rompe la pipeline. Per plan T13 round 2 P1-1 fix.
   - id: deploy-api
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
+    entrypoint: bash
+    # Promueve la revisión a 100% (--to-latest) y luego limpia los tags
+    # canary-signup-* viejos (cloud-run-canary-tag-cleanup, Opción A). El
+    # update-traffic es la acción crítica (set -e → falla el deploy si falla).
+    # La limpieza es FAIL-SAFE: corre POST-promoción (ningún canary tag sirve
+    # tráfico ya), preserva el tag de ESTE deploy para auditoría, y si su parseo
+    # falla solo loguea WARN (los tags siguen acumulando como hoy, no rompe el
+    # deploy). Sin esto los tags crecen 1/deploy → quota a ~50 (hoy ~10).
     args:
-      - run
-      - services
-      - update-traffic
-      - booster-ai-api
-      - --region=${_REGION}
-      - --platform=managed
-      - --to-latest
+      - -c
+      - |
+        set -e
+        gcloud run services update-traffic booster-ai-api \
+          --region=${_REGION} --platform=managed --to-latest
+        FULL_SHA='${_COMMIT_SHA}'
+        SHORT_SHA="$${FULL_SHA:0:12}"
+        CURRENT="canary-signup-$${SHORT_SHA}"
+        OLD=$(gcloud run services describe booster-ai-api --region=${_REGION} \
+                --format='value(spec.traffic[].tag)' 2>/dev/null \
+              | tr ';,' '\n' | grep '^canary-signup-' | grep -vx "$${CURRENT}" \
+              | sort -u | paste -sd, -) || true
+        if [ -n "$${OLD}" ]; then
+          gcloud run services update-traffic booster-ai-api \
+            --region=${_REGION} --platform=managed --remove-tags="$${OLD}" \
+            || echo "WARN: cleanup de canary tags falló (no-bloqueante): $${OLD}"
+        else
+          echo "Sin canary tags viejos que limpiar."
+        fi
     waitFor: [canary-verify]
 
   # =========================================================================


### PR DESCRIPTION
## Qué

`cloud-run-canary-tag-cleanup` (Opción A): cada deploy crea un tag de tráfico `canary-signup-<sha>` que Cloud Run retiene en la revisión → a cadencia diaria se acumulan hacia la quota (síntoma: `route-canary` falla con "tag already in use" a ~50). El step `deploy-api` ahora, tras `update-traffic --to-latest`, **remueve los tags `canary-signup-*` viejos** (preserva el de ESTE deploy para auditoría).

## Por qué es seguro shippear sin poder desplegarlo

**FAIL-SAFE por diseño:**
- Corre **POST-promoción** → ningún canary tag sirve tráfico ya, y se excluye el actual → removerlos no puede afectar el routing.
- Si el parseo del output de gcloud falla, solo loguea `WARN` (`|| echo`) → **NUNCA rompe el deploy** (peor caso = los tags siguen acumulando, igual que hoy).
- Solo el `update-traffic --to-latest` (la acción crítica, bajo `set -e`) puede fallar el step — igual que antes.

## Evidencia
- YAML validado con parser: el `id: deploy-api` + `waitFor: [canary-verify]` preservados (el downstream `waitFor: [deploy-api]` sigue resolviendo); 23 steps intactos.
- El owner lo valida en el 1er canary real post-merge (como cualquier cambio del pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)