### PR TITLE
docs(whatsapp): safety_alert v2 aprobado + live; v3 como fallback

### DIFF
--- a/.specs/safety-event-fanout/whatsapp-template.md
+++ b/.specs/safety-event-fanout/whatsapp-template.md
@@ -1,4 +1,4 @@
-# WhatsApp template — `safety_alert_v2`
+# WhatsApp template — `safety_alert` (v3)
 
 Template del fan-out de seguridad (P0-G): notifica al transportista ante eventos crash/unplug/jamming. Categoría **UTILITY** (notificación transaccional, no marketing → aprobación más rápida y enviable fuera de la ventana de 24h).
 
@@ -6,32 +6,58 @@ Template del fan-out de seguridad (P0-G): notifica al transportista ante eventos
 
 ---
 
-## Historial de rechazo (por qué v2)
+## Estado actual (2026-06-22) — v2 atascado en Meta
+
+`safety_alert_v2` (`HX48d541ad8f2cab4e4f65165cb26489b1`) lleva **>7 días en `pending`**, muy por encima del típico (5 min–48 h). Clave: v2 **pasó los auto-checks** de Meta (no quedó `rejected` como v1) — está atascado en **revisión humana**, casi seguro por su contenido sensible (contactos de emergencia 131/133, tono alarmista) que no se puede auto-triagear.
+
+Hay **dos caminos** para resolverlo (no son excluyentes; el segundo es el recomendado):
+
+| Camino | Acción | Quién | Trade-off |
+|---|---|---|---|
+| **A — destrabar v2** | Abrir un **Twilio support ticket** con el nombre `safety_alert_v2` + SID `HX48d541…`. Es la acción que Meta documenta para `pending >48h`. | Owner (consola Twilio) | Conserva el contenido exacto de v2 (con números de emergencia), pero depende de la cola de soporte. |
+| **B — reemplazar por v3** ✅ | Correr `scripts/create-safety-alert-template.sh` (ya apunta a `safety_alert_v3`, body de-riesgado). | Owner (corre el script; lee creds de Secret Manager) | Path auto-aprobable (sin el contenido que dispara revisión humana). El detalle de emergencia se mueve a la app/push, no al texto WhatsApp. |
+
+> Referencia de la regla de Meta: *"If a template remains in the Pending state for more than 48 hours, open a Twilio support ticket and include the template name."* (twilio.com/docs/whatsapp/tutorial/message-template-approvals-statuses).
+
+## Historial de aprobación
 
 | Template | Content SID | Estado |
 |---|---|---|
-| `safety_alert_v1` | `HX0d6363fd0162c2d71519ed4e3afe2e3d` | **rejected** por Meta |
-| `copy_of_safety_alert_v1` | `HX80819b02ce9a546b855d09ada1aac944` | **rejected** por Meta |
-| `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` | **pending** (creado y submiteado 2026-06-15T23:01Z; en revisión Meta) |
+| `safety_alert_v1` | `HX0d6363fd0162c2d71519ed4e3afe2e3d` | **rejected** (subCode 2388293: "too many variables for its length") |
+| `copy_of_safety_alert_v1` | `HX80819b02ce9a546b855d09ada1aac944` | **rejected** (mismo subCode) |
+| `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` | **pending >7d** (submiteado 2026-06-15T23:01Z) → atascado en revisión humana |
+| `safety_alert_v3` | _(lo asigna el script al crearlo)_ | **por submitear** (camino B) |
 
-Razón de Meta (`subCode 2388293`):
+**Por qué v3 cambia respecto de v2** (sin tocar el código — mismas 4 variables, mismo orden):
 
-> *"This template has too many variables for its length. Reduce the number of variables or increase the message length."*
+1. **Sin la instrucción de servicios de emergencia** (131/133). Pedirle al usuario que llame a emergencias es contenido sensible que Meta rutea a revisión humana. Esos contactos viven en la app / el push, no en el texto del template.
+2. **Sin líneas en blanco** (`\n\n` → `\n`). Meta lista "newlines, tabs, or more than four consecutive spaces" como motivo de fricción/rechazo; v3 usa solo saltos simples.
+3. **Tono claramente transaccional, sin emojis de alarma** (🚨⚠️ fuera). Un aviso sobre el propio vehículo del usuario es UTILITY legítimo; el tono neutro ayuda al auto-triage.
 
-El body de v1 era demasiado corto para 4 variables (ratio variables/texto muy alto). **v2 mantiene las mismas 4 variables** (para no tocar `dispatch-safety-notification.ts`) pero **alarga el texto fijo** que las rodea, lo que resuelve el ratio. Las variables además quedan cada una precedida por una etiqueta estática (nunca adyacentes entre sí ni al inicio/fin del body), otra regla que Meta valida.
-
-> El código referencia el template por **Content SID**, no por nombre — por eso el nombre nuevo (`safety_alert_v2`) no impacta nada. Se usa nombre nuevo porque Meta a veces bloquea reusar un nombre rechazado.
+> El código referencia el template por **Content SID**, no por nombre — el nombre nuevo (`safety_alert_v3`) no impacta nada. Se usa nombre nuevo porque Meta bloquea reusar el nombre de un template existente/rechazado por 30 días.
 
 ## Metadatos
 
 | Campo | Valor |
 |---|---|
-| **Template name** | `safety_alert_v2` (Twilio exige snake_case minúscula) |
+| **Template name** | `safety_alert_v3` (Twilio exige snake_case minúscula) |
 | **Category** | UTILITY |
 | **Language** | Spanish (`es`) |
 | **Content type** | `twilio/text` (body-only) — ver abajo variante con botón |
 
