### PR TITLE
ci(release): resetea concurrency group para destrabar la lane de deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,12 @@ on:
   workflow_dispatch: {}
 
 concurrency:
-  group: release-${{ github.workflow }}-main
+  # Grupo renombrado 2026-06-22 (era `release-${{ github.workflow }}-main`)
+  # para RESETEAR un lock de concurrency que quedó trabado tras la cascada de
+  # merges rápidos: TODO release run colgaba en `pending, 0 jobs` sin despachar
+  # (push y workflow_dispatch por igual). Un namespace de lock nuevo arranca
+  # limpio. Ver memoria ci-release-paths-ignore-2026-06.
+  group: release-deploy-${{ github.ref_name }}
   cancel-in-progress: false  # No cancelar deploys en progreso
 
 permissions:


### PR DESCRIPTION
## Problema
Tras la cascada de merges rápidos del 2026-06-22, la lane de `release.yml` quedó con un **lock de concurrency trabado**: TODO release run (push **y** `workflow_dispatch`) cuelga en `pending, 0 jobs` sin despachar jobs. CI y Security corren normal → es específico de la concurrency group de release, no un incidente de Actions.

## Fix
Renombra la concurrency group → **namespace de lock nuevo y limpio**:
```
release-${{ github.workflow }}-main   →   release-deploy-${{ github.ref_name }}
```
(de paso, sin el nombre-de-workflow-con-espacios en el lock).

## Efecto
Al mergear, el release run disparado usa el grupo nuevo → **debería despachar jobs por fin** → gate de `production` → aprobación humana → canary.

## Evidencia
- `yaml.safe_load` OK; `concurrency.group` = `release-deploy-${{ github.ref_name }}`.
- Cambio mínimo, no toca quality gates (coverage/lint/required checks intactos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)