### PR TITLE
feat(carbon): columnas opt-in de huella (Task 1)

### DIFF
--- a/apps/api/drizzle/0046_carbon_measurement_opt_in.sql
+++ b/apps/api/drizzle/0046_carbon_measurement_opt_in.sql
@@ -1,0 +1,32 @@
+-- Migration 0046 — opt-in de medición de huella de carbono (plan medicion-huella-segmento, Task 1)
+--
+-- Modela el opt-in de medición de huella estilo Uber: la empresa (cliente)
+-- activa la medición para sus viajes, y un viaje puede overridear ese default.
+-- El opt-in EFECTIVO es el OR de las empresas participantes (generador +
+-- transportista) con override por viaje — el resolver vive en Task 3; esta
+-- migración solo crea las columnas.
+--
+-- Naming inglés total (decisión PO): columnas nuevas en snake_case inglés,
+-- divergiendo a propósito de las legadas en español (es_generador_carga). Las
+-- legadas NO se migran.
+--
+-- Expand-only (ADR-066 / audit P1-H): solo ADD COLUMN.
+--   * empresas.carbon_measurement_enabled — NOT NULL DEFAULT false. El DEFAULT
+--     constante materializa en catálogo en Postgres 11+ (sin reescritura
+--     bloqueante de filas existentes); las empresas legacy quedan en false
+--     (opt-out) de forma consistente.
+--   * viajes.carbon_measurement_override — nullable sin default. NULL = heredar
+--     el opt-in de la empresa; true/false fuerza/desactiva por viaje.
+-- Sin DROP, sin RENAME, sin SET NOT NULL retroactivo. Ninguna columna tiene FK
+-- ni constraint obligatorio desde otra tabla → el reverse manual (down/0046)
+-- simplemente las dropea. Rollback de la revisión Cloud Run seguro: una versión
+-- previa ignora ambas columnas. Ver docs/runbooks/db-migration-rollback.md.
+--
+-- Nota: `trips` (const Drizzle) mapea a la tabla SQL `viajes`.
+
+ALTER TABLE empresas
+  ADD COLUMN carbon_measurement_enabled boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+
+ALTER TABLE viajes
+  ADD COLUMN carbon_measurement_override boolean;

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1780876800009,
       "tag": "0045_facturas_membership_dunning",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1780876800010,