-## Body (v2 — el que va a producción)
+## Body (v3 — el que va a producción)
+
+```
+Hola, te escribe el sistema de Booster AI. Detectamos un evento en uno de tus vehículos que necesita tu atención.
+Vehículo (patente): {{1}}
+Evento detectado: {{2}}
+Hora (Chile): {{3}}
+Viaje asociado: {{4}}
+Revisa cuanto antes el estado del vehículo y de la carga, y respóndenos por este chat para confirmar que recibiste este aviso. Encontrarás el detalle y los contactos de ayuda en la app de Booster AI.
+```
+
+<details>
+<summary>Body de v2 (atascado — solo referencia)</summary>
 
 ```
 🚨 Alerta de seguridad Booster AI
@@ -45,8 +71,11 @@ Detectamos un evento en uno de tus vehículos que requiere tu atención.
 
 Por favor verifica cuanto antes el estado del conductor y de la carga. Si se trata de una emergencia, llama a los servicios de emergencia (131 ambulancia · 133 Carabineros) y luego avísanos por este mismo chat. Si fue una falsa alarma, responde OK para que quede registrado.
 ```
+</details>
 
 ## Variables — sample values (Meta los exige para aprobar)
+
+Las 4 variables son **idénticas** entre v2 y v3 (mismo orden), por eso `dispatch-safety-notification.ts` no cambia.
 
 | Var | Significado (app) | Origen en código | Sample para el submit |
 |---|---|---|---|
@@ -62,25 +91,33 @@ Por favor verifica cuanto antes el estado del conductor y de la carga. Si se tra
 
 > El orden 1→4 y el mapping están fijados en `apps/api/src/services/dispatch-safety-notification.ts:121-126`. Si se cambia el body, NO reordenar ni agregar variables sin tocar también ese servicio (y sus tests).
 
-## Variante con botón (opcional — no en v2)
+## Variante con botón (opcional — no en v3)
 
-Se podría agregar un **botón URL dinámico** (`Ver vehículo` → `https://app.boosterchile.com/app/flota?v={{1}}`), pero agrega una variable extra y alarga la revisión de Meta. El deep-link igual sale por push, así que v2 va **body-only** para maximizar probabilidad de aprobación. El botón se evalúa en una v3 si se decide.
+Se podría agregar un **botón URL dinámico** (`Ver vehículo` → `https://app.boosterchile.com/app/flota?v={{1}}`), pero agrega una variable extra y alarga la revisión de Meta. El deep-link igual sale por push, así que v3 va **body-only** para maximizar probabilidad de aprobación. El botón se evalúa en una v4 si se decide.
 
 ## Después de aprobar
 
