### PR TITLE
docs(followups): cierra branch-protection-squash (ya enforced) + snapshot IaC

### DIFF
--- a/.specs/_followups/github-branch-protection-squash.md
+++ b/.specs/_followups/github-branch-protection-squash.md
@@ -1,6 +1,14 @@
 # Followup: github-branch-protection-squash
 
-**Status**: Draft (stub, no ejecutar todavía)
+> ✅ **RESUELTO / acceptance ya cumplido (verificado 2026-06-22)**. `gh api repos/boosterchile/booster-ai`
+> retorna `allow_squash_merge=true`, `allow_merge_commit=false`, `allow_rebase_merge=false` →
+> **squash es el ÚNICO método de merge posible** a nivel repo. El acceptance criteria del
+> stub ("la UI de PR solo ofrece 'Squash and merge'; `gh pr merge --merge`/`--rebase` rechaza")
+> **ya se cumple** — el outcome operacional está enforced, vía la restricción de merge-methods
+> del repo (equivalente, y de hecho más fuerte que una branch-protection rule, para este fin).
+> Nada que ejecutar.
+
+**Status**: ✅ RESUELTO (acceptance ya cumplido a nivel repo)
 **Created**: 2026-05-21
 **Triggered by**: Devils-advocate REVIEW round 2 — S2 finding ("Squash merge MANDATORIO en spec §6.2 es declarativo, NO enforceado a nivel de plataforma. PO podría ejecutar `gh pr merge --merge` por accidente y typos cosméticos quedan permanentes en main")
 **Estimated effort**: 5-10 min (configurar branch protection rule en GitHub UI o vía gh CLI)

--- a/.specs/_followups/main-branch-protection-terraform-iac.md
+++ b/.specs/_followups/main-branch-protection-terraform-iac.md
@@ -45,3 +45,18 @@ GitHub Terraform provider NO está en uso en `infrastructure/versions.tf` (solo 
 ## Recommendation
 
 Defer hasta Sprint 3+ o hasta que entre segundo developer al proyecto (cuando audit trail Terraform IaC empieza a tener valor real para coordinación). Priority P2 — non-blocking para SEC-001 cierre.
+
+## Estado actual verificado (2026-06-22) — insumo para encodear cuando se ejecute
+
+`gh api` (read-only) capturó la config viva de `main`, lista para traducir a
+`github_branch_protection` cuando el owner provea el PAT + agregue el provider GitHub:
+
+- **Merge methods (repo)**: `allow_squash_merge=true`, `allow_merge_commit=false`,
+  `allow_rebase_merge=false` (squash-only — ver [[github-branch-protection-squash]]).
+- **Branch protection `main`**: `enforce_admins=true`; `required_status_checks.contexts=["CI Success"]`;
+  `required_pull_request_reviews` con `required_approving_review_count=0`,
+  `dismiss_stale_reviews=false`, `require_code_owner_reviews=false`, `require_last_push_approval=false`.
+
+Sigue **owner-gated**: requiere provider `integrations/github` + PAT con scope admin (secreto
+del owner) + `terraform import` de la protección existente. El agente no puede aportar el PAT
+ni crear el provider; el snapshot de arriba es el insumo para hacerlo seguro sin loosen la protección.


### PR DESCRIPTION
## Qué

Verificación read-only vía `gh api`:

- **`github-branch-protection-squash`** → ✅ **RESUELTO**: el repo ya tiene `allow_merge_commit=false`, `allow_rebase_merge=false`, `allow_squash_merge=true` → **squash es el único método de merge posible** a main. El acceptance criteria del stub ("la UI de PR solo ofrece 'Squash and merge'") **ya se cumple** a nivel repo (equivalente, y más fuerte que una branch-protection rule, para este fin). Nada que ejecutar.
- **`main-branch-protection-terraform-iac`** → sigue **owner-gated** (requiere PAT admin + provider GitHub), pero capturé el **snapshot de la protección viva** (`enforce_admins=true`, `required_status_checks=["CI Success"]`, required PR, merge-methods) como insumo para encodearlo a `github_branch_protection` sin loosen la protección cuando el owner lo haga.

Solo docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)