### PR TITLE
ci: docker build + smoke del api (cacha fallos de contenedor pre-merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,11 +270,55 @@ jobs:
           retention-days: 7
 
   # ---------------------------------------------------------------------------
+  # Docker build + smoke del api — gate que faltaba (2026-06-22).
+  #
+  # El job `build` de arriba corre `pnpm build` con node_modules COMPLETO, así
+  # que tsup/esbuild resuelve todo y pasa. Pero el Dockerfile del api hace un
+  # `pnpm install` PARCIAL (solo los package.json COPY'd en el deps-stage) y
+  # luego `pnpm deploy --prod` para el runtime. Un cambio que rompe ese build/
+  # runtime del contenedor pasaba CI verde y solo fallaba en el deploy a prod.
+  # Causó 2 deploys de producción fallidos seguidos:
+  #   1. Build: esbuild "Could not resolve" (deps de un workspace package
+  #      bundleado que no estaban en el COPY del deps-stage). Fix PR #540.
+  #   2. Runtime: ERR_MODULE_NOT_FOUND al startup (esas deps no eran deps
+  #      DIRECTAS del api → pnpm deploy --prod no las metía). Fix PR #541.
+  # Este job reproduce el build real del contenedor (cacha #1) y verifica que
+  # los imports resuelven en el runtime (cacha #2). Patrón completo en la
+  # memoria api-bundled-pkg-runtime-deps-2026-06. Extensible a las otras apps
+  # con Dockerfile (web, whatsapp-bot, telemetry-*) vía matrix — follow-up.
+  # ---------------------------------------------------------------------------
+  docker-build:
+    name: Docker build + smoke (api)
+    needs: setup
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build imagen del api (reproduce el build de prod, install parcial)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/api/Dockerfile
+          tags: booster-ai-api:ci
+          load: true
+          cache-from: type=gha,scope=docker-api
+          cache-to: type=gha,mode=max,scope=docker-api
+      - name: Smoke — los imports resuelven en el runtime (cacha ERR_MODULE_NOT_FOUND)
+        run: |
+          # Corre el contenedor cargando los dos entrypoints. Si una dep externa
+          # de un workspace package bundleado falta en el flat node_modules del
+          # runtime, Node tira ERR_MODULE_NOT_FOUND al resolver el grafo (ANTES
+          # del config/DB) → este check falla. Otros errores (config/DB por
+          # falta de env) NO cuentan: significan que los módulos sí resolvieron.
+          docker run --rm booster-ai-api:ci node -e "Promise.allSettled([import('./dist/instrumentation.js'),import('./dist/main.js')]).then(rs=>{const m=rs.filter(r=>r.status==='rejected'&&r.reason&&r.reason.code==='ERR_MODULE_NOT_FOUND');if(m.length){m.forEach(x=>console.error('FALTA MODULO EN RUNTIME:',x.reason.message));process.exit(1)}console.log('OK: todos los imports resuelven en el runtime del contenedor');process.exit(0)})"
+
+  # ---------------------------------------------------------------------------
   # Final gate — todos los jobs previos deben pasar
   # ---------------------------------------------------------------------------
   ci-success:
     name: CI Success
-    needs: [lint, terraform-fmt, typecheck, test, integration-tests, migration-safety, build]
+    needs: [lint, terraform-fmt, typecheck, test, integration-tests, migration-safety, build, docker-build]
     runs-on: ubuntu-latest
     if: always()
     steps:
@@ -286,7 +330,8 @@ jobs:
              [ "${{ needs.test.result }}" != "success" ] || \
              [ "${{ needs.integration-tests.result }}" != "success" ] || \
              [ "${{ needs.migration-safety.result }}" != "success" ] || \
-             [ "${{ needs.build.result }}" != "success" ]; then
+             [ "${{ needs.build.result }}" != "success" ] || \
+             [ "${{ needs.docker-build.result }}" != "success" ]; then
             echo "::error::One or more CI jobs failed"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,12 +306,23 @@ jobs:
           cache-to: type=gha,mode=max,scope=docker-api
       - name: Smoke — los imports resuelven en el runtime (cacha ERR_MODULE_NOT_FOUND)
         run: |
-          # Corre el contenedor cargando los dos entrypoints. Si una dep externa
-          # de un workspace package bundleado falta en el flat node_modules del
-          # runtime, Node tira ERR_MODULE_NOT_FOUND al resolver el grafo (ANTES
-          # del config/DB) → este check falla. Otros errores (config/DB por
-          # falta de env) NO cuentan: significan que los módulos sí resolvieron.
-          docker run --rm booster-ai-api:ci node -e "Promise.allSettled([import('./dist/instrumentation.js'),import('./dist/main.js')]).then(rs=>{const m=rs.filter(r=>r.status==='rejected'&&r.reason&&r.reason.code==='ERR_MODULE_NOT_FOUND');if(m.length){m.forEach(x=>console.error('FALTA MODULO EN RUNTIME:',x.reason.message));process.exit(1)}console.log('OK: todos los imports resuelven en el runtime del contenedor');process.exit(0)})"
+          # Corre el entrypoint REAL del contenedor. El api hace process.exit(1)
+          # por env/config faltante (esperado en CI, sin env seteado) — eso NO
+          # importa. Lo que importa: si una dep externa de un workspace package
+          # bundleado falta en el flat node_modules del runtime, Node tira
+          # ERR_MODULE_NOT_FOUND al resolver el grafo de módulos ANTES de que
+          # corra el config. Por eso ignoramos el exit code (el config-exit lo
+          # dispara) y grepeamos la salida por esa firma exacta.
+          docker run --rm booster-ai-api:ci \
+            node --import ./dist/instrumentation.js dist/main.js > /tmp/api-boot.log 2>&1 || true
+          echo "--- salida del arranque del contenedor ---"
+          cat /tmp/api-boot.log
+          echo "------------------------------------------"
+          if grep -q "ERR_MODULE_NOT_FOUND" /tmp/api-boot.log; then
+            echo "::error::Falta una dep en el runtime del contenedor (ERR_MODULE_NOT_FOUND) — ver memoria api-bundled-pkg-runtime-deps"
+            exit 1
+          fi
+          echo "✓ Sin ERR_MODULE_NOT_FOUND — los módulos resuelven en runtime (el exit por config/env sin setear es esperado)"
 
   # ---------------------------------------------------------------------------
   # Final gate — todos los jobs previos deben pasar


### PR DESCRIPTION
## Problema (causa de fondo de los 2 deploys fallidos de hoy)
CI corre lint + test + tsc + `pnpm build`, pero el job `build` usa node_modules COMPLETO → tsup/esbuild resuelve todo y pasa. El Dockerfile del api, en cambio, hace `pnpm install` PARCIAL (solo los package.json COPY'd en el deps-stage) + `pnpm deploy --prod`. Un cambio que rompe ese build/runtime del contenedor **pasa CI verde y solo falla en el deploy a prod**.

El 2026-06-22 esto causó 2 deploys de producción fallidos seguidos con `apps/api`:
1. **Build**: `esbuild "Could not resolve"` para sharp / @hyzyla/pdfium / zxing-wasm / fast-xml-parser (deps de `transport-documents`, bundleado vía `noExternal`, ausentes del COPY del deps-stage). Fix [#540](https://github.com/boosterchile/booster-ai/pull/540).
2. **Runtime**: `ERR_MODULE_NOT_FOUND: zxing-wasm` al startup → el canary falló el startup probe (esas deps no eran `dependencies` directas del api → `pnpm deploy --prod` no las incluía). Fix [#541](https://github.com/boosterchile/booster-ai/pull/541).

Patrón completo en la memoria `api-bundled-pkg-runtime-deps-2026-06`.

## Fix
Nuevo job **`docker-build`** (bloqueante, en `ci-success.needs`):
1. **`docker build -f apps/api/Dockerfile`** con cache de capas GHA → reproduce el build real del contenedor (install parcial + pnpm deploy) → **cacha el fallo #1**.
2. **Smoke de módulos**: corre el contenedor cargando `dist/instrumentation.js` + `dist/main.js`; falla si Node tira `ERR_MODULE_NOT_FOUND` al resolver el grafo → **cacha el fallo #2**. Sin DB ni env (los errores de import preceden al config/DB; otros errores no cuentan).

## Evidencia
- `yaml.safe_load` OK; `docker-build` en `jobs` y en `ci-success.needs` (bloqueante).
- **El propio CI de este PR ejecuta el job nuevo** contra `main` (que ya tiene #540/#541) → el api buildea + los módulos resuelven → el job pasa = happy path validado. Si alguien rompe las deps de un workspace package bundleado, el job falla en su PR.
- Docker no está disponible localmente; la validación es el run de CI de este PR.

## Costo / follow-up
- Cache GHA (`type=gha`): el deps-stage se cachea salvo cambios en package.json/lockfile; un PR típico re-buildea solo el build-stage (~2-4 min).
- **Follow-up**: extender a las otras apps con Dockerfile (web, whatsapp-bot, telemetry-*, document-service) vía matrix — evaluar path-filtering por costo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)