-Meta devuelve (vía Twilio) el estado `approved` para el Content SID. Cargarlo en el secret `content-sid-safety-alert` (wiring de infra ya existe desde #476) y redeploy del api:
+Meta devuelve (vía Twilio) el estado `approved` para el Content SID. El env var `CONTENT_SID_SAFETY_ALERT` **ya está montado** en el api en prod (wiring de #476 + mount condicional A7 de #526), así que basta cargar el SID aprobado como nueva versión del secret + redeploy para tomar `:latest`:
 
 ```bash
-echo -n "HX48d541ad8f2cab4e4f65165cb26489b1" | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=booster-ai-494222
+# Reemplazá HX… por el Content SID que devolvió el script (v3) o el de v2 si se aprueba por el camino A.
+echo -n "HX…" | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=booster-ai-494222
 gcloud run services update booster-ai-api --region=southamerica-west1 \
   --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest --project=booster-ai-494222
 ```
 
-Hasta entonces el código skipea WhatsApp y notifica **solo por push** (sin romper nada). Detalle completo en `docs/runbooks/load-content-sids.md`.
+> El secret ya tiene una versión cargada en prod (el SID de v2, post-recovery INC-2026-06-19), por eso el api bootea sano hoy aunque el template esté pending. El canal WhatsApp solo queda **funcional** cuando el SID cargado corresponde a un template **approved**; hasta entonces el código degrada a **solo push** (sin romper nada). Detalle completo en `docs/runbooks/load-content-sids.md`.
 
-## Checklist de submit
+## Checklist
 
-- [x] Correr `scripts/create-safety-alert-template.sh` (o crear a mano en Content Editor con name `safety_alert_v2`, category UTILITY, language `es`, body de arriba, 4 sample values). — hecho 2026-06-15.
-- [x] Anotar el Content SID nuevo: `HX48d541ad8f2cab4e4f65165cb26489b1`.
-- [ ] Vigilar aprobación (`ApprovalRequests`, típico 24-48h). — en curso; status `pending` al 2026-06-16.
+**Camino B (v3 — recomendado):**
+- [ ] Correr `scripts/create-safety-alert-template.sh` (crea `safety_alert_v3` con el body de-riesgado y lo submitea, category UTILITY, language `es`).
+- [ ] Anotar el Content SID nuevo que imprime el script y registrarlo en la tabla de arriba.
+- [ ] Vigilar aprobación (`ApprovalRequests`; con v3 debería auto-aprobarse en minutos–horas, no días).
 - [ ] Al aprobar: cargar el SID en `content-sid-safety-alert` + redeploy (comandos arriba).
+- [ ] Smoke: disparar un evento de safety de prueba → confirmar que llega el WhatsApp.
+
+**Camino A (destrabar v2 — alternativa):**
+- [ ] Abrir Twilio support ticket: template `safety_alert_v2`, SID `HX48d541ad8f2cab4e4f65165cb26489b1`, "pending >7d, request manual review".
+- [ ] Si Meta lo aprueba: cargar `HX48d541…` en el secret + redeploy.
+- [ ] Si Meta lo rechaza: descartar y seguir el camino B.

--- a/.specs/safety-event-fanout/whatsapp-template.md
+++ b/.specs/safety-event-fanout/whatsapp-template.md
@@ -1,23 +1,20 @@
-# WhatsApp template — `safety_alert` (v3)
+# WhatsApp template — `safety_alert` (v2 aprobado + live)
 
-Template del fan-out de seguridad (P0-G): notifica al transportista ante eventos crash/unplug/jamming. Categoría **UTILITY** (notificación transaccional, no marketing → aprobación más rápida y enviable fuera de la ventana de 24h).
+Template del fan-out de seguridad (P0-G): notifica al transportista ante eventos crash/unplug/jamming. Categoría **UTILITY** (notificación transaccional, no marketing → enviable fuera de la ventana de 24h).
 
-**Forma de submit recomendada**: `scripts/create-safety-alert-template.sh` (crea el content vía Twilio Content API y lo submitea a Meta en un paso, sin hardcodear credenciales). El Content Editor de la consola también sirve, pero el script es reproducible.
+## Estado actual (2026-06-22) — ✅ APROBADO Y EN PRODUCCIÓN
 
----
+`safety_alert_v2` (`HX48d541ad8f2cab4e4f65165cb26489b1`) está **`approved`** por Meta y **cargado** en el secret `content-sid-safety-alert` + montado en el api. El canal WhatsApp de safety está **vivo**: las alertas se entregan al transportista (confirmado en prod, 2026-06-22).
 
-## Estado actual (2026-06-22) — v2 atascado en Meta
+Tardó ~7 días en `pending` (revisión humana de Meta, por el contenido sensible: contactos de emergencia + tono de alarma), bastante por encima del típico 5min–48h — pero **no estaba muerto**, Meta terminó aprobándolo. Verificación del estado en cualquier momento:
 
-`safety_alert_v2` (`HX48d541ad8f2cab4e4f65165cb26489b1`) lleva **>7 días en `pending`**, muy por encima del típico (5 min–48 h). Clave: v2 **pasó los auto-checks** de Meta (no quedó `rejected` como v1) — está atascado en **revisión humana**, casi seguro por su contenido sensible (contactos de emergencia 131/133, tono alarmista) que no se puede auto-triagear.
-
-Hay **dos caminos** para resolverlo (no son excluyentes; el segundo es el recomendado):
-
-| Camino | Acción | Quién | Trade-off |
-|---|---|---|---|
-| **A — destrabar v2** | Abrir un **Twilio support ticket** con el nombre `safety_alert_v2` + SID `HX48d541…`. Es la acción que Meta documenta para `pending >48h`. | Owner (consola Twilio) | Conserva el contenido exacto de v2 (con números de emergencia), pero depende de la cola de soporte. |
-| **B — reemplazar por v3** ✅ | Correr `scripts/create-safety-alert-template.sh` (ya apunta a `safety_alert_v3`, body de-riesgado). | Owner (corre el script; lee creds de Secret Manager) | Path auto-aprobable (sin el contenido que dispara revisión humana). El detalle de emergencia se mueve a la app/push, no al texto WhatsApp. |
-
-> Referencia de la regla de Meta: *"If a template remains in the Pending state for more than 48 hours, open a Twilio support ticket and include the template name."* (twilio.com/docs/whatsapp/tutorial/message-template-approvals-statuses).
+```bash
+TW_SID="$(gcloud secrets versions access latest --secret=twilio-account-sid --project=booster-ai-494222)"
+TW_TOK="$(gcloud secrets versions access latest --secret=twilio-auth-token  --project=booster-ai-494222)"
+curl -sS -u "$TW_SID:$TW_TOK" \
+  "https://content.twilio.com/v1/Content/HX48d541ad8f2cab4e4f65165cb26489b1/ApprovalRequests" | python3 -m json.tool
+# whatsapp.status == "approved"
+```
 
 ## Historial de aprobación
 
@@ -25,39 +22,10 @@ Hay **dos caminos** para resolverlo (no son excluyentes; el segundo es el recome
 |---|---|---|
 | `safety_alert_v1` | `HX0d6363fd0162c2d71519ed4e3afe2e3d` | **rejected** (subCode 2388293: "too many variables for its length") |
 | `copy_of_safety_alert_v1` | `HX80819b02ce9a546b855d09ada1aac944` | **rejected** (mismo subCode) |
-| `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` | **pending >7d** (submiteado 2026-06-15T23:01Z) → atascado en revisión humana |
-| `safety_alert_v3` | _(lo asigna el script al crearlo)_ | **por submitear** (camino B) |
+| `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` | **approved + live** ✅ (submiteado 2026-06-15, aprobado tras ~7d de revisión humana) |
+| `safety_alert_v3` | _(no creado)_ | **fallback de-riesgado** (no submitear salvo que v2 se pause/disable — ver abajo) |
 
-**Por qué v3 cambia respecto de v2** (sin tocar el código — mismas 4 variables, mismo orden):
-
-1. **Sin la instrucción de servicios de emergencia** (131/133). Pedirle al usuario que llame a emergencias es contenido sensible que Meta rutea a revisión humana. Esos contactos viven en la app / el push, no en el texto del template.
-2. **Sin líneas en blanco** (`\n\n` → `\n`). Meta lista "newlines, tabs, or more than four consecutive spaces" como motivo de fricción/rechazo; v3 usa solo saltos simples.
-3. **Tono claramente transaccional, sin emojis de alarma** (🚨⚠️ fuera). Un aviso sobre el propio vehículo del usuario es UTILITY legítimo; el tono neutro ayuda al auto-triage.
-
-> El código referencia el template por **Content SID**, no por nombre — el nombre nuevo (`safety_alert_v3`) no impacta nada. Se usa nombre nuevo porque Meta bloquea reusar el nombre de un template existente/rechazado por 30 días.
-
-## Metadatos
-
-| Campo | Valor |
-|---|---|
-| **Template name** | `safety_alert_v3` (Twilio exige snake_case minúscula) |
-| **Category** | UTILITY |
-| **Language** | Spanish (`es`) |
-| **Content type** | `twilio/text` (body-only) — ver abajo variante con botón |
-
-## Body (v3 — el que va a producción)
-
-```
-Hola, te escribe el sistema de Booster AI. Detectamos un evento en uno de tus vehículos que necesita tu atención.
-Vehículo (patente): {{1}}
-Evento detectado: {{2}}
-Hora (Chile): {{3}}
-Viaje asociado: {{4}}
-Revisa cuanto antes el estado del vehículo y de la carga, y respóndenos por este chat para confirmar que recibiste este aviso. Encontrarás el detalle y los contactos de ayuda en la app de Booster AI.
-```
-
-<details>
-<summary>Body de v2 (atascado — solo referencia)</summary>
+## Body (v2 — el que está en producción)
 
 ```
 🚨 Alerta de seguridad Booster AI
@@ -71,11 +39,10 @@ Detectamos un evento en uno de tus vehículos que requiere tu atención.
 
 Por favor verifica cuanto antes el estado del conductor y de la carga. Si se trata de una emergencia, llama a los servicios de emergencia (131 ambulancia · 133 Carabineros) y luego avísanos por este mismo chat. Si fue una falsa alarma, responde OK para que quede registrado.
 ```
-</details>
 
-## Variables — sample values (Meta los exige para aprobar)
+## Variables — sample values
 
-Las 4 variables son **idénticas** entre v2 y v3 (mismo orden), por eso `dispatch-safety-notification.ts` no cambia.
+Las 4 variables son **idénticas** entre v2 y el fallback v3 (mismo orden), por eso `dispatch-safety-notification.ts` no cambia si algún día se rota el template.
 
 | Var | Significado (app) | Origen en código | Sample para el submit |
 |---|---|---|---|
@@ -89,35 +56,27 @@ Las 4 variables son **idénticas** entre v2 y v3 (mismo orden), por eso `dispatc
 - `unplug` → `Desconexión de energía (manipulación)`
 - `jamming` → `Interferencia de señal GPS`
 
-> El orden 1→4 y el mapping están fijados en `apps/api/src/services/dispatch-safety-notification.ts:121-126`. Si se cambia el body, NO reordenar ni agregar variables sin tocar también ese servicio (y sus tests).
+> El orden 1→4 y el mapping están fijados en `apps/api/src/services/dispatch-safety-notification.ts:121-126`. Si se rota el template, NO reordenar ni agregar variables sin tocar también ese servicio (y sus tests). El código referencia por **Content SID**, no por nombre.
 
-## Variante con botón (opcional — no en v3)
+## Fallback de-riesgado (`safety_alert_v3`) — solo si Meta pausa/disable v2
 
-Se podría agregar un **botón URL dinámico** (`Ver vehículo` → `https://app.boosterchile.com/app/flota?v={{1}}`), pero agrega una variable extra y alarga la revisión de Meta. El deep-link igual sale por push, así que v3 va **body-only** para maximizar probabilidad de aprobación. El botón se evalúa en una v4 si se decide.
+Meta puede **pausar** o **deshabilitar** un template aprobado si acumula feedback negativo (bloqueos/spam reports). Si eso pasa con v2, hay un reemplazo **pre-de-riesgado** listo en `scripts/create-safety-alert-template.sh` (apunta a `safety_alert_v3`): mismo set de 4 variables, pero sin la instrucción de servicios de emergencia (van por app/push), sin líneas en blanco (`\n\n`→`\n`) y con tono transaccional sin emojis de alarma — para maximizar la probabilidad de auto-aprobación rápida.
 
-## Después de aprobar
-
-Meta devuelve (vía Twilio) el estado `approved` para el Content SID. El env var `CONTENT_SID_SAFETY_ALERT` **ya está montado** en el api en prod (wiring de #476 + mount condicional A7 de #526), así que basta cargar el SID aprobado como nueva versión del secret + redeploy para tomar `:latest`:
-
-```bash
-# Reemplazá HX… por el Content SID que devolvió el script (v3) o el de v2 si se aprueba por el camino A.
-echo -n "HX…" | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=booster-ai-494222
-gcloud run services update booster-ai-api --region=southamerica-west1 \
-  --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest --project=booster-ai-494222
+```
+Hola, te escribe el sistema de Booster AI. Detectamos un evento en uno de tus vehículos que necesita tu atención.
+Vehículo (patente): {{1}}
+Evento detectado: {{2}}
+Hora (Chile): {{3}}
+Viaje asociado: {{4}}
+Revisa cuanto antes el estado del vehículo y de la carga, y respóndenos por este chat para confirmar que recibiste este aviso. Encontrarás el detalle y los contactos de ayuda en la app de Booster AI.
 ```
 
-> El secret ya tiene una versión cargada en prod (el SID de v2, post-recovery INC-2026-06-19), por eso el api bootea sano hoy aunque el template esté pending. El canal WhatsApp solo queda **funcional** cuando el SID cargado corresponde a un template **approved**; hasta entonces el código degrada a **solo push** (sin romper nada). Detalle completo en `docs/runbooks/load-content-sids.md`.
+Flujo de rotación (solo si hace falta): correr el script → anota el SID de v3 → al aprobar Meta, `gcloud secrets versions add content-sid-safety-alert` (nueva versión) + redeploy del api. El env var ya está montado (mount A7 de #526), así que no toca Terraform.
 
 ## Checklist
 
-**Camino B (v3 — recomendado):**
-- [ ] Correr `scripts/create-safety-alert-template.sh` (crea `safety_alert_v3` con el body de-riesgado y lo submitea, category UTILITY, language `es`).
-- [ ] Anotar el Content SID nuevo que imprime el script y registrarlo en la tabla de arriba.
-- [ ] Vigilar aprobación (`ApprovalRequests`; con v3 debería auto-aprobarse en minutos–horas, no días).
-- [ ] Al aprobar: cargar el SID en `content-sid-safety-alert` + redeploy (comandos arriba).
-- [ ] Smoke: disparar un evento de safety de prueba → confirmar que llega el WhatsApp.
-
-**Camino A (destrabar v2 — alternativa):**
-- [ ] Abrir Twilio support ticket: template `safety_alert_v2`, SID `HX48d541ad8f2cab4e4f65165cb26489b1`, "pending >7d, request manual review".
-- [ ] Si Meta lo aprueba: cargar `HX48d541…` en el secret + redeploy.
-- [ ] Si Meta lo rechaza: descartar y seguir el camino B.
+- [x] Crear `safety_alert_v2`, submitear a Meta (UTILITY, es, 4 sample values). — 2026-06-15.
+- [x] Aprobación de Meta. — **approved** (tras ~7d de revisión humana).
+- [x] Cargar el SID en `content-sid-safety-alert` + montar en el api. — live en prod.
+- [x] Confirmar entrega real de WhatsApp al transportista. — confirmado 2026-06-22.
+- [ ] _(solo si Meta pausa/disable v2)_ rotar al fallback v3 vía el script.

--- a/docs/runbooks/load-content-sids.md
+++ b/docs/runbooks/load-content-sids.md
@@ -8,7 +8,7 @@ WhatsApp aprobados por Meta. Los secrets viven en Secret Manager:
 | `content-sid-offer-new` | Notificar carrier de nueva oferta (B.8) | `offer_new_v1` | `HXa30e82ea818a72d08bb12a4214610a86` |
 | `content-sid-chat-unread` | Fallback WhatsApp para chat no leído (P3.d) | `chat_unread_v1` | _pending Meta_ |
 | `content-sid-tracking` | Link público de tracking al shipper al asignar (Phase 5 PR-L3) | `tracking_link_v1` | `HXac1ef21ed9423258a2c38dad02f31e41` (submitted Meta 2026-05-10) |
-| `content-sid-safety-alert` | Alerta de seguridad al transportista (crash/unplug/jamming, P0-G) | `safety_alert_v3` (de-riesgado) | v2 `HX48d541ad8f2cab4e4f65165cb26489b1` quedó **pending >7d** (atascado en revisión humana de Meta); v1 `HX0d6363fd0162c2d71519ed4e3afe2e3d` y copy_of_v1 `HX80819b02ce9a546b855d09ada1aac944` fueron **rechazados** (subCode 2388293). Resolución (v3 vía script, o support ticket para v2): ver [`.specs/safety-event-fanout/whatsapp-template.md`](../../.specs/safety-event-fanout/whatsapp-template.md) |
+| `content-sid-safety-alert` | Alerta de seguridad al transportista (crash/unplug/jamming, P0-G) | `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` **approved + live** ✅ (aprobado tras ~7d de revisión humana; entregando en prod 2026-06-22). v1 `HX0d…3d` y copy_of_v1 `HX80…44` fueron **rechazados** (subCode 2388293). Fallback de-riesgado `safety_alert_v3` listo si Meta pausa v2: ver [`.specs/safety-event-fanout/whatsapp-template.md`](../../.specs/safety-event-fanout/whatsapp-template.md) |
 
 ### Body de `tracking_link_v1` (creado vía Twilio Content API 2026-05-10)
 
@@ -88,17 +88,16 @@ echo -n "HXabcdef0123456789abcdef0123456789" \
       --data-file=- \
       --project=booster-ai-494222
 
-# Para safety_alert: v2 (HX48d541…) quedó pending >7d en Meta. Recomendado:
-# correr scripts/create-safety-alert-template.sh (crea safety_alert_v3 de-riesgado)
-# y cargar el SID que imprime. Detalle + camino alternativo (support ticket v2):
-# .specs/safety-event-fanout/whatsapp-template.md
-echo -n "HX<sid-aprobado-v3-o-v2>" \
+# Para safety_alert: v2 (HX48d541…) ya está APPROVED + cargado + live en prod.
+# Este bloque solo aplica para ROTAR el template (p.ej. si Meta pausa v2 → crear
+# el fallback v3 con scripts/create-safety-alert-template.sh y cargar su SID):
+echo -n "HX<sid-del-template-approved>" \
   | gcloud secrets versions add content-sid-safety-alert \
       --data-file=- \
       --project=booster-ai-494222
 # Luego redeploy con --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest
-# El env var ya está montado (#476/#526); mientras el SID cargado no sea de un
-# template approved, el fan-out de safety sale solo por push (no bloquea).
+# El env var ya está montado (#476/#526); si el SID cargado no fuera de un
+# template approved, el fan-out de safety degradaría a solo push (no bloquea).
 ```
 
 ### 3. Forzar re-deploy del api Cloud Run para tomar el nuevo valor

--- a/docs/runbooks/load-content-sids.md
+++ b/docs/runbooks/load-content-sids.md
@@ -8,7 +8,7 @@ WhatsApp aprobados por Meta. Los secrets viven en Secret Manager:
 | `content-sid-offer-new` | Notificar carrier de nueva oferta (B.8) | `offer_new_v1` | `HXa30e82ea818a72d08bb12a4214610a86` |
 | `content-sid-chat-unread` | Fallback WhatsApp para chat no leído (P3.d) | `chat_unread_v1` | _pending Meta_ |
 | `content-sid-tracking` | Link público de tracking al shipper al asignar (Phase 5 PR-L3) | `tracking_link_v1` | `HXac1ef21ed9423258a2c38dad02f31e41` (submitted Meta 2026-05-10) |
-| `content-sid-safety-alert` | Alerta de seguridad al transportista (crash/unplug/jamming, P0-G) | `safety_alert_v2` | `HX48d541ad8f2cab4e4f65165cb26489b1` (en revisión Meta desde 2026-06-15; `safety_alert_v1` `HX0d6363fd0162c2d71519ed4e3afe2e3d` y `copy_of_safety_alert_v1` `HX80819b02ce9a546b855d09ada1aac944` fueron **rechazados** por subCode 2388293) |
+| `content-sid-safety-alert` | Alerta de seguridad al transportista (crash/unplug/jamming, P0-G) | `safety_alert_v3` (de-riesgado) | v2 `HX48d541ad8f2cab4e4f65165cb26489b1` quedó **pending >7d** (atascado en revisión humana de Meta); v1 `HX0d6363fd0162c2d71519ed4e3afe2e3d` y copy_of_v1 `HX80819b02ce9a546b855d09ada1aac944` fueron **rechazados** (subCode 2388293). Resolución (v3 vía script, o support ticket para v2): ver [`.specs/safety-event-fanout/whatsapp-template.md`](../../.specs/safety-event-fanout/whatsapp-template.md) |
 
 ### Body de `tracking_link_v1` (creado vía Twilio Content API 2026-05-10)
 
@@ -88,13 +88,17 @@ echo -n "HXabcdef0123456789abcdef0123456789" \
       --data-file=- \
       --project=booster-ai-494222
 
-# Para safety_alert (cuando Meta apruebe safety_alert_v2):
-echo -n "HX48d541ad8f2cab4e4f65165cb26489b1" \
+# Para safety_alert: v2 (HX48d541…) quedó pending >7d en Meta. Recomendado:
+# correr scripts/create-safety-alert-template.sh (crea safety_alert_v3 de-riesgado)
+# y cargar el SID que imprime. Detalle + camino alternativo (support ticket v2):
+# .specs/safety-event-fanout/whatsapp-template.md
+echo -n "HX<sid-aprobado-v3-o-v2>" \
   | gcloud secrets versions add content-sid-safety-alert \
       --data-file=- \
       --project=booster-ai-494222
 # Luego redeploy con --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest
-# Mientras esté en placeholder, el fan-out de safety sale solo por push (no bloquea).
+# El env var ya está montado (#476/#526); mientras el SID cargado no sea de un
+# template approved, el fan-out de safety sale solo por push (no bloquea).
 ```
 
 ### 3. Forzar re-deploy del api Cloud Run para tomar el nuevo valor

--- a/scripts/create-safety-alert-template.sh
+++ b/scripts/create-safety-alert-template.sh
@@ -1,22 +1,35 @@
 #!/usr/bin/env bash
 #
-# create-safety-alert-template.sh — crea el template WhatsApp `safety_alert_v2`
+# create-safety-alert-template.sh — crea el template WhatsApp `safety_alert_v3`
 # vía Twilio Content API y lo submitea a Meta para aprobación.
 #
 # CONTEXTO
 #   El fan-out de seguridad (P0-G) notifica al transportista ante eventos
 #   crash/unplug/jamming. El canal WhatsApp usa un template Twilio cuyo Content
 #   SID se carga en el secret `content-sid-safety-alert` (ver
-#   docs/runbooks/load-content-sids.md). El wiring de infra ya existe (#476);
-#   este script genera el template que falta.
+#   docs/runbooks/load-content-sids.md). El wiring de infra ya existe (#476).
 #
-#   Historia: `safety_alert_v1` (HX0d6363fd0162c2d71519ed4e3afe2e3d) y su copia
-#   `copy_of_safety_alert_v1` (HX80819b02ce9a546b855d09ada1aac944) fueron
-#   RECHAZADOS por Meta con subCode 2388293: "This template has too many
-#   variables for its length. Reduce the number of variables or increase the
-#   message length." Este script usa un body MÁS LARGO (más texto fijo por
-#   variable) manteniendo las mismas 4 variables {{1}}..{{4}} en el mismo orden,
-#   así `apps/api/src/services/dispatch-safety-notification.ts` no cambia.
+#   Historia de aprobación (Meta):
+#     v1            HX0d6363fd0162c2d71519ed4e3afe2e3d  REJECTED (subCode 2388293:
+#                   "too many variables for its length")
+#     copy_of_v1    HX80819b02ce9a546b855d09ada1aac944  REJECTED (mismo subCode)
+#     v2            HX48d541ad8f2cab4e4f65165cb26489b1  PENDING >7 días (anómalo;
+#                   el típico es 5min–48h). v2 pasó los auto-checks (no fue
+#                   rejected) pero su contenido —contactos de emergencia 131/133,
+#                   tono alarmista, líneas en blanco— probablemente lo ruteó a
+#                   revisión humana, que quedó atascada.
+#
+#   v3 (este script) de-riesga el contenido para volver a un path auto-aprobable:
+#     (a) sin la instrucción de servicios de emergencia (esos contactos viven en
+#         la app / push, no en el template);
+#     (b) sin líneas en blanco (\n\n → \n; regla de whitespace de Meta);
+#     (c) tono claramente transaccional, sin emojis de alarma.
+#   Mantiene las MISMAS 4 variables {{1}}..{{4}} en el mismo orden → cero cambios
+#   en apps/api/src/services/dispatch-safety-notification.ts ni en sus tests.
+#
+#   Si preferís destrabar v2 en vez de reemplazarlo: Meta documenta que un
+#   template >48h en pending se escala abriendo un Twilio support ticket con el
+#   nombre (`safety_alert_v2`) y el SID. Ver .specs/safety-event-fanout/whatsapp-template.md.
 #
 # VARIABLES (las arma el código, ver dispatch-safety-notification.ts:121-126)
 #   {{1}} patente del vehículo        (vehicleLabel = vehicle.plate)
@@ -34,30 +47,28 @@
 set -euo pipefail
 
 PROJ="booster-ai-494222"
-NAME="safety_alert_v2"
+NAME="safety_alert_v3"
 
 echo "→ Leyendo credenciales Twilio desde Secret Manager (proyecto $PROJ)…"
 TW_SID="$(gcloud secrets versions access latest --secret=twilio-account-sid --project="$PROJ")"
 TW_TOK="$(gcloud secrets versions access latest --secret=twilio-auth-token  --project="$PROJ")"
 
-# Payload de creación: python3 arma el JSON para escapar bien newlines, emoji y
-# acentos del body. El body es body-only (twilio/text); el deep-link al vehículo
-# va por push, no por el template (evita una variable extra que alarga la
-# revisión de Meta — ver la nota "variante con botón" en el spec).
+# Payload de creación: python3 arma el JSON para escapar bien newlines y acentos
+# del body. El body es body-only (twilio/text); el deep-link al vehículo y los
+# contactos de ayuda van por push / la app, no por el template.
 CREATE_PAYLOAD="$(python3 - "$NAME" <<'PY'
 import json, sys
 name = sys.argv[1]
 body = (
-    "🚨 Alerta de seguridad Booster AI\n\n"
-    "Detectamos un evento en uno de tus vehículos que requiere tu atención.\n\n"
-    "🚚 Vehículo (patente): {{1}}\n"
-    "⚠️ Evento detectado: {{2}}\n"
-    "🕐 Hora (Chile): {{3}}\n"
-    "📍 Viaje asociado: {{4}}\n\n"
-    "Por favor verifica cuanto antes el estado del conductor y de la carga. "
-    "Si se trata de una emergencia, llama a los servicios de emergencia "
-    "(131 ambulancia · 133 Carabineros) y luego avísanos por este mismo chat. "
-    "Si fue una falsa alarma, responde OK para que quede registrado."
+    "Hola, te escribe el sistema de Booster AI. Detectamos un evento en uno de "
+    "tus vehículos que necesita tu atención.\n"
+    "Vehículo (patente): {{1}}\n"
+    "Evento detectado: {{2}}\n"
+    "Hora (Chile): {{3}}\n"
+    "Viaje asociado: {{4}}\n"
+    "Revisa cuanto antes el estado del vehículo y de la carga, y respóndenos por "
+    "este chat para confirmar que recibiste este aviso. Encontrarás el detalle y "
+    "los contactos de ayuda en la app de Booster AI."
 )
 print(json.dumps({
     "friendly_name": name,
@@ -100,7 +111,8 @@ Próximos pasos (detalle completo en docs/runbooks/load-content-sids.md):
      este Content SID (${CONTENT_SID}) hasta que whatsapp.status == "approved".
      El comando exacto (curl autenticado) está en el runbook.
 
-  2. Al aprobar, cargar el SID en el secret + redeploy del api:
+  2. Al aprobar, cargar el SID como nueva versión del secret (el env var ya está
+     montado en prod desde #476, así que basta agregar la versión + redeploy):
        echo -n "${CONTENT_SID}" | gcloud secrets versions add content-sid-safety-alert --data-file=- --project=${PROJ}
        gcloud run services update booster-ai-api --region=southamerica-west1 \\
          --update-secrets=CONTENT_SID_SAFETY_ALERT=content-sid-safety-alert:latest --project=${PROJ}

--- a/scripts/create-safety-alert-template.sh
+++ b/scripts/create-safety-alert-template.sh
@@ -9,27 +9,23 @@
 #   SID se carga en el secret `content-sid-safety-alert` (ver
 #   docs/runbooks/load-content-sids.md). El wiring de infra ya existe (#476).
 #
+#   ESTADO (2026-06-22): `safety_alert_v2` (HX48d541ad8f2cab4e4f65165cb26489b1)
+#   está APPROVED por Meta y LIVE en prod — el canal WhatsApp de safety funciona.
+#   ESTE SCRIPT NO ES NECESARIO en condiciones normales; solo se corre como
+#   FALLBACK si Meta llegara a pausar/deshabilitar v2 (por feedback negativo).
+#
 #   Historia de aprobación (Meta):
-#     v1            HX0d6363fd0162c2d71519ed4e3afe2e3d  REJECTED (subCode 2388293:
-#                   "too many variables for its length")
+#     v1            HX0d6363fd0162c2d71519ed4e3afe2e3d  REJECTED (subCode 2388293)
 #     copy_of_v1    HX80819b02ce9a546b855d09ada1aac944  REJECTED (mismo subCode)
-#     v2            HX48d541ad8f2cab4e4f65165cb26489b1  PENDING >7 días (anómalo;
-#                   el típico es 5min–48h). v2 pasó los auto-checks (no fue
-#                   rejected) pero su contenido —contactos de emergencia 131/133,
-#                   tono alarmista, líneas en blanco— probablemente lo ruteó a
-#                   revisión humana, que quedó atascada.
+#     v2            HX48d541ad8f2cab4e4f65165cb26489b1  APPROVED + LIVE (tardó ~7d
+#                   en revisión humana por su contenido sensible, pero se aprobó).
 #
-#   v3 (este script) de-riesga el contenido para volver a un path auto-aprobable:
-#     (a) sin la instrucción de servicios de emergencia (esos contactos viven en
-#         la app / push, no en el template);
-#     (b) sin líneas en blanco (\n\n → \n; regla de whitespace de Meta);
-#     (c) tono claramente transaccional, sin emojis de alarma.
-#   Mantiene las MISMAS 4 variables {{1}}..{{4}} en el mismo orden → cero cambios
-#   en apps/api/src/services/dispatch-safety-notification.ts ni en sus tests.
-#
-#   Si preferís destrabar v2 en vez de reemplazarlo: Meta documenta que un
-#   template >48h en pending se escala abriendo un Twilio support ticket con el
-#   nombre (`safety_alert_v2`) y el SID. Ver .specs/safety-event-fanout/whatsapp-template.md.
+#   El fallback v3 que crea este script de-riesga el contenido para auto-aprobar
+#   rápido si v2 cae: (a) sin la instrucción de servicios de emergencia (van por
+#   app/push); (b) sin líneas en blanco (\n\n → \n); (c) tono transaccional sin
+#   emojis. Mantiene las MISMAS 4 variables {{1}}..{{4}} en el mismo orden → cero
+#   cambios en dispatch-safety-notification.ts. Ver el spec para el flujo de rotación:
+#   .specs/safety-event-fanout/whatsapp-template.md
 #
 # VARIABLES (las arma el código, ver dispatch-safety-notification.ts:121-126)
 #   {{1}} patente del vehículo        (vehicleLabel = vehicle.plate)


### PR DESCRIPTION
## Desenlace

`safety_alert_v2` (`HX48d541ad8f2cab4e4f65165cb26489b1`) **fue aprobado por Meta** y está **live en producción** — el canal WhatsApp de safety (P0-G) entrega las alertas al transportista (confirmado por el PO 2026-06-22). Verificado vía Twilio Content API: `whatsapp.status == "approved"`.

Lo que parecía "atascado >7d en pending" era en realidad la **cola de revisión humana** de Meta (el contenido sensible — contactos de emergencia + tono de alarma — no se auto-triagea). No estaba muerto; se aprobó. **Lección**: un pending largo de un template con contenido sensible no implica rechazo — verificar el status real vía Content API antes de asumir stuck.

## Qué deja este PR

Como v2 quedó aprobado, **no hace falta submitear v3**. El PR se reconcilia a documentación correcta + un fallback pre-armado:

- **spec / runbook / memoria**: corrigen el estado a "v2 approved + live"; el comando de verificación del status; la activación A7-aware (env var ya montado vía #476/#526).
- **`scripts/create-safety-alert-template.sh`**: conserva el `safety_alert_v3` **de-riesgado** (sin instrucción de emergencia, sin líneas en blanco, tono transaccional) pero **claramente etiquetado como FALLBACK** — se corre solo si Meta llegara a *pausar/deshabilitar* v2 por feedback negativo. Es drop-in (mismas 4 variables `{{1}}..{{4}}`, el código referencia por Content SID).

## Evidencia

```
SID cargado en content-sid-safety-alert: HX48d541ad8f2cab4e4f65165cb26489b1
ApprovalRequests → name: safety_alert_v2 · status: approved · category: UTILITY · rejection_reason: (ninguna)
```
- Drop-in confirmado: `dispatch-safety-notification.ts:117-126` envía por `contentSid` (no por nombre) con `contentVariables {1,2,3,4}` = `vehicleLabel,label,hora,viaje` — idénticas en v2 y el fallback v3.
- `bash -n` del script OK; payload v3 valida contra reglas de Meta (sin var al inicio/fin, sin `\n\n`, secuencial 1-4, 0 emojis).
- Pre-commit: gitleaks 0 leaks · biome OK · check-adr-numbering OK · spec-canonical-drift OK. **No cambió TypeScript.**

## Nota

No requiere ninguna acción de ops: v2 ya está live. El fallback v3 queda listo en el repo por si se necesita rotar el template en el futuro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)