### PR TITLE
fix(api): instala deps de transport-documents en el Docker build

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -24,6 +24,13 @@ COPY packages/whatsapp-client/package.json ./packages/whatsapp-client/
 #       (noExternal: /^@booster-ai\//). Sin este COPY, pnpm install no
 #       sabe de las deps y esbuild revienta con "Could not resolve".
 COPY packages/certificate-generator/package.json ./packages/certificate-generator/
+# F4 — apps/api importa @booster-ai/transport-documents (server.ts → rutas +
+#       middleware de rate-limit). Bundleado por noExternal /^@booster-ai\//;
+#       sus deps nativas/wasm (sharp, @hyzyla/pdfium, zxing-wasm,
+#       fast-xml-parser) van como external en tsup.config.ts y deben instalarse
+#       acá para que `pnpm deploy --prod` las incluya en el runtime. Sin este
+#       COPY, esbuild revienta con "Could not resolve". Igual que el de arriba.
+COPY packages/transport-documents/package.json ./packages/transport-documents/
 RUN pnpm install --frozen-lockfile
 
 # --- build stage ---

--- a/apps/api/tsup.config.ts
+++ b/apps/api/tsup.config.ts
@@ -63,5 +63,15 @@ export default defineConfig({
     '@signpdf/utils',
     'node-forge',
     'pdf-lib',
+    // F4 — @booster-ai/transport-documents (bundleado vía noExternal) importa
+    // estas deps nativas/wasm: sharp (libvips native), @hyzyla/pdfium y
+    // zxing-wasm (WASM), fast-xml-parser. Bundlearlas rompe (native bindings /
+    // dynamic require en ESM). External = Node las carga del flat node_modules
+    // que `pnpm deploy --prod` arma. Requiere COPY de su package.json en el
+    // Dockerfile (deps stage) para que queden instaladas.
+    'sharp',
+    '@hyzyla/pdfium',
+    'zxing-wasm',
+    'fast-xml-parser',
   ],
 });


### PR DESCRIPTION
## Problema (deploy-blocker)
El deploy aprobado fallo en Cloud Build (`fcde5d66`), step 0 `docker build apps/api`:
```
✘ Could not resolve "zxing-wasm/reader"  ← transport-documents/src/barcode/zxing-pdf417.ts
✘ Could not resolve "sharp"              ← .../preprocess/sharp-photo.ts
✘ Could not resolve "@hyzyla/pdfium"     ← .../raster/pdfium-renderer.ts
✘ Could not resolve "fast-xml-parser"    ← .../ted/parse-ted-dd.ts
→ ERR_PNPM... @booster-ai/api build: tsup → exit 1
```

## Root cause
El api importa `@booster-ai/transport-documents` (server.ts), bundleado por `noExternal: /^@booster-ai\//`. El stage `deps` del Dockerfile copia a mano los package.json de los workspace-packages bundleados, **pero faltaba transport-documents** → pnpm no instala sus deps nativas/wasm → esbuild no las resuelve. CI no lo cacho (no corre el docker build); la lane de release trabada oculto el gap (sin deploys). Al destrabar (#539), el deploy lo revelo.

## Fix (patron existente de certificate-generator)
- **Dockerfile**: `COPY packages/transport-documents/package.json` en el stage `deps`.
- **tsup.config.ts**: `sharp`, `@hyzyla/pdfium`, `zxing-wasm`, `fast-xml-parser` → `external` (no bundlear native/WASM; runtime las carga del flat node_modules de `pnpm deploy --prod`).

## Evidencia
- **Cierre transitivo del api**: transport-documents era el unico package bundleado con deps externas sin copiar que rompia (otel-bootstrap tambien falta del COPY pero no rompe — sus deps ya estan en la lista external).
- **Build tsup local**: `pnpm --filter @booster-ai/api build` → ✅ Build success.
- **Externalizacion en dist/**: `from"sharp"`, `from"@hyzyla/pdfium"`, `from "zxing-wasm/reader"`, `from"fast-xml-parser"` — las 4 quedan external (no bundleadas; main.js 719KB).
- **Runtime**: transport-documents es prod dep del api → `pnpm deploy --prod` incluye las 4 en el flat node_modules.
- ⚠️ **Verificacion final = el re-deploy**: docker no esta disponible local para reproducir el build con install parcial. Se confirma al re-desplegar (build + health del canary).

## Follow-up (no bloqueante)
La lista de COPY hand-maintained del Dockerfile es fragil (3er package que se suma) y CI no cacha fallos de docker build. Vale automatizar (copiar todos los package.json / turbo prune) + correr el docker build en CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)