### PR TITLE
ci(release): workflow_dispatch para re-disparar deploy manual

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ on:
       - 'references/**'
       - 'playbooks/**'
       - '*.md'
+  # Trigger manual: re-disparar el deploy de `main` sin depender de un push.
+  # Agregado tras el footgun 2026-06-22 (merges rápidos a main trabaron la
+  # lane de concurrency `cancel-in-progress:false` y la única vía de
+  # re-trigger era pushear). Uso: `gh workflow run release.yml --ref main`
+  # o Actions → Release + Deploy → Run workflow.
+  workflow_dispatch: {}
 
 concurrency:
   group: release-${{ github.workflow }}-main


### PR DESCRIPTION
## Qué hace
Agrega `workflow_dispatch` al trigger de `release.yml` → permite re-disparar el deploy de `main` desde la UI (Actions → Run workflow) o `gh workflow run release.yml --ref main`, **sin depender de un push a main**.

## Por qué (footgun 2026-06-22)
Al mergear 9 PRs rápidos a main, la lane de release (`concurrency: cancel-in-progress: false`) se trabó: los runs con código se cancelaron antes del paso de deploy y el último quedó en limbo `pending, 0 jobs` reteniendo el lock → **el deploy no corrió** y la única forma de re-disparar era un push a main (el agente no pushea a main). `workflow_dispatch` resuelve eso a futuro.

## Efecto inmediato
Mergear este PR (la lane ya está libre — se canceló el run trabado) **dispara un release run limpio** que despliega todo el código mergeado (geo, OTel, pricing, etc.) → gate de `production` → aprobación humana → canary.

## Evidencia
- `yaml.safe_load` OK; `workflow_dispatch: {}` agregado al `on:`.
- Cambio mínimo, additive, no toca quality gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)