+      "tag": "0046_carbon_measurement_opt_in",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -512,6 +512,14 @@ export const empresas = pgTable(
      * `compliance_requested_by_shipper_at` (futuro).
      */
     complianceEnabled: boolean('compliance_habilitado').notNull().default(false),
+    /**
+     * Opt-in de la empresa para medir la huella de carbono de sus viajes
+     * (Task 1, plan medicion-huella-segmento). Default false: la medición se
+     * activa explícitamente por cliente; un viaje puede overridear vía
+     * `trips.carbon_measurement_override`. Naming inglés total (decisión PO):
+     * columna en inglés, divergiendo a propósito de las legadas en español.
+     */
+    carbonMeasurementEnabled: boolean('carbon_measurement_enabled').notNull().default(false),
     planId: uuid('plan_id')
       .notNull()
       .references(() => plans.id),
@@ -1114,6 +1122,13 @@ export const trips = pgTable(
      */
     consigneeName: varchar('destinatario_nombre', { length: 100 }),
     consigneeWhatsappE164: varchar('destinatario_whatsapp_e164', { length: 20 }),
+    /**
+     * Override por viaje del opt-in de medición de huella. NULL = heredar el
+     * default de la empresa (`empresas.carbon_measurement_enabled`); true/false
+     * fuerza/desactiva la medición para este viaje (Task 1, plan
+     * medicion-huella-segmento). Naming inglés total (decisión PO).
+     */
+    carbonMeasurementOverride: boolean('carbon_measurement_override'),
     status: tripStatusEnum('estado').notNull().default('esperando_match'),
     createdAt: timestamp('creado_en', { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp('actualizado_en', { withTimezone: true }).notNull().defaultNow(),

--- a/apps/api/test/integration/carbon-opt-in-columns.integration.test.ts
+++ b/apps/api/test/integration/carbon-opt-in-columns.integration.test.ts
@@ -1,0 +1,52 @@
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { type TestDbHandle, createTestDb } from '../helpers/test-db.js';
+
+/**
+ * Task 1 — verificación a nivel DB de las columnas opt-in de huella tras
+ * aplicar la migración 0046 (globalSetup corre runMigrations). Complementa el
+ * test unitario del contrato Drizzle (`test/unit/carbon-opt-in-columns.test.ts`)
+ * con la prueba de que el SQL realmente crea las columnas en Postgres.
+ */
+interface ColumnRow {
+  data_type: string;
+  is_nullable: string;
+  column_default: string | null;
+}
+
+describe('integration: columnas opt-in de medición de huella (0046)', () => {
+  let handle: TestDbHandle;
+
+  beforeAll(() => {
+    handle = createTestDb();
+  });
+
+  afterAll(async () => {
+    await handle.pool.end();
+  });
+
+  test('empresas.carbon_measurement_enabled: boolean NOT NULL DEFAULT false', async () => {
+    const result = await handle.pool.query<ColumnRow>(
+      `SELECT data_type, is_nullable, column_default
+         FROM information_schema.columns
+        WHERE table_name = 'empresas' AND column_name = 'carbon_measurement_enabled'`,
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].data_type).toBe('boolean');
+    expect(result.rows[0].is_nullable).toBe('NO');
+    expect(result.rows[0].column_default).toContain('false');
+  });
+
+  test('viajes.carbon_measurement_override: boolean nullable sin default', async () => {
+    const result = await handle.pool.query<ColumnRow>(
+      `SELECT data_type, is_nullable, column_default
+         FROM information_schema.columns
+        WHERE table_name = 'viajes' AND column_name = 'carbon_measurement_override'`,
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].data_type).toBe('boolean');
+    expect(result.rows[0].is_nullable).toBe('YES');
+    expect(result.rows[0].column_default).toBeNull();
+  });
+});

--- a/apps/api/test/unit/carbon-opt-in-columns.test.ts
+++ b/apps/api/test/unit/carbon-opt-in-columns.test.ts
@@ -1,0 +1,36 @@
+import { getTableColumns } from 'drizzle-orm';
+import { describe, expect, test } from 'vitest';
+import { empresas, trips } from '../../src/db/schema.js';
+
+/**
+ * Task 1 — opt-in de medición de huella (plan medicion-huella-segmento).
+ *
+ * Contrato del schema (no toca DB): la empresa lleva el flag de opt-in y el
+ * viaje un override nullable. Naming inglés total (decisión PO): columnas SQL
+ * en snake_case inglés. Buscamos por nombre SQL para que el test sea type-safe
+ * aun antes de que la columna exista (RED limpio, no error de tipos).
+ */
+describe('opt-in de medición de huella — columnas', () => {
+  test('empresas: carbon_measurement_enabled es boolean NOT NULL DEFAULT false', () => {
+    const column = Object.values(getTableColumns(empresas)).find(
+      (c) => c.name === 'carbon_measurement_enabled',
+    );
+
+    expect(column).toBeDefined();
+    expect(column?.getSQLType()).toBe('boolean');
+    expect(column?.notNull).toBe(true);
+    expect(column?.hasDefault).toBe(true);
+    expect(column?.default).toBe(false);
+  });
+
+  test('trips: carbon_measurement_override es boolean nullable sin default', () => {
+    const column = Object.values(getTableColumns(trips)).find(
+      (c) => c.name === 'carbon_measurement_override',
+    );
+
+    expect(column).toBeDefined();
+    expect(column?.getSQLType()).toBe('boolean');
+    expect(column?.notNull).toBe(false);
+    expect(column?.hasDefault).toBe(false);
+  });
+});


### PR DESCRIPTION
Implementa Task 1 del plan medicion-huella-segmento: columnas opt-in de medición de huella.

## Cambios
- empresas.carbon_measurement_enabled (boolean NOT NULL DEFAULT false)
- viajes.carbon_measurement_override (boolean nullable; NULL = hereda de empresa)
- Migración 0046 hand-written, expand-only (ADR-066)
- Schema Drizzle + tests unitario (contrato) e integración (columnas en PG)

## Evidencia
- TDD: RED (columnas inexistentes) -> GREEN (2/2)
- migration-journal-integrity: 7/7
- check-migration-safety: OK (expand-only)
- typecheck + biome: limpios
- suite unitaria api: 1588 passed, 0 regresiones
- test de integracion valida columnas en PG en el job CI 'Integration tests (DB+Redis)'

## Nota
El plan referenciaba db:generate, pero este repo usa migraciones hand-written (snapshot congelado en 0000). La 0046 se escribio a mano siguiendo la convencion de 0045. Correccion del plan pendiente para Task 2.
