### PR TITLE
ci(release): excluir scripts/ de paths-ignore (no dispara deploy)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,17 @@ on:
     # NO agregar '**/*.md' acá: matchearía .changeset/*.md y rompería el
     # release de versiones. '*.md' (un solo '*') es root-only. Ver
     # .specs/ci-release-skip-docs-only/spec.md (R1/SC-3).
+    # 'scripts/**': tooling/dev no-desplegable. Verificado 2026-06-24: ningún
+    # script bajo scripts/ es ejecutado por el deploy (ni release.yml ni
+    # cloudbuild.production.yaml — deploy-telemetry-gateway.sh es manual/
+    # break-glass, ADR-065). ci.yml/security.yml igual los validan (corren sin
+    # paths-ignore). Footgun visto en #545.
     paths-ignore:
       - 'docs/**'
       - '.specs/**'
       - 'references/**'
       - 'playbooks/**'
+      - 'scripts/**'
       - '*.md'
   # Trigger manual: re-disparar el deploy de `main` sin depender de un push.
   # Agregado tras el footgun 2026-06-22 (merges rápidos a main trabaron la


### PR DESCRIPTION
## Contexto

El merge de [#545](https://github.com/boosterchile/booster-ai/pull/545) (cambio docs/script) disparó `release.yml` y dejó la lane de release esperando aprobación del gate de producción — un deploy que **no aplica** a cambios no-desplegables. Causa raíz: el `paths-ignore` de `release.yml` excluía `docs/**` pero **no** `scripts/**`, así que tocar un script disparaba el release. Cierra ese footgun antes del próximo run grande de implementación (que tocará `scripts/`).

## Cambio

Añade `scripts/**` al `paths-ignore` existente de `.github/workflows/release.yml` (**solo aditivo**; no quita exclusiones previas), con un comentario que documenta la verificación.

## Decisión de diseño: exclusión de TODO `scripts/**` es segura

Verificado de primera mano que **ningún** script bajo `scripts/` es ejecutado por el deploy:
- `release.yml` despliega vía `gcloud builds submit --config=cloudbuild.production.yaml` — no referencia `scripts/`.
- `cloudbuild.production.yaml` menciona `deploy-telemetry-gateway.sh` **solo en un comentario** (`:486`, break-glass). Es **manual** (ADR-065): el step de Cloud Build solo imprime instrucciones; el deploy recurrente del gateway lo hace `cloudbuild-primary-deploy.yaml`.
- `lint-rls.mjs` y `scripts/repo-checks/*` / `scripts/check-*` los corren **ci.yml** y **security.yml**, no el deploy.
- **Ningún Dockerfile COPYa `scripts/`** al runtime image.

**Red de seguridad intacta:** `ci.yml` y `security.yml` disparan en todo push/PR a `main` **sin `paths-ignore`**, así que un cambio en `scripts/` sigue recibiendo lint+test+coverage+build+security. Lo único que cambia: un push que toque **solo** `scripts/`/docs ya no dispara el **deploy de producción** (correcto — el deploy no depende de `scripts/`). Un push con `scripts/` + código de app **sí** despliega (semántica de `paths-ignore`: salta solo si *todos* los archivos matchean).

## Evidencia

- **YAML válido**: `python3 -c "import yaml; yaml.safe_load(...)"` OK → `paths-ignore = ['docs/**','.specs/**','references/**','playbooks/**','scripts/**','*.md']`.
- **Diff aditivo**: +`scripts/**` + 5 líneas de comentario; las 5 exclusiones previas confirmadas intactas.
- **Pre-commit**: gitleaks (0 leaks), numeración ADR OK.

## ⚠️ Nota sobre el merge de ESTE PR

El cambio toca `.github/workflows/release.yml`, que **no está** en `paths-ignore` (ni debe estarlo — los cambios de workflow deben poder disparar). Por eso **el merge de este PR sí disparará `release.yml` una última vez**, y como con #545 su `Deploy to production` quedará esperando aprobación y puede colgar la lane. Al mergear, cancelar ese run (`gh run cancel <id>`). Desde el **siguiente** cambio scripts-only, ya no disparará.

## Fuera de scope (para decisión futura del PO)

- `*.md` anidados fuera de `docs/` (READMEs de packages) hoy disparan deploy — requiere patrón cuidadoso (no `**/*.md`, rompe `.changeset/`).
- `audit-outputs/**` (reportes de auditoría) no excluido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)